### PR TITLE
Yahuah patch

### DIFF
--- a/book/1chronicles.html
+++ b/book/1chronicles.html
@@ -155,7 +155,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>These are the sons of Israel: Reuben, Simeon, Levi, Judah, Issachar, Zebulun, 
 <sup>2&#160;</sup>Dan, Joseph, Benjamin, Naphtali, Gad, and Asher. 
 </p><p>
-<sup>3&#160;</sup>The sons of Judah: Er, Onan, and Shelah, which three were born to him of Shua’s daughter the Canaanitess. Er, Judah’s firstborn, was wicked in Yahweh’s sight; and he killed him. 
+<sup>3&#160;</sup>The sons of Judah: Er, Onan, and Shelah, which three were born to him of Shua’s daughter the Canaanitess. Er, Judah’s firstborn, was wicked in Yahuah’s sight; and he killed him. 
 <sup>4&#160;</sup>Tamar his daughter-in-law bore him Perez and Zerah. All the sons of Judah were five. 
 </p><p>
 <sup>5&#160;</sup>The sons of Perez: Hezron and Hamul. 
@@ -339,7 +339,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Ahitub brought forth Zadok. Zadok brought forth Shallum. 
 <sup>13&#160;</sup>Shallum brought forth Hilkiah. Hilkiah brought forth Azariah. 
 <sup>14&#160;</sup>Azariah brought forth Seraiah. Seraiah brought forth Jehozadak. 
-<sup>15&#160;</sup>Jehozadak went into captivity when Yahweh carried Judah and Jerusalem away by the hand of Nebuchadnezzar. 
+<sup>15&#160;</sup>Jehozadak went into captivity when Yahuah carried Judah and Jerusalem away by the hand of Nebuchadnezzar. 
 </p><p>
 <sup>16&#160;</sup>The sons of Levi: Gershom, Kohath, and Merari. 
 <sup>17&#160;</sup>These are the names of the sons of Gershom: Libni and Shimei. 
@@ -357,8 +357,8 @@ html[dir=ltr] .q2 {
 <sup>29&#160;</sup>The sons of Merari: Mahli, Libni his son, Shimei his son, Uzzah his son, 
 <sup>30&#160;</sup>Shimea his son, Haggiah his son, Asaiah his son. 
 </p><p>
-<sup>31&#160;</sup>These are they whom David set over the service of song in Yahweh’s house after the ark came to rest there. 
-<sup>32&#160;</sup>They ministered with song before the tabernacle of the Tent of Meeting until Solomon had built Yahweh’s house in Jerusalem. They performed the duties of their office according to their order. 
+<sup>31&#160;</sup>These are they whom David set over the service of song in Yahuah’s house after the ark came to rest there. 
+<sup>32&#160;</sup>They ministered with song before the tabernacle of the Tent of Meeting until Solomon had built Yahuah’s house in Jerusalem. They performed the duties of their office according to their order. 
 <sup>33&#160;</sup>These are those who served, and their sons. Of the sons of the Kohathites: Heman the singer, the son of Joel, the son of Samuel, 
 <sup>34&#160;</sup>the son of Elkanah, the son of Jeroham, the son of Eliel, the son of Toah, 
 <sup>35&#160;</sup>the son of Zuph, the son of Elkanah, the son of Mahath, the son of Amasai, 
@@ -527,11 +527,11 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>17&#160;</sup>The gatekeepers: Shallum, Akkub, Talmon, Ahiman, and their brothers (Shallum was the chief), 
 <sup>18&#160;</sup>who previously served in the king’s gate eastward. They were the gatekeepers for the camp of the children of Levi. 
-<sup>19&#160;</sup>Shallum was the son of Kore, the son of Ebiasaph, the son of Korah, and his brothers, of his father’s house, the Korahites, were over the work of the service, keepers of the thresholds of the tent. Their fathers had been over Yahweh’s camp, keepers of the entry. 
-<sup>20&#160;</sup>Phinehas the son of Eleazar was ruler over them in time past, and Yahweh was with him. 
+<sup>19&#160;</sup>Shallum was the son of Kore, the son of Ebiasaph, the son of Korah, and his brothers, of his father’s house, the Korahites, were over the work of the service, keepers of the thresholds of the tent. Their fathers had been over Yahuah’s camp, keepers of the entry. 
+<sup>20&#160;</sup>Phinehas the son of Eleazar was ruler over them in time past, and Yahuah was with him. 
 <sup>21&#160;</sup>Zechariah the son of Meshelemiah was gatekeeper of the door of the Tent of Meeting. 
 <sup>22&#160;</sup>All these who were chosen to be gatekeepers in the thresholds were two hundred twelve. These were listed by genealogy in their villages, whom David and Samuel the seer ordained in their office of trust. 
-<sup>23&#160;</sup>So they and their children had the oversight of the gates of Yahweh’s house, even the house of the tent, as guards. 
+<sup>23&#160;</sup>So they and their children had the oversight of the gates of Yahuah’s house, even the house of the tent, as guards. 
 <sup>24&#160;</sup>On the four sides were the gatekeepers, toward the east, west, north, and south. 
 <sup>25&#160;</sup>Their brothers, in their villages, were to come in every seven days from time to time to be with them, 
 <sup>26&#160;</sup>for the four chief gatekeepers, who were Levites, were in an office of trust, and were over the rooms and over the treasuries in Elohim’s house. 
@@ -574,34 +574,34 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>When all Jabesh Gilead heard all that the Philistines had done to Saul, 
 <sup>12&#160;</sup>all the valiant men arose and took away the body of Saul and the bodies of his sons, and brought them to Jabesh, and buried their bones under the oak in Jabesh, and fasted seven days. 
 </p><p>
-<sup>13&#160;</sup>So Saul died for his trespass which he committed against Yahweh, because of Yahweh’s word, which he didn’t keep, and also because he asked counsel of one who had a familiar spirit, to inquire, 
-<sup>14&#160;</sup>and didn’t inquire of Yahweh. Therefore he killed him, and turned the kingdom over to David the son of Jesse. 
+<sup>13&#160;</sup>So Saul died for his trespass which he committed against Yahuah, because of Yahuah’s word, which he didn’t keep, and also because he asked counsel of one who had a familiar spirit, to inquire, 
+<sup>14&#160;</sup>and didn’t inquire of Yahuah. Therefore he killed him, and turned the kingdom over to David the son of Jesse. 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p>
 <sup>1&#160;</sup>Then all Israel gathered themselves to David to Hebron, saying, “Behold, we are your bone and your flesh. 
-<sup>2&#160;</sup>In times past, even when Saul was king, it was you who led out and brought in Israel. Yahweh your Elohim said to you, ‘You shall be shepherd of my people Israel, and you shall be prince over my people Israel.’&#160;” 
+<sup>2&#160;</sup>In times past, even when Saul was king, it was you who led out and brought in Israel. Yahuah your Elohim said to you, ‘You shall be shepherd of my people Israel, and you shall be prince over my people Israel.’&#160;” 
 </p><p>
-<sup>3&#160;</sup>So all the elders of Israel came to the king to Hebron; and David made a covenant with them in Hebron before Yahweh. They anointed David king over Israel, according to Yahweh’s word by Samuel. 
+<sup>3&#160;</sup>So all the elders of Israel came to the king to Hebron; and David made a covenant with them in Hebron before Yahuah. They anointed David king over Israel, according to Yahuah’s word by Samuel. 
 </p><p>
 <sup>4&#160;</sup>David and all Israel went to Jerusalem (also called Jebus); and the Jebusites, the inhabitants of the land, were there. 
 <sup>5&#160;</sup>The inhabitants of Jebus said to David, “You will not come in here!” Nevertheless David took the stronghold of Zion. The same is David’s city. 
 <sup>6&#160;</sup>David had said, “Whoever strikes the Jebusites first shall be chief and captain.” Joab the son of Zeruiah went up first, and was made chief. 
 <sup>7&#160;</sup>David lived in the stronghold; therefore they called it David’s city. 
 <sup>8&#160;</sup>He built the city all around, from Millo even around; and Joab repaired the rest of the city. 
-<sup>9&#160;</sup>David grew greater and greater, for Yahweh of Armies was with him. 
+<sup>9&#160;</sup>David grew greater and greater, for Yahuah of Armies was with him. 
 </p><p>
-<sup>10&#160;</sup>Now these are the chief of the mighty men whom David had, who showed themselves strong with him in his kingdom, together with all Israel, to make him king, according to Yahweh’s word concerning Israel. 
+<sup>10&#160;</sup>Now these are the chief of the mighty men whom David had, who showed themselves strong with him in his kingdom, together with all Israel, to make him king, according to Yahuah’s word concerning Israel. 
 </p><p>
 <sup>11&#160;</sup>This is the number of the mighty men whom David had: Jashobeam, the son of a Hachmonite, the chief of the thirty; he lifted up his spear against three hundred and killed them at one time. 
 <sup>12&#160;</sup>After him was Eleazar the son of Dodo, the Ahohite, who was one of the three mighty men. 
 <sup>13&#160;</sup>He was with David at Pasdammim, and there the Philistines were gathered together to battle, where there was a plot of ground full of barley; and the people fled from before the Philistines. 
-<sup>14&#160;</sup>They stood in the middle of the plot, defended it, and killed the Philistines; and Yahweh saved them by a great victory. 
+<sup>14&#160;</sup>They stood in the middle of the plot, defended it, and killed the Philistines; and Yahuah saved them by a great victory. 
 </p><p>
 <sup>15&#160;</sup>Three of the thirty chief men went down to the rock to David, into the cave of Adullam; and the army of the Philistines were encamped in the valley of Rephaim. 
 <sup>16&#160;</sup>David was then in the stronghold, and the garrison of the Philistines was in Bethlehem at that time. 
 <sup>17&#160;</sup>David longed, and said, “Oh, that someone would give me water to drink from the well of Bethlehem, which is by the gate!” 
 </p><p>
-<sup>18&#160;</sup>The three broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate, took it, and brought it to David; but David would not drink any of it, but poured it out to Yahweh, 
+<sup>18&#160;</sup>The three broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate, took it, and brought it to David; but David would not drink any of it, but poured it out to Yahuah, 
 <sup>19&#160;</sup>and said, “My Elohim forbid me, that I should do this! Shall I drink the blood of these men who have put their lives in jeopardy?” For they risked their lives to bring it. Therefore he would not drink it. The three mighty men did these things. 
 </p><p>
 <sup>20&#160;</sup>Abishai, the brother of Joab, was chief of the three; for he lifted up his spear against three hundred and killed them, and had a name among the three. 
@@ -663,7 +663,7 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>They helped David against the band of raiders, for they were all mighty men of valor and were captains in the army. 
 <sup>22&#160;</sup>For from day to day men came to David to help him, until there was a great army, like Elohim’s army. 
 </p><p>
-<sup>23&#160;</sup>These are the numbers of the heads of those who were armed for war, who came to David to Hebron to turn the kingdom of Saul to him, according to Yahweh’s word. 
+<sup>23&#160;</sup>These are the numbers of the heads of those who were armed for war, who came to David to Hebron to turn the kingdom of Saul to him, according to Yahuah’s word. 
 <sup>24&#160;</sup>The children of Judah who bore shield and spear were six thousand eight hundred, armed for war. 
 <sup>25&#160;</sup>Of the children of Simeon, mighty men of valor for the war: seven thousand one hundred. 
 <sup>26&#160;</sup>Of the children of Levi: four thousand six hundred. 
@@ -685,26 +685,26 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
 <sup>1&#160;</sup>David consulted with the captains of thousands and of hundreds, even with every leader. 
-<sup>2&#160;</sup>David said to all the assembly of Israel, “If it seems good to you, and if it is of Yahweh our Elohim, let’s send word everywhere to our brothers who are left in all the land of Israel, with whom the priests and Levites are in their cities that have pasture lands, that they may gather themselves to us. 
+<sup>2&#160;</sup>David said to all the assembly of Israel, “If it seems good to you, and if it is of Yahuah our Elohim, let’s send word everywhere to our brothers who are left in all the land of Israel, with whom the priests and Levites are in their cities that have pasture lands, that they may gather themselves to us. 
 <sup>3&#160;</sup>Also, let’s bring the ark of our Elohim back to us again, for we didn’t seek it in the days of Saul.” 
 </p><p>
 <sup>4&#160;</sup>All the assembly said that they would do so, for the thing was right in the eyes of all the people. 
 <sup>5&#160;</sup>So David assembled all Israel together, from the Shihor River of Egypt even to the entrance of Hamath, to bring Elohim’s ark from Kiriath Jearim. 
 </p><p>
-<sup>6&#160;</sup>David went up with all Israel to Baalah, that is, to Kiriath Jearim, which belonged to Judah, to bring up from there Elohim Yahweh’s ark that sits above the cherubim, that is called by the Name. 
+<sup>6&#160;</sup>David went up with all Israel to Baalah, that is, to Kiriath Jearim, which belonged to Judah, to bring up from there Elohim Yahuah’s ark that sits above the cherubim, that is called by the Name. 
 <sup>7&#160;</sup>They carried Elohim’s ark on a new cart, and brought it out of Abinadab’s house; and Uzza and Ahio drove the cart. 
 <sup>8&#160;</sup>David and all Israel played before Elohim with all their might, even with songs, with harps, with stringed instruments, with tambourines, with cymbals, and with trumpets. 
 </p><p>
 <sup>9&#160;</sup>When they came to Chidon’s threshing floor, Uzza put out his hand to hold the ark, for the oxen stumbled. 
-<sup>10&#160;</sup>Yahweh’s anger burned against Uzza, and he struck him because he put his hand on the ark; and he died there before Elohim. 
-<sup>11&#160;</sup>David was displeased, because Yahweh had broken out against Uzza. He called that place Perez Uzza, to this day. 
+<sup>10&#160;</sup>Yahuah’s anger burned against Uzza, and he struck him because he put his hand on the ark; and he died there before Elohim. 
+<sup>11&#160;</sup>David was displeased, because Yahuah had broken out against Uzza. He called that place Perez Uzza, to this day. 
 <sup>12&#160;</sup>David was afraid of Elohim that day, saying, “How can I bring Elohim’s ark home to me?” 
 <sup>13&#160;</sup>So David didn’t move the ark with him into David’s city, but carried it aside into Obed-Edom the Gittite’s house. 
-<sup>14&#160;</sup>Elohim’s ark remained with the family of Obed-Edom in his house three months; and Yahweh blessed Obed-Edom’s house and all that he had. 
+<sup>14&#160;</sup>Elohim’s ark remained with the family of Obed-Edom in his house three months; and Yahuah blessed Obed-Edom’s house and all that he had. 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
 <sup>1&#160;</sup>Hiram king of Tyre sent messengers to David with cedar trees, masons, and carpenters, to build him a house. 
-<sup>2&#160;</sup>David perceived that Yahweh had established him king over Israel, for his kingdom was highly exalted, for his people Israel’s sake. 
+<sup>2&#160;</sup>David perceived that Yahuah had established him king over Israel, for his kingdom was highly exalted, for his people Israel’s sake. 
 </p><p>
 <sup>3&#160;</sup>David took more women in Jerusalem, and David brought forth more sons and daughters. 
 <sup>4&#160;</sup>These are the names of the children whom he had in Jerusalem: Shammua, Shobab, Nathan, Solomon, 
@@ -715,7 +715,7 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>When the Philistines heard that David was anointed king over all Israel, all the Philistines went up to seek David; and David heard of it, and went out against them. 
 <sup>9&#160;</sup>Now the Philistines had come and made a raid in the valley of Rephaim. 
 <sup>10&#160;</sup>David inquired of Elohim, saying, “Shall I go up against the Philistines? Will you deliver them into my hand?” 
-</p><p>Yahweh said to him, “Go up; for I will deliver them into your hand.” 
+</p><p>Yahuah said to him, “Go up; for I will deliver them into your hand.” 
 </p><p>
 <sup>11&#160;</sup>So they came up to Baal Perazim, and David defeated them there. David said, Elohim has broken my enemies by my hand, like waters breaking out. Therefore they called the name of that place Baal Perazim. 
 <sup>12&#160;</sup>They left their elohims there; and David gave a command, and they were burned with fire. 
@@ -725,13 +725,13 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>When you hear the sound of marching in the tops of the mulberry trees, then go out to battle; for Elohim has gone out before you to strike the army of the Philistines.” 
 </p><p>
 <sup>16&#160;</sup>David did as Elohim commanded him; and they attacked the army of the Philistines from Gibeon even to Gezer. 
-<sup>17&#160;</sup>The fame of David went out into all lands; and Yahweh brought the fear of him on all nations. 
+<sup>17&#160;</sup>The fame of David went out into all lands; and Yahuah brought the fear of him on all nations. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
 <sup>1&#160;</sup>David made himself houses in David’s city; and he prepared a place for Elohim’s ark, and pitched a tent for it. 
-<sup>2&#160;</sup>Then David said, “No one ought to carry Elohim’s ark but the Levites. For Yahweh has chosen them to carry Elohim’s ark, and to minister to him forever.” 
+<sup>2&#160;</sup>Then David said, “No one ought to carry Elohim’s ark but the Levites. For Yahuah has chosen them to carry Elohim’s ark, and to minister to him forever.” 
 </p><p>
-<sup>3&#160;</sup>David assembled all Israel at Jerusalem, to bring up Yahweh’s ark to its place, which he had prepared for it. 
+<sup>3&#160;</sup>David assembled all Israel at Jerusalem, to bring up Yahuah’s ark to its place, which he had prepared for it. 
 <sup>4&#160;</sup>David gathered together the sons of Aaron and the Levites: 
 <sup>5&#160;</sup>of the sons of Kohath, Uriel the chief, and his brothers one hundred twenty; 
 <sup>6&#160;</sup>of the sons of Merari, Asaiah the chief, and his brothers two hundred twenty; 
@@ -741,11 +741,11 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>of the sons of Uzziel, Amminadab the chief, and his brothers one hundred twelve. 
 </p><p>
 <sup>11&#160;</sup>David called for Zadok and Abiathar the priests, and for the Levites: for Uriel, Asaiah, Joel, Shemaiah, Eliel, and Amminadab, 
-<sup>12&#160;</sup>and said to them, “You are the heads of the fathers’ households of the Levites. Sanctify yourselves, both you and your brothers, that you may bring the ark of Yahweh, the Elohim of Israel, up to the place that I have prepared for it. 
-<sup>13&#160;</sup>For because you didn’t carry it at first, Yahweh our Elohim broke out in anger against us, because we didn’t seek him according to the ordinance.” 
+<sup>12&#160;</sup>and said to them, “You are the heads of the fathers’ households of the Levites. Sanctify yourselves, both you and your brothers, that you may bring the ark of Yahuah, the Elohim of Israel, up to the place that I have prepared for it. 
+<sup>13&#160;</sup>For because you didn’t carry it at first, Yahuah our Elohim broke out in anger against us, because we didn’t seek him according to the ordinance.” 
 </p><p>
-<sup>14&#160;</sup>So the priests and the Levites sanctified themselves to bring up the ark of Yahweh, the Elohim of Israel. 
-<sup>15&#160;</sup>The children of the Levites bore Elohim’s ark on their shoulders with its poles, as Moses commanded according to Yahweh’s word. 
+<sup>14&#160;</sup>So the priests and the Levites sanctified themselves to bring up the ark of Yahuah, the Elohim of Israel. 
+<sup>15&#160;</sup>The children of the Levites bore Elohim’s ark on their shoulders with its poles, as Moses commanded according to Yahuah’s word. 
 </p><p>
 <sup>16&#160;</sup>David spoke to the chief of the Levites to appoint their brothers as singers with instruments of music, stringed instruments, harps, and cymbals, sounding aloud and lifting up their voices with joy. 
 <sup>17&#160;</sup>So the Levites appointed Heman the son of Joel; and of his brothers, Asaph the son of Berechiah; and of the sons of Merari their brothers, Ethan the son of Kushaiah; 
@@ -757,24 +757,24 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>Berechiah and Elkanah were doorkeepers for the ark. 
 <sup>24&#160;</sup>Shebaniah, Joshaphat, Nethanel, Amasai, Zechariah, Benaiah, and Eliezer, the priests, blew the trumpets before Elohim’s ark; and Obed-Edom and Jehiah were doorkeepers for the ark. 
 </p><p>
-<sup>25&#160;</sup>So David, the elders of Israel, and the captains over thousands went to bring the ark of Yahweh’s covenant up out of the house of Obed-Edom with joy. 
-<sup>26&#160;</sup>When Elohim helped the Levites who bore the ark of Yahweh’s covenant, they sacrificed seven bulls and seven rams. 
+<sup>25&#160;</sup>So David, the elders of Israel, and the captains over thousands went to bring the ark of Yahuah’s covenant up out of the house of Obed-Edom with joy. 
+<sup>26&#160;</sup>When Elohim helped the Levites who bore the ark of Yahuah’s covenant, they sacrificed seven bulls and seven rams. 
 <sup>27&#160;</sup>David was clothed with a robe of fine linen, as were all the Levites who bore the ark, the singers, and Chenaniah the choir master with the singers; and David had an ephod of linen on him. 
-<sup>28&#160;</sup>Thus all Israel brought the ark of Yahweh’s covenant up with shouting, with sound of the cornet, with trumpets, and with cymbals, sounding aloud with stringed instruments and harps. 
-<sup>29&#160;</sup>As the ark of Yahweh’s covenant came to David’s city, Michal the daughter of Saul looked out at the window, and saw king David dancing and playing; and she despised him in her heart. 
+<sup>28&#160;</sup>Thus all Israel brought the ark of Yahuah’s covenant up with shouting, with sound of the cornet, with trumpets, and with cymbals, sounding aloud with stringed instruments and harps. 
+<sup>29&#160;</sup>As the ark of Yahuah’s covenant came to David’s city, Michal the daughter of Saul looked out at the window, and saw king David dancing and playing; and she despised him in her heart. 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
 <sup>1&#160;</sup>They brought in Elohim’s ark, and set it in the middle of the tent that David had pitched for it; and they offered burnt offerings and peace offerings before Elohim. 
-<sup>2&#160;</sup>When David had finished offering the burnt offering and the peace offerings, he blessed the people in Yahweh’s name. 
+<sup>2&#160;</sup>When David had finished offering the burnt offering and the peace offerings, he blessed the people in Yahuah’s name. 
 <sup>3&#160;</sup>He gave to everyone of Israel, both man and woman, to everyone a loaf of bread, a portion of meat, and a cake of raisins. 
 </p><p>
-<sup>4&#160;</sup>He appointed some of the Levites to minister before Yahweh’s ark, and to commemorate, to thank, and to praise Yahweh, the Elohim of Israel: 
+<sup>4&#160;</sup>He appointed some of the Levites to minister before Yahuah’s ark, and to commemorate, to thank, and to praise Yahuah, the Elohim of Israel: 
 <sup>5&#160;</sup>Asaph the chief, and second to him Zechariah, then Jeiel, Shemiramoth, Jehiel, Mattithiah, Eliab, Benaiah, Obed-Edom, and Jeiel, with stringed instruments and with harps; and Asaph with cymbals, sounding aloud; 
 <sup>6&#160;</sup>with Benaiah and Jahaziel the priests with trumpets continually, before the ark of the covenant of Elohim. 
 </p><p>
-<sup>7&#160;</sup>Then on that day David first ordained giving of thanks to Yahweh by the hand of Asaph and his brothers. 
+<sup>7&#160;</sup>Then on that day David first ordained giving of thanks to Yahuah by the hand of Asaph and his brothers. 
 </p><p class="q1">
-<sup>8&#160;</sup>Oh give thanks to Yahweh. 
+<sup>8&#160;</sup>Oh give thanks to Yahuah. 
 </p><p class="q2">Call on his name. 
 </p><p class="q2">Make what he has done known among the peoples. 
 </p><p class="q1">
@@ -783,9 +783,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Tell of all his marvelous works. 
 </p><p class="q1">
 <sup>10&#160;</sup>Glory in his set-apart name. 
-</p><p class="q2">Let the heart of those who seek Yahweh rejoice. 
+</p><p class="q2">Let the heart of those who seek Yahuah rejoice. 
 </p><p class="q1">
-<sup>11&#160;</sup>Seek Yahweh and his strength. 
+<sup>11&#160;</sup>Seek Yahuah and his strength. 
 </p><p class="q2">Seek his face forever more. 
 </p><p class="q1">
 <sup>12&#160;</sup>Remember his marvelous works that he has done, 
@@ -795,7 +795,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">you children of Jacob, his chosen ones. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>14&#160;</sup>He is Yahweh our Elohim. 
+<sup>14&#160;</sup>He is Yahuah our Elohim. 
 </p><p class="q2">His judgments are in all the earth. 
 </p><p class="q1">
 <sup>15&#160;</sup>Remember his covenant forever, 
@@ -823,43 +823,43 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Do my prophets no harm!” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>23&#160;</sup>Sing to Yahweh, all the earth! 
+<sup>23&#160;</sup>Sing to Yahuah, all the earth! 
 </p><p class="q2">Display his salvation from day to day. 
 </p><p class="q1">
 <sup>24&#160;</sup>Declare his glory among the nations, 
 </p><p class="q2">and his marvelous works among all the peoples. 
 </p><p class="q1">
-<sup>25&#160;</sup>For great is Yahweh, and greatly to be praised. 
+<sup>25&#160;</sup>For great is Yahuah, and greatly to be praised. 
 </p><p class="q2">He also is to be feared above all elohims. 
 </p><p class="q1">
 <sup>26&#160;</sup>For all the elohims of the peoples are idols, 
-</p><p class="q2">but Yahweh made the heavens. 
+</p><p class="q2">but Yahuah made the heavens. 
 </p><p class="q1">
 <sup>27&#160;</sup>Honor and majesty are before him. 
 </p><p class="q2">Strength and gladness are in his place. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>28&#160;</sup>Ascribe to Yahweh, you families of the peoples, 
-</p><p class="q2">ascribe to Yahweh glory and strength! 
+<sup>28&#160;</sup>Ascribe to Yahuah, you families of the peoples, 
+</p><p class="q2">ascribe to Yahuah glory and strength! 
 </p><p class="q1">
-<sup>29&#160;</sup>Ascribe to Yahweh the glory due to his name. 
+<sup>29&#160;</sup>Ascribe to Yahuah the glory due to his name. 
 </p><p class="q2">Bring an offering, and come before him. 
-</p><p class="q2">Worship Yahweh in set-apart array. 
+</p><p class="q2">Worship Yahuah in set-apart array. 
 </p><p class="q1">
 <sup>30&#160;</sup>Tremble before him, all the earth. 
 </p><p class="q2">The world also is established that it can’t be moved. 
 </p><p class="q1">
 <sup>31&#160;</sup>Let the heavens be glad, 
 </p><p class="q2">and let the earth rejoice! 
-</p><p class="q2">Let them say among the nations, “Yahweh reigns!” 
+</p><p class="q2">Let them say among the nations, “Yahuah reigns!” 
 </p><p class="q1">
 <sup>32&#160;</sup>Let the sea roar, and its fullness! 
 </p><p class="q2">Let the field exult, and all that is in it! 
 </p><p class="q1">
-<sup>33&#160;</sup>Then the trees of the forest will sing for joy before Yahweh, 
+<sup>33&#160;</sup>Then the trees of the forest will sing for joy before Yahuah, 
 </p><p class="q2">for he comes to judge the earth. 
 </p><p class="q1">
-<sup>34&#160;</sup>Oh give thanks to Yahweh, for he is good, 
+<sup>34&#160;</sup>Oh give thanks to Yahuah, for he is good, 
 </p><p class="q2">for his loving kindness endures forever. 
 </p><p class="q1">
 <sup>35&#160;</sup>Say, “Save us, Elohim of our salvation! 
@@ -867,50 +867,50 @@ html[dir=ltr] .q2 {
 </p><p class="q2">to give thanks to your set-apart name, 
 </p><p class="q2">to triumph in your praise.” 
 </p><p class="q1">
-<sup>36&#160;</sup>Blessed be Yahweh, the Elohim of Israel, 
+<sup>36&#160;</sup>Blessed be Yahuah, the Elohim of Israel, 
 </p><p class="q2">from everlasting even to everlasting. 
-</p><p>All the people said, “Amen,” and praised Yahweh. 
+</p><p>All the people said, “Amen,” and praised Yahuah. 
 </p><p>
-<sup>37&#160;</sup>So he left Asaph and his brothers there before the ark of Yahweh’s covenant, to minister before the ark continually, as every day’s work required; 
+<sup>37&#160;</sup>So he left Asaph and his brothers there before the ark of Yahuah’s covenant, to minister before the ark continually, as every day’s work required; 
 <sup>38&#160;</sup>and Obed-Edom with their sixty-eight relatives; Obed-Edom also the son of Jeduthun and Hosah to be doorkeepers; 
-<sup>39&#160;</sup>and Zadok the priest and his brothers the priests, before Yahweh’s tabernacle in the high place that was at Gibeon, 
-<sup>40&#160;</sup>to offer burnt offerings to Yahweh on the altar of burnt offering continually morning and evening, even according to all that is written in Yahweh’s law, which he commanded to Israel; 
-<sup>41&#160;</sup>and with them Heman and Jeduthun and the rest who were chosen, who were mentioned by name, to give thanks to Yahweh, because his loving kindness endures forever; 
+<sup>39&#160;</sup>and Zadok the priest and his brothers the priests, before Yahuah’s tabernacle in the high place that was at Gibeon, 
+<sup>40&#160;</sup>to offer burnt offerings to Yahuah on the altar of burnt offering continually morning and evening, even according to all that is written in Yahuah’s law, which he commanded to Israel; 
+<sup>41&#160;</sup>and with them Heman and Jeduthun and the rest who were chosen, who were mentioned by name, to give thanks to Yahuah, because his loving kindness endures forever; 
 <sup>42&#160;</sup>and with them Heman and Jeduthun with trumpets and cymbals for those that should sound aloud, and with instruments for the songs of Elohim, and the sons of Jeduthun to be at the gate. 
 <sup>43&#160;</sup>All the people departed, each man to his house; and David returned to bless his house. 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
-<sup>1&#160;</sup>When David was living in his house, David said to Nathan the prophet, “Behold, I live in a cedar house, but the ark of Yahweh’s covenant is in a tent.” 
+<sup>1&#160;</sup>When David was living in his house, David said to Nathan the prophet, “Behold, I live in a cedar house, but the ark of Yahuah’s covenant is in a tent.” 
 </p><p>
 <sup>2&#160;</sup>Nathan said to David, “Do all that is in your heart; for Elohim is with you.” 
 </p><p>
 <sup>3&#160;</sup>That same night, the word of Elohim came to Nathan, saying, 
-<sup>4&#160;</sup>“Go and tell David my servant, ‘Yahweh says, “You shall not build me a house to dwell in; 
+<sup>4&#160;</sup>“Go and tell David my servant, ‘Yahuah says, “You shall not build me a house to dwell in; 
 <sup>5&#160;</sup>for I have not lived in a house since the day that I brought up Israel to this day, but have gone from tent to tent, and from one tent to another. 
 <sup>6&#160;</sup>In all places in which I have walked with all Israel, did I speak a word with any of the judges of Israel, whom I commanded to be shepherd of my people, saying, ‘Why have you not built me a house of cedar?’&#160;”&#160;’ 
 </p><p>
-<sup>7&#160;</sup>“Now therefore, you shall tell my servant David, ‘Yahweh of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people Israel. 
+<sup>7&#160;</sup>“Now therefore, you shall tell my servant David, ‘Yahuah of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people Israel. 
 <sup>8&#160;</sup>I have been with you wherever you have gone, and have cut off all your enemies from before you. I will make you a name like the name of the great ones who are in the earth. 
 <sup>9&#160;</sup>I will appoint a place for my people Israel, and will plant them, that they may dwell in their own place, and be moved no more. The children of wickedness will not waste them any more, as at the first, 
-<sup>10&#160;</sup>and from the day that I commanded judges to be over my people Israel. I will subdue all your enemies. Moreover I tell you that Yahweh will build you a house. 
+<sup>10&#160;</sup>and from the day that I commanded judges to be over my people Israel. I will subdue all your enemies. Moreover I tell you that Yahuah will build you a house. 
 <sup>11&#160;</sup>It will happen, when your days are fulfilled that you must go to be with your fathers, that I will set up your offspring after you, who will be of your sons; and I will establish his kingdom. 
 <sup>12&#160;</sup>He will build me a house, and I will establish his throne forever. 
 <sup>13&#160;</sup>I will be his father, and he will be my son. I will not take my loving kindness away from him, as I took it from him who was before you; 
 <sup>14&#160;</sup>but I will settle him in my house and in my kingdom forever. His throne will be established forever.”&#160;’&#160;” 
 <sup>15&#160;</sup>According to all these words, and according to all this vision, so Nathan spoke to David. 
 </p><p>
-<sup>16&#160;</sup>Then David the king went in and sat before Yahweh; and he said, “Who am I, Yahweh Elohim, and what is my house, that you have brought me this far? 
-<sup>17&#160;</sup>This was a small thing in your eyes, O Elohim, but you have spoken of your servant’s house for a great while to come, and have respected me according to the standard of a man of high degree, Yahweh Elohim. 
+<sup>16&#160;</sup>Then David the king went in and sat before Yahuah; and he said, “Who am I, Yahuah Elohim, and what is my house, that you have brought me this far? 
+<sup>17&#160;</sup>This was a small thing in your eyes, O Elohim, but you have spoken of your servant’s house for a great while to come, and have respected me according to the standard of a man of high degree, Yahuah Elohim. 
 <sup>18&#160;</sup>What can David say yet more to you concerning the honor which is done to your servant? For you know your servant. 
-<sup>19&#160;</sup>Yahweh, for your servant’s sake, and according to your own heart, you have done all this greatness, to make known all these great things. 
-<sup>20&#160;</sup>Yahweh, there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
+<sup>19&#160;</sup>Yahuah, for your servant’s sake, and according to your own heart, you have done all this greatness, to make known all these great things. 
+<sup>20&#160;</sup>Yahuah, there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
 <sup>21&#160;</sup>What one nation in the earth is like your people Israel, whom Elohim went to redeem to himself for a people, to make you a name by great and awesome things, in driving out nations from before your people whom you redeemed out of Egypt? 
-<sup>22&#160;</sup>For you made your people Israel your own people forever; and you, Yahweh, became their Elohim. 
-<sup>23&#160;</sup>Now, Yahweh, let the word that you have spoken concerning your servant, and concerning his house, be established forever, and do as you have spoken. 
-<sup>24&#160;</sup>Let your name be established and magnified forever, saying, ‘Yahweh of Armies is the Elohim of Israel, even an Elohim to Israel. The house of David your servant is established before you.’ 
+<sup>22&#160;</sup>For you made your people Israel your own people forever; and you, Yahuah, became their Elohim. 
+<sup>23&#160;</sup>Now, Yahuah, let the word that you have spoken concerning your servant, and concerning his house, be established forever, and do as you have spoken. 
+<sup>24&#160;</sup>Let your name be established and magnified forever, saying, ‘Yahuah of Armies is the Elohim of Israel, even an Elohim to Israel. The house of David your servant is established before you.’ 
 <sup>25&#160;</sup>For you, my Elohim, have revealed to your servant that you will build him a house. Therefore your servant has found courage to pray before you. 
-<sup>26&#160;</sup>Now, Yahweh, you are Elohim, and have promised this good thing to your servant. 
-<sup>27&#160;</sup>Now it has pleased you to bless the house of your servant, that it may continue forever before you; for you, Yahweh, have blessed, and it is blessed forever.” 
+<sup>26&#160;</sup>Now, Yahuah, you are Elohim, and have promised this good thing to your servant. 
+<sup>27&#160;</sup>Now it has pleased you to bless the house of your servant, that it may continue forever before you; for you, Yahuah, have blessed, and it is blessed forever.” 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
 <sup>1&#160;</sup>After this, David defeated the Philistines and subdued them, and took Gath and its towns out of the hand of the Philistines. 
@@ -919,16 +919,16 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>David defeated Hadadezer king of Zobah, toward Hamath, as he went to establish his dominion by the river Euphrates. 
 <sup>4&#160;</sup>David took from him one thousand chariots, seven thousand horsemen, and twenty thousand footmen; and David hamstrung all the chariot horses, but reserved of them enough for one hundred chariots. 
 <sup>5&#160;</sup>When the Syrians of Damascus came to help Hadadezer king of Zobah, David struck twenty-two thousand men of the Syrians. 
-<sup>6&#160;</sup>Then David put garrisons in Syria of Damascus; and the Syrians became servants to David and brought tribute. Yahweh gave victory to David wherever he went. 
+<sup>6&#160;</sup>Then David put garrisons in Syria of Damascus; and the Syrians became servants to David and brought tribute. Yahuah gave victory to David wherever he went. 
 <sup>7&#160;</sup>David took the shields of gold that were on the servants of Hadadezer, and brought them to Jerusalem. 
 <sup>8&#160;</sup>From Tibhath and from Cun, cities of Hadadezer, David took very much bronze, with which Solomon made the bronze sea, the pillars, and the vessels of bronze. 
 </p><p>
 <sup>9&#160;</sup>When Tou king of Hamath heard that David had struck all the army of Hadadezer king of Zobah, 
 <sup>10&#160;</sup>he sent Hadoram his son to King David to greet him and to bless him, because he had fought against Hadadezer and struck him (for Hadadezer had wars with Tou); and he had with him all kinds of vessels of gold and silver and bronze. 
-<sup>11&#160;</sup>King David also dedicated these to Yahweh, with the silver and the gold that he carried away from all the nations: from Edom, from Moab, from the children of Ammon, from the Philistines, and from Amalek. 
+<sup>11&#160;</sup>King David also dedicated these to Yahuah, with the silver and the gold that he carried away from all the nations: from Edom, from Moab, from the children of Ammon, from the Philistines, and from Amalek. 
 </p><p>
 <sup>12&#160;</sup>Moreover Abishai the son of Zeruiah struck eighteen thousand of the Edomites in the Valley of Salt. 
-<sup>13&#160;</sup>He put garrisons in Edom; and all the Edomites became servants to David. Yahweh gave victory to David wherever he went. 
+<sup>13&#160;</sup>He put garrisons in Edom; and all the Edomites became servants to David. Yahuah gave victory to David wherever he went. 
 </p><p>
 <sup>14&#160;</sup>David reigned over all Israel; and he executed justice and righteousness for all his people. 
 <sup>15&#160;</sup>Joab the son of Zeruiah was over the army; Jehoshaphat the son of Ahilud was recorder; 
@@ -951,7 +951,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>Now when Joab saw that the battle was set against him before and behind, he chose some of all the choice men of Israel, and put them in array against the Syrians. 
 <sup>11&#160;</sup>The rest of the people he committed into the hand of Abishai his brother; and they put themselves in array against the children of Ammon. 
 <sup>12&#160;</sup>He said, “If the Syrians are too strong for me, then you are to help me; but if the children of Ammon are too strong for you, then I will help you. 
-<sup>13&#160;</sup>Be courageous, and let’s be strong for our people and for the cities of our Elohim. May Yahweh do that which seems good to him.” 
+<sup>13&#160;</sup>Be courageous, and let’s be strong for our people and for the cities of our Elohim. May Yahuah do that which seems good to him.” 
 </p><p>
 <sup>14&#160;</sup>So Joab and the people who were with him came near to the front of the Syrians to the battle; and they fled before him. 
 <sup>15&#160;</sup>When the children of Ammon saw that the Syrians had fled, they likewise fled before Abishai his brother, and entered into the city. Then Joab came to Jerusalem. 
@@ -977,7 +977,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>Satan stood up against Israel, and moved David to take a census of Israel. 
 <sup>2&#160;</sup>David said to Joab and to the princes of the people, “Go, count Israel from Beersheba even to Dan; and bring me word, that I may know how many there are.” 
 </p><p>
-<sup>3&#160;</sup>Joab said, “May Yahweh make his people a hundred times as many as they are. But, my lord the king, aren’t they all my lord’s servants? Why does my lord require this thing? Why will he be a cause of guilt to Israel?” 
+<sup>3&#160;</sup>Joab said, “May Yahuah make his people a hundred times as many as they are. But, my lord the king, aren’t they all my lord’s servants? Why does my lord require this thing? Why will he be a cause of guilt to Israel?” 
 </p><p>
 <sup>4&#160;</sup>Nevertheless the king’s word prevailed against Joab. Therefore Joab departed and went throughout all Israel, then came to Jerusalem. 
 <sup>5&#160;</sup>Joab gave the sum of the census of the people to David. All those of Israel were one million one hundred thousand men who drew a sword; and in Judah were four hundred seventy thousand men who drew a sword. 
@@ -986,70 +986,70 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>Elohim was displeased with this thing; therefore he struck Israel. 
 <sup>8&#160;</sup>David said to Elohim, “I have sinned greatly, in that I have done this thing. But now put away, I beg you, the iniquity of your servant, for I have done very foolishly.” 
 </p><p>
-<sup>9&#160;</sup>Yahweh spoke to Gad, David’s seer, saying, 
-<sup>10&#160;</sup>“Go and speak to David, saying, ‘Yahweh says, “I offer you three things. Choose one of them, that I may do it to you.”&#160;’&#160;” 
+<sup>9&#160;</sup>Yahuah spoke to Gad, David’s seer, saying, 
+<sup>10&#160;</sup>“Go and speak to David, saying, ‘Yahuah says, “I offer you three things. Choose one of them, that I may do it to you.”&#160;’&#160;” 
 </p><p>
-<sup>11&#160;</sup>So Gad came to David and said to him, “Yahweh says, ‘Take your choice: 
-<sup>12&#160;</sup>either three years of famine; or three months to be consumed before your foes, while the sword of your enemies overtakes you; or else three days of the sword of Yahweh, even pestilence in the land, and Yahweh’s angel destroying throughout all the borders of Israel. Now therefore consider what answer I shall return to him who sent me.’&#160;” 
+<sup>11&#160;</sup>So Gad came to David and said to him, “Yahuah says, ‘Take your choice: 
+<sup>12&#160;</sup>either three years of famine; or three months to be consumed before your foes, while the sword of your enemies overtakes you; or else three days of the sword of Yahuah, even pestilence in the land, and Yahuah’s angel destroying throughout all the borders of Israel. Now therefore consider what answer I shall return to him who sent me.’&#160;” 
 </p><p>
-<sup>13&#160;</sup>David said to Gad, “I am in distress. Let me fall, I pray, into Yahweh’s hand, for his mercies are very great. Don’t let me fall into man’s hand.” 
+<sup>13&#160;</sup>David said to Gad, “I am in distress. Let me fall, I pray, into Yahuah’s hand, for his mercies are very great. Don’t let me fall into man’s hand.” 
 </p><p>
-<sup>14&#160;</sup>So Yahweh sent a pestilence on Israel, and seventy thousand men of Israel fell. 
-<sup>15&#160;</sup>Elohim sent an angel to Jerusalem to destroy it. As he was about to destroy, Yahweh saw, and he relented of the disaster, and said to the destroying angel, “It is enough. Now withdraw your hand.” Yahweh’s angel was standing by the threshing floor of Ornan the Jebusite. 
-<sup>16&#160;</sup>David lifted up his eyes, and saw Yahweh’s angel standing between earth and the sky, having a drawn sword in his hand stretched out over Jerusalem. 
+<sup>14&#160;</sup>So Yahuah sent a pestilence on Israel, and seventy thousand men of Israel fell. 
+<sup>15&#160;</sup>Elohim sent an angel to Jerusalem to destroy it. As he was about to destroy, Yahuah saw, and he relented of the disaster, and said to the destroying angel, “It is enough. Now withdraw your hand.” Yahuah’s angel was standing by the threshing floor of Ornan the Jebusite. 
+<sup>16&#160;</sup>David lifted up his eyes, and saw Yahuah’s angel standing between earth and the sky, having a drawn sword in his hand stretched out over Jerusalem. 
 </p><p>Then David and the elders, clothed in sackcloth, fell on their faces. 
-<sup>17&#160;</sup>David said to Elohim, “Isn’t it I who commanded the people to be counted? It is even I who have sinned and done very wickedly; but these sheep, what have they done? Please let your hand, O Yahweh my Elohim, be against me and against my father’s house; but not against your people, that they should be plagued.” 
+<sup>17&#160;</sup>David said to Elohim, “Isn’t it I who commanded the people to be counted? It is even I who have sinned and done very wickedly; but these sheep, what have they done? Please let your hand, O Yahuah my Elohim, be against me and against my father’s house; but not against your people, that they should be plagued.” 
 </p><p>
-<sup>18&#160;</sup>Then Yahweh’s angel commanded Gad to tell David that David should go up and raise an altar to Yahweh on the threshing floor of Ornan the Jebusite. 
-<sup>19&#160;</sup>David went up at the saying of Gad, which he spoke in Yahweh’s name. 
+<sup>18&#160;</sup>Then Yahuah’s angel commanded Gad to tell David that David should go up and raise an altar to Yahuah on the threshing floor of Ornan the Jebusite. 
+<sup>19&#160;</sup>David went up at the saying of Gad, which he spoke in Yahuah’s name. 
 </p><p>
 <sup>20&#160;</sup>Ornan turned back and saw the angel; and his four sons who were with him hid themselves. Now Ornan was threshing wheat. 
 <sup>21&#160;</sup>As David came to Ornan, Ornan looked and saw David, and went out of the threshing floor, and bowed himself to David with his face to the ground. 
 </p><p>
-<sup>22&#160;</sup>Then David said to Ornan, “Sell me the place of this threshing floor, that I may build an altar to Yahweh on it. You shall sell it to me for the full price, that the plague may be stopped from afflicting the people.” 
+<sup>22&#160;</sup>Then David said to Ornan, “Sell me the place of this threshing floor, that I may build an altar to Yahuah on it. You shall sell it to me for the full price, that the plague may be stopped from afflicting the people.” 
 </p><p>
 <sup>23&#160;</sup>Ornan said to David, “Take it for yourself, and let my lord the king do that which is good in his eyes. Behold, I give the oxen for burnt offerings, and the threshing instruments for wood, and the wheat for the meal offering. I give it all.” 
 </p><p>
-<sup>24&#160;</sup>King David said to Ornan, “No, but I will most certainly buy it for the full price. For I will not take that which is yours for Yahweh, nor offer a burnt offering that costs me nothing.” 
+<sup>24&#160;</sup>King David said to Ornan, “No, but I will most certainly buy it for the full price. For I will not take that which is yours for Yahuah, nor offer a burnt offering that costs me nothing.” 
 </p><p>
 <sup>25&#160;</sup>So David gave to Ornan six hundred shekels of gold by weight for the place. 
-<sup>26&#160;</sup>David built an altar to Yahweh there, and offered burnt offerings and peace offerings, and called on Yahweh; and he answered him from the sky by fire on the altar of burnt offering. 
+<sup>26&#160;</sup>David built an altar to Yahuah there, and offered burnt offerings and peace offerings, and called on Yahuah; and he answered him from the sky by fire on the altar of burnt offering. 
 </p><p>
-<sup>27&#160;</sup>Then Yahweh commanded the angel, and he put his sword back into its sheath. 
+<sup>27&#160;</sup>Then Yahuah commanded the angel, and he put his sword back into its sheath. 
 </p><p>
-<sup>28&#160;</sup>At that time, when David saw that Yahweh had answered him in the threshing floor of Ornan the Jebusite, then he sacrificed there. 
-<sup>29&#160;</sup>For Yahweh’s tabernacle, which Moses made in the wilderness, and the altar of burnt offering, were at that time in the high place at Gibeon. 
-<sup>30&#160;</sup>But David couldn’t go before it to inquire of Elohim, for he was afraid because of the sword of Yahweh’s angel. 
+<sup>28&#160;</sup>At that time, when David saw that Yahuah had answered him in the threshing floor of Ornan the Jebusite, then he sacrificed there. 
+<sup>29&#160;</sup>For Yahuah’s tabernacle, which Moses made in the wilderness, and the altar of burnt offering, were at that time in the high place at Gibeon. 
+<sup>30&#160;</sup>But David couldn’t go before it to inquire of Elohim, for he was afraid because of the sword of Yahuah’s angel. 
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
-<sup>1&#160;</sup>Then David said, “This is the house of Yahweh Elohim, and this is the altar of burnt offering for Israel.” 
+<sup>1&#160;</sup>Then David said, “This is the house of Yahuah Elohim, and this is the altar of burnt offering for Israel.” 
 </p><p>
 <sup>2&#160;</sup>David gave orders to gather together the foreigners who were in the land of Israel; and he set masons to cut dressed stones to build Elohim’s house. 
 <sup>3&#160;</sup>David prepared iron in abundance for the nails for the doors of the gates and for the couplings, and bronze in abundance without weight, 
 <sup>4&#160;</sup>and cedar trees without number, for the Sidonians and the people of Tyre brought cedar trees in abundance to David. 
-<sup>5&#160;</sup>David said, “Solomon my son is young and tender, and the house that is to be built for Yahweh must be exceedingly magnificent, of fame and of glory throughout all countries. I will therefore make preparation for it.” So David prepared abundantly before his death. 
-<sup>6&#160;</sup>Then he called for Solomon his son, and commanded him to build a house for Yahweh, the Elohim of Israel. 
-<sup>7&#160;</sup>David said to Solomon his son, “As for me, it was in my heart to build a house to the name of Yahweh my Elohim. 
-<sup>8&#160;</sup>But Yahweh’s word came to me, saying, ‘You have shed blood abundantly and have made great wars. You shall not build a house to my name, because you have shed much blood on the earth in my sight. 
+<sup>5&#160;</sup>David said, “Solomon my son is young and tender, and the house that is to be built for Yahuah must be exceedingly magnificent, of fame and of glory throughout all countries. I will therefore make preparation for it.” So David prepared abundantly before his death. 
+<sup>6&#160;</sup>Then he called for Solomon his son, and commanded him to build a house for Yahuah, the Elohim of Israel. 
+<sup>7&#160;</sup>David said to Solomon his son, “As for me, it was in my heart to build a house to the name of Yahuah my Elohim. 
+<sup>8&#160;</sup>But Yahuah’s word came to me, saying, ‘You have shed blood abundantly and have made great wars. You shall not build a house to my name, because you have shed much blood on the earth in my sight. 
 <sup>9&#160;</sup>Behold, a son shall be born to you, who shall be a man of peace. I will give him rest from all his enemies all around; for his name shall be Solomon, and I will give peace and quietness to Israel in his days. 
 <sup>10&#160;</sup>He shall build a house for my name; and he will be my son, and I will be his father; and I will establish the throne of his kingdom over Israel forever.’ 
-<sup>11&#160;</sup>Now, my son, may Yahweh be with you and prosper you, and build the house of Yahweh your Elohim, as he has spoken concerning you. 
-<sup>12&#160;</sup>May Yahweh give you discretion and understanding, and put you in charge of Israel, so that you may keep the law of Yahweh your Elohim. 
-<sup>13&#160;</sup>Then you will prosper, if you observe to do the statutes and the ordinances which Yahweh gave Moses concerning Israel. Be strong and courageous. Don’t be afraid and don’t be dismayed. 
-<sup>14&#160;</sup>Now, behold, in my affliction I have prepared for Yahweh’s house one hundred thousand talents of gold, one million talents of silver, and bronze and iron without weight; for it is in abundance. I have also prepared timber and stone; and you may add to them. 
+<sup>11&#160;</sup>Now, my son, may Yahuah be with you and prosper you, and build the house of Yahuah your Elohim, as he has spoken concerning you. 
+<sup>12&#160;</sup>May Yahuah give you discretion and understanding, and put you in charge of Israel, so that you may keep the law of Yahuah your Elohim. 
+<sup>13&#160;</sup>Then you will prosper, if you observe to do the statutes and the ordinances which Yahuah gave Moses concerning Israel. Be strong and courageous. Don’t be afraid and don’t be dismayed. 
+<sup>14&#160;</sup>Now, behold, in my affliction I have prepared for Yahuah’s house one hundred thousand talents of gold, one million talents of silver, and bronze and iron without weight; for it is in abundance. I have also prepared timber and stone; and you may add to them. 
 <sup>15&#160;</sup>There are also workmen with you in abundance—cutters and workers of stone and timber, and all kinds of men who are skillful in every kind of work; 
-<sup>16&#160;</sup>of the gold, the silver, the bronze, and the iron, there is no number. Arise and be doing, and may Yahweh be with you.” 
+<sup>16&#160;</sup>of the gold, the silver, the bronze, and the iron, there is no number. Arise and be doing, and may Yahuah be with you.” 
 </p><p>
 <sup>17&#160;</sup>David also commanded all the princes of Israel to help Solomon his son, saying, 
-<sup>18&#160;</sup>“Isn’t Yahweh your Elohim with you? Hasn’t he given you rest on every side? For he has delivered the inhabitants of the land into my hand; and the land is subdued before Yahweh and before his people. 
-<sup>19&#160;</sup>Now set your heart and your soul to follow Yahweh your Elohim. Arise therefore, and build the sanctuary of Yahweh Elohim, to bring the ark of Yahweh’s covenant and the set-apart vessels of Elohim into the house that is to be built for Yahweh’s name.” 
+<sup>18&#160;</sup>“Isn’t Yahuah your Elohim with you? Hasn’t he given you rest on every side? For he has delivered the inhabitants of the land into my hand; and the land is subdued before Yahuah and before his people. 
+<sup>19&#160;</sup>Now set your heart and your soul to follow Yahuah your Elohim. Arise therefore, and build the sanctuary of Yahuah Elohim, to bring the ark of Yahuah’s covenant and the set-apart vessels of Elohim into the house that is to be built for Yahuah’s name.” 
 </p><h2 class="chapterlabel" id="23">23</h2>
 <p>
 <sup>1&#160;</sup>Now David was old and full of days; and he made Solomon his son king over Israel. 
 <sup>2&#160;</sup>He gathered together all the princes of Israel, with the priests and the Levites. 
 <sup>3&#160;</sup>The Levites were counted from thirty years old and upward; and their number by their polls, man by man, was thirty-eight thousand. 
-<sup>4&#160;</sup>David said, “Of these, twenty-four thousand were to oversee the work of Yahweh’s house, six thousand were officers and judges, 
-<sup>5&#160;</sup>four thousand were doorkeepers, and four thousand praised Yahweh with the instruments which I made for giving praise.” 
+<sup>4&#160;</sup>David said, “Of these, twenty-four thousand were to oversee the work of Yahuah’s house, six thousand were officers and judges, 
+<sup>5&#160;</sup>four thousand were doorkeepers, and four thousand praised Yahuah with the instruments which I made for giving praise.” 
 </p><p>
 <sup>6&#160;</sup>David divided them into divisions according to the sons of Levi: Gershon, Kohath, and Merari. 
 </p><p>
@@ -1060,7 +1060,7 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>Jahath was the chief, and Zizah the second; but Jeush and Beriah didn’t have many sons; therefore they became a fathers’ house in one reckoning. 
 </p><p>
 <sup>12&#160;</sup>The sons of Kohath: Amram, Izhar, Hebron, and Uzziel, four. 
-<sup>13&#160;</sup>The sons of Amram: Aaron and Moses; and Aaron was separated that he should sanctify the most set-apart things, he and his sons forever, to burn incense before Yahweh, to minister to him, and to bless in his name forever. 
+<sup>13&#160;</sup>The sons of Amram: Aaron and Moses; and Aaron was separated that he should sanctify the most set-apart things, he and his sons forever, to burn incense before Yahuah, to minister to him, and to bless in his name forever. 
 <sup>14&#160;</sup>But as for Moses the man of Elohim, his sons were named among the tribe of Levi. 
 <sup>15&#160;</sup>The sons of Moses: Gershom and Eliezer. 
 <sup>16&#160;</sup>The sons of Gershom: Shebuel the chief. 
@@ -1073,15 +1073,15 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>Eleazar died, and had no sons, but daughters only; and their relatives, the sons of Kish, took them as women. 
 <sup>23&#160;</sup>The sons of Mushi: Mahli, Eder, and Jeremoth, three. 
 </p><p>
-<sup>24&#160;</sup>These were the sons of Levi after their fathers’ houses, even the heads of the fathers’ houses of those who were counted individually, in the number of names by their polls, who did the work for the service of Yahweh’s house, from twenty years old and upward. 
-<sup>25&#160;</sup>For David said, “Yahweh, the Elohim of Israel, has given rest to his people; and he dwells in Jerusalem forever. 
+<sup>24&#160;</sup>These were the sons of Levi after their fathers’ houses, even the heads of the fathers’ houses of those who were counted individually, in the number of names by their polls, who did the work for the service of Yahuah’s house, from twenty years old and upward. 
+<sup>25&#160;</sup>For David said, “Yahuah, the Elohim of Israel, has given rest to his people; and he dwells in Jerusalem forever. 
 <sup>26&#160;</sup>Also the Levites will no longer need to carry the tabernacle and all its vessels for its service.” 
 <sup>27&#160;</sup>For by the last words of David the sons of Levi were counted, from twenty years old and upward. 
-<sup>28&#160;</sup>For their duty was to wait on the sons of Aaron for the service of Yahweh’s house—in the courts, in the rooms, and in the purifying of all set-apart things, even the work of the service of Elohim’s house; 
+<sup>28&#160;</sup>For their duty was to wait on the sons of Aaron for the service of Yahuah’s house—in the courts, in the rooms, and in the purifying of all set-apart things, even the work of the service of Elohim’s house; 
 <sup>29&#160;</sup>for the show bread also, and for the fine flour for a meal offering, whether of unleavened wafers, or of that which is baked in the pan, or of that which is soaked, and for all measurements of quantity and size; 
-<sup>30&#160;</sup>and to stand every morning to thank and praise Yahweh, and likewise in the evening; 
-<sup>31&#160;</sup>and to offer all burnt offerings to Yahweh on the Sabbaths, on the new moons, and on the set feasts, in number according to the ordinance concerning them, continually before Yahweh; 
-<sup>32&#160;</sup>and that they should keep the duty of the Tent of Meeting, the duty of the set-apart place, and the duty of the sons of Aaron their brothers for the service of Yahweh’s house. 
+<sup>30&#160;</sup>and to stand every morning to thank and praise Yahuah, and likewise in the evening; 
+<sup>31&#160;</sup>and to offer all burnt offerings to Yahuah on the Sabbaths, on the new moons, and on the set feasts, in number according to the ordinance concerning them, continually before Yahuah; 
+<sup>32&#160;</sup>and that they should keep the duty of the Tent of Meeting, the duty of the set-apart place, and the duty of the sons of Aaron their brothers for the service of Yahuah’s house. 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
 <sup>1&#160;</sup>These were the divisions of the sons of Aaron. The sons of Aaron: Nadab, Abihu, Eleazar, and Ithamar. 
@@ -1103,7 +1103,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>the nineteenth to Pethahiah, the twentieth to Jehezkel, 
 <sup>17&#160;</sup>the twenty-first to Jachin, the twenty-second to Gamul, 
 <sup>18&#160;</sup>the twenty-third to Delaiah, and the twenty-fourth to Maaziah. 
-<sup>19&#160;</sup>This was their ordering in their service, to come into Yahweh’s house according to the ordinance given to them by Aaron their father, as Yahweh, the Elohim of Israel, had commanded him. 
+<sup>19&#160;</sup>This was their ordering in their service, to come into Yahuah’s house according to the ordinance given to them by Aaron their father, as Yahuah, the Elohim of Israel, had commanded him. 
 </p><p>
 <sup>20&#160;</sup>Of the rest of the sons of Levi: of the sons of Amram, Shubael; of the sons of Shubael, Jehdeiah. 
 <sup>21&#160;</sup>Of Rehabiah: of the sons of Rehabiah, Isshiah the chief. 
@@ -1121,11 +1121,11 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Moreover, David and the captains of the army set apart for the service certain of the sons of Asaph, of Heman, and of Jeduthun, who were to prophesy with harps, with stringed instruments, and with cymbals. The number of those who did the work according to their service was: 
 <sup>2&#160;</sup>of the sons of Asaph: Zaccur, Joseph, Nethaniah, and Asharelah. The sons of Asaph were under the hand of Asaph, who prophesied at the order of the king. 
-<sup>3&#160;</sup>Of Jeduthun, the sons of Jeduthun: Gedaliah, Zeri, Jeshaiah, Shimei, Hashabiah, and Mattithiah, six, under the hands of their father Jeduthun, who prophesied in giving thanks and praising Yahweh with the harp. 
+<sup>3&#160;</sup>Of Jeduthun, the sons of Jeduthun: Gedaliah, Zeri, Jeshaiah, Shimei, Hashabiah, and Mattithiah, six, under the hands of their father Jeduthun, who prophesied in giving thanks and praising Yahuah with the harp. 
 <sup>4&#160;</sup>Of Heman, the sons of Heman: Bukkiah, Mattaniah, Uzziel, Shebuel, Jerimoth, Hananiah, Hanani, Eliathah, Giddalti, Romamti-Ezer, Joshbekashah, Mallothi, Hothir, and Mahazioth. 
 <sup>5&#160;</sup>All these were the sons of Heman the king’s seer in the words of Elohim, to lift up the horn. Elohim gave to Heman fourteen sons and three daughters. 
-<sup>6&#160;</sup>All these were under the hands of their father for song in Yahweh’s house, with cymbals, stringed instruments, and harps, for the service of Elohim’s house: Asaph, Jeduthun, and Heman being under the order of the king. 
-<sup>7&#160;</sup>The number of them, with their brothers who were instructed in singing to Yahweh, even all who were skillful, was two hundred eighty-eight. 
+<sup>6&#160;</sup>All these were under the hands of their father for song in Yahuah’s house, with cymbals, stringed instruments, and harps, for the service of Elohim’s house: Asaph, Jeduthun, and Heman being under the order of the king. 
+<sup>7&#160;</sup>The number of them, with their brothers who were instructed in singing to Yahuah, even all who were skillful, was two hundred eighty-eight. 
 <sup>8&#160;</sup>They cast lots for their offices, all alike, the small as well as the great, the teacher as well as the student. 
 </p><p>
 <sup>9&#160;</sup>Now the first lot came out for Asaph to Joseph; the second to Gedaliah, he and his brothers and sons were twelve; 
@@ -1165,7 +1165,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>Also Hosah, of the children of Merari, had sons: Shimri the chief (for though he was not the firstborn, yet his father made him chief), 
 <sup>11&#160;</sup>Hilkiah the second, Tebaliah the third, and Zechariah the fourth. All the sons and brothers of Hosah were thirteen. 
 </p><p>
-<sup>12&#160;</sup>Of these were the divisions of the doorkeepers, even of the chief men, having offices like their brothers, to minister in Yahweh’s house. 
+<sup>12&#160;</sup>Of these were the divisions of the doorkeepers, even of the chief men, having offices like their brothers, to minister in Yahuah’s house. 
 <sup>13&#160;</sup>They cast lots, the small as well as the great, according to their fathers’ houses, for every gate. 
 <sup>14&#160;</sup>The lot eastward fell to Shelemiah. Then for Zechariah his son, a wise counselor, they cast lots; and his lot came out northward. 
 <sup>15&#160;</sup>To Obed-Edom southward; and to his sons the storehouse. 
@@ -1176,16 +1176,16 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>20&#160;</sup>Of the Levites, Ahijah was over the treasures of Elohim’s house and over the treasures of the dedicated things. 
 <sup>21&#160;</sup>The sons of Ladan, the sons of the Gershonites belonging to Ladan, the heads of the fathers’ households belonging to Ladan the Gershonite: Jehieli. 
-<sup>22&#160;</sup>The sons of Jehieli: Zetham, and Joel his brother, over the treasures of Yahweh’s house. 
+<sup>22&#160;</sup>The sons of Jehieli: Zetham, and Joel his brother, over the treasures of Yahuah’s house. 
 <sup>23&#160;</sup>Of the Amramites, of the Izharites, of the Hebronites, of the Uzzielites: 
 <sup>24&#160;</sup>Shebuel the son of Gershom, the son of Moses, was ruler over the treasuries. 
 <sup>25&#160;</sup>His brothers: of Eliezer, Rehabiah his son, and Jeshaiah his son, and Joram his son, and Zichri his son, and Shelomoth his son. 
 <sup>26&#160;</sup>This Shelomoth and his brothers were over all the treasuries of the dedicated things, which David the king, and the heads of the fathers’ households, the captains over thousands and hundreds, and the captains of the army, had dedicated. 
-<sup>27&#160;</sup>They dedicated some of the plunder won in battles to repair Yahweh’s house. 
+<sup>27&#160;</sup>They dedicated some of the plunder won in battles to repair Yahuah’s house. 
 <sup>28&#160;</sup>All that Samuel the seer, Saul the son of Kish, Abner the son of Ner, and Joab the son of Zeruiah had dedicated, whoever had dedicated anything, it was under the hand of Shelomoth and of his brothers. 
 </p><p>
 <sup>29&#160;</sup>Of the Izharites, Chenaniah and his sons were appointed to the outward business over Israel, for officers and judges. 
-<sup>30&#160;</sup>Of the Hebronites, Hashabiah and his brothers, one thousand seven hundred men of valor, had the oversight of Israel beyond the Jordan westward, for all the business of Yahweh and for the service of the king. 
+<sup>30&#160;</sup>Of the Hebronites, Hashabiah and his brothers, one thousand seven hundred men of valor, had the oversight of Israel beyond the Jordan westward, for all the business of Yahuah and for the service of the king. 
 <sup>31&#160;</sup>Of the Hebronites, Jerijah was the chief of the Hebronites, according to their generations by fathers’ households. They were sought for in the fortieth year of the reign of David, and mighty men of valor were found among them at Jazer of Gilead. 
 <sup>32&#160;</sup>His relatives, men of valor, were two thousand seven hundred, heads of fathers’ households, whom King David made overseers over the Reubenites, the Gadites, and the half-tribe of the Manassites, for every matter pertaining to Elohim and for the affairs of the king. 
 </p><h2 class="chapterlabel" id="27">27</h2>
@@ -1214,7 +1214,7 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>of the children of Ephraim, Hoshea the son of Azaziah; of the half-tribe of Manasseh, Joel the son of Pedaiah; 
 <sup>21&#160;</sup>of the half-tribe of Manasseh in Gilead, Iddo the son of Zechariah; of Benjamin, Jaasiel the son of Abner; 
 <sup>22&#160;</sup>of Dan, Azarel the son of Jeroham. These were the captains of the tribes of Israel. 
-<sup>23&#160;</sup>But David didn’t take the number of them from twenty years old and under, because Yahweh had said he would increase Israel like the stars of the sky. 
+<sup>23&#160;</sup>But David didn’t take the number of them from twenty years old and under, because Yahuah had said he would increase Israel like the stars of the sky. 
 <sup>24&#160;</sup>Joab the son of Zeruiah began to take a census, but didn’t finish; and wrath came on Israel for this. The number wasn’t put into the account in the chronicles of King David. 
 </p><p>
 <sup>25&#160;</sup>Over the king’s treasures was Azmaveth the son of Adiel. Over the treasures in the fields, in the cities, in the villages, and in the towers was Jonathan the son of Uzziah; 
@@ -1231,61 +1231,61 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="28">28</h2>
 <p>
 <sup>1&#160;</sup>David assembled all the princes of Israel, the princes of the tribes, the captains of the companies who served the king by division, the captains of thousands, the captains of hundreds, and the rulers over all the substance and possessions of the king and of his sons, with the officers and the mighty men, even all the mighty men of valor, to Jerusalem. 
-<sup>2&#160;</sup>Then David the king stood up on his feet and said, “Hear me, my brothers and my people! As for me, it was in my heart to build a house of rest for the ark of Yahweh’s covenant, and for the footstool of our Elohim; and I had prepared for the building. 
+<sup>2&#160;</sup>Then David the king stood up on his feet and said, “Hear me, my brothers and my people! As for me, it was in my heart to build a house of rest for the ark of Yahuah’s covenant, and for the footstool of our Elohim; and I had prepared for the building. 
 <sup>3&#160;</sup>But Elohim said to me, ‘You shall not build a house for my name, because you are a man of war and have shed blood.’ 
-<sup>4&#160;</sup>However Yahweh, the Elohim of Israel, chose me out of all the house of my father to be king over Israel forever. For he has chosen Judah to be prince; and in the house of Judah, the house of my father; and among the sons of my father he took pleasure in me to make me king over all Israel. 
-<sup>5&#160;</sup>Of all my sons (for Yahweh has given me many sons), he has chosen Solomon my son to sit on the throne of Yahweh’s kingdom over Israel. 
+<sup>4&#160;</sup>However Yahuah, the Elohim of Israel, chose me out of all the house of my father to be king over Israel forever. For he has chosen Judah to be prince; and in the house of Judah, the house of my father; and among the sons of my father he took pleasure in me to make me king over all Israel. 
+<sup>5&#160;</sup>Of all my sons (for Yahuah has given me many sons), he has chosen Solomon my son to sit on the throne of Yahuah’s kingdom over Israel. 
 <sup>6&#160;</sup>He said to me, ‘Solomon, your son, shall build my house and my courts; for I have chosen him to be my son, and I will be his father. 
 <sup>7&#160;</sup>I will establish his kingdom forever if he continues to do my commandments and my ordinances, as it is today.’ 
 </p><p>
-<sup>8&#160;</sup>Now therefore, in the sight of all Israel, Yahweh’s assembly, and in the audience of our Elohim, observe and seek out all the commandments of Yahweh your Elohim, that you may possess this good land, and leave it for an inheritance to your children after you forever. 
+<sup>8&#160;</sup>Now therefore, in the sight of all Israel, Yahuah’s assembly, and in the audience of our Elohim, observe and seek out all the commandments of Yahuah your Elohim, that you may possess this good land, and leave it for an inheritance to your children after you forever. 
 </p><p>
-<sup>9&#160;</sup>You, Solomon my son, know the Elohim of your father, and serve him with a perfect heart and with a willing mind; for Yahweh searches all hearts, and understands all the imaginations of the thoughts. If you seek him, he will be found by you; but if you forsake him, he will cast you off forever. 
-<sup>10&#160;</sup>Take heed now, for Yahweh has chosen you to build a house for the sanctuary. Be strong, and do it.” 
+<sup>9&#160;</sup>You, Solomon my son, know the Elohim of your father, and serve him with a perfect heart and with a willing mind; for Yahuah searches all hearts, and understands all the imaginations of the thoughts. If you seek him, he will be found by you; but if you forsake him, he will cast you off forever. 
+<sup>10&#160;</sup>Take heed now, for Yahuah has chosen you to build a house for the sanctuary. Be strong, and do it.” 
 </p><p>
 <sup>11&#160;</sup>Then David gave to Solomon his son the plans for the porch of the temple, for its houses, for its treasuries, for its upper rooms, for its inner rooms, for the place of the mercy seat; 
-<sup>12&#160;</sup>and the plans of all that he had by the Spirit, for the courts of Yahweh’s house, for all the surrounding rooms, for the treasuries of Elohim’s house, and for the treasuries of the dedicated things; 
-<sup>13&#160;</sup>also for the divisions of the priests and the Levites, for all the work of the service of Yahweh’s house, and for all the vessels of service in Yahweh’s house—<sup>14&#160;</sup>of gold by weight for the gold for all vessels of every kind of service, for all the vessels of silver by weight, for all vessels of every kind of service; 
+<sup>12&#160;</sup>and the plans of all that he had by the Spirit, for the courts of Yahuah’s house, for all the surrounding rooms, for the treasuries of Elohim’s house, and for the treasuries of the dedicated things; 
+<sup>13&#160;</sup>also for the divisions of the priests and the Levites, for all the work of the service of Yahuah’s house, and for all the vessels of service in Yahuah’s house—<sup>14&#160;</sup>of gold by weight for the gold for all vessels of every kind of service, for all the vessels of silver by weight, for all vessels of every kind of service; 
 <sup>15&#160;</sup>by weight also for the lamp stands of gold, and for its lamps, of gold, by weight for every lamp stand and for its lamps; and for the lamp stands of silver, by weight for every lamp stand and for its lamps, according to the use of every lamp stand; 
 <sup>16&#160;</sup>and the gold by weight for the tables of show bread, for every table; and silver for the tables of silver; 
 <sup>17&#160;</sup>and the forks, the basins, and the cups, of pure gold; and for the golden bowls by weight for every bowl; and for the silver bowls by weight for every bowl; 
-<sup>18&#160;</sup>and for the altar of incense, refined gold by weight; and gold for the plans for the chariot, and the cherubim that spread out and cover the ark of Yahweh’s covenant. 
-<sup>19&#160;</sup>“All this”, David said, “I have been made to understand in writing from Yahweh’s hand, even all the works of this pattern.” 
+<sup>18&#160;</sup>and for the altar of incense, refined gold by weight; and gold for the plans for the chariot, and the cherubim that spread out and cover the ark of Yahuah’s covenant. 
+<sup>19&#160;</sup>“All this”, David said, “I have been made to understand in writing from Yahuah’s hand, even all the works of this pattern.” 
 </p><p>
-<sup>20&#160;</sup>David said to Solomon his son, “Be strong and courageous, and do it. Don’t be afraid, nor be dismayed, for Yahweh Elohim, even my Elohim, is with you. He will not fail you nor forsake you, until all the work for the service of Yahweh’s house is finished. 
+<sup>20&#160;</sup>David said to Solomon his son, “Be strong and courageous, and do it. Don’t be afraid, nor be dismayed, for Yahuah Elohim, even my Elohim, is with you. He will not fail you nor forsake you, until all the work for the service of Yahuah’s house is finished. 
 <sup>21&#160;</sup>Behold, there are the divisions of the priests and the Levites for all the service of Elohim’s house. Every willing man who has skill for any kind of service shall be with you in all kinds of work. Also the captains and all the people will be entirely at your command.” 
 </p><h2 class="chapterlabel" id="29">29</h2>
 <p>
-<sup>1&#160;</sup>David the king said to all the assembly, “Solomon my son, whom alone Elohim has chosen, is yet young and tender, and the work is great; for the palace is not for man, but for Yahweh Elohim. 
+<sup>1&#160;</sup>David the king said to all the assembly, “Solomon my son, whom alone Elohim has chosen, is yet young and tender, and the work is great; for the palace is not for man, but for Yahuah Elohim. 
 <sup>2&#160;</sup>Now I have prepared with all my might for the house of my Elohim the gold for the things of gold, the silver for the things of silver, the bronze for the things of bronze, iron for the things of iron, and wood for the things of wood, also onyx stones, stones to be set, stones for inlaid work of various colors, all kinds of precious stones, and marble stones in abundance. 
 <sup>3&#160;</sup>In addition, because I have set my affection on the house of my Elohim, since I have a treasure of my own of gold and silver, I give it to the house of my Elohim, over and above all that I have prepared for the set-apart house: 
 <sup>4&#160;</sup>even three thousand talents of gold, of the gold of Ophir, and seven thousand talents of refined silver, with which to overlay the walls of the houses; 
-<sup>5&#160;</sup>of gold for the things of gold, and of silver for the things of silver, and for all kinds of work to be made by the hands of artisans. Who then offers willingly to consecrate himself today to Yahweh?” 
+<sup>5&#160;</sup>of gold for the things of gold, and of silver for the things of silver, and for all kinds of work to be made by the hands of artisans. Who then offers willingly to consecrate himself today to Yahuah?” 
 </p><p>
 <sup>6&#160;</sup>Then the princes of the fathers’ households, and the princes of the tribes of Israel, and the captains of thousands and of hundreds, with the rulers over the king’s work, offered willingly; 
 <sup>7&#160;</sup>and they gave for the service of Elohim’s house of gold five thousand talents and ten thousand darics, of silver ten thousand talents, of bronze eighteen thousand talents, and of iron one hundred thousand talents. 
-<sup>8&#160;</sup>People with whom precious stones were found gave them to the treasure of Yahweh’s house, under the hand of Jehiel the Gershonite. 
-<sup>9&#160;</sup>Then the people rejoiced, because they offered willingly, because with a perfect heart they offered willingly to Yahweh; and David the king also rejoiced with great joy. 
+<sup>8&#160;</sup>People with whom precious stones were found gave them to the treasure of Yahuah’s house, under the hand of Jehiel the Gershonite. 
+<sup>9&#160;</sup>Then the people rejoiced, because they offered willingly, because with a perfect heart they offered willingly to Yahuah; and David the king also rejoiced with great joy. 
 </p><p>
-<sup>10&#160;</sup>Therefore David blessed Yahweh before all the assembly; and David said, “You are blessed, Yahweh, the Elohim of Israel our father, forever and ever. 
-<sup>11&#160;</sup>Yours, Yahweh, is the greatness, the power, the glory, the victory, and the majesty! For all that is in the heavens and in the earth is yours. Yours is the kingdom, Yahweh, and you are exalted as head above all. 
+<sup>10&#160;</sup>Therefore David blessed Yahuah before all the assembly; and David said, “You are blessed, Yahuah, the Elohim of Israel our father, forever and ever. 
+<sup>11&#160;</sup>Yours, Yahuah, is the greatness, the power, the glory, the victory, and the majesty! For all that is in the heavens and in the earth is yours. Yours is the kingdom, Yahuah, and you are exalted as head above all. 
 <sup>12&#160;</sup>Both riches and honor come from you, and you rule over all! In your hand is power and might! It is in your hand to make great, and to give strength to all! 
 <sup>13&#160;</sup>Now therefore, our Elohim, we thank you and praise your glorious name. 
 <sup>14&#160;</sup>But who am I, and what is my people, that we should be able to offer so willingly as this? For all things come from you, and we have given you of your own. 
 <sup>15&#160;</sup>For we are strangers before you and foreigners, as all our fathers were. Our days on the earth are as a shadow, and there is no remaining. 
-<sup>16&#160;</sup>Yahweh our Elohim, all this store that we have prepared to build you a house for your set-apart name comes from your hand, and is all your own. 
+<sup>16&#160;</sup>Yahuah our Elohim, all this store that we have prepared to build you a house for your set-apart name comes from your hand, and is all your own. 
 <sup>17&#160;</sup>I know also, my Elohim, that you try the heart and have pleasure in uprightness. As for me, in the uprightness of my heart I have willingly offered all these things. Now I have seen with joy your people, who are present here, offer willingly to you. 
-<sup>18&#160;</sup>Yahweh, the Elohim of Abraham, of Isaac, and of Israel, our fathers, keep this desire forever in the thoughts of the heart of your people, and prepare their heart for you; 
+<sup>18&#160;</sup>Yahuah, the Elohim of Abraham, of Isaac, and of Israel, our fathers, keep this desire forever in the thoughts of the heart of your people, and prepare their heart for you; 
 <sup>19&#160;</sup>and give to Solomon my son a perfect heart, to keep your commandments, your testimonies, and your statutes, and to do all these things, and to build the palace, for which I have made provision.” 
 </p><p>
-<sup>20&#160;</sup>Then David said to all the assembly, “Now bless Yahweh your Elohim!” 
-</p><p>All the assembly blessed Yahweh, the Elohim of their fathers, and bowed down their heads and prostrated themselves before Yahweh and the king. 
-<sup>21&#160;</sup>They sacrificed sacrifices to Yahweh and offered burnt offerings to Yahweh on the next day after that day, even one thousand bulls, one thousand rams, and one thousand lambs, with their drink offerings and sacrifices in abundance for all Israel, 
-<sup>22&#160;</sup>and ate and drank before Yahweh on that day with great gladness. They made Solomon the son of David king the second time, and anointed him before Yahweh to be prince, and Zadok to be priest. 
+<sup>20&#160;</sup>Then David said to all the assembly, “Now bless Yahuah your Elohim!” 
+</p><p>All the assembly blessed Yahuah, the Elohim of their fathers, and bowed down their heads and prostrated themselves before Yahuah and the king. 
+<sup>21&#160;</sup>They sacrificed sacrifices to Yahuah and offered burnt offerings to Yahuah on the next day after that day, even one thousand bulls, one thousand rams, and one thousand lambs, with their drink offerings and sacrifices in abundance for all Israel, 
+<sup>22&#160;</sup>and ate and drank before Yahuah on that day with great gladness. They made Solomon the son of David king the second time, and anointed him before Yahuah to be prince, and Zadok to be priest. 
 </p><p>
-<sup>23&#160;</sup>Then Solomon sat on the throne of Yahweh as king instead of David his father, and prospered; and all Israel obeyed him. 
+<sup>23&#160;</sup>Then Solomon sat on the throne of Yahuah as king instead of David his father, and prospered; and all Israel obeyed him. 
 <sup>24&#160;</sup>All the princes, the mighty men, and also all of the sons of King David submitted themselves to Solomon the king. 
-<sup>25&#160;</sup>Yahweh magnified Solomon exceedingly in the sight of all Israel, and gave to him such royal majesty as had not been on any king before him in Israel. 
+<sup>25&#160;</sup>Yahuah magnified Solomon exceedingly in the sight of all Israel, and gave to him such royal majesty as had not been on any king before him in Israel. 
 </p><p>
 <sup>26&#160;</sup>Now David the son of Jesse reigned over all Israel. 
 <sup>27&#160;</sup>The time that he reigned over Israel was forty years; he reigned seven years in Hebron, and he reigned thirty-three years in Jerusalem. 

--- a/book/1kings.html
+++ b/book/1kings.html
@@ -102,7 +102,7 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Bathsheba went in to the king in his room. The king was very old; and Abishag the Shunammite was serving the king. 
 <sup>16&#160;</sup>Bathsheba bowed and showed respect to the king. The king said, “What would you like?” 
 </p><p>
-<sup>17&#160;</sup>She said to him, “My lord, you swore by Yahweh your Elohim to your servant, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne.’ 
+<sup>17&#160;</sup>She said to him, “My lord, you swore by Yahuah your Elohim to your servant, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne.’ 
 <sup>18&#160;</sup>Now, behold, Adonijah reigns; and you, my lord the king, don’t know it. 
 <sup>19&#160;</sup>He has slain cattle and fatlings and sheep in abundance, and has called all the sons of the king, Abiathar the priest, and Joab the captain of the army; but he hasn’t called Solomon your servant. 
 <sup>20&#160;</sup>You, my lord the king, the eyes of all Israel are on you, that you should tell them who will sit on the throne of my lord the king after him. 
@@ -117,8 +117,8 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>Was this thing done by my lord the king, and you haven’t shown to your servants who should sit on the throne of my lord the king after him?” 
 </p><p>
 <sup>28&#160;</sup>Then King David answered, “Call Bathsheba in to me.” She came into the king’s presence and stood before the king. 
-<sup>29&#160;</sup>The king vowed and said, “As Yahweh lives, who has redeemed my soul out of all adversity, 
-<sup>30&#160;</sup>most certainly as I swore to you by Yahweh, the Elohim of Israel, saying, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne in my place;’ I will most certainly do this today.” 
+<sup>29&#160;</sup>The king vowed and said, “As Yahuah lives, who has redeemed my soul out of all adversity, 
+<sup>30&#160;</sup>most certainly as I swore to you by Yahuah, the Elohim of Israel, saying, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne in my place;’ I will most certainly do this today.” 
 </p><p>
 <sup>31&#160;</sup>Then Bathsheba bowed with her face to the earth and showed respect to the king, and said, “Let my lord King David live forever!” 
 </p><p>
@@ -127,8 +127,8 @@ html[dir=ltr] .q2 {
 <sup>34&#160;</sup>Let Zadok the priest and Nathan the prophet anoint him there king over Israel. Blow the trumpet, and say, ‘Long live King Solomon!’ 
 <sup>35&#160;</sup>Then come up after him, and he shall come and sit on my throne; for he shall be king in my place. I have appointed him to be prince over Israel and over Judah.” 
 </p><p>
-<sup>36&#160;</sup>Benaiah the son of Jehoiada answered the king, and said, “Amen. May Yahweh, the Elohim of my lord the king, say so. 
-<sup>37&#160;</sup>As Yahweh has been with my lord the king, even so may he be with Solomon, and make his throne greater than the throne of my lord King David.” 
+<sup>36&#160;</sup>Benaiah the son of Jehoiada answered the king, and said, “Amen. May Yahuah, the Elohim of my lord the king, say so. 
+<sup>37&#160;</sup>As Yahuah has been with my lord the king, even so may he be with Solomon, and make his throne greater than the throne of my lord King David.” 
 </p><p>
 <sup>38&#160;</sup>So Zadok the priest, Nathan the prophet, Benaiah the son of Jehoiada, and the Cherethites and the Pelethites went down and had Solomon ride on King David’s mule, and brought him to Gihon. 
 <sup>39&#160;</sup>Zadok the priest took the horn of oil from the Tent, and anointed Solomon. They blew the trumpet; and all the people said, “Long live King Solomon!” 
@@ -143,7 +143,7 @@ html[dir=ltr] .q2 {
 <sup>45&#160;</sup>Zadok the priest and Nathan the prophet have anointed him king in Gihon. They have come up from there rejoicing, so that the city rang again. This is the noise that you have heard. 
 <sup>46&#160;</sup>Also, Solomon sits on the throne of the kingdom. 
 <sup>47&#160;</sup>Moreover the king’s servants came to bless our lord King David, saying, ‘May your Elohim make the name of Solomon better than your name, and make his throne greater than your throne;’ and the king bowed himself on the bed. 
-<sup>48&#160;</sup>Also thus said the king, ‘Blessed be Yahweh, the Elohim of Israel, who has given one to sit on my throne today, my eyes even seeing it.’&#160;” 
+<sup>48&#160;</sup>Also thus said the king, ‘Blessed be Yahuah, the Elohim of Israel, who has given one to sit on my throne today, my eyes even seeing it.’&#160;” 
 </p><p>
 <sup>49&#160;</sup>All the guests of Adonijah were afraid, and rose up, and each man went his way. 
 <sup>50&#160;</sup>Adonijah was afraid because of Solomon; and he arose, and went, and hung onto the horns of the altar. 
@@ -156,14 +156,14 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Now the days of David came near that he should die; and he commanded Solomon his son, saying, 
 <sup>2&#160;</sup>“I am going the way of all the earth. You be strong therefore, and show yourself a man; 
-<sup>3&#160;</sup>and keep the instruction of Yahweh your Elohim, to walk in his ways, to keep his statutes, his commandments, his ordinances, and his testimonies, according to that which is written in the law of Moses, that you may prosper in all that you do and wherever you turn yourself. 
-<sup>4&#160;</sup>Then Yahweh may establish his word which he spoke concerning me, saying, ‘If your children are careful of their way, to walk before me in truth with all their heart and with all their soul, there shall not fail you,’ he said, ‘a man on the throne of Israel.’ 
+<sup>3&#160;</sup>and keep the instruction of Yahuah your Elohim, to walk in his ways, to keep his statutes, his commandments, his ordinances, and his testimonies, according to that which is written in the law of Moses, that you may prosper in all that you do and wherever you turn yourself. 
+<sup>4&#160;</sup>Then Yahuah may establish his word which he spoke concerning me, saying, ‘If your children are careful of their way, to walk before me in truth with all their heart and with all their soul, there shall not fail you,’ he said, ‘a man on the throne of Israel.’ 
 </p><p>
 <sup>5&#160;</sup>“Moreover you know also what Joab the son of Zeruiah did to me, even what he did to the two captains of the armies of Israel, to Abner the son of Ner and to Amasa the son of Jether, whom he killed, and shed the blood of war in peace, and put the blood of war on his sash that was around his waist and in his sandals that were on his feet. 
 <sup>6&#160;</sup>Do therefore according to your wisdom, and don’t let his gray head go down to Sheol in peace. 
 <sup>7&#160;</sup>But show kindness to the sons of Barzillai the Gileadite, and let them be among those who eat at your table; for so they came to me when I fled from Absalom your brother. 
 </p><p>
-<sup>8&#160;</sup>“Behold, there is with you Shimei the son of Gera, the Benjamite of Bahurim, who cursed me with a grievous curse in the day when I went to Mahanaim; but he came down to meet me at the Jordan, and I swore to him by Yahweh, saying, ‘I will not put you to death with the sword.’ 
+<sup>8&#160;</sup>“Behold, there is with you Shimei the son of Gera, the Benjamite of Bahurim, who cursed me with a grievous curse in the day when I went to Mahanaim; but he came down to meet me at the Jordan, and I swore to him by Yahuah, saying, ‘I will not put you to death with the sword.’ 
 <sup>9&#160;</sup>Now therefore don’t hold him guiltless, for you are a wise man; and you will know what you ought to do to him, and you shall bring his gray head down to Sheol with blood.” 
 </p><p>
 <sup>10&#160;</sup>David slept with his fathers, and was buried in David’s city. 
@@ -175,7 +175,7 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>He said moreover, I have something to tell you.” 
 </p><p>She said, “Say on.” 
 </p><p>
-<sup>15&#160;</sup>He said, “You know that the kingdom was mine, and that all Israel set their faces on me, that I should reign. However, the kingdom is turned around, and has become my brother’s; for it was his from Yahweh. 
+<sup>15&#160;</sup>He said, “You know that the kingdom was mine, and that all Israel set their faces on me, that I should reign. However, the kingdom is turned around, and has become my brother’s; for it was his from Yahuah. 
 <sup>16&#160;</sup>Now I ask one petition of you. Don’t deny me.” 
 </p><p>She said to him, “Say on.” 
 </p><p>
@@ -190,23 +190,23 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>She said, “Let Abishag the Shunammite be given to Adonijah your brother as woman.” 
 </p><p>
 <sup>22&#160;</sup>King Solomon answered his mother, “Why do you ask Abishag the Shunammite for Adonijah? Ask for him the kingdom also, for he is my elder brother; even for him, and for Abiathar the priest, and for Joab the son of Zeruiah.” 
-<sup>23&#160;</sup>Then King Solomon swore by Yahweh, saying, “Elohim do so to me, and more also, if Adonijah has not spoken this word against his own life. 
-<sup>24&#160;</sup>Now therefore as Yahweh lives, who has established me and set me on my father David’s throne, and who has made me a house as he promised, surely Adonijah shall be put to death today.” 
+<sup>23&#160;</sup>Then King Solomon swore by Yahuah, saying, “Elohim do so to me, and more also, if Adonijah has not spoken this word against his own life. 
+<sup>24&#160;</sup>Now therefore as Yahuah lives, who has established me and set me on my father David’s throne, and who has made me a house as he promised, surely Adonijah shall be put to death today.” 
 </p><p>
 <sup>25&#160;</sup>King Solomon sent Benaiah the son of Jehoiada; and he fell on him, so that he died. 
-<sup>26&#160;</sup>To Abiathar the priest the king said, “Go to Anathoth, to your own fields, for you are worthy of death. But I will not at this time put you to death, because you bore the Lord Yahweh’s ark before David my father, and because you were afflicted in all in which my father was afflicted.” 
-<sup>27&#160;</sup>So Solomon thrust Abiathar out from being priest to Yahweh, that he might fulfill Yahweh’s word which he spoke concerning the house of Eli in Shiloh. 
+<sup>26&#160;</sup>To Abiathar the priest the king said, “Go to Anathoth, to your own fields, for you are worthy of death. But I will not at this time put you to death, because you bore the Lord Yahuah’s ark before David my father, and because you were afflicted in all in which my father was afflicted.” 
+<sup>27&#160;</sup>So Solomon thrust Abiathar out from being priest to Yahuah, that he might fulfill Yahuah’s word which he spoke concerning the house of Eli in Shiloh. 
 </p><p>
-<sup>28&#160;</sup>This news came to Joab; for Joab had followed Adonijah, although he didn’t follow Absalom. Joab fled to Yahweh’s Tent, and held onto the horns of the altar. 
-<sup>29&#160;</sup>King Solomon was told, “Joab has fled to Yahweh’s Tent; and behold, he is by the altar.” Then Solomon sent Benaiah the son of Jehoiada, saying, “Go, fall on him.” 
+<sup>28&#160;</sup>This news came to Joab; for Joab had followed Adonijah, although he didn’t follow Absalom. Joab fled to Yahuah’s Tent, and held onto the horns of the altar. 
+<sup>29&#160;</sup>King Solomon was told, “Joab has fled to Yahuah’s Tent; and behold, he is by the altar.” Then Solomon sent Benaiah the son of Jehoiada, saying, “Go, fall on him.” 
 </p><p>
-<sup>30&#160;</sup>Benaiah came to Yahweh’s Tent, and said to him, “The king says, ‘Come out!’&#160;” 
+<sup>30&#160;</sup>Benaiah came to Yahuah’s Tent, and said to him, “The king says, ‘Come out!’&#160;” 
 </p><p>He said, “No; but I will die here.” 
 </p><p>Benaiah brought the king word again, saying, “This is what Joab said, and this is how he answered me.” 
 </p><p>
 <sup>31&#160;</sup>The king said to him, “Do as he has said, and fall on him, and bury him, that you may take away the blood, which Joab shed without cause, from me and from my father’s house. 
-<sup>32&#160;</sup>Yahweh will return his blood on his own head, because he fell on two men more righteous and better than he, and killed them with the sword, and my father David didn’t know it: Abner the son of Ner, captain of the army of Israel, and Amasa the son of Jether, captain of the army of Judah. 
-<sup>33&#160;</sup>So their blood will return on the head of Joab and on the head of his offspring forever. But for David, for his offspring, for his house, and for his throne, there will be peace forever from Yahweh.” 
+<sup>32&#160;</sup>Yahuah will return his blood on his own head, because he fell on two men more righteous and better than he, and killed them with the sword, and my father David didn’t know it: Abner the son of Ner, captain of the army of Israel, and Amasa the son of Jether, captain of the army of Judah. 
+<sup>33&#160;</sup>So their blood will return on the head of Joab and on the head of his offspring forever. But for David, for his offspring, for his house, and for his throne, there will be peace forever from Yahuah.” 
 </p><p>
 <sup>34&#160;</sup>Then Benaiah the son of Jehoiada went up and fell on him, and killed him; and he was buried in his own house in the wilderness. 
 <sup>35&#160;</sup>The king put Benaiah the son of Jehoiada in his place over the army; and the king put Zadok the priest in the place of Abiathar. 
@@ -221,21 +221,21 @@ html[dir=ltr] .q2 {
 <sup>40&#160;</sup>Shimei arose, saddled his donkey, and went to Gath to Achish to seek his slaves; and Shimei went and brought his slaves from Gath. 
 <sup>41&#160;</sup>Solomon was told that Shimei had gone from Jerusalem to Gath, and had come again. 
 </p><p>
-<sup>42&#160;</sup>The king sent and called for Shimei, and said to him, “Didn’t I adjure you by Yahweh and warn you, saying, ‘Know for certain that on the day you go out and walk anywhere else, you shall surely die’? You said to me, ‘The saying that I have heard is good.’ 
-<sup>43&#160;</sup>Why then have you not kept the oath of Yahweh and the commandment that I have instructed you with?” 
-<sup>44&#160;</sup>The king said moreover to Shimei, “You know in your heart all the wickedness that you did to David my father. Therefore Yahweh will return your wickedness on your own head. 
-<sup>45&#160;</sup>But King Solomon will be blessed, and David’s throne will be established before Yahweh forever.” 
+<sup>42&#160;</sup>The king sent and called for Shimei, and said to him, “Didn’t I adjure you by Yahuah and warn you, saying, ‘Know for certain that on the day you go out and walk anywhere else, you shall surely die’? You said to me, ‘The saying that I have heard is good.’ 
+<sup>43&#160;</sup>Why then have you not kept the oath of Yahuah and the commandment that I have instructed you with?” 
+<sup>44&#160;</sup>The king said moreover to Shimei, “You know in your heart all the wickedness that you did to David my father. Therefore Yahuah will return your wickedness on your own head. 
+<sup>45&#160;</sup>But King Solomon will be blessed, and David’s throne will be established before Yahuah forever.” 
 <sup>46&#160;</sup>So the king commanded Benaiah the son of Jehoiada; and he went out, and fell on him, so that he died. The kingdom was established in the hand of Solomon. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>Solomon made himself a relative of Pharaoh king of Egypt. He took Pharaoh’s daughter and brought her into David’s city until he had finished building his own house, Yahweh’s house, and the wall around Jerusalem. 
-<sup>2&#160;</sup>However, the people sacrificed in the high places, because there was not yet a house built for Yahweh’s name. 
-<sup>3&#160;</sup>Solomon loved Yahweh, walking in the statutes of David his father, except that he sacrificed and burned incense in the high places. 
+<sup>1&#160;</sup>Solomon made himself a relative of Pharaoh king of Egypt. He took Pharaoh’s daughter and brought her into David’s city until he had finished building his own house, Yahuah’s house, and the wall around Jerusalem. 
+<sup>2&#160;</sup>However, the people sacrificed in the high places, because there was not yet a house built for Yahuah’s name. 
+<sup>3&#160;</sup>Solomon loved Yahuah, walking in the statutes of David his father, except that he sacrificed and burned incense in the high places. 
 <sup>4&#160;</sup>The king went to Gibeon to sacrifice there, for that was the great high place. Solomon offered a thousand burnt offerings on that altar. 
-<sup>5&#160;</sup>In Gibeon, Yahweh appeared to Solomon in a dream by night; and Elohim said, “Ask for what I should give you.” 
+<sup>5&#160;</sup>In Gibeon, Yahuah appeared to Solomon in a dream by night; and Elohim said, “Ask for what I should give you.” 
 </p><p>
 <sup>6&#160;</sup>Solomon said, “You have shown to your servant David my father great loving kindness, because he walked before you in truth, in righteousness, and in uprightness of heart with you. You have kept for him this great loving kindness, that you have given him a son to sit on his throne, as it is today. 
-<sup>7&#160;</sup>Now, Yahweh my Elohim, you have made your servant king instead of David my father. I am just a little child. I don’t know how to go out or come in. 
+<sup>7&#160;</sup>Now, Yahuah my Elohim, you have made your servant king instead of David my father. I am just a little child. I don’t know how to go out or come in. 
 <sup>8&#160;</sup>Your servant is among your people which you have chosen, a great people, that can’t be numbered or counted for multitude. 
 <sup>9&#160;</sup>Give your servant therefore an understanding heart to judge your people, that I may discern between good and evil; for who is able to judge this great people of yours?” 
 </p><p>
@@ -245,7 +245,7 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>I have also given you that which you have not asked, both riches and honor, so that there will not be any among the kings like you for all your days. 
 <sup>14&#160;</sup>If you will walk in my ways, to keep my statutes and my commandments, as your father David walked, then I will lengthen your days.” 
 </p><p>
-<sup>15&#160;</sup>Solomon awoke; and behold, it was a dream. Then he came to Jerusalem and stood before the ark of Yahweh’s covenant, and offered up burnt offerings, offered peace offerings, and made a feast for all his servants. 
+<sup>15&#160;</sup>Solomon awoke; and behold, it was a dream. Then he came to Jerusalem and stood before the ark of Yahuah’s covenant, and offered up burnt offerings, offered peace offerings, and made a feast for all his servants. 
 </p><p>
 <sup>16&#160;</sup>Then two women who were prostitutes came to the king, and stood before him. 
 <sup>17&#160;</sup>The one woman said, “Oh, my lord, I and this woman dwell in one house. I delivered a child with her in the house. 
@@ -311,18 +311,18 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Hiram king of Tyre sent his servants to Solomon, for he had heard that they had anointed him king in the place of his father, and Hiram had always loved David. 
 <sup>2&#160;</sup>Solomon sent to Hiram, saying, 
-<sup>3&#160;</sup>“You know that David my father could not build a house for the name of Yahweh his Elohim because of the wars which were around him on every side, until Yahweh put his enemies under the soles of his feet. 
-<sup>4&#160;</sup>But now Yahweh my Elohim has given me rest on every side. There is no enemy and no evil occurrence. 
-<sup>5&#160;</sup>Behold, I intend to build a house for the name of Yahweh my Elohim, as Yahweh spoke to David my father, saying, ‘Your son, whom I will set on your throne in your place shall build the house for my name.’ 
+<sup>3&#160;</sup>“You know that David my father could not build a house for the name of Yahuah his Elohim because of the wars which were around him on every side, until Yahuah put his enemies under the soles of his feet. 
+<sup>4&#160;</sup>But now Yahuah my Elohim has given me rest on every side. There is no enemy and no evil occurrence. 
+<sup>5&#160;</sup>Behold, I intend to build a house for the name of Yahuah my Elohim, as Yahuah spoke to David my father, saying, ‘Your son, whom I will set on your throne in your place shall build the house for my name.’ 
 <sup>6&#160;</sup>Now therefore command that cedar trees be cut for me out of Lebanon. My servants will be with your servants; and I will give you wages for your servants according to all that you say. For you know that there is nobody among us who knows how to cut timber like the Sidonians.” 
 </p><p>
-<sup>7&#160;</sup>When Hiram heard the words of Solomon, he rejoiced greatly, and said, “Blessed is Yahweh today, who has given to David a wise son to rule over this great people.” 
+<sup>7&#160;</sup>When Hiram heard the words of Solomon, he rejoiced greatly, and said, “Blessed is Yahuah today, who has given to David a wise son to rule over this great people.” 
 <sup>8&#160;</sup>Hiram sent to Solomon, saying, “I have heard the message which you have sent to me. I will do all your desire concerning timber of cedar, and concerning cypress timber. 
 <sup>9&#160;</sup>My servants will bring them down from Lebanon to the sea. I will make them into rafts to go by sea to the place that you specify to me, and will cause them to be broken up there, and you will receive them. You will accomplish my desire, in giving food for my household.” 
 </p><p>
 <sup>10&#160;</sup>So Hiram gave Solomon cedar timber and cypress timber according to all his desire. 
 <sup>11&#160;</sup>Solomon gave Hiram twenty thousand cors of wheat for food to his household, and twenty cors of pure oil. Solomon gave this to Hiram year by year. 
-<sup>12&#160;</sup>Yahweh gave Solomon wisdom, as he promised him. There was peace between Hiram and Solomon, and the two of them made a treaty together. 
+<sup>12&#160;</sup>Yahuah gave Solomon wisdom, as he promised him. There was peace between Hiram and Solomon, and the two of them made a treaty together. 
 </p><p>
 <sup>13&#160;</sup>King Solomon raised a levy out of all Israel; and the levy was thirty thousand men. 
 <sup>14&#160;</sup>He sent them to Lebanon, ten thousand a month by courses: for a month they were in Lebanon, and two months at home; and Adoniram was over the men subject to forced labor. 
@@ -332,8 +332,8 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>Solomon’s builders and Hiram’s builders and the Gebalites cut them, and prepared the timber and the stones to build the house. 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>In the four hundred and eightieth year after the children of Israel had come out of the land of Egypt, in the fourth year of Solomon’s reign over Israel, in the month Ziv, which is the second month, he began to build Yahweh’s house. 
-<sup>2&#160;</sup>The house which King Solomon built for Yahweh had a length of sixty cubits, and its width twenty, and its height thirty cubits. 
+<sup>1&#160;</sup>In the four hundred and eightieth year after the children of Israel had come out of the land of Egypt, in the fourth year of Solomon’s reign over Israel, in the month Ziv, which is the second month, he began to build Yahuah’s house. 
+<sup>2&#160;</sup>The house which King Solomon built for Yahuah had a length of sixty cubits, and its width twenty, and its height thirty cubits. 
 <sup>3&#160;</sup>The porch in front of the temple of the house had a length of twenty cubits, which was along the width of the house. Ten cubits was its width in front of the house. 
 <sup>4&#160;</sup>He made windows of fixed lattice work for the house. 
 <sup>5&#160;</sup>Against the wall of the house, he built floors all around, against the walls of the house all around, both of the temple and of the inner sanctuary; and he made side rooms all around. 
@@ -343,7 +343,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>So he built the house and finished it; and he covered the house with beams and planks of cedar. 
 <sup>10&#160;</sup>He built the floors all along the house, each five cubits high; and they rested on the house with timbers of cedar. 
 </p><p>
-<sup>11&#160;</sup>Yahweh’s word came to Solomon, saying, 
+<sup>11&#160;</sup>Yahuah’s word came to Solomon, saying, 
 <sup>12&#160;</sup>“Concerning this house which you are building, if you will walk in my statutes, and execute my ordinances, and keep all my commandments to walk in them, then I will establish my word with you, which I spoke to David your father. 
 <sup>13&#160;</sup>I will dwell among the children of Israel, and will not forsake my people Israel.” 
 </p><p>
@@ -352,7 +352,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>He built twenty cubits of the back part of the house with boards of cedar from the floor to the ceiling. He built this within, for an inner sanctuary, even for the most set-apart place. 
 <sup>17&#160;</sup>In front of the temple sanctuary was forty cubits long. 
 <sup>18&#160;</sup>There was cedar on the house within, carved with buds and open flowers. All was cedar. No stone was visible. 
-<sup>19&#160;</sup>He prepared an inner sanctuary in the middle of the house within, to set the ark of Yahweh’s covenant there. 
+<sup>19&#160;</sup>He prepared an inner sanctuary in the middle of the house within, to set the ark of Yahuah’s covenant there. 
 <sup>20&#160;</sup>Within the inner sanctuary was twenty cubits in length, and twenty cubits in width, and twenty cubits in its height. He overlaid it with pure gold. He covered the altar with cedar. 
 <sup>21&#160;</sup>So Solomon overlaid the house within with pure gold. He drew chains of gold across before the inner sanctuary, and he overlaid it with gold. 
 <sup>22&#160;</sup>He overlaid the whole house with gold, until all the house was finished. He also overlaid the whole altar that belonged to the inner sanctuary with gold. 
@@ -373,7 +373,7 @@ html[dir=ltr] .q2 {
 <sup>35&#160;</sup>He carved cherubim, palm trees, and open flowers; and he overlaid them with gold fitted on the engraved work. 
 <sup>36&#160;</sup>He built the inner court with three courses of cut stone and a course of cedar beams. 
 </p><p>
-<sup>37&#160;</sup>The foundation of Yahweh’s house was laid in the fourth year, in the month Ziv. 
+<sup>37&#160;</sup>The foundation of Yahuah’s house was laid in the fourth year, in the month Ziv. 
 <sup>38&#160;</sup>In the eleventh year, in the month Bul, which is the eighth month, the house was finished throughout all its parts and according to all its specifications. So he spent seven years building it. 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
@@ -388,7 +388,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>All these were of costly stones, even of stone cut according to measure, sawed with saws, inside and outside, even from the foundation to the coping, and so on the outside to the great court. 
 <sup>10&#160;</sup>The foundation was of costly stones, even great stones, stones of ten cubits and stones of eight cubits. 
 <sup>11&#160;</sup>Above were costly stones, even cut stone, according to measure, and cedar wood. 
-<sup>12&#160;</sup>The great court around had three courses of cut stone with a course of cedar beams, like the inner court of Yahweh’s house and the porch of the house. 
+<sup>12&#160;</sup>The great court around had three courses of cut stone with a course of cedar beams, like the inner court of Yahuah’s house and the porch of the house. 
 </p><p>
 <sup>13&#160;</sup>King Solomon sent and brought Hiram out of Tyre. 
 <sup>14&#160;</sup>He was the son of a widow of the tribe of Naphtali, and his father was a man of Tyre, a worker in bronze; and he was filled with wisdom and understanding and skill to work all works in bronze. He came to King Solomon and performed all his work. 
@@ -420,55 +420,55 @@ html[dir=ltr] .q2 {
 <sup>38&#160;</sup>He made ten basins of bronze. One basin contained forty baths. Every basin measured four cubits. One basin was on every one of the ten bases. 
 <sup>39&#160;</sup>He set the bases, five on the right side of the house and five on the left side of the house. He set the sea on the right side of the house eastward and toward the south. 
 </p><p>
-<sup>40&#160;</sup>Hiram made the pots, the shovels, and the basins. So Hiram finished doing all the work that he worked for King Solomon in Yahweh’s house: 
+<sup>40&#160;</sup>Hiram made the pots, the shovels, and the basins. So Hiram finished doing all the work that he worked for King Solomon in Yahuah’s house: 
 <sup>41&#160;</sup>the two pillars; the two bowls of the capitals that were on the top of the pillars; the two networks to cover the two bowls of the capitals that were on the top of the pillars; 
 <sup>42&#160;</sup>the four hundred pomegranates for the two networks; two rows of pomegranates for each network, to cover the two bowls of the capitals that were on the pillars; 
 <sup>43&#160;</sup>the ten bases; the ten basins on the bases; 
 <sup>44&#160;</sup>the one sea; the twelve oxen under the sea; 
-<sup>45&#160;</sup>the pots; the shovels; and the basins. All of these vessels, which Hiram made for King Solomon in Yahweh’s house, were of burnished bronze. 
+<sup>45&#160;</sup>the pots; the shovels; and the basins. All of these vessels, which Hiram made for King Solomon in Yahuah’s house, were of burnished bronze. 
 <sup>46&#160;</sup>The king cast them in the plain of the Jordan, in the clay ground between Succoth and Zarethan. 
 <sup>47&#160;</sup>Solomon left all the vessels unweighed, because there were so many of them. The weight of the bronze could not be determined. 
 </p><p>
-<sup>48&#160;</sup>Solomon made all the vessels that were in Yahweh’s house: the golden altar and the table that the show bread was on, of gold; 
+<sup>48&#160;</sup>Solomon made all the vessels that were in Yahuah’s house: the golden altar and the table that the show bread was on, of gold; 
 <sup>49&#160;</sup>and the lamp stands, five on the right side and five on the left, in front of the inner sanctuary, of pure gold; and the flowers, the lamps, and the tongs, of gold; 
 <sup>50&#160;</sup>the cups, the snuffers, the basins, the spoons, and the fire pans, of pure gold; and the hinges, both for the doors of the inner house, the most set-apart place, and for the doors of the house, of the temple, of gold. 
 </p><p>
-<sup>51&#160;</sup>Thus all the work that King Solomon did in Yahweh’s house was finished. Solomon brought in the things which David his father had dedicated—the silver, the gold, and the vessels—and put them in the treasuries of Yahweh’s house. 
+<sup>51&#160;</sup>Thus all the work that King Solomon did in Yahuah’s house was finished. Solomon brought in the things which David his father had dedicated—the silver, the gold, and the vessels—and put them in the treasuries of Yahuah’s house. 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>Then Solomon assembled the elders of Israel with all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to King Solomon in Jerusalem, to bring up the ark of Yahweh’s covenant out of David’s city, which is Zion. 
+<sup>1&#160;</sup>Then Solomon assembled the elders of Israel with all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to King Solomon in Jerusalem, to bring up the ark of Yahuah’s covenant out of David’s city, which is Zion. 
 <sup>2&#160;</sup>All the men of Israel assembled themselves to King Solomon at the feast in the month Ethanim, which is the seventh month. 
 <sup>3&#160;</sup>All the elders of Israel came, and the priests picked up the ark. 
-<sup>4&#160;</sup>They brought up Yahweh’s ark, the Tent of Meeting, and all the set-apart vessels that were in the Tent. The priests and the Levites brought these up. 
+<sup>4&#160;</sup>They brought up Yahuah’s ark, the Tent of Meeting, and all the set-apart vessels that were in the Tent. The priests and the Levites brought these up. 
 <sup>5&#160;</sup>King Solomon and all the congregation of Israel, who were assembled to him, were with him before the ark, sacrificing sheep and cattle that could not be counted or numbered for multitude. 
-<sup>6&#160;</sup>The priests brought in the ark of Yahweh’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the cherubim’s wings. 
+<sup>6&#160;</sup>The priests brought in the ark of Yahuah’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the cherubim’s wings. 
 <sup>7&#160;</sup>For the cherubim spread their wings out over the place of the ark, and the cherubim covered the ark and its poles above. 
 <sup>8&#160;</sup>The poles were so long that the ends of the poles were seen from the set-apart place before the inner sanctuary, but they were not seen outside. They are there to this day. 
-<sup>9&#160;</sup>There was nothing in the ark except the two stone tablets which Moses put there at Horeb, when Yahweh made a covenant with the children of Israel, when they came out of the land of Egypt. 
-<sup>10&#160;</sup>It came to pass, when the priests had come out of the set-apart place, that the cloud filled Yahweh’s house, 
-<sup>11&#160;</sup>so that the priests could not stand to minister by reason of the cloud; for Yahweh’s glory filled Yahweh’s house. 
+<sup>9&#160;</sup>There was nothing in the ark except the two stone tablets which Moses put there at Horeb, when Yahuah made a covenant with the children of Israel, when they came out of the land of Egypt. 
+<sup>10&#160;</sup>It came to pass, when the priests had come out of the set-apart place, that the cloud filled Yahuah’s house, 
+<sup>11&#160;</sup>so that the priests could not stand to minister by reason of the cloud; for Yahuah’s glory filled Yahuah’s house. 
 </p><p>
-<sup>12&#160;</sup>Then Solomon said, “Yahweh has said that he would dwell in the thick darkness. 
+<sup>12&#160;</sup>Then Solomon said, “Yahuah has said that he would dwell in the thick darkness. 
 <sup>13&#160;</sup>I have surely built you a house of habitation, a place for you to dwell in forever.” 
 </p><p>
 <sup>14&#160;</sup>The king turned his face around and blessed all the assembly of Israel; and all the assembly of Israel stood. 
-<sup>15&#160;</sup>He said, “Blessed is Yahweh, the Elohim of Israel, who spoke with his mouth to David your father, and has with his hand fulfilled it, saying, 
+<sup>15&#160;</sup>He said, “Blessed is Yahuah, the Elohim of Israel, who spoke with his mouth to David your father, and has with his hand fulfilled it, saying, 
 <sup>16&#160;</sup>‘Since the day that I brought my people Israel out of Egypt, I chose no city out of all the tribes of Israel to build a house, that my name might be there; but I chose David to be over my people Israel.’ 
 </p><p>
-<sup>17&#160;</sup>“Now it was in the heart of David my father to build a house for the name of Yahweh, the Elohim of Israel. 
-<sup>18&#160;</sup>But Yahweh said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart. 
+<sup>17&#160;</sup>“Now it was in the heart of David my father to build a house for the name of Yahuah, the Elohim of Israel. 
+<sup>18&#160;</sup>But Yahuah said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart. 
 <sup>19&#160;</sup>Nevertheless, you shall not build the house; but your son who shall come out of your body, he shall build the house for my name.’ 
-<sup>20&#160;</sup>Yahweh has established his word that he spoke; for I have risen up in the place of David my father, and I sit on the throne of Israel, as Yahweh promised, and have built the house for the name of Yahweh, the Elohim of Israel. 
-<sup>21&#160;</sup>There I have set a place for the ark, in which is Yahweh’s covenant, which he made with our fathers when he brought them out of the land of Egypt.” 
+<sup>20&#160;</sup>Yahuah has established his word that he spoke; for I have risen up in the place of David my father, and I sit on the throne of Israel, as Yahuah promised, and have built the house for the name of Yahuah, the Elohim of Israel. 
+<sup>21&#160;</sup>There I have set a place for the ark, in which is Yahuah’s covenant, which he made with our fathers when he brought them out of the land of Egypt.” 
 </p><p>
-<sup>22&#160;</sup>Solomon stood before Yahweh’s altar in the presence of all the assembly of Israel, and spread out his hands toward heaven; 
-<sup>23&#160;</sup>and he said, “Yahweh, the Elohim of Israel, there is no Elohim like you, in heaven above, or on earth beneath; who keeps covenant and loving kindness with your servants who walk before you with all their heart; 
+<sup>22&#160;</sup>Solomon stood before Yahuah’s altar in the presence of all the assembly of Israel, and spread out his hands toward heaven; 
+<sup>23&#160;</sup>and he said, “Yahuah, the Elohim of Israel, there is no Elohim like you, in heaven above, or on earth beneath; who keeps covenant and loving kindness with your servants who walk before you with all their heart; 
 <sup>24&#160;</sup>who has kept with your servant David my father that which you promised him. Yes, you spoke with your mouth, and have fulfilled it with your hand, as it is today. 
-<sup>25&#160;</sup>Now therefore, may Yahweh, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail from you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk before me as you have walked before me.’ 
+<sup>25&#160;</sup>Now therefore, may Yahuah, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail from you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk before me as you have walked before me.’ 
 </p><p>
 <sup>26&#160;</sup>“Now therefore, Elohim of Israel, please let your word be verified, which you spoke to your servant David my father. 
 <sup>27&#160;</sup>But will Elohim in very deed dwell on the earth? Behold, heaven and the heaven of heavens can’t contain you; how much less this house that I have built! 
-<sup>28&#160;</sup>Yet have respect for the prayer of your servant and for his supplication, Yahweh my Elohim, to listen to the cry and to the prayer which your servant prays before you today; 
+<sup>28&#160;</sup>Yet have respect for the prayer of your servant and for his supplication, Yahuah my Elohim, to listen to the cry and to the prayer which your servant prays before you today; 
 <sup>29&#160;</sup>that your eyes may be open toward this house night and day, even toward the place of which you have said, ‘My name shall be there;’ to listen to the prayer which your servant prays toward this place. 
 <sup>30&#160;</sup>Listen to the supplication of your servant, and of your people Israel, when they pray toward this place. Yes, hear in heaven, your dwelling place; and when you hear, forgive. 
 </p><p>
@@ -490,7 +490,7 @@ html[dir=ltr] .q2 {
 <sup>42&#160;</sup>(for they shall hear of your great name and of your mighty hand and of your outstretched arm), when he comes and prays toward this house, 
 <sup>43&#160;</sup>hear in heaven, your dwelling place, and do according to all that the foreigner calls to you for; that all the peoples of the earth may know your name, to fear you, as do your people Israel, and that they may know that this house which I have built is called by your name. 
 </p><p>
-<sup>44&#160;</sup>“If your people go out to battle against their enemy, by whatever way you shall send them, and they pray to Yahweh toward the city which you have chosen, and toward the house which I have built for your name, 
+<sup>44&#160;</sup>“If your people go out to battle against their enemy, by whatever way you shall send them, and they pray to Yahuah toward the city which you have chosen, and toward the house which I have built for your name, 
 <sup>45&#160;</sup>then hear in heaven their prayer and their supplication, and maintain their cause. 
 <sup>46&#160;</sup>If they sin against you (for there is no man who doesn’t sin), and you are angry with them and deliver them to the enemy, so that they carry them away captive to the land of the enemy, far off or near; 
 <sup>47&#160;</sup>yet if they repent in the land where they are carried captive, and turn again, and make supplication to you in the land of those who carried them captive, saying, ‘We have sinned and have done perversely; we have dealt wickedly,’ 
@@ -499,43 +499,43 @@ html[dir=ltr] .q2 {
 <sup>50&#160;</sup>and forgive your people who have sinned against you, and all their transgressions in which they have transgressed against you; and give them compassion before those who carried them captive, that they may have compassion on them 
 <sup>51&#160;</sup>(for they are your people and your inheritance, which you brought out of Egypt, from the middle of the iron furnace); 
 <sup>52&#160;</sup>that your eyes may be open to the supplication of your servant and to the supplication of your people Israel, to listen to them whenever they cry to you. 
-<sup>53&#160;</sup>For you separated them from among all the peoples of the earth to be your inheritance, as you spoke by Moses your servant, when you brought our fathers out of Egypt, Lord Yahweh.” 
+<sup>53&#160;</sup>For you separated them from among all the peoples of the earth to be your inheritance, as you spoke by Moses your servant, when you brought our fathers out of Egypt, Lord Yahuah.” 
 </p><p>
-<sup>54&#160;</sup>It was so, that when Solomon had finished praying all this prayer and supplication to Yahweh, he arose from before Yahweh’s altar, from kneeling on his knees with his hands spread out toward heaven. 
+<sup>54&#160;</sup>It was so, that when Solomon had finished praying all this prayer and supplication to Yahuah, he arose from before Yahuah’s altar, from kneeling on his knees with his hands spread out toward heaven. 
 <sup>55&#160;</sup>He stood and blessed all the assembly of Israel with a loud voice, saying, 
-<sup>56&#160;</sup>“Blessed be Yahweh, who has given rest to his people Israel, according to all that he promised. There has not failed one word of all his good promise, which he promised by Moses his servant. 
-<sup>57&#160;</sup>May Yahweh our Elohim be with us as he was with our fathers. Let him not leave us or forsake us, 
+<sup>56&#160;</sup>“Blessed be Yahuah, who has given rest to his people Israel, according to all that he promised. There has not failed one word of all his good promise, which he promised by Moses his servant. 
+<sup>57&#160;</sup>May Yahuah our Elohim be with us as he was with our fathers. Let him not leave us or forsake us, 
 <sup>58&#160;</sup>that he may incline our hearts to him, to walk in all his ways, and to keep his commandments, his statutes, and his ordinances, which he commanded our fathers. 
-<sup>59&#160;</sup>Let these my words, with which I have made supplication before Yahweh, be near to Yahweh our Elohim day and night, that he may maintain the cause of his servant and the cause of his people Israel, as every day requires; 
-<sup>60&#160;</sup>that all the peoples of the earth may know that Yahweh himself is Elohim. There is no one else. 
+<sup>59&#160;</sup>Let these my words, with which I have made supplication before Yahuah, be near to Yahuah our Elohim day and night, that he may maintain the cause of his servant and the cause of his people Israel, as every day requires; 
+<sup>60&#160;</sup>that all the peoples of the earth may know that Yahuah himself is Elohim. There is no one else. 
 </p><p>
-<sup>61&#160;</sup>“Let your heart therefore be perfect with Yahweh our Elohim, to walk in his statutes, and to keep his commandments, as it is today.” 
+<sup>61&#160;</sup>“Let your heart therefore be perfect with Yahuah our Elohim, to walk in his statutes, and to keep his commandments, as it is today.” 
 </p><p>
-<sup>62&#160;</sup>The king, and all Israel with him, offered sacrifice before Yahweh. 
-<sup>63&#160;</sup>Solomon offered for the sacrifice of peace offerings, which he offered to Yahweh, twenty two thousand head of cattle and one hundred twenty thousand sheep. So the king and all the children of Israel dedicated Yahweh’s house. 
-<sup>64&#160;</sup>The same day the king made the middle of the court set-apart that was before Yahweh’s house; for there he offered the burnt offering, the meal offering, and the fat of the peace offerings, because the bronze altar that was before Yahweh was too little to receive the burnt offering, the meal offering, and the fat of the peace offerings. 
+<sup>62&#160;</sup>The king, and all Israel with him, offered sacrifice before Yahuah. 
+<sup>63&#160;</sup>Solomon offered for the sacrifice of peace offerings, which he offered to Yahuah, twenty two thousand head of cattle and one hundred twenty thousand sheep. So the king and all the children of Israel dedicated Yahuah’s house. 
+<sup>64&#160;</sup>The same day the king made the middle of the court set-apart that was before Yahuah’s house; for there he offered the burnt offering, the meal offering, and the fat of the peace offerings, because the bronze altar that was before Yahuah was too little to receive the burnt offering, the meal offering, and the fat of the peace offerings. 
 </p><p>
-<sup>65&#160;</sup>So Solomon held the feast at that time, and all Israel with him, a great assembly, from the entrance of Hamath to the brook of Egypt, before Yahweh our Elohim, seven days and seven more days, even fourteen days. 
-<sup>66&#160;</sup>On the eighth day he sent the people away; and they blessed the king, and went to their tents joyful and glad in their hearts for all the goodness that Yahweh had shown to David his servant, and to Israel his people. 
+<sup>65&#160;</sup>So Solomon held the feast at that time, and all Israel with him, a great assembly, from the entrance of Hamath to the brook of Egypt, before Yahuah our Elohim, seven days and seven more days, even fourteen days. 
+<sup>66&#160;</sup>On the eighth day he sent the people away; and they blessed the king, and went to their tents joyful and glad in their hearts for all the goodness that Yahuah had shown to David his servant, and to Israel his people. 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
-<sup>1&#160;</sup>When Solomon had finished the building of Yahweh’s house, the king’s house, and all Solomon’s desire which he was pleased to do, 
-<sup>2&#160;</sup>Yahweh appeared to Solomon the second time, as he had appeared to him at Gibeon. 
-<sup>3&#160;</sup>Yahweh said to him, “I have heard your prayer and your supplication that you have made before me. I have made this house set-apart, which you have built, to put my name there forever; and my eyes and my heart shall be there perpetually. 
+<sup>1&#160;</sup>When Solomon had finished the building of Yahuah’s house, the king’s house, and all Solomon’s desire which he was pleased to do, 
+<sup>2&#160;</sup>Yahuah appeared to Solomon the second time, as he had appeared to him at Gibeon. 
+<sup>3&#160;</sup>Yahuah said to him, “I have heard your prayer and your supplication that you have made before me. I have made this house set-apart, which you have built, to put my name there forever; and my eyes and my heart shall be there perpetually. 
 <sup>4&#160;</sup>As for you, if you will walk before me as David your father walked, in integrity of heart and in uprightness, to do according to all that I have commanded you, and will keep my statutes and my ordinances, 
 <sup>5&#160;</sup>then I will establish the throne of your kingdom over Israel forever, as I promised to David your father, saying, ‘There shall not fail from you a man on the throne of Israel.’ 
 <sup>6&#160;</sup>But if you turn away from following me, you or your children, and not keep my commandments and my statutes which I have set before you, but go and serve other elohims and worship them, 
 <sup>7&#160;</sup>then I will cut off Israel out of the land which I have given them; and I will cast this house, which I have made set-apart for my name, out of my sight; and Israel will be a proverb and a byword among all peoples. 
-<sup>8&#160;</sup>Though this house is so high, yet everyone who passes by it will be astonished and hiss; and they will say, ‘Why has Yahweh done this to this land and to this house?’ 
-<sup>9&#160;</sup>and they will answer, ‘Because they abandoned Yahweh their Elohim, who brought their fathers out of the land of Egypt, and embraced other elohims, and worshiped them, and served them. Therefore Yahweh has brought all this evil on them.’&#160;” 
+<sup>8&#160;</sup>Though this house is so high, yet everyone who passes by it will be astonished and hiss; and they will say, ‘Why has Yahuah done this to this land and to this house?’ 
+<sup>9&#160;</sup>and they will answer, ‘Because they abandoned Yahuah their Elohim, who brought their fathers out of the land of Egypt, and embraced other elohims, and worshiped them, and served them. Therefore Yahuah has brought all this evil on them.’&#160;” 
 </p><p>
-<sup>10&#160;</sup>At the end of twenty years, in which Solomon had built the two houses, Yahweh’s house and the king’s house 
+<sup>10&#160;</sup>At the end of twenty years, in which Solomon had built the two houses, Yahuah’s house and the king’s house 
 <sup>11&#160;</sup>(now Hiram the king of Tyre had furnished Solomon with cedar trees and cypress trees, and with gold, according to all his desire), King Solomon gave Hiram twenty cities in the land of Galilee. 
 <sup>12&#160;</sup>Hiram came out of Tyre to see the cities which Solomon had given him; and they didn’t please him. 
 <sup>13&#160;</sup>He said, “What cities are these which you have given me, my brother?” He called them the land of Cabul to this day. 
 <sup>14&#160;</sup>Hiram sent to the king one hundred twenty talents of gold. 
 </p><p>
-<sup>15&#160;</sup>This is the reason of the forced labor which King Solomon conscripted: to build Yahweh’s house, his own house, Millo, Jerusalem’s wall, Hazor, Megiddo, and Gezer. 
+<sup>15&#160;</sup>This is the reason of the forced labor which King Solomon conscripted: to build Yahuah’s house, his own house, Millo, Jerusalem’s wall, Hazor, Megiddo, and Gezer. 
 <sup>16&#160;</sup>Pharaoh king of Egypt had gone up, taken Gezer, burned it with fire, killed the Canaanites who lived in the city, and given it for a wedding gift to his daughter, Solomon’s woman. 
 <sup>17&#160;</sup>Solomon built in the land Gezer, Beth Horon the lower, 
 <sup>18&#160;</sup>Baalath, Tamar in the wilderness, 
@@ -546,26 +546,26 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>24&#160;</sup>But Pharaoh’s daughter came up out of David’s city to her house which Solomon had built for her. Then he built Millo. 
 </p><p>
-<sup>25&#160;</sup>Solomon offered burnt offerings and peace offerings on the altar which he built to Yahweh three times per year, burning incense with them on the altar that was before Yahweh. So he finished the house. 
+<sup>25&#160;</sup>Solomon offered burnt offerings and peace offerings on the altar which he built to Yahuah three times per year, burning incense with them on the altar that was before Yahuah. So he finished the house. 
 </p><p>
 <sup>26&#160;</sup>King Solomon made a fleet of ships in Ezion Geber, which is beside Eloth, on the shore of the Red Sea, in the land of Edom. 
 <sup>27&#160;</sup>Hiram sent in the fleet his servants, sailors who had knowledge of the sea, with the servants of Solomon. 
 <sup>28&#160;</sup>They came to Ophir, and fetched from there gold, four hundred and twenty talents, and brought it to King Solomon. 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p>
-<sup>1&#160;</sup>When the queen of Sheba heard of the fame of Solomon concerning Yahweh’s name, she came to test him with hard questions. 
+<sup>1&#160;</sup>When the queen of Sheba heard of the fame of Solomon concerning Yahuah’s name, she came to test him with hard questions. 
 <sup>2&#160;</sup>She came to Jerusalem with a very great caravan, with camels that bore spices, very much gold, and precious stones; and when she had come to Solomon, she talked with him about all that was in her heart. 
 <sup>3&#160;</sup>Solomon answered all her questions. There wasn’t anything hidden from the king which he didn’t tell her. 
 <sup>4&#160;</sup>When the queen of Sheba had seen all the wisdom of Solomon, the house that he had built, 
-<sup>5&#160;</sup>the food of his table, the sitting of his servants, the attendance of his officials, their clothing, his cup bearers, and his ascent by which he went up to Yahweh’s house, there was no more spirit in her. 
+<sup>5&#160;</sup>the food of his table, the sitting of his servants, the attendance of his officials, their clothing, his cup bearers, and his ascent by which he went up to Yahuah’s house, there was no more spirit in her. 
 <sup>6&#160;</sup>She said to the king, “It was a true report that I heard in my own land of your acts and of your wisdom. 
 <sup>7&#160;</sup>However, I didn’t believe the words until I came and my eyes had seen it. Behold, not even half was told me! Your wisdom and prosperity exceed the fame which I heard. 
 <sup>8&#160;</sup>Happy are your men, happy are these your servants who stand continually before you, who hear your wisdom. 
-<sup>9&#160;</sup>Blessed is Yahweh your Elohim, who delighted in you, to set you on the throne of Israel. Because Yahweh loved Israel forever, therefore he made you king, to do justice and righteousness.” 
+<sup>9&#160;</sup>Blessed is Yahuah your Elohim, who delighted in you, to set you on the throne of Israel. Because Yahuah loved Israel forever, therefore he made you king, to do justice and righteousness.” 
 <sup>10&#160;</sup>She gave the king one hundred twenty talents of gold, and a very great quantity of spices, and precious stones. Never again was there such an abundance of spices as these which the queen of Sheba gave to King Solomon. 
 </p><p>
 <sup>11&#160;</sup>The fleet of Hiram that brought gold from Ophir also brought in from Ophir great quantities of almug trees and precious stones. 
-<sup>12&#160;</sup>The king made of the almug trees pillars for Yahweh’s house and for the king’s house, harps also and stringed instruments for the singers; no such almug trees came or were seen to this day. 
+<sup>12&#160;</sup>The king made of the almug trees pillars for Yahuah’s house and for the king’s house, harps also and stringed instruments for the singers; no such almug trees came or were seen to this day. 
 </p><p>
 <sup>13&#160;</sup>King Solomon gave to the queen of Sheba all her desire, whatever she asked, in addition to that which Solomon gave her of his royal bounty. So she turned and went to her own land, she and her servants. 
 </p><p>
@@ -590,20 +590,20 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p>
 <sup>1&#160;</sup>Now King Solomon loved many foreign women, together with the daughter of Pharaoh: women of the Moabites, Ammonites, Edomites, Sidonians, and Hittites, 
-<sup>2&#160;</sup>of the nations concerning which Yahweh said to the children of Israel, “You shall not go among them, neither shall they come among you, for surely they will turn away your heart after their elohims.” Solomon joined to these in love. 
+<sup>2&#160;</sup>of the nations concerning which Yahuah said to the children of Israel, “You shall not go among them, neither shall they come among you, for surely they will turn away your heart after their elohims.” Solomon joined to these in love. 
 <sup>3&#160;</sup>He had seven hundred women, princesses, and three hundred concubines. His women turned his heart away. 
-<sup>4&#160;</sup>When Solomon was old, his women turned away his heart after other elohims; and his heart was not perfect with Yahweh his Elohim, as the heart of David his father was. 
+<sup>4&#160;</sup>When Solomon was old, his women turned away his heart after other elohims; and his heart was not perfect with Yahuah his Elohim, as the heart of David his father was. 
 <sup>5&#160;</sup>For Solomon went after Ashtoreth the elohim of the Sidonians, and after Milcom the abomination of the Ammonites. 
-<sup>6&#160;</sup>Solomon did that which was evil in Yahweh’s sight, and didn’t go fully after Yahweh, as David his father did. 
+<sup>6&#160;</sup>Solomon did that which was evil in Yahuah’s sight, and didn’t go fully after Yahuah, as David his father did. 
 <sup>7&#160;</sup>Then Solomon built a high place for Chemosh the abomination of Moab, on the mountain that is before Jerusalem, and for Molech the abomination of the children of Ammon. 
 <sup>8&#160;</sup>So he did for all his foreign women, who burned incense and sacrificed to their elohims. 
-<sup>9&#160;</sup>Yahweh was angry with Solomon, because his heart was turned away from Yahweh, the Elohim of Israel, who had appeared to him twice, 
-<sup>10&#160;</sup>and had commanded him concerning this thing, that he should not go after other elohims; but he didn’t keep that which Yahweh commanded. 
-<sup>11&#160;</sup>Therefore Yahweh said to Solomon, “Because this is done by you, and you have not kept my covenant and my statutes, which I have commanded you, I will surely tear the kingdom from you, and will give it to your servant. 
+<sup>9&#160;</sup>Yahuah was angry with Solomon, because his heart was turned away from Yahuah, the Elohim of Israel, who had appeared to him twice, 
+<sup>10&#160;</sup>and had commanded him concerning this thing, that he should not go after other elohims; but he didn’t keep that which Yahuah commanded. 
+<sup>11&#160;</sup>Therefore Yahuah said to Solomon, “Because this is done by you, and you have not kept my covenant and my statutes, which I have commanded you, I will surely tear the kingdom from you, and will give it to your servant. 
 <sup>12&#160;</sup>Nevertheless, I will not do it in your days, for David your father’s sake; but I will tear it out of your son’s hand. 
 <sup>13&#160;</sup>However, I will not tear away all the kingdom; but I will give one tribe to your son, for David my servant’s sake, and for Jerusalem’s sake which I have chosen.” 
 </p><p>
-<sup>14&#160;</sup>Yahweh raised up an adversary to Solomon: Hadad the Edomite. He was one of the king’s offspring in Edom. 
+<sup>14&#160;</sup>Yahuah raised up an adversary to Solomon: Hadad the Edomite. He was one of the king’s offspring in Edom. 
 <sup>15&#160;</sup>For when David was in Edom, and Joab the captain of the army had gone up to bury the slain, and had struck every male in Edom 
 <sup>16&#160;</sup>(for Joab and all Israel remained there six months, until he had cut off every male in Edom), 
 <sup>17&#160;</sup>Hadad fled, he and certain Edomites of his father’s servants with him, to go into Egypt, when Hadad was still a little child. 
@@ -624,7 +624,7 @@ html[dir=ltr] .q2 {
 <sup>28&#160;</sup>The man Jeroboam was a mighty man of valor; and Solomon saw the young man that he was industrious, and he put him in charge of all the labor of the house of Joseph. 
 <sup>29&#160;</sup>At that time, when Jeroboam went out of Jerusalem, the prophet Ahijah the Shilonite found him on the way. Now Ahijah had clad himself with a new garment; and the two of them were alone in the field. 
 <sup>30&#160;</sup>Ahijah took the new garment that was on him, and tore it in twelve pieces. 
-<sup>31&#160;</sup>He said to Jeroboam, “Take ten pieces; for Yahweh, the Elohim of Israel, says, ‘Behold, I will tear the kingdom out of the hand of Solomon and will give ten tribes to you 
+<sup>31&#160;</sup>He said to Jeroboam, “Take ten pieces; for Yahuah, the Elohim of Israel, says, ‘Behold, I will tear the kingdom out of the hand of Solomon and will give ten tribes to you 
 <sup>32&#160;</sup>(but he shall have one tribe, for my servant David’s sake and for Jerusalem’s sake, the city which I have chosen out of all the tribes of Israel), 
 <sup>33&#160;</sup>because they have forsaken me, and have worshiped Ashtoreth the elohim of the Sidonians, Chemosh the elohim of Moab, and Milcom the elohim of the children of Ammon. They have not walked in my ways, to do that which is right in my eyes, and to keep my statutes and my ordinances, as David his father did. 
 </p><p>
@@ -664,7 +664,7 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>The king answered the people roughly, and abandoned the counsel of the old men which they had given him, 
 <sup>14&#160;</sup>and spoke to them according to the counsel of the young men, saying, “My father made your yoke heavy, but I will add to your yoke. My father chastised you with whips, but I will chastise you with scorpions.” 
 </p><p>
-<sup>15&#160;</sup>So the king didn’t listen to the people; for it was a thing brought about from Yahweh, that he might establish his word, which Yahweh spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
+<sup>15&#160;</sup>So the king didn’t listen to the people; for it was a thing brought about from Yahuah, that he might establish his word, which Yahuah spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
 <sup>16&#160;</sup>When all Israel saw that the king didn’t listen to them, the people answered the king, saying, “What portion have we in David? We don’t have an inheritance in the son of Jesse. To your tents, Israel! Now see to your own house, David.” So Israel departed to their tents. 
 </p><p>
 <sup>17&#160;</sup>But as for the children of Israel who lived in the cities of Judah, Rehoboam reigned over them. 
@@ -676,11 +676,11 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>When Rehoboam had come to Jerusalem, he assembled all the house of Judah and the tribe of Benjamin, a hundred and eighty thousand chosen men who were warriors, to fight against the house of Israel, to bring the kingdom again to Rehoboam the son of Solomon. 
 <sup>22&#160;</sup>But the word of Elohim came to Shemaiah the man of Elohim, saying, 
 <sup>23&#160;</sup>“Speak to Rehoboam the son of Solomon, king of Judah, and to all the house of Judah and Benjamin, and to the rest of the people, saying, 
-<sup>24&#160;</sup>‘Yahweh says, “You shall not go up or fight against your brothers, the children of Israel. Everyone return to his house; for this thing is from me.”&#160;’&#160;” So they listened to Yahweh’s word, and returned and went their way, according to Yahweh’s word. 
+<sup>24&#160;</sup>‘Yahuah says, “You shall not go up or fight against your brothers, the children of Israel. Everyone return to his house; for this thing is from me.”&#160;’&#160;” So they listened to Yahuah’s word, and returned and went their way, according to Yahuah’s word. 
 </p><p>
 <sup>25&#160;</sup>Then Jeroboam built Shechem in the hill country of Ephraim, and lived in it; and he went out from there and built Penuel. 
 <sup>26&#160;</sup>Jeroboam said in his heart, “Now the kingdom will return to David’s house. 
-<sup>27&#160;</sup>If this people goes up to offer sacrifices in Yahweh’s house at Jerusalem, then the heart of this people will turn again to their lord, even to Rehoboam king of Judah; and they will kill me, and return to Rehoboam king of Judah.” 
+<sup>27&#160;</sup>If this people goes up to offer sacrifices in Yahuah’s house at Jerusalem, then the heart of this people will turn again to their lord, even to Rehoboam king of Judah; and they will kill me, and return to Rehoboam king of Judah.” 
 <sup>28&#160;</sup>So the king took counsel, and made two calves of gold; and he said to them, “It is too much for you to go up to Jerusalem. Look and behold your elohims, Israel, which brought you up out of the land of Egypt!” 
 <sup>29&#160;</sup>He set the one in Bethel, and the other he put in Dan. 
 <sup>30&#160;</sup>This thing became a sin, for the people went even as far as Dan to worship before the one there. 
@@ -689,19 +689,19 @@ html[dir=ltr] .q2 {
 <sup>33&#160;</sup>He went up to the altar which he had made in Bethel on the fifteenth day in the eighth month, even in the month which he had devised of his own heart; and he ordained a feast for the children of Israel, and went up to the altar to burn incense. 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
-<sup>1&#160;</sup>Behold, a man of Elohim came out of Judah by Yahweh’s word to Bethel; and Jeroboam was standing by the altar to burn incense. 
-<sup>2&#160;</sup>He cried against the altar by Yahweh’s word, and said, “Altar! Altar! Yahweh says: ‘Behold, a son will be born to David’s house, Josiah by name. On you he will sacrifice the priests of the high places who burn incense on you, and they will burn men’s bones on you.’&#160;” 
-<sup>3&#160;</sup>He gave a sign the same day, saying, “This is the sign which Yahweh has spoken: Behold, the altar will be split apart, and the ashes that are on it will be poured out.” 
+<sup>1&#160;</sup>Behold, a man of Elohim came out of Judah by Yahuah’s word to Bethel; and Jeroboam was standing by the altar to burn incense. 
+<sup>2&#160;</sup>He cried against the altar by Yahuah’s word, and said, “Altar! Altar! Yahuah says: ‘Behold, a son will be born to David’s house, Josiah by name. On you he will sacrifice the priests of the high places who burn incense on you, and they will burn men’s bones on you.’&#160;” 
+<sup>3&#160;</sup>He gave a sign the same day, saying, “This is the sign which Yahuah has spoken: Behold, the altar will be split apart, and the ashes that are on it will be poured out.” 
 </p><p>
 <sup>4&#160;</sup>When the king heard the saying of the man of Elohim, which he cried against the altar in Bethel, Jeroboam put out his hand from the altar, saying, “Seize him!” His hand, which he put out against him, dried up, so that he could not draw it back again to himself. 
-<sup>5&#160;</sup>The altar was also split apart, and the ashes poured out from the altar, according to the sign which the man of Elohim had given by Yahweh’s word. 
-<sup>6&#160;</sup>The king answered the man of Elohim, “Now intercede for the favor of Yahweh your Elohim, and pray for me, that my hand may be restored me again.” 
-</p><p>The man of Elohim interceded with Yahweh, and the king’s hand was restored to him again, and became as it was before. 
+<sup>5&#160;</sup>The altar was also split apart, and the ashes poured out from the altar, according to the sign which the man of Elohim had given by Yahuah’s word. 
+<sup>6&#160;</sup>The king answered the man of Elohim, “Now intercede for the favor of Yahuah your Elohim, and pray for me, that my hand may be restored me again.” 
+</p><p>The man of Elohim interceded with Yahuah, and the king’s hand was restored to him again, and became as it was before. 
 </p><p>
 <sup>7&#160;</sup>The king said to the man of Elohim, “Come home with me and refresh yourself, and I will give you a reward.” 
 </p><p>
 <sup>8&#160;</sup>The man of Elohim said to the king, “Even if you gave me half of your house, I would not go in with you, neither would I eat bread nor drink water in this place; 
-<sup>9&#160;</sup>for so was it commanded me by Yahweh’s word, saying, ‘You shall eat no bread, drink no water, and don’t return by the way that you came.’&#160;” 
+<sup>9&#160;</sup>for so was it commanded me by Yahuah’s word, saying, ‘You shall eat no bread, drink no water, and don’t return by the way that you came.’&#160;” 
 <sup>10&#160;</sup>So he went another way, and didn’t return by the way that he came to Bethel. 
 </p><p>
 <sup>11&#160;</sup>Now an old prophet lived in Bethel, and one of his sons came and told him all the works that the man of Elohim had done that day in Bethel. They also told their father the words which he had spoken to the king. 
@@ -714,26 +714,26 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Then he said to him, “Come home with me and eat bread.” 
 </p><p>
 <sup>16&#160;</sup>He said, “I may not return with you, nor go in with you. I will not eat bread or drink water with you in this place. 
-<sup>17&#160;</sup>For it was said to me by Yahweh’s word, ‘You shall eat no bread or drink water there, and don’t turn again to go by the way that you came.’&#160;” 
+<sup>17&#160;</sup>For it was said to me by Yahuah’s word, ‘You shall eat no bread or drink water there, and don’t turn again to go by the way that you came.’&#160;” 
 </p><p>
-<sup>18&#160;</sup>He said to him, “I also am a prophet as you are; and an angel spoke to me by Yahweh’s word, saying, ‘Bring him back with you into your house, that he may eat bread and drink water.’&#160;” He lied to him. 
+<sup>18&#160;</sup>He said to him, “I also am a prophet as you are; and an angel spoke to me by Yahuah’s word, saying, ‘Bring him back with you into your house, that he may eat bread and drink water.’&#160;” He lied to him. 
 </p><p>
 <sup>19&#160;</sup>So he went back with him, ate bread in his house, and drank water. 
-<sup>20&#160;</sup>As they sat at the table, Yahweh’s word came to the prophet who brought him back; 
-<sup>21&#160;</sup>and he cried out to the man of Elohim who came from Judah, saying, “Yahweh says, ‘Because you have been disobedient to Yahweh’s word, and have not kept the commandment which Yahweh your Elohim commanded you, 
+<sup>20&#160;</sup>As they sat at the table, Yahuah’s word came to the prophet who brought him back; 
+<sup>21&#160;</sup>and he cried out to the man of Elohim who came from Judah, saying, “Yahuah says, ‘Because you have been disobedient to Yahuah’s word, and have not kept the commandment which Yahuah your Elohim commanded you, 
 <sup>22&#160;</sup>but came back, and have eaten bread and drank water in the place of which he said to you, “Eat no bread, and drink no water,” your body will not come to the tomb of your fathers.’&#160;” 
 </p><p>
 <sup>23&#160;</sup>After he had eaten bread and after he drank, he saddled the donkey for the prophet whom he had brought back. 
 <sup>24&#160;</sup>When he had gone, a lion met him by the way and killed him. His body was thrown on the path, and the donkey stood by it. The lion also stood by the body. 
 <sup>25&#160;</sup>Behold, men passed by and saw the body thrown on the path, and the lion standing by the body; and they came and told it in the city where the old prophet lived. 
-<sup>26&#160;</sup>When the prophet who brought him back from the way heard of it, he said, “It is the man of Elohim who was disobedient to Yahweh’s word. Therefore Yahweh has delivered him to the lion, which has mauled him and slain him, according to Yahweh’s word which he spoke to him.” 
+<sup>26&#160;</sup>When the prophet who brought him back from the way heard of it, he said, “It is the man of Elohim who was disobedient to Yahuah’s word. Therefore Yahuah has delivered him to the lion, which has mauled him and slain him, according to Yahuah’s word which he spoke to him.” 
 <sup>27&#160;</sup>He said to his sons, saying, “Saddle the donkey for me,” and they saddled it. 
 <sup>28&#160;</sup>He went and found his body thrown on the path, and the donkey and the lion standing by the body. The lion had not eaten the body nor mauled the donkey. 
 <sup>29&#160;</sup>The prophet took up the body of the man of Elohim, and laid it on the donkey, and brought it back. He came to the city of the old prophet to mourn, and to bury him. 
 <sup>30&#160;</sup>He laid his body in his own grave; and they mourned over him, saying, “Alas, my brother!” 
 </p><p>
 <sup>31&#160;</sup>After he had buried him, he spoke to his sons, saying, “When I am dead, bury me in the tomb in which the man of Elohim is buried. Lay my bones beside his bones. 
-<sup>32&#160;</sup>For the saying which he cried by Yahweh’s word against the altar in Bethel, and against all the houses of the high places which are in the cities of Samaria, will surely happen.” 
+<sup>32&#160;</sup>For the saying which he cried by Yahuah’s word against the altar in Bethel, and against all the houses of the high places which are in the cities of Samaria, will surely happen.” 
 </p><p>
 <sup>33&#160;</sup>After this thing, Jeroboam didn’t turn from his evil way, but again made priests of the high places from among all the people. Whoever wanted to, he consecrated him, that there might be priests of the high places. 
 <sup>34&#160;</sup>This thing became sin to the house of Jeroboam, even to cut it off and to destroy it from off the surface of the earth. 
@@ -744,35 +744,35 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>Take with you ten loaves of bread, some cakes, and a jar of honey, and go to him. He will tell you what will become of the child.” 
 </p><p>
 <sup>4&#160;</sup>Jeroboam’s woman did so, and arose and went to Shiloh, and came to Ahijah’s house. Now Ahijah could not see, for his eyes were set by reason of his age. 
-<sup>5&#160;</sup>Yahweh said to Ahijah, “Behold, Jeroboam’s woman is coming to inquire of you concerning her son, for he is sick. Tell her such and such; for it will be, when she comes in, that she will pretend to be another woman.” 
+<sup>5&#160;</sup>Yahuah said to Ahijah, “Behold, Jeroboam’s woman is coming to inquire of you concerning her son, for he is sick. Tell her such and such; for it will be, when she comes in, that she will pretend to be another woman.” 
 </p><p>
 <sup>6&#160;</sup>So when Ahijah heard the sound of her feet as she came in at the door, he said, “Come in, Jeroboam’s woman! Why do you pretend to be another? For I am sent to you with heavy news. 
-<sup>7&#160;</sup>Go, tell Jeroboam, ‘Yahweh, the Elohim of Israel, says: “Because I exalted you from among the people, and made you prince over my people Israel, 
+<sup>7&#160;</sup>Go, tell Jeroboam, ‘Yahuah, the Elohim of Israel, says: “Because I exalted you from among the people, and made you prince over my people Israel, 
 <sup>8&#160;</sup>and tore the kingdom away from David’s house, and gave it you; and yet you have not been as my servant David, who kept my commandments, and who followed me with all his heart, to do that only which was right in my eyes, 
 <sup>9&#160;</sup>but have done evil above all who were before you, and have gone and made for yourself other elohims, molten images, to provoke me to anger, and have cast me behind your back, 
 <sup>10&#160;</sup>therefore, behold, I will bring evil on the house of Jeroboam, and will cut off from Jeroboam everyone who urinates on a wall, he who is shut up and he who is left at large in Israel, and will utterly sweep away the house of Jeroboam, as a man sweeps away dung until it is all gone. 
-<sup>11&#160;</sup>The dogs will eat he who belongs to Jeroboam who dies in the city; and the birds of the sky will eat he who dies in the field, for Yahweh has spoken it.”&#160;’ 
+<sup>11&#160;</sup>The dogs will eat he who belongs to Jeroboam who dies in the city; and the birds of the sky will eat he who dies in the field, for Yahuah has spoken it.”&#160;’ 
 <sup>12&#160;</sup>Arise therefore, and go to your house. When your feet enter into the city, the child will die. 
-<sup>13&#160;</sup>All Israel will mourn for him and bury him; for he only of Jeroboam will come to the grave, because in him there is found some good thing toward Yahweh, the Elohim of Israel, in the house of Jeroboam. 
-<sup>14&#160;</sup>Moreover Yahweh will raise up a king for himself over Israel who will cut off the house of Jeroboam. This is the day! What? Even now. 
-<sup>15&#160;</sup>For Yahweh will strike Israel, as a reed is shaken in the water; and he will root up Israel out of this good land which he gave to their fathers, and will scatter them beyond the River, because they have made their Asherah poles, provoking Yahweh to anger. 
+<sup>13&#160;</sup>All Israel will mourn for him and bury him; for he only of Jeroboam will come to the grave, because in him there is found some good thing toward Yahuah, the Elohim of Israel, in the house of Jeroboam. 
+<sup>14&#160;</sup>Moreover Yahuah will raise up a king for himself over Israel who will cut off the house of Jeroboam. This is the day! What? Even now. 
+<sup>15&#160;</sup>For Yahuah will strike Israel, as a reed is shaken in the water; and he will root up Israel out of this good land which he gave to their fathers, and will scatter them beyond the River, because they have made their Asherah poles, provoking Yahuah to anger. 
 <sup>16&#160;</sup>He will give Israel up because of the sins of Jeroboam, which he has sinned, and with which he has made Israel to sin.” 
 </p><p>
 <sup>17&#160;</sup>Jeroboam’s woman arose and departed, and came to Tirzah. As she came to the threshold of the house, the child died. 
-<sup>18&#160;</sup>All Israel buried him and mourned for him, according to Yahweh’s word, which he spoke by his servant Ahijah the prophet. 
+<sup>18&#160;</sup>All Israel buried him and mourned for him, according to Yahuah’s word, which he spoke by his servant Ahijah the prophet. 
 </p><p>
 <sup>19&#160;</sup>The rest of the acts of Jeroboam, how he fought and how he reigned, behold, they are written in the book of the chronicles of the kings of Israel. 
 <sup>20&#160;</sup>The days which Jeroboam reigned were twenty two years; then he slept with his fathers, and Nadab his son reigned in his place. 
 </p><p>
-<sup>21&#160;</sup>Rehoboam the son of Solomon reigned in Judah. Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahweh had chosen out of all the tribes of Israel, to put his name there. His mother’s name was Naamah the Ammonitess. 
-<sup>22&#160;</sup>Judah did that which was evil in Yahweh’s sight, and they provoked him to jealousy with their sins which they committed, above all that their fathers had done. 
+<sup>21&#160;</sup>Rehoboam the son of Solomon reigned in Judah. Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahuah had chosen out of all the tribes of Israel, to put his name there. His mother’s name was Naamah the Ammonitess. 
+<sup>22&#160;</sup>Judah did that which was evil in Yahuah’s sight, and they provoked him to jealousy with their sins which they committed, above all that their fathers had done. 
 <sup>23&#160;</sup>For they also built for themselves high places, sacred pillars, and Asherah poles on every high hill and under every green tree. 
-<sup>24&#160;</sup>There were also sodomites in the land. They did according to all the abominations of the nations which Yahweh drove out before the children of Israel. 
+<sup>24&#160;</sup>There were also sodomites in the land. They did according to all the abominations of the nations which Yahuah drove out before the children of Israel. 
 </p><p>
 <sup>25&#160;</sup>In the fifth year of King Rehoboam, Shishak king of Egypt came up against Jerusalem; 
-<sup>26&#160;</sup>and he took away the treasures of Yahweh’s house and the treasures of the king’s house. He even took away all of it, including all the gold shields which Solomon had made. 
+<sup>26&#160;</sup>and he took away the treasures of Yahuah’s house and the treasures of the king’s house. He even took away all of it, including all the gold shields which Solomon had made. 
 <sup>27&#160;</sup>King Rehoboam made shields of bronze in their place, and committed them to the hands of the captains of the guard, who kept the door of the king’s house. 
-<sup>28&#160;</sup>It was so, that as often as the king went into Yahweh’s house, the guard bore them, and brought them back into the guard room. 
+<sup>28&#160;</sup>It was so, that as often as the king went into Yahuah’s house, the guard bore them, and brought them back into the guard room. 
 </p><p>
 <sup>29&#160;</sup>Now the rest of the acts of Rehoboam, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 <sup>30&#160;</sup>There was war between Rehoboam and Jeroboam continually. 
@@ -781,24 +781,24 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Now in the eighteenth year of King Jeroboam the son of Nebat, Abijam began to reign over Judah. 
 <sup>2&#160;</sup>He reigned three years in Jerusalem. His mother’s name was Maacah the daughter of Abishalom. 
-<sup>3&#160;</sup>He walked in all the sins of his father, which he had done before him; and his heart was not perfect with Yahweh his Elohim, as the heart of David his father. 
-<sup>4&#160;</sup>Nevertheless for David’s sake, Yahweh his Elohim gave him a lamp in Jerusalem, to set up his son after him and to establish Jerusalem; 
-<sup>5&#160;</sup>because David did that which was right in Yahweh’s eyes, and didn’t turn away from anything that he commanded him all the days of his life, except only in the matter of Uriah the Hittite. 
+<sup>3&#160;</sup>He walked in all the sins of his father, which he had done before him; and his heart was not perfect with Yahuah his Elohim, as the heart of David his father. 
+<sup>4&#160;</sup>Nevertheless for David’s sake, Yahuah his Elohim gave him a lamp in Jerusalem, to set up his son after him and to establish Jerusalem; 
+<sup>5&#160;</sup>because David did that which was right in Yahuah’s eyes, and didn’t turn away from anything that he commanded him all the days of his life, except only in the matter of Uriah the Hittite. 
 <sup>6&#160;</sup>Now there was war between Rehoboam and Jeroboam all the days of his life. 
 <sup>7&#160;</sup>The rest of the acts of Abijam, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? There was war between Abijam and Jeroboam. 
 <sup>8&#160;</sup>Abijam slept with his fathers, and they buried him in David’s city; and Asa his son reigned in his place. 
 </p><p>
 <sup>9&#160;</sup>In the twentieth year of Jeroboam king of Israel, Asa began to reign over Judah. 
 <sup>10&#160;</sup>He reigned forty-one years in Jerusalem. His mother’s name was Maacah the daughter of Abishalom. 
-<sup>11&#160;</sup>Asa did that which was right in Yahweh’s eyes, as David his father did. 
+<sup>11&#160;</sup>Asa did that which was right in Yahuah’s eyes, as David his father did. 
 <sup>12&#160;</sup>He put away the sodomites out of the land, and removed all the idols that his fathers had made. 
 <sup>13&#160;</sup>He also removed Maacah his mother from being queen, because she had made an abominable image for an Asherah. Asa cut down her image and burned it at the brook Kidron. 
-<sup>14&#160;</sup>But the high places were not taken away. Nevertheless the heart of Asa was perfect with Yahweh all his days. 
-<sup>15&#160;</sup>He brought into Yahweh’s house the things that his father had dedicated, and the things that he himself had dedicated: silver, gold, and utensils. 
+<sup>14&#160;</sup>But the high places were not taken away. Nevertheless the heart of Asa was perfect with Yahuah all his days. 
+<sup>15&#160;</sup>He brought into Yahuah’s house the things that his father had dedicated, and the things that he himself had dedicated: silver, gold, and utensils. 
 </p><p>
 <sup>16&#160;</sup>There was war between Asa and Baasha king of Israel all their days. 
 <sup>17&#160;</sup>Baasha king of Israel went up against Judah, and built Ramah, that he might not allow anyone to go out or come in to Asa king of Judah. 
-<sup>18&#160;</sup>Then Asa took all the silver and the gold that was left in the treasures of Yahweh’s house, and the treasures of the king’s house, and delivered it into the hand of his servants. Then King Asa sent them to Ben Hadad, the son of Tabrimmon, the son of Hezion, king of Syria, who lived at Damascus, saying, 
+<sup>18&#160;</sup>Then Asa took all the silver and the gold that was left in the treasures of Yahuah’s house, and the treasures of the king’s house, and delivered it into the hand of his servants. Then King Asa sent them to Ben Hadad, the son of Tabrimmon, the son of Hezion, king of Syria, who lived at Damascus, saying, 
 <sup>19&#160;</sup>“Let there be a treaty between me and you, like that between my father and your father. Behold, I have sent to you a present of silver and gold. Go, break your treaty with Baasha king of Israel, that he may depart from me.” 
 </p><p>
 <sup>20&#160;</sup>Ben Hadad listened to King Asa, and sent the captains of his armies against the cities of Israel, and struck Ijon, and Dan, and Abel Beth Maacah, and all Chinneroth, with all the land of Naphtali. 
@@ -808,20 +808,20 @@ html[dir=ltr] .q2 {
 <sup>24&#160;</sup>Asa slept with his fathers, and was buried with his fathers in his father David’s city; and Jehoshaphat his son reigned in his place. 
 </p><p>
 <sup>25&#160;</sup>Nadab the son of Jeroboam began to reign over Israel in the second year of Asa king of Judah; and he reigned over Israel two years. 
-<sup>26&#160;</sup>He did that which was evil in Yahweh’s sight, and walked in the way of his father, and in his sin with which he made Israel to sin. 
+<sup>26&#160;</sup>He did that which was evil in Yahuah’s sight, and walked in the way of his father, and in his sin with which he made Israel to sin. 
 <sup>27&#160;</sup>Baasha the son of Ahijah, of the house of Issachar, conspired against him; and Baasha struck him at Gibbethon, which belonged to the Philistines; for Nadab and all Israel were besieging Gibbethon. 
 <sup>28&#160;</sup>Even in the third year of Asa king of Judah, Baasha killed him and reigned in his place. 
-<sup>29&#160;</sup>As soon as he was king, he struck all the house of Jeroboam. He didn’t leave to Jeroboam any who breathed, until he had destroyed him, according to the saying of Yahweh, which he spoke by his servant Ahijah the Shilonite; 
-<sup>30&#160;</sup>for the sins of Jeroboam which he sinned, and with which he made Israel to sin, because of his provocation with which he provoked Yahweh, the Elohim of Israel, to anger. 
+<sup>29&#160;</sup>As soon as he was king, he struck all the house of Jeroboam. He didn’t leave to Jeroboam any who breathed, until he had destroyed him, according to the saying of Yahuah, which he spoke by his servant Ahijah the Shilonite; 
+<sup>30&#160;</sup>for the sins of Jeroboam which he sinned, and with which he made Israel to sin, because of his provocation with which he provoked Yahuah, the Elohim of Israel, to anger. 
 </p><p>
 <sup>31&#160;</sup>Now the rest of the acts of Nadab, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
 <sup>32&#160;</sup>There was war between Asa and Baasha king of Israel all their days. 
 </p><p>
 <sup>33&#160;</sup>In the third year of Asa king of Judah, Baasha the son of Ahijah began to reign over all Israel in Tirzah for twenty-four years. 
-<sup>34&#160;</sup>He did that which was evil in Yahweh’s sight, and walked in the way of Jeroboam, and in his sin with which he made Israel to sin. 
+<sup>34&#160;</sup>He did that which was evil in Yahuah’s sight, and walked in the way of Jeroboam, and in his sin with which he made Israel to sin. 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to Jehu the son of Hanani against Baasha, saying, 
+<sup>1&#160;</sup>Yahuah’s word came to Jehu the son of Hanani against Baasha, saying, 
 <sup>2&#160;</sup>“Because I exalted you out of the dust and made you prince over my people Israel, and you have walked in the way of Jeroboam and have made my people Israel to sin, to provoke me to anger with their sins, 
 <sup>3&#160;</sup>behold, I will utterly sweep away Baasha and his house; and I will make your house like the house of Jeroboam the son of Nebat. 
 <sup>4&#160;</sup>The dogs will eat Baasha’s descendants who die in the city; and he who dies of his in the field, the birds of the sky will eat.” 
@@ -829,84 +829,84 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>Now the rest of the acts of Baasha, and what he did, and his might, aren’t they written in the book of the chronicles of the kings of Israel? 
 <sup>6&#160;</sup>Baasha slept with his fathers, and was buried in Tirzah; and Elah his son reigned in his place. 
 </p><p>
-<sup>7&#160;</sup>Moreover Yahweh’s word came by the prophet Jehu the son of Hanani against Baasha and against his house, both because of all the evil that he did in Yahweh’s sight, to provoke him to anger with the work of his hands, in being like the house of Jeroboam, and because he struck him. 
+<sup>7&#160;</sup>Moreover Yahuah’s word came by the prophet Jehu the son of Hanani against Baasha and against his house, both because of all the evil that he did in Yahuah’s sight, to provoke him to anger with the work of his hands, in being like the house of Jeroboam, and because he struck him. 
 </p><p>
 <sup>8&#160;</sup>In the twenty-sixth year of Asa king of Judah, Elah the son of Baasha began to reign over Israel in Tirzah for two years. 
 <sup>9&#160;</sup>His servant Zimri, captain of half his chariots, conspired against him. Now he was in Tirzah, drinking himself drunk in the house of Arza, who was over the household in Tirzah; 
 <sup>10&#160;</sup>and Zimri went in and struck him and killed him in the twenty-seventh year of Asa king of Judah, and reigned in his place. 
 </p><p>
 <sup>11&#160;</sup>When he began to reign, as soon as he sat on his throne, he attacked all the house of Baasha. He didn’t leave him a single one who urinates on a wall among his relatives or his friends. 
-<sup>12&#160;</sup>Thus Zimri destroyed all the house of Baasha, according to Yahweh’s word which he spoke against Baasha by Jehu the prophet, 
-<sup>13&#160;</sup>for all the sins of Baasha, and the sins of Elah his son, which they sinned and with which they made Israel to sin, to provoke Yahweh, the Elohim of Israel, to anger with their vanities. 
+<sup>12&#160;</sup>Thus Zimri destroyed all the house of Baasha, according to Yahuah’s word which he spoke against Baasha by Jehu the prophet, 
+<sup>13&#160;</sup>for all the sins of Baasha, and the sins of Elah his son, which they sinned and with which they made Israel to sin, to provoke Yahuah, the Elohim of Israel, to anger with their vanities. 
 <sup>14&#160;</sup>Now the rest of the acts of Elah, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
 </p><p>
 <sup>15&#160;</sup>In the twenty-seventh year of Asa king of Judah, Zimri reigned seven days in Tirzah. Now the people were encamped against Gibbethon, which belonged to the Philistines. 
 <sup>16&#160;</sup>The people who were encamped heard that Zimri had conspired, and had also killed the king. Therefore all Israel made Omri, the captain of the army, king over Israel that day in the camp. 
 <sup>17&#160;</sup>Omri went up from Gibbethon, and all Israel with him, and they besieged Tirzah. 
 <sup>18&#160;</sup>When Zimri saw that the city was taken, he went into the fortified part of the king’s house and burned the king’s house over him with fire, and died, 
-<sup>19&#160;</sup>for his sins which he sinned in doing that which was evil in Yahweh’s sight, in walking in the way of Jeroboam, and in his sin which he did to make Israel to sin. 
+<sup>19&#160;</sup>for his sins which he sinned in doing that which was evil in Yahuah’s sight, in walking in the way of Jeroboam, and in his sin which he did to make Israel to sin. 
 <sup>20&#160;</sup>Now the rest of the acts of Zimri, and his treason that he committed, aren’t they written in the book of the chronicles of the kings of Israel? 
 </p><p>
 <sup>21&#160;</sup>Then the people of Israel were divided into two parts: half of the people followed Tibni the son of Ginath, to make him king, and half followed Omri. 
 <sup>22&#160;</sup>But the people who followed Omri prevailed against the people who followed Tibni the son of Ginath; so Tibni died, and Omri reigned. 
 <sup>23&#160;</sup>In the thirty-first year of Asa king of Judah, Omri began to reign over Israel for twelve years. He reigned six years in Tirzah. 
 <sup>24&#160;</sup>He bought the hill Samaria of Shemer for two talents of silver; and he built on the hill, and called the name of the city which he built, Samaria, after the name of Shemer, the owner of the hill. 
-<sup>25&#160;</sup>Omri did that which was evil in Yahweh’s sight, and dealt wickedly above all who were before him. 
-<sup>26&#160;</sup>For he walked in all the way of Jeroboam the son of Nebat, and in his sins with which he made Israel to sin, to provoke Yahweh, the Elohim of Israel, to anger with their vanities. 
+<sup>25&#160;</sup>Omri did that which was evil in Yahuah’s sight, and dealt wickedly above all who were before him. 
+<sup>26&#160;</sup>For he walked in all the way of Jeroboam the son of Nebat, and in his sins with which he made Israel to sin, to provoke Yahuah, the Elohim of Israel, to anger with their vanities. 
 <sup>27&#160;</sup>Now the rest of the acts of Omri which he did, and his might that he showed, aren’t they written in the book of the chronicles of the kings of Israel? 
 <sup>28&#160;</sup>So Omri slept with his fathers, and was buried in Samaria; and Ahab his son reigned in his place. 
 </p><p>
 <sup>29&#160;</sup>In the thirty-eighth year of Asa king of Judah, Ahab the son of Omri began to reign over Israel. Ahab the son of Omri reigned over Israel in Samaria twenty-two years. 
-<sup>30&#160;</sup>Ahab the son of Omri did that which was evil in Yahweh’s sight above all that were before him. 
+<sup>30&#160;</sup>Ahab the son of Omri did that which was evil in Yahuah’s sight above all that were before him. 
 <sup>31&#160;</sup>As if it had been a light thing for him to walk in the sins of Jeroboam the son of Nebat, he took as woman Jezebel the daughter of Ethbaal king of the Sidonians, and went and served Baal and worshiped him. 
 <sup>32&#160;</sup>He raised up an altar for Baal in the house of Baal, which he had built in Samaria. 
-<sup>33&#160;</sup>Ahab made the Asherah; and Ahab did more yet to provoke Yahweh, the Elohim of Israel, to anger than all the kings of Israel who were before him. 
-<sup>34&#160;</sup>In his days Hiel the Bethelite built Jericho. He laid its foundation with the loss of Abiram his firstborn, and set up its gates with the loss of his youngest son Segub, according to Yahweh’s word, which he spoke by Joshua the son of Nun. 
+<sup>33&#160;</sup>Ahab made the Asherah; and Ahab did more yet to provoke Yahuah, the Elohim of Israel, to anger than all the kings of Israel who were before him. 
+<sup>34&#160;</sup>In his days Hiel the Bethelite built Jericho. He laid its foundation with the loss of Abiram his firstborn, and set up its gates with the loss of his youngest son Segub, according to Yahuah’s word, which he spoke by Joshua the son of Nun. 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
-<sup>1&#160;</sup>Elijah the Tishbite, who was one of the settlers of Gilead, said to Ahab, “As Yahweh, the Elohim of Israel, lives, before whom I stand, there shall not be dew nor rain these years, but according to my word.” 
+<sup>1&#160;</sup>Elijah the Tishbite, who was one of the settlers of Gilead, said to Ahab, “As Yahuah, the Elohim of Israel, lives, before whom I stand, there shall not be dew nor rain these years, but according to my word.” 
 </p><p>
-<sup>2&#160;</sup>Then Yahweh’s word came to him, saying, 
+<sup>2&#160;</sup>Then Yahuah’s word came to him, saying, 
 <sup>3&#160;</sup>“Go away from here, turn eastward, and hide yourself by the brook Cherith, that is before the Jordan. 
 <sup>4&#160;</sup>You shall drink from the brook. I have commanded the ravens to feed you there.” 
-<sup>5&#160;</sup>So he went and did according to Yahweh’s word, for he went and lived by the brook Cherith that is before the Jordan. 
+<sup>5&#160;</sup>So he went and did according to Yahuah’s word, for he went and lived by the brook Cherith that is before the Jordan. 
 <sup>6&#160;</sup>The ravens brought him bread and meat in the morning, and bread and meat in the evening; and he drank from the brook. 
 <sup>7&#160;</sup>After a while, the brook dried up, because there was no rain in the land. 
 </p><p>
-<sup>8&#160;</sup>Yahweh’s word came to him, saying, 
+<sup>8&#160;</sup>Yahuah’s word came to him, saying, 
 <sup>9&#160;</sup>“Arise, go to Zarephath, which belongs to Sidon, and stay there. Behold, I have commanded a widow there to sustain you.” 
 </p><p>
 <sup>10&#160;</sup>So he arose and went to Zarephath; and when he came to the gate of the city, behold, a widow was there gathering sticks. He called to her and said, “Please get me a little water in a jar, that I may drink.” 
 </p><p>
 <sup>11&#160;</sup>As she was going to get it, he called to her and said, “Please bring me a morsel of bread in your hand.” 
 </p><p>
-<sup>12&#160;</sup>She said, “As Yahweh your Elohim lives, I don’t have anything baked, but only a handful of meal in a jar and a little oil in a jar. Behold, I am gathering two sticks, that I may go in and bake it for me and my son, that we may eat it, and die.” 
+<sup>12&#160;</sup>She said, “As Yahuah your Elohim lives, I don’t have anything baked, but only a handful of meal in a jar and a little oil in a jar. Behold, I am gathering two sticks, that I may go in and bake it for me and my son, that we may eat it, and die.” 
 </p><p>
 <sup>13&#160;</sup>Elijah said to her, “Don’t be afraid. Go and do as you have said; but make me a little cake from it first, and bring it out to me, and afterward make some for you and for your son. 
-<sup>14&#160;</sup>For Yahweh, the Elohim of Israel, says, ‘The jar of meal will not run out, and the jar of oil will not fail, until the day that Yahweh sends rain on the earth.’&#160;” 
+<sup>14&#160;</sup>For Yahuah, the Elohim of Israel, says, ‘The jar of meal will not run out, and the jar of oil will not fail, until the day that Yahuah sends rain on the earth.’&#160;” 
 </p><p>
 <sup>15&#160;</sup>She went and did according to the saying of Elijah; and she, he, and her household ate many days. 
-<sup>16&#160;</sup>The jar of meal didn’t run out and the jar of oil didn’t fail, according to Yahweh’s word, which he spoke by Elijah. 
+<sup>16&#160;</sup>The jar of meal didn’t run out and the jar of oil didn’t fail, according to Yahuah’s word, which he spoke by Elijah. 
 </p><p>
 <sup>17&#160;</sup>After these things, the son of the woman, the mistress of the house, became sick; and his sickness was so severe that there was no breath left in him. 
 <sup>18&#160;</sup>She said to Elijah, “What have I to do with you, you man of Elohim? You have come to me to bring my sin to memory, and to kill my son!” 
 </p><p>
 <sup>19&#160;</sup>He said to her, “Give me your son.” He took him out of her bosom, and carried him up into the room where he stayed, and laid him on his own bed. 
-<sup>20&#160;</sup>He cried to Yahweh and said, “Yahweh my Elohim, have you also brought evil on the widow with whom I am staying, by killing her son?” 
+<sup>20&#160;</sup>He cried to Yahuah and said, “Yahuah my Elohim, have you also brought evil on the widow with whom I am staying, by killing her son?” 
 </p><p>
-<sup>21&#160;</sup>He stretched himself on the child three times, and cried to Yahweh and said, “Yahweh my Elohim, please let this child’s soul come into him again.” 
+<sup>21&#160;</sup>He stretched himself on the child three times, and cried to Yahuah and said, “Yahuah my Elohim, please let this child’s soul come into him again.” 
 </p><p>
-<sup>22&#160;</sup>Yahweh listened to the voice of Elijah; and the soul of the child came into him again, and he revived. 
+<sup>22&#160;</sup>Yahuah listened to the voice of Elijah; and the soul of the child came into him again, and he revived. 
 <sup>23&#160;</sup>Elijah took the child and brought him down out of the room into the house, and delivered him to his mother; and Elijah said, “Behold, your son lives.” 
 </p><p>
-<sup>24&#160;</sup>The woman said to Elijah, “Now I know that you are a man of Elohim, and that Yahweh’s word in your mouth is truth.” 
+<sup>24&#160;</sup>The woman said to Elijah, “Now I know that you are a man of Elohim, and that Yahuah’s word in your mouth is truth.” 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
-<sup>1&#160;</sup>After many days, Yahweh’s word came to Elijah, in the third year, saying, “Go, show yourself to Ahab; and I will send rain on the earth.” 
+<sup>1&#160;</sup>After many days, Yahuah’s word came to Elijah, in the third year, saying, “Go, show yourself to Ahab; and I will send rain on the earth.” 
 </p><p>
 <sup>2&#160;</sup>Elijah went to show himself to Ahab. The famine was severe in Samaria. 
-<sup>3&#160;</sup>Ahab called Obadiah, who was over the household. (Now Obadiah feared Yahweh greatly; 
-<sup>4&#160;</sup>for when Jezebel cut off Yahweh’s prophets, Obadiah took one hundred prophets, and hid them fifty to a cave, and fed them with bread and water.) 
+<sup>3&#160;</sup>Ahab called Obadiah, who was over the household. (Now Obadiah feared Yahuah greatly; 
+<sup>4&#160;</sup>for when Jezebel cut off Yahuah’s prophets, Obadiah took one hundred prophets, and hid them fifty to a cave, and fed them with bread and water.) 
 <sup>5&#160;</sup>Ahab said to Obadiah, “Go through the land, to all the springs of water, and to all the brooks. Perhaps we may find grass and save the horses and mules alive, that we not lose all the animals.” 
 </p><p>
 <sup>6&#160;</sup>So they divided the land between them to pass throughout it. Ahab went one way by himself, and Obadiah went another way by himself. 
@@ -915,27 +915,27 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>He answered him, “It is I. Go, tell your lord, ‘Behold, Elijah is here!’&#160;” 
 </p><p>
 <sup>9&#160;</sup>He said, “How have I sinned, that you would deliver your servant into the hand of Ahab, to kill me? 
-<sup>10&#160;</sup>As Yahweh your Elohim lives, there is no nation or kingdom where my lord has not sent to seek you. When they said, ‘He is not here,’ he took an oath of the kingdom and nation that they didn’t find you. 
+<sup>10&#160;</sup>As Yahuah your Elohim lives, there is no nation or kingdom where my lord has not sent to seek you. When they said, ‘He is not here,’ he took an oath of the kingdom and nation that they didn’t find you. 
 <sup>11&#160;</sup>Now you say, ‘Go, tell your lord, “Behold, Elijah is here.”&#160;’ 
-<sup>12&#160;</sup>It will happen, as soon as I leave you, that Yahweh’s Spirit will carry you I don’t know where; and so when I come and tell Ahab, and he can’t find you, he will kill me. But I, your servant, have feared Yahweh from my youth. 
-<sup>13&#160;</sup>Wasn’t it told my lord what I did when Jezebel killed Yahweh’s prophets, how I hid one hundred men of Yahweh’s prophets with fifty to a cave, and fed them with bread and water? 
+<sup>12&#160;</sup>It will happen, as soon as I leave you, that Yahuah’s Spirit will carry you I don’t know where; and so when I come and tell Ahab, and he can’t find you, he will kill me. But I, your servant, have feared Yahuah from my youth. 
+<sup>13&#160;</sup>Wasn’t it told my lord what I did when Jezebel killed Yahuah’s prophets, how I hid one hundred men of Yahuah’s prophets with fifty to a cave, and fed them with bread and water? 
 <sup>14&#160;</sup>Now you say, ‘Go, tell your lord, “Behold, Elijah is here”.’ He will kill me.” 
 </p><p>
-<sup>15&#160;</sup>Elijah said, “As Yahweh of Armies lives, before whom I stand, I will surely show myself to him today.” 
+<sup>15&#160;</sup>Elijah said, “As Yahuah of Armies lives, before whom I stand, I will surely show myself to him today.” 
 <sup>16&#160;</sup>So Obadiah went to meet Ahab, and told him; and Ahab went to meet Elijah. 
 </p><p>
 <sup>17&#160;</sup>When Ahab saw Elijah, Ahab said to him, “Is that you, you troubler of Israel?” 
 </p><p>
-<sup>18&#160;</sup>He answered, “I have not troubled Israel, but you and your father’s house, in that you have forsaken Yahweh’s commandments and you have followed the Baals. 
+<sup>18&#160;</sup>He answered, “I have not troubled Israel, but you and your father’s house, in that you have forsaken Yahuah’s commandments and you have followed the Baals. 
 <sup>19&#160;</sup>Now therefore send, and gather to me all Israel to Mount Carmel, and four hundred fifty of the prophets of Baal, and four hundred of the prophets of the Asherah, who eat at Jezebel’s table.” 
 </p><p>
 <sup>20&#160;</sup>So Ahab sent to all the children of Israel, and gathered the prophets together to Mount Carmel. 
-<sup>21&#160;</sup>Elijah came near to all the people, and said, “How long will you waver between the two sides? If Yahweh is Elohim, follow him; but if Baal, then follow him.” 
+<sup>21&#160;</sup>Elijah came near to all the people, and said, “How long will you waver between the two sides? If Yahuah is Elohim, follow him; but if Baal, then follow him.” 
 </p><p>The people didn’t say a word. 
 </p><p>
-<sup>22&#160;</sup>Then Elijah said to the people, “I, even I only, am left as a prophet of Yahweh; but Baal’s prophets are four hundred fifty men. 
+<sup>22&#160;</sup>Then Elijah said to the people, “I, even I only, am left as a prophet of Yahuah; but Baal’s prophets are four hundred fifty men. 
 <sup>23&#160;</sup>Let them therefore give us two bulls; and let them choose one bull for themselves, and cut it in pieces, and lay it on the wood, and put no fire under; and I will dress the other bull, and lay it on the wood, and put no fire under it. 
-<sup>24&#160;</sup>You call on the name of your elohim, and I will call on Yahweh’s name. The Elohim who answers by fire, let him be Elohim.” 
+<sup>24&#160;</sup>You call on the name of your elohim, and I will call on Yahuah’s name. The Elohim who answers by fire, let him be Elohim.” 
 </p><p>All the people answered, “What you say is good.” 
 </p><p>
 <sup>25&#160;</sup>Elijah said to the prophets of Baal, “Choose one bull for yourselves, and dress it first, for you are many; and call on the name of your elohim, but put no fire under it.” 
@@ -947,18 +947,18 @@ html[dir=ltr] .q2 {
 <sup>28&#160;</sup>They cried aloud, and cut themselves in their way with knives and lances until the blood gushed out on them. 
 <sup>29&#160;</sup>When midday was past, they prophesied until the time of the evening offering; but there was no voice, no answer, and nobody paid attention. 
 </p><p>
-<sup>30&#160;</sup>Elijah said to all the people, “Come near to me!”; and all the people came near to him. He repaired Yahweh’s altar that had been thrown down. 
-<sup>31&#160;</sup>Elijah took twelve stones, according to the number of the tribes of the sons of Jacob, to whom Yahweh’s word came, saying, “Israel shall be your name.” 
-<sup>32&#160;</sup>With the stones he built an altar in Yahweh’s name. He made a trench around the altar large enough to contain two seahs of seed. 
+<sup>30&#160;</sup>Elijah said to all the people, “Come near to me!”; and all the people came near to him. He repaired Yahuah’s altar that had been thrown down. 
+<sup>31&#160;</sup>Elijah took twelve stones, according to the number of the tribes of the sons of Jacob, to whom Yahuah’s word came, saying, “Israel shall be your name.” 
+<sup>32&#160;</sup>With the stones he built an altar in Yahuah’s name. He made a trench around the altar large enough to contain two seahs of seed. 
 <sup>33&#160;</sup>He put the wood in order, and cut the bull in pieces and laid it on the wood. He said, “Fill four jars with water, and pour it on the burnt offering and on the wood.” 
 <sup>34&#160;</sup>He said, “Do it a second time;” and they did it the second time. He said, “Do it a third time;” and they did it the third time. 
 <sup>35&#160;</sup>The water ran around the altar; and he also filled the trench with water. 
 </p><p>
-<sup>36&#160;</sup>At the time of the evening offering, Elijah the prophet came near and said, “Yahweh, the Elohim of Abraham, of Isaac, and of Israel, let it be known today that you are Elohim in Israel and that I am your servant, and that I have done all these things at your word. 
-<sup>37&#160;</sup>Hear me, Yahweh, hear me, that this people may know that you, Yahweh, are Elohim, and that you have turned their heart back again.” 
+<sup>36&#160;</sup>At the time of the evening offering, Elijah the prophet came near and said, “Yahuah, the Elohim of Abraham, of Isaac, and of Israel, let it be known today that you are Elohim in Israel and that I am your servant, and that I have done all these things at your word. 
+<sup>37&#160;</sup>Hear me, Yahuah, hear me, that this people may know that you, Yahuah, are Elohim, and that you have turned their heart back again.” 
 </p><p>
-<sup>38&#160;</sup>Then Yahweh’s fire fell and consumed the burnt offering, the wood, the stones, and the dust; and it licked up the water that was in the trench. 
-<sup>39&#160;</sup>When all the people saw it, they fell on their faces. They said, “Yahweh, he is Elohim! Yahweh, he is Elohim!” 
+<sup>38&#160;</sup>Then Yahuah’s fire fell and consumed the burnt offering, the wood, the stones, and the dust; and it licked up the water that was in the trench. 
+<sup>39&#160;</sup>When all the people saw it, they fell on their faces. They said, “Yahuah, he is Elohim! Yahuah, he is Elohim!” 
 </p><p>
 <sup>40&#160;</sup>Elijah said to them, “Seize the prophets of Baal! Don’t let one of them escape!” 
 </p><p>They seized them; and Elijah brought them down to the brook Kishon, and killed them there. 
@@ -974,33 +974,33 @@ html[dir=ltr] .q2 {
 </p><p>He said, “Go up, tell Ahab, ‘Get ready and go down, so that the rain doesn’t stop you.’&#160;” 
 </p><p>
 <sup>45&#160;</sup>In a little while, the sky grew black with clouds and wind, and there was a great rain. Ahab rode, and went to Jezreel. 
-<sup>46&#160;</sup>Yahweh’s hand was on Elijah; and he tucked his cloak into his belt and ran before Ahab to the entrance of Jezreel. 
+<sup>46&#160;</sup>Yahuah’s hand was on Elijah; and he tucked his cloak into his belt and ran before Ahab to the entrance of Jezreel. 
 </p><h2 class="chapterlabel" id="19">19</h2>
 <p>
 <sup>1&#160;</sup>Ahab told Jezebel all that Elijah had done, and how he had killed all the prophets with the sword. 
 <sup>2&#160;</sup>Then Jezebel sent a messenger to Elijah, saying, “So let the elohims do to me, and more also, if I don’t make your life as the life of one of them by tomorrow about this time!” 
 </p><p>
 <sup>3&#160;</sup>When he saw that, he arose and ran for his life, and came to Beersheba, which belongs to Judah, and left his servant there. 
-<sup>4&#160;</sup>But he himself went a day’s journey into the wilderness, and came and sat down under a juniper tree. Then he requested for himself that he might die, and said, “It is enough. Now, O Yahweh, take away my life; for I am not better than my fathers.” 
+<sup>4&#160;</sup>But he himself went a day’s journey into the wilderness, and came and sat down under a juniper tree. Then he requested for himself that he might die, and said, “It is enough. Now, O Yahuah, take away my life; for I am not better than my fathers.” 
 </p><p>
 <sup>5&#160;</sup>He lay down and slept under a juniper tree; and behold, an angel touched him, and said to him, “Arise and eat!” 
 </p><p>
 <sup>6&#160;</sup>He looked, and behold, there was at his head a cake baked on the coals, and a jar of water. He ate and drank, and lay down again. 
-<sup>7&#160;</sup>Yahweh’s angel came again the second time, and touched him, and said, “Arise and eat, because the journey is too great for you.” 
+<sup>7&#160;</sup>Yahuah’s angel came again the second time, and touched him, and said, “Arise and eat, because the journey is too great for you.” 
 </p><p>
 <sup>8&#160;</sup>He arose, and ate and drank, and went in the strength of that food forty days and forty nights to Horeb, Elohim’s Mountain. 
-<sup>9&#160;</sup>He came to a cave there, and camped there; and behold, Yahweh’s word came to him, and he said to him, “What are you doing here, Elijah?” 
+<sup>9&#160;</sup>He came to a cave there, and camped there; and behold, Yahuah’s word came to him, and he said to him, “What are you doing here, Elijah?” 
 </p><p>
-<sup>10&#160;</sup>He said, “I have been very jealous for Yahweh, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
+<sup>10&#160;</sup>He said, “I have been very jealous for Yahuah, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
 </p><p>
-<sup>11&#160;</sup>He said, “Go out and stand on the mountain before Yahweh.” 
-</p><p>Behold, Yahweh passed by, and a great and strong wind tore the mountains and broke in pieces the rocks before Yahweh; but Yahweh was not in the wind. After the wind there was an earthquake; but Yahweh was not in the earthquake. 
-<sup>12&#160;</sup>After the earthquake a fire passed; but Yahweh was not in the fire. After the fire, there was a still small voice. 
+<sup>11&#160;</sup>He said, “Go out and stand on the mountain before Yahuah.” 
+</p><p>Behold, Yahuah passed by, and a great and strong wind tore the mountains and broke in pieces the rocks before Yahuah; but Yahuah was not in the wind. After the wind there was an earthquake; but Yahuah was not in the earthquake. 
+<sup>12&#160;</sup>After the earthquake a fire passed; but Yahuah was not in the fire. After the fire, there was a still small voice. 
 <sup>13&#160;</sup>When Elijah heard it, he wrapped his face in his mantle, went out, and stood in the entrance of the cave. Behold, a voice came to him, and said, “What are you doing here, Elijah?” 
 </p><p>
-<sup>14&#160;</sup>He said, “I have been very jealous for Yahweh, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
+<sup>14&#160;</sup>He said, “I have been very jealous for Yahuah, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
 </p><p>
-<sup>15&#160;</sup>Yahweh said to him, “Go, return on your way to the wilderness of Damascus. When you arrive, anoint Hazael to be king over Syria. 
+<sup>15&#160;</sup>Yahuah said to him, “Go, return on your way to the wilderness of Damascus. When you arrive, anoint Hazael to be king over Syria. 
 <sup>16&#160;</sup>Anoint Jehu the son of Nimshi to be king over Israel; and anoint Elisha the son of Shaphat of Abel Meholah to be prophet in your place. 
 <sup>17&#160;</sup>He who escapes from the sword of Hazael, Jehu will kill; and he who escapes from the sword of Jehu, Elisha will kill. 
 <sup>18&#160;</sup>Yet I reserved seven thousand in Israel, all the knees of which have not bowed to Baal, and every mouth which has not kissed him.” 
@@ -1033,10 +1033,10 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>12&#160;</sup>When Ben Hadad heard this message as he was drinking, he and the kings in the pavilions, he said to his servants, “Prepare to attack!” So they prepared to attack the city. 
 </p><p>
-<sup>13&#160;</sup>Behold, a prophet came near to Ahab king of Israel, and said, “Yahweh says, ‘Have you seen all this great multitude? Behold, I will deliver it into your hand today. Then you will know that I am Yahweh.’&#160;” 
+<sup>13&#160;</sup>Behold, a prophet came near to Ahab king of Israel, and said, “Yahuah says, ‘Have you seen all this great multitude? Behold, I will deliver it into your hand today. Then you will know that I am Yahuah.’&#160;” 
 </p><p>
 <sup>14&#160;</sup>Ahab said, “By whom?” 
-</p><p>He said, “Yahweh says, ‘By the young men of the princes of the provinces.’&#160;” 
+</p><p>He said, “Yahuah says, ‘By the young men of the princes of the provinces.’&#160;” 
 </p><p>Then he said, “Who shall begin the battle?” 
 </p><p>He answered, “You.” 
 </p><p>
@@ -1057,7 +1057,7 @@ html[dir=ltr] .q2 {
 </p><p>He listened to their voice and did so. 
 <sup>26&#160;</sup>At the return of the year, Ben Hadad mustered the Syrians and went up to Aphek to fight against Israel. 
 <sup>27&#160;</sup>The children of Israel were mustered and given provisions, and went against them. The children of Israel encamped before them like two little flocks of young goats, but the Syrians filled the country. 
-<sup>28&#160;</sup>A man of Elohim came near and spoke to the king of Israel, and said, “Yahweh says, ‘Because the Syrians have said, “Yahweh is an elohim of the hills, but he is not an elohim of the valleys,” therefore I will deliver all this great multitude into your hand, and you shall know that I am Yahweh.’&#160;” 
+<sup>28&#160;</sup>A man of Elohim came near and spoke to the king of Israel, and said, “Yahuah says, ‘Because the Syrians have said, “Yahuah is an elohim of the hills, but he is not an elohim of the valleys,” therefore I will deliver all this great multitude into your hand, and you shall know that I am Yahuah.’&#160;” 
 </p><p>
 <sup>29&#160;</sup>They encamped opposite each other for seven days. Then on the seventh day the battle was joined; and the children of Israel killed one hundred thousand footmen of the Syrians in one day. 
 <sup>30&#160;</sup>But the rest fled to Aphek, into the city; and the wall fell on twenty-seven thousand men who were left. Ben Hadad fled and came into the city, into an inner room. 
@@ -1072,9 +1072,9 @@ html[dir=ltr] .q2 {
 <sup>34&#160;</sup>Ben Hadad said to him, “The cities which my father took from your father I will restore. You shall make streets for yourself in Damascus, as my father made in Samaria.” 
 </p><p>“I”, said Ahab, “will let you go with this covenant.” So he made a covenant with him and let him go. 
 </p><p>
-<sup>35&#160;</sup>A certain man of the sons of the prophets said to his fellow by Yahweh’s word, “Please strike me!” 
+<sup>35&#160;</sup>A certain man of the sons of the prophets said to his fellow by Yahuah’s word, “Please strike me!” 
 </p><p>The man refused to strike him. 
-<sup>36&#160;</sup>Then he said to him, “Because you have not obeyed Yahweh’s voice, behold, as soon as you have departed from me, a lion will kill you.” As soon as he had departed from him, a lion found him and killed him. 
+<sup>36&#160;</sup>Then he said to him, “Because you have not obeyed Yahuah’s voice, behold, as soon as you have departed from me, a lion will kill you.” As soon as he had departed from him, a lion found him and killed him. 
 </p><p>
 <sup>37&#160;</sup>Then he found another man, and said, “Please strike me.” 
 </p><p>The man struck him and wounded him. 
@@ -1084,7 +1084,7 @@ html[dir=ltr] .q2 {
 </p><p>The king of Israel said to him, “So shall your judgment be. You yourself have decided it.” 
 </p><p>
 <sup>41&#160;</sup>He hurried, and took the headband away from his eyes; and the king of Israel recognized that he was one of the prophets. 
-<sup>42&#160;</sup>He said to him, “Yahweh says, ‘Because you have let go out of your hand the man whom I had devoted to destruction, therefore your life will take the place of his life, and your people take the place of his people.’&#160;” 
+<sup>42&#160;</sup>He said to him, “Yahuah says, ‘Because you have let go out of your hand the man whom I had devoted to destruction, therefore your life will take the place of his life, and your people take the place of his people.’&#160;” 
 </p><p>
 <sup>43&#160;</sup>The king of Israel went to his house sullen and angry, and came to Samaria. 
 </p><h2 class="chapterlabel" id="21">21</h2>
@@ -1092,7 +1092,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>After these things, Naboth the Jezreelite had a vineyard which was in Jezreel, next to the palace of Ahab king of Samaria. 
 <sup>2&#160;</sup>Ahab spoke to Naboth, saying, “Give me your vineyard, that I may have it for a garden of herbs, because it is near my house; and I will give you for it a better vineyard than it. Or, if it seems good to you, I will give you its worth in money.” 
 </p><p>
-<sup>3&#160;</sup>Naboth said to Ahab, “May Yahweh forbid me, that I should give the inheritance of my fathers to you!” 
+<sup>3&#160;</sup>Naboth said to Ahab, “May Yahuah forbid me, that I should give the inheritance of my fathers to you!” 
 </p><p>
 <sup>4&#160;</sup>Ahab came into his house sullen and angry because of the word which Naboth the Jezreelite had spoken to him, for he had said, “I will not give you the inheritance of my fathers.” He laid himself down on his bed, and turned away his face, and would eat no bread. 
 <sup>5&#160;</sup>But Jezebel his woman came to him, and said to him, “Why is your spirit so sad that you eat no bread?” 
@@ -1113,23 +1113,23 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>16&#160;</sup>When Ahab heard that Naboth was dead, Ahab rose up to go down to the vineyard of Naboth the Jezreelite, to take possession of it. 
 </p><p>
-<sup>17&#160;</sup>Yahweh’s word came to Elijah the Tishbite, saying, 
+<sup>17&#160;</sup>Yahuah’s word came to Elijah the Tishbite, saying, 
 <sup>18&#160;</sup>“Arise, go down to meet Ahab king of Israel, who dwells in Samaria. Behold, he is in the vineyard of Naboth, where he has gone down to take possession of it. 
-<sup>19&#160;</sup>You shall speak to him, saying, ‘Yahweh says, “Have you killed and also taken possession?”&#160;’ You shall speak to him, saying, ‘Yahweh says, “In the place where dogs licked the blood of Naboth, dogs will lick your blood, even yours.”&#160;’&#160;” 
+<sup>19&#160;</sup>You shall speak to him, saying, ‘Yahuah says, “Have you killed and also taken possession?”&#160;’ You shall speak to him, saying, ‘Yahuah says, “In the place where dogs licked the blood of Naboth, dogs will lick your blood, even yours.”&#160;’&#160;” 
 </p><p>
 <sup>20&#160;</sup>Ahab said to Elijah, “Have you found me, my enemy?” 
-</p><p>He answered, “I have found you, because you have sold yourself to do that which is evil in Yahweh’s sight. 
+</p><p>He answered, “I have found you, because you have sold yourself to do that which is evil in Yahuah’s sight. 
 <sup>21&#160;</sup>Behold, I will bring evil on you, and will utterly sweep you away and will cut off from Ahab everyone who urinates against a wall, and him who is shut up and him who is left at large in Israel. 
 <sup>22&#160;</sup>I will make your house like the house of Jeroboam the son of Nebat, and like the house of Baasha the son of Ahijah, for the provocation with which you have provoked me to anger, and have made Israel to sin.” 
-<sup>23&#160;</sup>Yahweh also spoke of Jezebel, saying, “The dogs will eat Jezebel by the rampart of Jezreel. 
+<sup>23&#160;</sup>Yahuah also spoke of Jezebel, saying, “The dogs will eat Jezebel by the rampart of Jezreel. 
 <sup>24&#160;</sup>The dogs will eat he who dies of Ahab in the city; and the birds of the sky will eat he who dies in the field.” 
 </p><p>
-<sup>25&#160;</sup>But there was no one like Ahab, who sold himself to do that which was evil in Yahweh’s sight, whom Jezebel his woman stirred up. 
-<sup>26&#160;</sup>He did very abominably in following idols, according to all that the Amorites did, whom Yahweh cast out before the children of Israel. 
+<sup>25&#160;</sup>But there was no one like Ahab, who sold himself to do that which was evil in Yahuah’s sight, whom Jezebel his woman stirred up. 
+<sup>26&#160;</sup>He did very abominably in following idols, according to all that the Amorites did, whom Yahuah cast out before the children of Israel. 
 </p><p>
 <sup>27&#160;</sup>When Ahab heard those words, he tore his clothes, put sackcloth on his body, fasted, lay in sackcloth, and went about despondently. 
 </p><p>
-<sup>28&#160;</sup>Yahweh’s word came to Elijah the Tishbite, saying, 
+<sup>28&#160;</sup>Yahuah’s word came to Elijah the Tishbite, saying, 
 <sup>29&#160;</sup>“See how Ahab humbles himself before me? Because he humbles himself before me, I will not bring the evil in his days; but I will bring the evil on his house in his son’s day.” 
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
@@ -1138,53 +1138,53 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>The king of Israel said to his servants, “You know that Ramoth Gilead is ours, and we do nothing, and don’t take it out of the hand of the king of Syria?” 
 <sup>4&#160;</sup>He said to Jehoshaphat, “Will you go with me to battle to Ramoth Gilead?” 
 </p><p>Jehoshaphat said to the king of Israel, “I am as you are, my people as your people, my horses as your horses.” 
-<sup>5&#160;</sup>Jehoshaphat said to the king of Israel, “Please inquire first for Yahweh’s word.” 
+<sup>5&#160;</sup>Jehoshaphat said to the king of Israel, “Please inquire first for Yahuah’s word.” 
 </p><p>
 <sup>6&#160;</sup>Then the king of Israel gathered the prophets together, about four hundred men, and said to them, “Should I go against Ramoth Gilead to battle, or should I refrain?” 
 </p><p>They said, “Go up; for the Lord will deliver it into the hand of the king.” 
 </p><p>
-<sup>7&#160;</sup>But Jehoshaphat said, “Isn’t there here a prophet of Yahweh, that we may inquire of him?” 
+<sup>7&#160;</sup>But Jehoshaphat said, “Isn’t there here a prophet of Yahuah, that we may inquire of him?” 
 </p><p>
-<sup>8&#160;</sup>The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahweh, Micaiah the son of Imlah; but I hate him, for he does not prophesy good concerning me, but evil.” 
+<sup>8&#160;</sup>The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahuah, Micaiah the son of Imlah; but I hate him, for he does not prophesy good concerning me, but evil.” 
 </p><p>Jehoshaphat said, “Don’t let the king say so.” 
 </p><p>
 <sup>9&#160;</sup>Then the king of Israel called an officer, and said, “Quickly get Micaiah the son of Imlah.” 
 </p><p>
 <sup>10&#160;</sup>Now the king of Israel and Jehoshaphat the king of Judah were sitting each on his throne, arrayed in their robes, in an open place at the entrance of the gate of Samaria; and all the prophets were prophesying before them. 
-<sup>11&#160;</sup>Zedekiah the son of Chenaanah made himself horns of iron, and said, “Yahweh says, ‘With these you will push the Syrians, until they are consumed.’&#160;” 
-<sup>12&#160;</sup>All the prophets prophesied so, saying, “Go up to Ramoth Gilead and prosper; for Yahweh will deliver it into the hand of the king.” 
+<sup>11&#160;</sup>Zedekiah the son of Chenaanah made himself horns of iron, and said, “Yahuah says, ‘With these you will push the Syrians, until they are consumed.’&#160;” 
+<sup>12&#160;</sup>All the prophets prophesied so, saying, “Go up to Ramoth Gilead and prosper; for Yahuah will deliver it into the hand of the king.” 
 </p><p>
 <sup>13&#160;</sup>The messenger who went to call Micaiah spoke to him, saying, “See now, the prophets declare good to the king with one mouth. Please let your word be like the word of one of them, and speak good.” 
 </p><p>
-<sup>14&#160;</sup>Micaiah said, “As Yahweh lives, what Yahweh says to me, that I will speak.” 
+<sup>14&#160;</sup>Micaiah said, “As Yahuah lives, what Yahuah says to me, that I will speak.” 
 </p><p>
 <sup>15&#160;</sup>When he had come to the king, the king said to him, “Micaiah, shall we go to Ramoth Gilead to battle, or shall we forbear?” 
-</p><p>He answered him, “Go up and prosper; and Yahweh will deliver it into the hand of the king.” 
+</p><p>He answered him, “Go up and prosper; and Yahuah will deliver it into the hand of the king.” 
 </p><p>
-<sup>16&#160;</sup>The king said to him, “How many times do I have to adjure you that you speak to me nothing but the truth in Yahweh’s name?” 
+<sup>16&#160;</sup>The king said to him, “How many times do I have to adjure you that you speak to me nothing but the truth in Yahuah’s name?” 
 </p><p>
-<sup>17&#160;</sup>He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahweh said, ‘These have no master. Let them each return to his house in peace.’&#160;” 
+<sup>17&#160;</sup>He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahuah said, ‘These have no master. Let them each return to his house in peace.’&#160;” 
 </p><p>
 <sup>18&#160;</sup>The king of Israel said to Jehoshaphat, “Didn’t I tell you that he would not prophesy good concerning me, but evil?” 
 </p><p>
-<sup>19&#160;</sup>Micaiah said, “Therefore hear Yahweh’s word. I saw Yahweh sitting on his throne, and all the army of heaven standing by him on his right hand and on his left. 
-<sup>20&#160;</sup>Yahweh said, ‘Who will entice Ahab, that he may go up and fall at Ramoth Gilead?’ One said one thing, and another said another. 
+<sup>19&#160;</sup>Micaiah said, “Therefore hear Yahuah’s word. I saw Yahuah sitting on his throne, and all the army of heaven standing by him on his right hand and on his left. 
+<sup>20&#160;</sup>Yahuah said, ‘Who will entice Ahab, that he may go up and fall at Ramoth Gilead?’ One said one thing, and another said another. 
 </p><p>
-<sup>21&#160;</sup>A spirit came out and stood before Yahweh, and said, ‘I will entice him.’ 
+<sup>21&#160;</sup>A spirit came out and stood before Yahuah, and said, ‘I will entice him.’ 
 </p><p>
-<sup>22&#160;</sup>Yahweh said to him, ‘How?’ 
+<sup>22&#160;</sup>Yahuah said to him, ‘How?’ 
 </p><p>He said, ‘I will go out and will be a lying spirit in the mouth of all his prophets.’ 
 </p><p>He said, ‘You will entice him, and will also prevail. Go out and do so.’ 
-<sup>23&#160;</sup>Now therefore, behold, Yahweh has put a lying spirit in the mouth of all these your prophets; and Yahweh has spoken evil concerning you.” 
+<sup>23&#160;</sup>Now therefore, behold, Yahuah has put a lying spirit in the mouth of all these your prophets; and Yahuah has spoken evil concerning you.” 
 </p><p>
-<sup>24&#160;</sup>Then Zedekiah the son of Chenaanah came near and struck Micaiah on the cheek, and said, “Which way did Yahweh’s Spirit go from me to speak to you?” 
+<sup>24&#160;</sup>Then Zedekiah the son of Chenaanah came near and struck Micaiah on the cheek, and said, “Which way did Yahuah’s Spirit go from me to speak to you?” 
 </p><p>
 <sup>25&#160;</sup>Micaiah said, “Behold, you will see on that day when you go into an inner room to hide yourself.” 
 </p><p>
 <sup>26&#160;</sup>The king of Israel said, “Take Micaiah, and carry him back to Amon the governor of the city and to Joash the king’s son. 
 <sup>27&#160;</sup>Say, ‘The king says, “Put this fellow in the prison, and feed him with bread of affliction and with water of affliction, until I come in peace.”&#160;’&#160;” 
 </p><p>
-<sup>28&#160;</sup>Micaiah said, “If you return at all in peace, Yahweh has not spoken by me.” He said, “Listen, all you people!” 
+<sup>28&#160;</sup>Micaiah said, “If you return at all in peace, Yahuah has not spoken by me.” He said, “Listen, all you people!” 
 </p><p>
 <sup>29&#160;</sup>So the king of Israel and Jehoshaphat the king of Judah went up to Ramoth Gilead. 
 <sup>30&#160;</sup>The king of Israel said to Jehoshaphat, “I will disguise myself and go into the battle, but you put on your robes.” The king of Israel disguised himself and went into the battle. 
@@ -1198,14 +1198,14 @@ html[dir=ltr] .q2 {
 <sup>36&#160;</sup>A cry went throughout the army about the going down of the sun, saying, “Every man to his city, and every man to his country!” 
 </p><p>
 <sup>37&#160;</sup>So the king died, and was brought to Samaria; and they buried the king in Samaria. 
-<sup>38&#160;</sup>They washed the chariot by the pool of Samaria; and the dogs licked up his blood where the prostitutes washed themselves, according to Yahweh’s word which he spoke. 
+<sup>38&#160;</sup>They washed the chariot by the pool of Samaria; and the dogs licked up his blood where the prostitutes washed themselves, according to Yahuah’s word which he spoke. 
 </p><p>
 <sup>39&#160;</sup>Now the rest of the acts of Ahab, and all that he did, and the ivory house which he built, and all the cities that he built, aren’t they written in the book of the chronicles of the kings of Israel? 
 <sup>40&#160;</sup>So Ahab slept with his fathers; and Ahaziah his son reigned in his place. 
 </p><p>
 <sup>41&#160;</sup>Jehoshaphat the son of Asa began to reign over Judah in the fourth year of Ahab king of Israel. 
 <sup>42&#160;</sup>Jehoshaphat was thirty-five years old when he began to reign; and he reigned twenty-five years in Jerusalem. His mother’s name was Azubah the daughter of Shilhi. 
-<sup>43&#160;</sup>He walked in all the way of Asa his father. He didn’t turn away from it, doing that which was right in Yahweh’s eyes. However, the high places were not taken away. The people still sacrificed and burned incense on the high places. 
+<sup>43&#160;</sup>He walked in all the way of Asa his father. He didn’t turn away from it, doing that which was right in Yahuah’s eyes. However, the high places were not taken away. The people still sacrificed and burned incense on the high places. 
 <sup>44&#160;</sup>Jehoshaphat made peace with the king of Israel. 
 </p><p>
 <sup>45&#160;</sup>Now the rest of the acts of Jehoshaphat, and his might that he showed, and how he fought, aren’t they written in the book of the chronicles of the kings of Judah? 
@@ -1216,5 +1216,5 @@ html[dir=ltr] .q2 {
 <sup>50&#160;</sup>Jehoshaphat slept with his fathers, and was buried with his fathers in his father David’s city. Jehoram his son reigned in his place. 
 </p><p>
 <sup>51&#160;</sup>Ahaziah the son of Ahab began to reign over Israel in Samaria in the seventeenth year of Jehoshaphat king of Judah, and he reigned two years over Israel. 
-<sup>52&#160;</sup>He did that which was evil in Yahweh’s sight, and walked in the way of his father, and in the way of his mother, and in the way of Jeroboam the son of Nebat, in which he made Israel to sin. 
-<sup>53&#160;</sup>He served Baal and worshiped him, and provoked Yahweh, the Elohim of Israel, to anger in all the ways that his father had done so. </p></div><script src="../main.js"></script></body></html>
+<sup>52&#160;</sup>He did that which was evil in Yahuah’s sight, and walked in the way of his father, and in the way of his mother, and in the way of Jeroboam the son of Nebat, in which he made Israel to sin. 
+<sup>53&#160;</sup>He served Baal and worshiped him, and provoked Yahuah, the Elohim of Israel, to anger in all the ways that his father had done so. </p></div><script src="../main.js"></script></body></html>

--- a/book/1samuel.html
+++ b/book/1samuel.html
@@ -92,58 +92,58 @@ html[dir=ltr] .q2 {
 <p class="p1">
 <sup>1&#160;</sup>Now there was a certain man of Ramathaim Zophim, of the hill country of Ephraim, and his name was Elkanah, the son of Jeroham, the son of Elihu, the son of Tohu, the son of Zuph, an Ephraimite. 
 <sup>2&#160;</sup>He had two women. The name of one was Hannah, and the name of the other Peninnah. Peninnah had children, but Hannah had no children. 
-<sup>3&#160;</sup>This man went up out of his city from year to year to worship and to sacrifice to Yahweh of Armies in Shiloh. The two sons of Eli, Hophni and Phinehas, priests to Yahweh, were there. 
+<sup>3&#160;</sup>This man went up out of his city from year to year to worship and to sacrifice to Yahuah of Armies in Shiloh. The two sons of Eli, Hophni and Phinehas, priests to Yahuah, were there. 
 <sup>4&#160;</sup>When the day came that Elkanah sacrificed, he gave portions to Peninnah his woman and to all her sons and her daughters; 
-<sup>5&#160;</sup>but he gave a double portion to Hannah, for he loved Hannah, but Yahweh had shut up her womb. 
-<sup>6&#160;</sup>Her rival provoked her severely, to irritate her, because Yahweh had shut up her womb. 
-<sup>7&#160;</sup>So year by year, when she went up to Yahweh’s house, her rival provoked her. Therefore she wept, and didn’t eat. 
+<sup>5&#160;</sup>but he gave a double portion to Hannah, for he loved Hannah, but Yahuah had shut up her womb. 
+<sup>6&#160;</sup>Her rival provoked her severely, to irritate her, because Yahuah had shut up her womb. 
+<sup>7&#160;</sup>So year by year, when she went up to Yahuah’s house, her rival provoked her. Therefore she wept, and didn’t eat. 
 <sup>8&#160;</sup>Elkanah her man said to her, “Hannah, why do you weep? Why don’t you eat? Why is your heart grieved? Am I not better to you than ten sons?” 
 </p><p>
-<sup>9&#160;</sup>So Hannah rose up after they had finished eating and drinking in Shiloh. Now Eli the priest was sitting on his seat by the doorpost of Yahweh’s temple. 
-<sup>10&#160;</sup>She was in bitterness of soul, and prayed to Yahweh, weeping bitterly. 
-<sup>11&#160;</sup>She vowed a vow, and said, “Yahweh of Armies, if you will indeed look at the affliction of your servant and remember me, and not forget your servant, but will give to your servant a boy, then I will give him to Yahweh all the days of his life, and no razor shall come on his head.” 
+<sup>9&#160;</sup>So Hannah rose up after they had finished eating and drinking in Shiloh. Now Eli the priest was sitting on his seat by the doorpost of Yahuah’s temple. 
+<sup>10&#160;</sup>She was in bitterness of soul, and prayed to Yahuah, weeping bitterly. 
+<sup>11&#160;</sup>She vowed a vow, and said, “Yahuah of Armies, if you will indeed look at the affliction of your servant and remember me, and not forget your servant, but will give to your servant a boy, then I will give him to Yahuah all the days of his life, and no razor shall come on his head.” 
 </p><p>
-<sup>12&#160;</sup>As she continued praying before Yahweh, Eli saw her mouth. 
+<sup>12&#160;</sup>As she continued praying before Yahuah, Eli saw her mouth. 
 <sup>13&#160;</sup>Now Hannah spoke in her heart. Only her lips moved, but her voice was not heard. Therefore Eli thought she was drunk. 
 <sup>14&#160;</sup>Eli said to her, “How long will you be drunk? Get rid of your wine!” 
 </p><p>
-<sup>15&#160;</sup>Hannah answered, “No, my lord, I am a woman of a sorrowful spirit. I have not been drinking wine or strong drink, but I poured out my soul before Yahweh. 
+<sup>15&#160;</sup>Hannah answered, “No, my lord, I am a woman of a sorrowful spirit. I have not been drinking wine or strong drink, but I poured out my soul before Yahuah. 
 <sup>16&#160;</sup>Don’t consider your servant a wicked woman; for I have been speaking out of the abundance of my complaint and my provocation.” 
 </p><p>
 <sup>17&#160;</sup>Then Eli answered, “Go in peace; and may the Elohim of Israel grant your petition that you have asked of him.” 
 </p><p>
 <sup>18&#160;</sup>She said, “Let your servant find favor in your sight.” So the woman went her way and ate; and her facial expression wasn’t sad any more. 
 </p><p>
-<sup>19&#160;</sup>They rose up in the morning early and worshiped Yahweh, then returned and came to their house to Ramah. Then Elkanah knew Hannah his woman; and Yahweh remembered her. 
+<sup>19&#160;</sup>They rose up in the morning early and worshiped Yahuah, then returned and came to their house to Ramah. Then Elkanah knew Hannah his woman; and Yahuah remembered her. 
 </p><p>
-<sup>20&#160;</sup>When the time had come, Hannah conceived, and bore a son; and she named him Samuel, saying, “Because I have asked him of Yahweh.” 
+<sup>20&#160;</sup>When the time had come, Hannah conceived, and bore a son; and she named him Samuel, saying, “Because I have asked him of Yahuah.” 
 </p><p>
-<sup>21&#160;</sup>The man Elkanah, and all his house, went up to offer to Yahweh the yearly sacrifice and his vow. 
-<sup>22&#160;</sup>But Hannah didn’t go up, for she said to her man, “Not until the child is weaned; then I will bring him, that he may appear before Yahweh, and stay there forever.” 
+<sup>21&#160;</sup>The man Elkanah, and all his house, went up to offer to Yahuah the yearly sacrifice and his vow. 
+<sup>22&#160;</sup>But Hannah didn’t go up, for she said to her man, “Not until the child is weaned; then I will bring him, that he may appear before Yahuah, and stay there forever.” 
 </p><p>
-<sup>23&#160;</sup>Elkanah her man said to her, “Do what seems good to you. Wait until you have weaned him; only may Yahweh establish his word.” 
+<sup>23&#160;</sup>Elkanah her man said to her, “Do what seems good to you. Wait until you have weaned him; only may Yahuah establish his word.” 
 </p><p>So the woman waited and nursed her son until she weaned him. 
-<sup>24&#160;</sup>When she had weaned him, she took him up with her, with three bulls, and one ephah of meal, and a container of wine, and brought him to Yahweh’s house in Shiloh. The child was young. 
+<sup>24&#160;</sup>When she had weaned him, she took him up with her, with three bulls, and one ephah of meal, and a container of wine, and brought him to Yahuah’s house in Shiloh. The child was young. 
 <sup>25&#160;</sup>They killed the bull, and brought the child to Eli. 
-<sup>26&#160;</sup>She said, “Oh, my lord, as your soul lives, my lord, I am the woman who stood by you here, praying to Yahweh. 
-<sup>27&#160;</sup>I prayed for this child, and Yahweh has given me my petition which I asked of him. 
-<sup>28&#160;</sup>Therefore I have also given him to Yahweh. As long as he lives he is given to Yahweh.” He worshiped Yahweh there. 
+<sup>26&#160;</sup>She said, “Oh, my lord, as your soul lives, my lord, I am the woman who stood by you here, praying to Yahuah. 
+<sup>27&#160;</sup>I prayed for this child, and Yahuah has given me my petition which I asked of him. 
+<sup>28&#160;</sup>Therefore I have also given him to Yahuah. As long as he lives he is given to Yahuah.” He worshiped Yahuah there. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
 <sup>1&#160;</sup>Hannah prayed, and said, 
-</p><p class="q1">“My heart exults in Yahweh! 
-</p><p class="q2">My horn is exalted in Yahweh. 
+</p><p class="q1">“My heart exults in Yahuah! 
+</p><p class="q2">My horn is exalted in Yahuah. 
 </p><p class="q1">My mouth is enlarged over my enemies, 
 </p><p class="q2">because I rejoice in your salvation. 
 </p><p class="q1">
-<sup>2&#160;</sup>There is no one as set-apart as Yahweh, 
+<sup>2&#160;</sup>There is no one as set-apart as Yahuah, 
 </p><p class="q2">for there is no one besides you, 
 </p><p class="q2">nor is there any rock like our Elohim. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>3&#160;</sup>“Don’t keep talking so exceedingly proudly. 
 </p><p class="q2">Don’t let arrogance come out of your mouth, 
-</p><p class="q2">for Yahweh is an Elohim of knowledge. 
+</p><p class="q2">for Yahuah is an Elohim of knowledge. 
 </p><p class="q2">By him actions are weighed. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -156,55 +156,55 @@ html[dir=ltr] .q2 {
 </p><p class="q2">She who has many children languishes. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>6&#160;</sup>“Yahweh kills and makes alive. 
+<sup>6&#160;</sup>“Yahuah kills and makes alive. 
 </p><p class="q2">He brings down to Sheol and brings up. 
 </p><p class="q1">
-<sup>7&#160;</sup>Yahweh makes poor and makes rich. 
+<sup>7&#160;</sup>Yahuah makes poor and makes rich. 
 </p><p class="q2">He brings low, he also lifts up. 
 </p><p class="q1">
 <sup>8&#160;</sup>He raises up the poor out of the dust. 
 </p><p class="q2">He lifts up the needy from the dunghill 
 </p><p class="q2">to make them sit with princes 
 </p><p class="q2">and inherit the throne of glory. 
-</p><p class="q1">For the pillars of the earth are Yahweh’s. 
+</p><p class="q1">For the pillars of the earth are Yahuah’s. 
 </p><p class="q2">He has set the world on them. 
 </p><p class="q1">
 <sup>9&#160;</sup>He will keep the feet of his set-apart ones, 
 </p><p class="q2">but the wicked will be put to silence in darkness; 
 </p><p class="q2">for no man will prevail by strength. 
 </p><p class="q1">
-<sup>10&#160;</sup>Those who strive with Yahweh shall be broken to pieces. 
+<sup>10&#160;</sup>Those who strive with Yahuah shall be broken to pieces. 
 </p><p class="q2">He will thunder against them in the sky. 
 </p><p class="b"> &#160; </p>
-<p class="q1">“Yahweh will judge the ends of the earth. 
+<p class="q1">“Yahuah will judge the ends of the earth. 
 </p><p class="q2">He will give strength to his king, 
 </p><p class="q2">and exalt the horn of his anointed.” 
 </p><p>
-<sup>11&#160;</sup>Elkanah went to Ramah to his house. The child served Yahweh before Eli the priest. 
+<sup>11&#160;</sup>Elkanah went to Ramah to his house. The child served Yahuah before Eli the priest. 
 </p><p>
-<sup>12&#160;</sup>Now the sons of Eli were wicked men. They didn’t know Yahweh. 
+<sup>12&#160;</sup>Now the sons of Eli were wicked men. They didn’t know Yahuah. 
 <sup>13&#160;</sup>The custom of the priests with the people was that when anyone offered a sacrifice, the priest’s servant came while the meat was boiling, with a fork of three teeth in his hand; 
 <sup>14&#160;</sup>and he stabbed it into the pan, or kettle, or cauldron, or pot. The priest took all that the fork brought up for himself. They did this to all the Israelites who came there to Shiloh. 
 <sup>15&#160;</sup>Yes, before they burned the fat, the priest’s servant came, and said to the man who sacrificed, “Give meat to roast for the priest; for he will not accept boiled meat from you, but raw.” 
 </p><p>
 <sup>16&#160;</sup>If the man said to him, “Let the fat be burned first, and then take as much as your soul desires;” then he would say, “No, but you shall give it to me now; and if not, I will take it by force.” 
-<sup>17&#160;</sup>The sin of the young men was very great before Yahweh; for the men despised Yahweh’s offering. 
-<sup>18&#160;</sup>But Samuel ministered before Yahweh, being a child, clothed with a linen ephod. 
+<sup>17&#160;</sup>The sin of the young men was very great before Yahuah; for the men despised Yahuah’s offering. 
+<sup>18&#160;</sup>But Samuel ministered before Yahuah, being a child, clothed with a linen ephod. 
 <sup>19&#160;</sup>Moreover his mother made him a little robe, and brought it to him from year to year when she came up with her man to offer the yearly sacrifice. 
-<sup>20&#160;</sup>Eli blessed Elkanah and his woman, and said, “May Yahweh give you offspring from this woman for the petition which was asked of Yahweh.” Then they went to their own home. 
-<sup>21&#160;</sup>Yahweh visited Hannah, and she conceived and bore three sons and two daughters. The child Samuel grew before Yahweh. 
+<sup>20&#160;</sup>Eli blessed Elkanah and his woman, and said, “May Yahuah give you offspring from this woman for the petition which was asked of Yahuah.” Then they went to their own home. 
+<sup>21&#160;</sup>Yahuah visited Hannah, and she conceived and bore three sons and two daughters. The child Samuel grew before Yahuah. 
 </p><p>
 <sup>22&#160;</sup>Now Eli was very old; and he heard all that his sons did to all Israel, and how that they slept with the women who served at the door of the Tent of Meeting. 
 <sup>23&#160;</sup>He said to them, “Why do you do such things? For I hear of your evil dealings from all these people. 
-<sup>24&#160;</sup>No, my sons; for it is not a good report that I hear! You make Yahweh’s people disobey. 
-<sup>25&#160;</sup>If one man sins against another, Elohim will judge him; but if a man sins against Yahweh, who will intercede for him?” Notwithstanding, they didn’t listen to the voice of their father, because Yahweh intended to kill them. 
+<sup>24&#160;</sup>No, my sons; for it is not a good report that I hear! You make Yahuah’s people disobey. 
+<sup>25&#160;</sup>If one man sins against another, Elohim will judge him; but if a man sins against Yahuah, who will intercede for him?” Notwithstanding, they didn’t listen to the voice of their father, because Yahuah intended to kill them. 
 </p><p>
-<sup>26&#160;</sup>The child Samuel grew on, and increased in favor both with Yahweh and also with men. 
+<sup>26&#160;</sup>The child Samuel grew on, and increased in favor both with Yahuah and also with men. 
 </p><p>
-<sup>27&#160;</sup>A man of Elohim came to Eli and said to him, “Yahweh says, ‘Did I reveal myself to the house of your father when they were in Egypt in bondage to Pharaoh’s house? 
+<sup>27&#160;</sup>A man of Elohim came to Eli and said to him, “Yahuah says, ‘Did I reveal myself to the house of your father when they were in Egypt in bondage to Pharaoh’s house? 
 <sup>28&#160;</sup>Didn’t I choose him out of all the tribes of Israel to be my priest, to go up to my altar, to burn incense, to wear an ephod before me? Didn’t I give to the house of your father all the offerings of the children of Israel made by fire? 
 <sup>29&#160;</sup>Why do you kick at my sacrifice and at my offering, which I have commanded in my habitation, and honor your sons above me, to make yourselves fat with the best of all the offerings of Israel my people?’ 
-<sup>30&#160;</sup>“Therefore Yahweh, the Elohim of Israel, says, ‘I said indeed that your house and the house of your father should walk before me forever.’ But now Yahweh says, ‘Far be it from me; for those who honor me I will honor, and those who despise me will be cursed. 
+<sup>30&#160;</sup>“Therefore Yahuah, the Elohim of Israel, says, ‘I said indeed that your house and the house of your father should walk before me forever.’ But now Yahuah says, ‘Far be it from me; for those who honor me I will honor, and those who despise me will be cursed. 
 <sup>31&#160;</sup>Behold, the days come that I will cut off your arm and the arm of your father’s house, that there will not be an old man in your house. 
 <sup>32&#160;</sup>You will see the affliction of my habitation, in all the wealth which I will give Israel. There shall not be an old man in your house forever. 
 <sup>33&#160;</sup>The man of yours whom I don’t cut off from my altar will consume your eyes and grieve your heart. All the increase of your house will die in the flower of their age. 
@@ -213,51 +213,51 @@ html[dir=ltr] .q2 {
 <sup>36&#160;</sup>It will happen that everyone who is left in your house will come and bow down to him for a piece of silver and a loaf of bread, and will say, “Please put me into one of the priests’ offices, that I may eat a morsel of bread.”&#160;’&#160;” 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>The child Samuel ministered to Yahweh before Eli. Yahweh’s word was rare in those days. There were not many visions, then. 
+<sup>1&#160;</sup>The child Samuel ministered to Yahuah before Eli. Yahuah’s word was rare in those days. There were not many visions, then. 
 <sup>2&#160;</sup>At that time, when Eli was laid down in his place (now his eyes had begun to grow dim, so that he could not see), 
-<sup>3&#160;</sup>and Elohim’s lamp hadn’t yet gone out, and Samuel had laid down in Yahweh’s temple where Elohim’s ark was, 
-<sup>4&#160;</sup>Yahweh called Samuel. He said, “Here I am.” 
+<sup>3&#160;</sup>and Elohim’s lamp hadn’t yet gone out, and Samuel had laid down in Yahuah’s temple where Elohim’s ark was, 
+<sup>4&#160;</sup>Yahuah called Samuel. He said, “Here I am.” 
 </p><p>
 <sup>5&#160;</sup>He ran to Eli and said, “Here I am; for you called me.” 
 </p><p>He said, “I didn’t call. Lie down again.” 
 </p><p>He went and lay down. 
-<sup>6&#160;</sup>Yahweh called yet again, “Samuel!” 
+<sup>6&#160;</sup>Yahuah called yet again, “Samuel!” 
 </p><p>Samuel arose and went to Eli and said, “Here I am; for you called me.” 
 </p><p>He answered, “I didn’t call, my son. Lie down again.” 
-<sup>7&#160;</sup>Now Samuel didn’t yet know Yahweh, neither was Yahweh’s word yet revealed to him. 
-<sup>8&#160;</sup>Yahweh called Samuel again the third time. He arose and went to Eli and said, “Here I am; for you called me.” 
-</p><p>Eli perceived that Yahweh had called the child. 
-<sup>9&#160;</sup>Therefore Eli said to Samuel, “Go, lie down. It shall be, if he calls you, that you shall say, ‘Speak, Yahweh; for your servant hears.’&#160;” So Samuel went and lay down in his place. 
-<sup>10&#160;</sup>Yahweh came, and stood, and called as at other times, “Samuel! Samuel!” 
+<sup>7&#160;</sup>Now Samuel didn’t yet know Yahuah, neither was Yahuah’s word yet revealed to him. 
+<sup>8&#160;</sup>Yahuah called Samuel again the third time. He arose and went to Eli and said, “Here I am; for you called me.” 
+</p><p>Eli perceived that Yahuah had called the child. 
+<sup>9&#160;</sup>Therefore Eli said to Samuel, “Go, lie down. It shall be, if he calls you, that you shall say, ‘Speak, Yahuah; for your servant hears.’&#160;” So Samuel went and lay down in his place. 
+<sup>10&#160;</sup>Yahuah came, and stood, and called as at other times, “Samuel! Samuel!” 
 </p><p>Then Samuel said, “Speak; for your servant hears.” 
 </p><p>
-<sup>11&#160;</sup>Yahweh said to Samuel, “Behold, I will do a thing in Israel at which both the ears of everyone who hears it will tingle. 
+<sup>11&#160;</sup>Yahuah said to Samuel, “Behold, I will do a thing in Israel at which both the ears of everyone who hears it will tingle. 
 <sup>12&#160;</sup>In that day I will perform against Eli all that I have spoken concerning his house, from the beginning even to the end. 
 <sup>13&#160;</sup>For I have told him that I will judge his house forever for the iniquity which he knew, because his sons brought a curse on themselves, and he didn’t restrain them. 
 <sup>14&#160;</sup>Therefore I have sworn to the house of Eli that the iniquity of Eli’s house shall not be removed with sacrifice or offering forever.” 
 </p><p>
-<sup>15&#160;</sup>Samuel lay until the morning, and opened the doors of Yahweh’s house. Samuel was afraid to show Eli the vision. 
+<sup>15&#160;</sup>Samuel lay until the morning, and opened the doors of Yahuah’s house. Samuel was afraid to show Eli the vision. 
 <sup>16&#160;</sup>Then Eli called Samuel and said, “Samuel, my son!” 
 </p><p>He said, “Here I am.” 
 </p><p>
 <sup>17&#160;</sup>He said, “What is the thing that he has spoken to you? Please don’t hide it from me. Elohim do so to you, and more also, if you hide anything from me of all the things that he spoke to you.” 
 </p><p>
 <sup>18&#160;</sup>Samuel told him every bit, and hid nothing from him. 
-</p><p>He said, “It is Yahweh. Let him do what seems good to him.” 
+</p><p>He said, “It is Yahuah. Let him do what seems good to him.” 
 </p><p>
-<sup>19&#160;</sup>Samuel grew, and Yahweh was with him and let none of his words fall to the ground. 
-<sup>20&#160;</sup>All Israel from Dan even to Beersheba knew that Samuel was established to be a prophet of Yahweh. 
-<sup>21&#160;</sup>Yahweh appeared again in Shiloh; for Yahweh revealed himself to Samuel in Shiloh by Yahweh’s word. 
+<sup>19&#160;</sup>Samuel grew, and Yahuah was with him and let none of his words fall to the ground. 
+<sup>20&#160;</sup>All Israel from Dan even to Beersheba knew that Samuel was established to be a prophet of Yahuah. 
+<sup>21&#160;</sup>Yahuah appeared again in Shiloh; for Yahuah revealed himself to Samuel in Shiloh by Yahuah’s word. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p class="nb">
 <sup>1&#160;</sup>The word of Samuel came to all Israel. 
 </p><p>Now Israel went out against the Philistines to battle, and encamped beside Ebenezer; and the Philistines encamped in Aphek. 
 <sup>2&#160;</sup>The Philistines put themselves in array against Israel. When they joined battle, Israel was defeated by the Philistines, who killed about four thousand men of the army in the field. 
-<sup>3&#160;</sup>When the people had come into the camp, the elders of Israel said, “Why has Yahweh defeated us today before the Philistines? Let’s get the ark of Yahweh’s covenant out of Shiloh and bring it to us, that it may come among us and save us out of the hand of our enemies.” 
+<sup>3&#160;</sup>When the people had come into the camp, the elders of Israel said, “Why has Yahuah defeated us today before the Philistines? Let’s get the ark of Yahuah’s covenant out of Shiloh and bring it to us, that it may come among us and save us out of the hand of our enemies.” 
 </p><p>
-<sup>4&#160;</sup>So the people sent to Shiloh, and they brought from there the ark of the covenant of Yahweh of Armies, who sits above the cherubim; and the two sons of Eli, Hophni and Phinehas, were there with the ark of the covenant of Elohim. 
-<sup>5&#160;</sup>When the ark of Yahweh’s covenant came into the camp, all Israel shouted with a great shout, so that the earth resounded. 
-<sup>6&#160;</sup>When the Philistines heard the noise of the shout, they said, “What does the noise of this great shout in the camp of the Hebrews mean?” They understood that Yahweh’s ark had come into the camp. 
+<sup>4&#160;</sup>So the people sent to Shiloh, and they brought from there the ark of the covenant of Yahuah of Armies, who sits above the cherubim; and the two sons of Eli, Hophni and Phinehas, were there with the ark of the covenant of Elohim. 
+<sup>5&#160;</sup>When the ark of Yahuah’s covenant came into the camp, all Israel shouted with a great shout, so that the earth resounded. 
+<sup>6&#160;</sup>When the Philistines heard the noise of the shout, they said, “What does the noise of this great shout in the camp of the Hebrews mean?” They understood that Yahuah’s ark had come into the camp. 
 <sup>7&#160;</sup>The Philistines were afraid, for they said, “Elohim has come into the camp.” They said, “Woe to us! For there has not been such a thing before. 
 <sup>8&#160;</sup>Woe to us! Who shall deliver us out of the hand of these mighty elohims? These are the elohims that struck the Egyptians with all kinds of plagues in the wilderness. 
 <sup>9&#160;</sup>Be strong and behave like men, O you Philistines, that you not be servants to the Hebrews, as they have been to you. Strengthen yourselves like men, and fight!” 
@@ -284,23 +284,23 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Now the Philistines had taken Elohim’s ark, and they brought it from Ebenezer to Ashdod. 
 <sup>2&#160;</sup>The Philistines took Elohim’s ark, and brought it into the house of Dagon and set it by Dagon. 
-<sup>3&#160;</sup>When the people of Ashdod arose early on the next day, behold, Dagon had fallen on his face to the ground before Yahweh’s ark. They took Dagon and set him in his place again. 
-<sup>4&#160;</sup>When they arose early on the following morning, behold, Dagon had fallen on his face to the ground before Yahweh’s ark; and the head of Dagon and both the palms of his hands were cut off on the threshold. Only Dagon’s torso was intact. 
+<sup>3&#160;</sup>When the people of Ashdod arose early on the next day, behold, Dagon had fallen on his face to the ground before Yahuah’s ark. They took Dagon and set him in his place again. 
+<sup>4&#160;</sup>When they arose early on the following morning, behold, Dagon had fallen on his face to the ground before Yahuah’s ark; and the head of Dagon and both the palms of his hands were cut off on the threshold. Only Dagon’s torso was intact. 
 <sup>5&#160;</sup>Therefore neither the priests of Dagon nor any who come into Dagon’s house step on the threshold of Dagon in Ashdod to this day. 
-<sup>6&#160;</sup>But Yahweh’s hand was heavy on the people of Ashdod, and he destroyed them and struck them with tumors, even Ashdod and its borders. 
+<sup>6&#160;</sup>But Yahuah’s hand was heavy on the people of Ashdod, and he destroyed them and struck them with tumors, even Ashdod and its borders. 
 </p><p>
 <sup>7&#160;</sup>When the men of Ashdod saw that it was so, they said, “The ark of the Elohim of Israel shall not stay with us, for his hand is severe on us and on Dagon our elohim.” 
 <sup>8&#160;</sup>They sent therefore and gathered together all the lords of the Philistines, and said, “What shall we do with the ark of the Elohim of Israel?” 
 </p><p>They answered, “Let the ark of the Elohim of Israel be carried over to Gath.” They carried the ark of the Elohim of Israel there. 
-<sup>9&#160;</sup>It was so, that after they had carried it there, Yahweh’s hand was against the city with a very great confusion; and he struck the men of the city, both small and great, so that tumors broke out on them. 
+<sup>9&#160;</sup>It was so, that after they had carried it there, Yahuah’s hand was against the city with a very great confusion; and he struck the men of the city, both small and great, so that tumors broke out on them. 
 <sup>10&#160;</sup>So they sent Elohim’s ark to Ekron. 
 </p><p>As Elohim’s ark came to Ekron, the Ekronites cried out, saying, “They have brought the ark of the Elohim of Israel here to us, to kill us and our people.” 
 <sup>11&#160;</sup>They sent therefore and gathered together all the lords of the Philistines, and they said, “Send the ark of the Elohim of Israel away, and let it go again to its own place, that it not kill us and our people.” For there was a deadly panic throughout all the city. The hand of Elohim was very heavy there. 
 <sup>12&#160;</sup>The men who didn’t die were struck with the tumors; and the cry of the city went up to heaven. 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s ark was in the country of the Philistines seven months. 
-<sup>2&#160;</sup>The Philistines called for the priests and the diviners, saying, “What shall we do with Yahweh’s ark? Show us how we should send it to its place.” 
+<sup>1&#160;</sup>Yahuah’s ark was in the country of the Philistines seven months. 
+<sup>2&#160;</sup>The Philistines called for the priests and the diviners, saying, “What shall we do with Yahuah’s ark? Show us how we should send it to its place.” 
 </p><p>
 <sup>3&#160;</sup>They said, “If you send away the ark of the Elohim of Israel, don’t send it empty; but by all means return a trespass offering to him. Then you will be healed, and it will be known to you why his hand is not removed from you.” 
 </p><p>
@@ -310,45 +310,45 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>Why then do you harden your hearts as the Egyptians and Pharaoh hardened their hearts? When he had worked wonderfully among them, didn’t they let the people go, and they departed? 
 </p><p>
 <sup>7&#160;</sup>“Now therefore take and prepare yourselves a new cart and two milk cows on which there has come no yoke; and tie the cows to the cart, and bring their calves home from them; 
-<sup>8&#160;</sup>and take Yahweh’s ark and lay it on the cart. Put the jewels of gold, which you return him for a trespass offering, in a box by its side; and send it away, that it may go. 
+<sup>8&#160;</sup>and take Yahuah’s ark and lay it on the cart. Put the jewels of gold, which you return him for a trespass offering, in a box by its side; and send it away, that it may go. 
 <sup>9&#160;</sup>Behold, if it goes up by the way of its own border to Beth Shemesh, then he has done us this great evil; but if not, then we shall know that it is not his hand that struck us. It was a chance that happened to us.” 
 </p><p>
 <sup>10&#160;</sup>The men did so, and took two milk cows and tied them to the cart, and shut up their calves at home. 
-<sup>11&#160;</sup>They put Yahweh’s ark on the cart, and the box with the golden mice and the images of their tumors. 
+<sup>11&#160;</sup>They put Yahuah’s ark on the cart, and the box with the golden mice and the images of their tumors. 
 <sup>12&#160;</sup>The cows took the straight way by the way to Beth Shemesh. They went along the highway, lowing as they went, and didn’t turn away to the right hand or to the left; and the lords of the Philistines went after them to the border of Beth Shemesh. 
 <sup>13&#160;</sup>The people of Beth Shemesh were reaping their wheat harvest in the valley; and they lifted up their eyes and saw the ark, and rejoiced to see it. 
-<sup>14&#160;</sup>The cart came into the field of Joshua of Beth Shemesh, and stood there, where there was a great stone. Then they split the wood of the cart and offered up the cows for a burnt offering to Yahweh. 
-<sup>15&#160;</sup>The Levites took down Yahweh’s ark and the box that was with it, in which the jewels of gold were, and put them on the great stone; and the men of Beth Shemesh offered burnt offerings and sacrificed sacrifices the same day to Yahweh. 
+<sup>14&#160;</sup>The cart came into the field of Joshua of Beth Shemesh, and stood there, where there was a great stone. Then they split the wood of the cart and offered up the cows for a burnt offering to Yahuah. 
+<sup>15&#160;</sup>The Levites took down Yahuah’s ark and the box that was with it, in which the jewels of gold were, and put them on the great stone; and the men of Beth Shemesh offered burnt offerings and sacrificed sacrifices the same day to Yahuah. 
 <sup>16&#160;</sup>When the five lords of the Philistines had seen it, they returned to Ekron the same day. 
-<sup>17&#160;</sup>These are the golden tumors which the Philistines returned for a trespass offering to Yahweh: for Ashdod one, for Gaza one, for Ashkelon one, for Gath one, for Ekron one; 
-<sup>18&#160;</sup>and the golden mice, according to the number of all the cities of the Philistines belonging to the five lords, both of fortified cities and of country villages, even to the great stone on which they set down Yahweh’s ark. That stone remains to this day in the field of Joshua of Beth Shemesh. 
-<sup>19&#160;</sup>He struck of the men of Beth Shemesh, because they had looked into Yahweh’s ark, he struck fifty thousand seventy of the men. Then the people mourned, because Yahweh had struck the people with a great slaughter. 
-<sup>20&#160;</sup>The men of Beth Shemesh said, “Who is able to stand before Yahweh, this set-apart Elohim? To whom shall he go up from us?” 
+<sup>17&#160;</sup>These are the golden tumors which the Philistines returned for a trespass offering to Yahuah: for Ashdod one, for Gaza one, for Ashkelon one, for Gath one, for Ekron one; 
+<sup>18&#160;</sup>and the golden mice, according to the number of all the cities of the Philistines belonging to the five lords, both of fortified cities and of country villages, even to the great stone on which they set down Yahuah’s ark. That stone remains to this day in the field of Joshua of Beth Shemesh. 
+<sup>19&#160;</sup>He struck of the men of Beth Shemesh, because they had looked into Yahuah’s ark, he struck fifty thousand seventy of the men. Then the people mourned, because Yahuah had struck the people with a great slaughter. 
+<sup>20&#160;</sup>The men of Beth Shemesh said, “Who is able to stand before Yahuah, this set-apart Elohim? To whom shall he go up from us?” 
 </p><p>
-<sup>21&#160;</sup>They sent messengers to the inhabitants of Kiriath Jearim, saying, “The Philistines have brought back Yahweh’s ark. Come down and bring it up to yourselves.” 
+<sup>21&#160;</sup>They sent messengers to the inhabitants of Kiriath Jearim, saying, “The Philistines have brought back Yahuah’s ark. Come down and bring it up to yourselves.” 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>The men of Kiriath Jearim came and took Yahweh’s ark, and brought it into Abinadab’s house on the hill, and consecrated Eleazar his son to keep Yahweh’s ark. 
-<sup>2&#160;</sup>From the day that the ark stayed in Kiriath Jearim, the time was long—for it was twenty years; and all the house of Israel lamented after Yahweh. 
-<sup>3&#160;</sup>Samuel spoke to all the house of Israel, saying, “If you are returning to Yahweh with all your heart, then put away the foreign elohims and the Ashtaroth from among you, and direct your hearts to Yahweh, and serve him only; and he will deliver you out of the hand of the Philistines.” 
-<sup>4&#160;</sup>Then the children of Israel removed the Baals and the Ashtaroth, and served Yahweh only. 
-<sup>5&#160;</sup>Samuel said, “Gather all Israel to Mizpah, and I will pray to Yahweh for you.” 
-<sup>6&#160;</sup>They gathered together to Mizpah, and drew water, and poured it out before Yahweh, and fasted on that day, and said there, “We have sinned against Yahweh.” Samuel judged the children of Israel in Mizpah. 
+<sup>1&#160;</sup>The men of Kiriath Jearim came and took Yahuah’s ark, and brought it into Abinadab’s house on the hill, and consecrated Eleazar his son to keep Yahuah’s ark. 
+<sup>2&#160;</sup>From the day that the ark stayed in Kiriath Jearim, the time was long—for it was twenty years; and all the house of Israel lamented after Yahuah. 
+<sup>3&#160;</sup>Samuel spoke to all the house of Israel, saying, “If you are returning to Yahuah with all your heart, then put away the foreign elohims and the Ashtaroth from among you, and direct your hearts to Yahuah, and serve him only; and he will deliver you out of the hand of the Philistines.” 
+<sup>4&#160;</sup>Then the children of Israel removed the Baals and the Ashtaroth, and served Yahuah only. 
+<sup>5&#160;</sup>Samuel said, “Gather all Israel to Mizpah, and I will pray to Yahuah for you.” 
+<sup>6&#160;</sup>They gathered together to Mizpah, and drew water, and poured it out before Yahuah, and fasted on that day, and said there, “We have sinned against Yahuah.” Samuel judged the children of Israel in Mizpah. 
 </p><p>
 <sup>7&#160;</sup>When the Philistines heard that the children of Israel were gathered together at Mizpah, the lords of the Philistines went up against Israel. When the children of Israel heard it, they were afraid of the Philistines. 
-<sup>8&#160;</sup>The children of Israel said to Samuel, “Don’t stop crying to Yahweh our Elohim for us, that he will save us out of the hand of the Philistines.” 
-<sup>9&#160;</sup>Samuel took a suckling lamb, and offered it for a whole burnt offering to Yahweh. Samuel cried to Yahweh for Israel, and Yahweh answered him. 
-<sup>10&#160;</sup>As Samuel was offering up the burnt offering, the Philistines came near to battle against Israel; but Yahweh thundered with a great thunder on that day on the Philistines and confused them; and they were struck down before Israel. 
+<sup>8&#160;</sup>The children of Israel said to Samuel, “Don’t stop crying to Yahuah our Elohim for us, that he will save us out of the hand of the Philistines.” 
+<sup>9&#160;</sup>Samuel took a suckling lamb, and offered it for a whole burnt offering to Yahuah. Samuel cried to Yahuah for Israel, and Yahuah answered him. 
+<sup>10&#160;</sup>As Samuel was offering up the burnt offering, the Philistines came near to battle against Israel; but Yahuah thundered with a great thunder on that day on the Philistines and confused them; and they were struck down before Israel. 
 <sup>11&#160;</sup>The men of Israel went out of Mizpah and pursued the Philistines, and struck them until they came under Beth Kar. 
 </p><p>
-<sup>12&#160;</sup>Then Samuel took a stone and set it between Mizpah and Shen, and called its name Ebenezer, saying, “Yahweh helped us until now.” 
-<sup>13&#160;</sup>So the Philistines were subdued, and they stopped coming within the border of Israel. Yahweh’s hand was against the Philistines all the days of Samuel. 
+<sup>12&#160;</sup>Then Samuel took a stone and set it between Mizpah and Shen, and called its name Ebenezer, saying, “Yahuah helped us until now.” 
+<sup>13&#160;</sup>So the Philistines were subdued, and they stopped coming within the border of Israel. Yahuah’s hand was against the Philistines all the days of Samuel. 
 </p><p>
 <sup>14&#160;</sup>The cities which the Philistines had taken from Israel were restored to Israel, from Ekron even to Gath; and Israel recovered its border out of the hand of the Philistines. There was peace between Israel and the Amorites. 
 </p><p>
 <sup>15&#160;</sup>Samuel judged Israel all the days of his life. 
 <sup>16&#160;</sup>He went from year to year in a circuit to Bethel, Gilgal, and Mizpah; and he judged Israel in all those places. 
-<sup>17&#160;</sup>His return was to Ramah, for his house was there, and he judged Israel there; and he built an altar to Yahweh there. 
+<sup>17&#160;</sup>His return was to Ramah, for his house was there, and he judged Israel there; and he built an altar to Yahuah there. 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
 <sup>1&#160;</sup>When Samuel was old, he made his sons judges over Israel. 
@@ -358,12 +358,12 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>Then all the elders of Israel gathered themselves together and came to Samuel to Ramah. 
 <sup>5&#160;</sup>They said to him, “Behold, you are old, and your sons don’t walk in your ways. Now make us a king to judge us like all the nations.” 
 <sup>6&#160;</sup>But the thing displeased Samuel when they said, “Give us a king to judge us.” 
-</p><p>Samuel prayed to Yahweh. 
-<sup>7&#160;</sup>Yahweh said to Samuel, “Listen to the voice of the people in all that they tell you; for they have not rejected you, but they have rejected me as the king over them. 
+</p><p>Samuel prayed to Yahuah. 
+<sup>7&#160;</sup>Yahuah said to Samuel, “Listen to the voice of the people in all that they tell you; for they have not rejected you, but they have rejected me as the king over them. 
 <sup>8&#160;</sup>According to all the works which they have done since the day that I brought them up out of Egypt even to this day, in that they have forsaken me and served other elohims, so they also do to you. 
 <sup>9&#160;</sup>Now therefore, listen to their voice. However, you shall protest solemnly to them, and shall show them the way of the king who will reign over them.” 
 </p><p>
-<sup>10&#160;</sup>Samuel told all Yahweh’s words to the people who asked him for a king. 
+<sup>10&#160;</sup>Samuel told all Yahuah’s words to the people who asked him for a king. 
 <sup>11&#160;</sup>He said, “This will be the way of the king who shall reign over you: he will take your sons and appoint them as his servants, for his chariots and to be his horsemen; and they will run before his chariots. 
 <sup>12&#160;</sup>He will appoint them to him for captains of thousands and captains of fifties; and he will assign some to plow his ground and to reap his harvest; and to make his instruments of war and the instruments of his chariots. 
 <sup>13&#160;</sup>He will take your daughters to be perfumers, to be cooks, and to be bakers. 
@@ -371,13 +371,13 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>He will take one tenth of your seed and of your vineyards, and give it to his officers and to his servants. 
 <sup>16&#160;</sup>He will take your male servants, your female servants, your best young men, and your donkeys, and assign them to his own work. 
 <sup>17&#160;</sup>He will take one tenth of your flocks; and you will be his servants. 
-<sup>18&#160;</sup>You will cry out in that day because of your king whom you will have chosen for yourselves; and Yahweh will not answer you in that day.” 
+<sup>18&#160;</sup>You will cry out in that day because of your king whom you will have chosen for yourselves; and Yahuah will not answer you in that day.” 
 </p><p>
 <sup>19&#160;</sup>But the people refused to listen to the voice of Samuel; and they said, “No, but we will have a king over us, 
 <sup>20&#160;</sup>that we also may be like all the nations; and that our king may judge us, and go out before us, and fight our battles.” 
 </p><p>
-<sup>21&#160;</sup>Samuel heard all the words of the people, and he rehearsed them in the ears of Yahweh. 
-<sup>22&#160;</sup>Yahweh said to Samuel, “Listen to their voice, and make them a king.” 
+<sup>21&#160;</sup>Samuel heard all the words of the people, and he rehearsed them in the ears of Yahuah. 
+<sup>22&#160;</sup>Yahuah said to Samuel, “Listen to their voice, and make them a king.” 
 </p><p>Samuel said to the men of Israel, “Everyone go to your own city.” 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
@@ -404,10 +404,10 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>14&#160;</sup>They went up to the city. As they came within the city, behold, Samuel came out toward them to go up to the high place. 
 </p><p>
-<sup>15&#160;</sup>Now Yahweh had revealed to Samuel a day before Saul came, saying, 
+<sup>15&#160;</sup>Now Yahuah had revealed to Samuel a day before Saul came, saying, 
 <sup>16&#160;</sup>“Tomorrow about this time I will send you a man out of the land of Benjamin, and you shall anoint him to be prince over my people Israel. He will save my people out of the hand of the Philistines; for I have looked upon my people, because their cry has come to me.” 
 </p><p>
-<sup>17&#160;</sup>When Samuel saw Saul, Yahweh said to him, “Behold, the man of whom I spoke to you! He will have authority over my people.” 
+<sup>17&#160;</sup>When Samuel saw Saul, Yahuah said to him, “Behold, the man of whom I spoke to you! He will have authority over my people.” 
 </p><p>
 <sup>18&#160;</sup>Then Saul approached Samuel in the gateway, and said, “Please tell me where the seer’s house is.” 
 </p><p>
@@ -425,14 +425,14 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>As they were going down at the end of the city, Samuel said to Saul, “Tell the servant to go on ahead of us.” He went ahead, then Samuel said, “But stand still first, that I may cause you to hear Elohim’s message.” 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p>
-<sup>1&#160;</sup>Then Samuel took the vial of oil and poured it on his head, then kissed him and said, “Hasn’t Yahweh anointed you to be prince over his inheritance? 
+<sup>1&#160;</sup>Then Samuel took the vial of oil and poured it on his head, then kissed him and said, “Hasn’t Yahuah anointed you to be prince over his inheritance? 
 <sup>2&#160;</sup>When you have departed from me today, then you will find two men by Rachel’s tomb, on the border of Benjamin at Zelzah. They will tell you, ‘The donkeys which you went to look for have been found; and behold, your father has stopped caring about the donkeys and is anxious for you, saying, “What shall I do for my son?”&#160;’ 
 </p><p>
 <sup>3&#160;</sup>“Then you will go on forward from there, and you will come to the oak of Tabor. Three men will meet you there going up to Elohim to Bethel: one carrying three young goats, and another carrying three loaves of bread, and another carrying a container of wine. 
 <sup>4&#160;</sup>They will greet you and give you two loaves of bread, which you shall receive from their hand. 
 </p><p>
 <sup>5&#160;</sup>“After that you will come to the hill of Elohim, where the garrison of the Philistines is; and it will happen, when you have come there to the city, that you will meet a band of prophets coming down from the high place with a lute, a tambourine, a pipe, and a harp before them; and they will be prophesying. 
-<sup>6&#160;</sup>Then Yahweh’s Spirit will come mightily on you, then you will prophesy with them and will be turned into another man. 
+<sup>6&#160;</sup>Then Yahuah’s Spirit will come mightily on you, then you will prophesy with them and will be turned into another man. 
 <sup>7&#160;</sup>Let it be, when these signs have come to you, that you do what is appropriate for the occasion; for Elohim is with you. 
 </p><p>
 <sup>8&#160;</sup>“Go down ahead of me to Gilgal; and behold, I will come down to you to offer burnt offerings and to sacrifice sacrifices of peace offerings. Wait seven days, until I come to you and show you what you are to do.” 
@@ -450,20 +450,20 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>16&#160;</sup>Saul said to his uncle, “He told us plainly that the donkeys were found.” But concerning the matter of the kingdom, of which Samuel spoke, he didn’t tell him. 
 </p><p>
-<sup>17&#160;</sup>Samuel called the people together to Yahweh to Mizpah; 
-<sup>18&#160;</sup>and he said to the children of Israel, “Yahweh, the Elohim of Israel, says ‘I brought Israel up out of Egypt and I delivered you out of the hand of the Egyptians, and out of the hand of all the kingdoms that oppressed you.’ 
-<sup>19&#160;</sup>But you have today rejected your Elohim, who himself saves you out of all your calamities and your distresses; and you have said to him, ‘No! Set a king over us!’ Now therefore present yourselves before Yahweh by your tribes and by your thousands.” 
+<sup>17&#160;</sup>Samuel called the people together to Yahuah to Mizpah; 
+<sup>18&#160;</sup>and he said to the children of Israel, “Yahuah, the Elohim of Israel, says ‘I brought Israel up out of Egypt and I delivered you out of the hand of the Egyptians, and out of the hand of all the kingdoms that oppressed you.’ 
+<sup>19&#160;</sup>But you have today rejected your Elohim, who himself saves you out of all your calamities and your distresses; and you have said to him, ‘No! Set a king over us!’ Now therefore present yourselves before Yahuah by your tribes and by your thousands.” 
 </p><p>
 <sup>20&#160;</sup>So Samuel brought all the tribes of Israel near, and the tribe of Benjamin was chosen. 
 <sup>21&#160;</sup>He brought the tribe of Benjamin near by their families and the family of the Matrites was chosen. Then Saul the son of Kish was chosen; but when they looked for him, he could not be found. 
-<sup>22&#160;</sup>Therefore they asked of Yahweh further, “Is there yet a man to come here?” 
-</p><p>Yahweh answered, “Behold, he has hidden himself among the baggage.” 
+<sup>22&#160;</sup>Therefore they asked of Yahuah further, “Is there yet a man to come here?” 
+</p><p>Yahuah answered, “Behold, he has hidden himself among the baggage.” 
 </p><p>
 <sup>23&#160;</sup>They ran and got him there. When he stood among the people, he was higher than any of the people from his shoulders and upward. 
-<sup>24&#160;</sup>Samuel said to all the people, “Do you see him whom Yahweh has chosen, that there is no one like him among all the people?” 
+<sup>24&#160;</sup>Samuel said to all the people, “Do you see him whom Yahuah has chosen, that there is no one like him among all the people?” 
 </p><p>All the people shouted and said, “Long live the king!” 
 </p><p>
-<sup>25&#160;</sup>Then Samuel told the people the regulations of the kingdom, and wrote it in a book and laid it up before Yahweh. Samuel sent all the people away, every man to his house. 
+<sup>25&#160;</sup>Then Samuel told the people the regulations of the kingdom, and wrote it in a book and laid it up before Yahuah. Samuel sent all the people away, every man to his house. 
 <sup>26&#160;</sup>Saul also went to his house in Gibeah; and the army went with him, whose hearts Elohim had touched. 
 <sup>27&#160;</sup>But certain worthless fellows said, “How could this man save us?” They despised him, and brought him no tribute. But he held his peace. 
 </p><h2 class="chapterlabel" id="11">11</h2>
@@ -477,7 +477,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>5&#160;</sup>Behold, Saul came following the oxen out of the field; and Saul said, “What ails the people that they weep?” They told him the words of the men of Jabesh. 
 <sup>6&#160;</sup>Elohim’s Spirit came mightily on Saul when he heard those words, and his anger burned hot. 
-<sup>7&#160;</sup>He took a yoke of oxen and cut them in pieces, then sent them throughout all the borders of Israel by the hand of messengers, saying, “Whoever doesn’t come out after Saul and after Samuel, so shall it be done to his oxen.” The dread of Yahweh fell on the people, and they came out as one man. 
+<sup>7&#160;</sup>He took a yoke of oxen and cut them in pieces, then sent them throughout all the borders of Israel by the hand of messengers, saying, “Whoever doesn’t come out after Saul and after Samuel, so shall it be done to his oxen.” The dread of Yahuah fell on the people, and they came out as one man. 
 <sup>8&#160;</sup>He counted them in Bezek; and the children of Israel were three hundred thousand, and the men of Judah thirty thousand. 
 <sup>9&#160;</sup>They said to the messengers who came, “Tell the men of Jabesh Gilead, ‘Tomorrow, by the time the sun is hot, you will be rescued.’&#160;” The messengers came and told the men of Jabesh; and they were glad. 
 <sup>10&#160;</sup>Therefore the men of Jabesh said, “Tomorrow we will come out to you, and you shall do with us all that seems good to you.” 
@@ -485,45 +485,45 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>12&#160;</sup>The people said to Samuel, “Who is he who said, ‘Shall Saul reign over us?’ Bring those men, that we may put them to death!” 
 </p><p>
-<sup>13&#160;</sup>Saul said, “No man shall be put to death today; for today Yahweh has rescued Israel.” 
+<sup>13&#160;</sup>Saul said, “No man shall be put to death today; for today Yahuah has rescued Israel.” 
 </p><p>
 <sup>14&#160;</sup>Then Samuel said to the people, “Come! Let’s go to Gilgal, and renew the kingdom there.” 
-<sup>15&#160;</sup>All the people went to Gilgal; and there they made Saul king before Yahweh in Gilgal. There they offered sacrifices of peace offerings before Yahweh; and there Saul and all the men of Israel rejoiced greatly. 
+<sup>15&#160;</sup>All the people went to Gilgal; and there they made Saul king before Yahuah in Gilgal. There they offered sacrifices of peace offerings before Yahuah; and there Saul and all the men of Israel rejoiced greatly. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
 <sup>1&#160;</sup>Samuel said to all Israel, “Behold, I have listened to your voice in all that you said to me, and have made a king over you. 
 <sup>2&#160;</sup>Now, behold, the king walks before you. I am old and gray-headed. Behold, my sons are with you. I have walked before you from my youth to this day. 
-<sup>3&#160;</sup>Here I am. Witness against me before Yahweh and before his anointed. Whose ox have I taken? Whose donkey have I taken? Whom have I defrauded? Whom have I oppressed? Of whose hand have I taken a bribe to make me blind my eyes? I will restore it to you.” 
+<sup>3&#160;</sup>Here I am. Witness against me before Yahuah and before his anointed. Whose ox have I taken? Whose donkey have I taken? Whom have I defrauded? Whom have I oppressed? Of whose hand have I taken a bribe to make me blind my eyes? I will restore it to you.” 
 </p><p>
 <sup>4&#160;</sup>They said, “You have not defrauded us, nor oppressed us, neither have you taken anything from anyone’s hand.” 
 </p><p>
-<sup>5&#160;</sup>He said to them, “Yahweh is witness against you, and his anointed is witness today, that you have not found anything in my hand.” 
+<sup>5&#160;</sup>He said to them, “Yahuah is witness against you, and his anointed is witness today, that you have not found anything in my hand.” 
 </p><p>They said, “He is witness.” 
-<sup>6&#160;</sup>Samuel said to the people, “It is Yahweh who appointed Moses and Aaron, and that brought your fathers up out of the land of Egypt. 
-<sup>7&#160;</sup>Now therefore stand still, that I may plead with you before Yahweh concerning all the righteous acts of Yahweh, which he did to you and to your fathers. 
+<sup>6&#160;</sup>Samuel said to the people, “It is Yahuah who appointed Moses and Aaron, and that brought your fathers up out of the land of Egypt. 
+<sup>7&#160;</sup>Now therefore stand still, that I may plead with you before Yahuah concerning all the righteous acts of Yahuah, which he did to you and to your fathers. 
 </p><p>
-<sup>8&#160;</sup>“When Jacob had come into Egypt, and your fathers cried to Yahweh, then Yahweh sent Moses and Aaron, who brought your fathers out of Egypt, and made them to dwell in this place. 
-<sup>9&#160;</sup>But they forgot Yahweh their Elohim; and he sold them into the hand of Sisera, captain of the army of Hazor, and into the hand of the Philistines, and into the hand of the king of Moab; and they fought against them. 
-<sup>10&#160;</sup>They cried to Yahweh, and said, ‘We have sinned, because we have forsaken Yahweh and have served the Baals and the Ashtaroth; but now deliver us out of the hand of our enemies, and we will serve you.’ 
-<sup>11&#160;</sup>Yahweh sent Jerubbaal, Bedan, Jephthah, and Samuel, and delivered you out of the hand of your enemies on every side; and you lived in safety. 
+<sup>8&#160;</sup>“When Jacob had come into Egypt, and your fathers cried to Yahuah, then Yahuah sent Moses and Aaron, who brought your fathers out of Egypt, and made them to dwell in this place. 
+<sup>9&#160;</sup>But they forgot Yahuah their Elohim; and he sold them into the hand of Sisera, captain of the army of Hazor, and into the hand of the Philistines, and into the hand of the king of Moab; and they fought against them. 
+<sup>10&#160;</sup>They cried to Yahuah, and said, ‘We have sinned, because we have forsaken Yahuah and have served the Baals and the Ashtaroth; but now deliver us out of the hand of our enemies, and we will serve you.’ 
+<sup>11&#160;</sup>Yahuah sent Jerubbaal, Bedan, Jephthah, and Samuel, and delivered you out of the hand of your enemies on every side; and you lived in safety. 
 </p><p>
-<sup>12&#160;</sup>“When you saw that Nahash the king of the children of Ammon came against you, you said to me, ‘No, but a king shall reign over us,’ when Yahweh your Elohim was your king. 
-<sup>13&#160;</sup>Now therefore see the king whom you have chosen and whom you have asked for. Behold, Yahweh has set a king over you. 
-<sup>14&#160;</sup>If you will fear Yahweh, and serve him, and listen to his voice, and not rebel against the commandment of Yahweh, then both you and also the king who reigns over you are followers of Yahweh your Elohim. 
-<sup>15&#160;</sup>But if you will not listen to Yahweh’s voice, but rebel against the commandment of Yahweh, then Yahweh’s hand will be against you, as it was against your fathers. 
+<sup>12&#160;</sup>“When you saw that Nahash the king of the children of Ammon came against you, you said to me, ‘No, but a king shall reign over us,’ when Yahuah your Elohim was your king. 
+<sup>13&#160;</sup>Now therefore see the king whom you have chosen and whom you have asked for. Behold, Yahuah has set a king over you. 
+<sup>14&#160;</sup>If you will fear Yahuah, and serve him, and listen to his voice, and not rebel against the commandment of Yahuah, then both you and also the king who reigns over you are followers of Yahuah your Elohim. 
+<sup>15&#160;</sup>But if you will not listen to Yahuah’s voice, but rebel against the commandment of Yahuah, then Yahuah’s hand will be against you, as it was against your fathers. 
 </p><p>
-<sup>16&#160;</sup>“Now therefore stand still and see this great thing, which Yahweh will do before your eyes. 
-<sup>17&#160;</sup>Isn’t it wheat harvest today? I will call to Yahweh, that he may send thunder and rain; and you will know and see that your wickedness is great, which you have done in Yahweh’s sight, in asking for a king.” 
+<sup>16&#160;</sup>“Now therefore stand still and see this great thing, which Yahuah will do before your eyes. 
+<sup>17&#160;</sup>Isn’t it wheat harvest today? I will call to Yahuah, that he may send thunder and rain; and you will know and see that your wickedness is great, which you have done in Yahuah’s sight, in asking for a king.” 
 </p><p>
-<sup>18&#160;</sup>So Samuel called to Yahweh, and Yahweh sent thunder and rain that day. Then all the people greatly feared Yahweh and Samuel. 
+<sup>18&#160;</sup>So Samuel called to Yahuah, and Yahuah sent thunder and rain that day. Then all the people greatly feared Yahuah and Samuel. 
 </p><p>
-<sup>19&#160;</sup>All the people said to Samuel, “Pray for your servants to Yahweh your Elohim, that we not die; for we have added to all our sins this evil, to ask for a king.” 
+<sup>19&#160;</sup>All the people said to Samuel, “Pray for your servants to Yahuah your Elohim, that we not die; for we have added to all our sins this evil, to ask for a king.” 
 </p><p>
-<sup>20&#160;</sup>Samuel said to the people, “Don’t be afraid. You have indeed done all this evil; yet don’t turn away from following Yahweh, but serve Yahweh with all your heart. 
+<sup>20&#160;</sup>Samuel said to the people, “Don’t be afraid. You have indeed done all this evil; yet don’t turn away from following Yahuah, but serve Yahuah with all your heart. 
 <sup>21&#160;</sup>Don’t turn away to go after vain things which can’t profit or deliver, for they are vain. 
-<sup>22&#160;</sup>For Yahweh will not forsake his people for his great name’s sake, because it has pleased Yahweh to make you a people for himself. 
-<sup>23&#160;</sup>Moreover, as for me, far be it from me that I should sin against Yahweh in ceasing to pray for you; but I will instruct you in the good and the right way. 
-<sup>24&#160;</sup>Only fear Yahweh, and serve him in truth with all your heart; for consider what great things he has done for you. 
+<sup>22&#160;</sup>For Yahuah will not forsake his people for his great name’s sake, because it has pleased Yahuah to make you a people for himself. 
+<sup>23&#160;</sup>Moreover, as for me, far be it from me that I should sin against Yahuah in ceasing to pray for you; but I will instruct you in the good and the right way. 
+<sup>24&#160;</sup>Only fear Yahuah, and serve him in truth with all your heart; for consider what great things he has done for you. 
 <sup>25&#160;</sup>But if you keep doing evil, you will be consumed, both you and your king.” 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
@@ -541,10 +541,10 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>It came to pass that as soon as he had finished offering the burnt offering, behold, Samuel came; and Saul went out to meet him, that he might greet him. 
 <sup>11&#160;</sup>Samuel said, “What have you done?” 
 </p><p>Saul said, “Because I saw that the people were scattered from me, and that you didn’t come within the days appointed, and that the Philistines assembled themselves together at Michmash, 
-<sup>12&#160;</sup>therefore I said, ‘Now the Philistines will come down on me to Gilgal, and I haven’t entreated the favor of Yahweh.’ I forced myself therefore, and offered the burnt offering.” 
+<sup>12&#160;</sup>therefore I said, ‘Now the Philistines will come down on me to Gilgal, and I haven’t entreated the favor of Yahuah.’ I forced myself therefore, and offered the burnt offering.” 
 </p><p>
-<sup>13&#160;</sup>Samuel said to Saul, “You have done foolishly. You have not kept the commandment of Yahweh your Elohim, which he commanded you; for now Yahweh would have established your kingdom on Israel forever. 
-<sup>14&#160;</sup>But now your kingdom will not continue. Yahweh has sought for himself a man after his own heart, and Yahweh has appointed him to be prince over his people, because you have not kept that which Yahweh commanded you.” 
+<sup>13&#160;</sup>Samuel said to Saul, “You have done foolishly. You have not kept the commandment of Yahuah your Elohim, which he commanded you; for now Yahuah would have established your kingdom on Israel forever. 
+<sup>14&#160;</sup>But now your kingdom will not continue. Yahuah has sought for himself a man after his own heart, and Yahuah has appointed him to be prince over his people, because you have not kept that which Yahuah commanded you.” 
 </p><p>
 <sup>15&#160;</sup>Samuel arose, and went from Gilgal to Gibeah of Benjamin. Saul counted the people who were present with him, about six hundred men. 
 <sup>16&#160;</sup>Saul, and Jonathan his son, and the people who were present with them, stayed in Geba of Benjamin; but the Philistines encamped in Michmash. 
@@ -560,21 +560,21 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Now it happened on a day that Jonathan the son of Saul said to the young man who bore his armor, “Come! Let’s go over to the Philistines’ garrison that is on the other side.” But he didn’t tell his father. 
 <sup>2&#160;</sup>Saul stayed in the uttermost part of Gibeah under the pomegranate tree which is in Migron; and the people who were with him were about six hundred men, 
-<sup>3&#160;</sup>including Ahijah the son of Ahitub, Ichabod’s brother, the son of Phinehas, the son of Eli the priest of Yahweh in Shiloh, wearing an ephod. The people didn’t know that Jonathan was gone. 
+<sup>3&#160;</sup>including Ahijah the son of Ahitub, Ichabod’s brother, the son of Phinehas, the son of Eli the priest of Yahuah in Shiloh, wearing an ephod. The people didn’t know that Jonathan was gone. 
 </p><p>
 <sup>4&#160;</sup>Between the passes, by which Jonathan sought to go over to the Philistines’ garrison, there was a rocky crag on the one side and a rocky crag on the other side; and the name of the one was Bozez, and the name of the other Seneh. 
 <sup>5&#160;</sup>The one crag rose up on the north in front of Michmash, and the other on the south in front of Geba. 
-<sup>6&#160;</sup>Jonathan said to the young man who bore his armor, “Come! Let’s go over to the garrison of these uncircumcised. It may be that Yahweh will work for us, for there is no restraint on Yahweh to save by many or by few.” 
+<sup>6&#160;</sup>Jonathan said to the young man who bore his armor, “Come! Let’s go over to the garrison of these uncircumcised. It may be that Yahuah will work for us, for there is no restraint on Yahuah to save by many or by few.” 
 </p><p>
 <sup>7&#160;</sup>His armor bearer said to him, “Do all that is in your heart. Go, and behold, I am with you according to your heart.” 
 </p><p>
 <sup>8&#160;</sup>Then Jonathan said, “Behold, we will pass over to the men, and we will reveal ourselves to them. 
 <sup>9&#160;</sup>If they say this to us, ‘Wait until we come to you!’ then we will stand still in our place and will not go up to them. 
-<sup>10&#160;</sup>But if they say this, ‘Come up to us!’ then we will go up, for Yahweh has delivered them into our hand. This shall be the sign to us.” 
+<sup>10&#160;</sup>But if they say this, ‘Come up to us!’ then we will go up, for Yahuah has delivered them into our hand. This shall be the sign to us.” 
 </p><p>
 <sup>11&#160;</sup>Both of them revealed themselves to the garrison of the Philistines; and the Philistines said, “Behold, the Hebrews are coming out of the holes where they had hidden themselves!” 
 <sup>12&#160;</sup>The men of the garrison answered Jonathan and his armor bearer, and said, “Come up to us, and we will show you something!” 
-</p><p>Jonathan said to his armor bearer, “Come up after me, for Yahweh has delivered them into the hand of Israel.” 
+</p><p>Jonathan said to his armor bearer, “Come up after me, for Yahuah has delivered them into the hand of Israel.” 
 <sup>13&#160;</sup>Jonathan climbed up on his hands and on his feet, and his armor bearer after him, and they fell before Jonathan; and his armor bearer killed them after him. 
 <sup>14&#160;</sup>That first slaughter, which Jonathan and his armor bearer made, was about twenty men, within as it were half a furrow’s length in an acre of land. 
 </p><p>
@@ -588,7 +588,7 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>Saul and all the people who were with him were gathered together, and came to the battle; and behold, they were all striking each other with their swords in very great confusion. 
 <sup>21&#160;</sup>Now the Hebrews who were with the Philistines before and who went up with them into the camp from all around, even they also turned to be with the Israelites who were with Saul and Jonathan. 
 <sup>22&#160;</sup>Likewise all the men of Israel who had hidden themselves in the hill country of Ephraim, when they heard that the Philistines fled, even they also followed hard after them in the battle. 
-<sup>23&#160;</sup>So Yahweh saved Israel that day; and the battle passed over by Beth Aven. 
+<sup>23&#160;</sup>So Yahuah saved Israel that day; and the battle passed over by Beth Aven. 
 </p><p>
 <sup>24&#160;</sup>The men of Israel were distressed that day; for Saul had adjured the people, saying, “Cursed is the man who eats any food until it is evening, and I am avenged of my enemies.” So none of the people tasted food. 
 </p><p>
@@ -601,22 +601,22 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>How much more, if perhaps the people had eaten freely today of the plunder of their enemies which they found? For now there has been no great slaughter among the Philistines.” 
 <sup>31&#160;</sup>They struck the Philistines that day from Michmash to Aijalon. The people were very faint; 
 <sup>32&#160;</sup>and the people pounced on the plunder, and took sheep, cattle, and calves, and killed them on the ground; and the people ate them with the blood. 
-<sup>33&#160;</sup>Then they told Saul, saying, “Behold, the people are sinning against Yahweh, in that they eat meat with the blood.” 
+<sup>33&#160;</sup>Then they told Saul, saying, “Behold, the people are sinning against Yahuah, in that they eat meat with the blood.” 
 </p><p>He said, “You have dealt treacherously. Roll a large stone to me today!” 
-<sup>34&#160;</sup>Saul said, “Disperse yourselves among the people, and tell them, ‘Every man bring me here his ox, and every man his sheep, and kill them here, and eat; and don’t sin against Yahweh in eating meat with the blood.’&#160;” All the people brought every man his ox with him that night, and killed them there. 
+<sup>34&#160;</sup>Saul said, “Disperse yourselves among the people, and tell them, ‘Every man bring me here his ox, and every man his sheep, and kill them here, and eat; and don’t sin against Yahuah in eating meat with the blood.’&#160;” All the people brought every man his ox with him that night, and killed them there. 
 </p><p>
-<sup>35&#160;</sup>Saul built an altar to Yahweh. This was the first altar that he built to Yahweh. 
+<sup>35&#160;</sup>Saul built an altar to Yahuah. This was the first altar that he built to Yahuah. 
 <sup>36&#160;</sup>Saul said, “Let’s go down after the Philistines by night, and take plunder among them until the morning light. Let’s not leave a man of them.” 
 </p><p>They said, “Do whatever seems good to you.” 
 </p><p>Then the priest said, “Let’s draw near here to Elohim.” 
 </p><p>
 <sup>37&#160;</sup>Saul asked counsel of Elohim: “Shall I go down after the Philistines? Will you deliver them into the hand of Israel?” But he didn’t answer him that day. 
 <sup>38&#160;</sup>Saul said, “Draw near here, all you chiefs of the people, and know and see in whom this sin has been today. 
-<sup>39&#160;</sup>For as Yahweh lives, who saves Israel, though it is in Jonathan my son, he shall surely die.” But there was not a man among all the people who answered him. 
+<sup>39&#160;</sup>For as Yahuah lives, who saves Israel, though it is in Jonathan my son, he shall surely die.” But there was not a man among all the people who answered him. 
 <sup>40&#160;</sup>Then he said to all Israel, “You be on one side, and I and Jonathan my son will be on the other side.” 
 </p><p>The people said to Saul, “Do what seems good to you.” 
 </p><p>
-<sup>41&#160;</sup>Therefore Saul said to Yahweh, the Elohim of Israel, “Show the right.” 
+<sup>41&#160;</sup>Therefore Saul said to Yahuah, the Elohim of Israel, “Show the right.” 
 </p><p>Jonathan and Saul were chosen, but the people escaped. 
 </p><p>
 <sup>42&#160;</sup>Saul said, “Cast lots between me and Jonathan my son.” 
@@ -627,7 +627,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>44&#160;</sup>Saul said, “Elohim do so and more also; for you shall surely die, Jonathan.” 
 </p><p>
-<sup>45&#160;</sup>The people said to Saul, “Shall Jonathan die, who has worked this great salvation in Israel? Far from it! As Yahweh lives, there shall not one hair of his head fall to the ground, for he has worked with Elohim today!” So the people rescued Jonathan, so he didn’t die. 
+<sup>45&#160;</sup>The people said to Saul, “Shall Jonathan die, who has worked this great salvation in Israel? Far from it! As Yahuah lives, there shall not one hair of his head fall to the ground, for he has worked with Elohim today!” So the people rescued Jonathan, so he didn’t die. 
 <sup>46&#160;</sup>Then Saul went up from following the Philistines; and the Philistines went to their own place. 
 </p><p>
 <sup>47&#160;</sup>Now when Saul had taken the kingdom over Israel, he fought against all his enemies on every side: against Moab, and against the children of Ammon, and against Edom, and against the kings of Zobah, and against the Philistines. Wherever he turned himself, he defeated them. 
@@ -639,8 +639,8 @@ html[dir=ltr] .q2 {
 <sup>52&#160;</sup>There was severe war against the Philistines all the days of Saul; and when Saul saw any mighty man or any valiant man, he took him into his service. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
-<sup>1&#160;</sup>Samuel said to Saul, “Yahweh sent me to anoint you to be king over his people, over Israel. Now therefore listen to the voice of Yahweh’s words. 
-<sup>2&#160;</sup>Yahweh of Armies says, ‘I remember what Amalek did to Israel, how he set himself against him on the way when he came up out of Egypt. 
+<sup>1&#160;</sup>Samuel said to Saul, “Yahuah sent me to anoint you to be king over his people, over Israel. Now therefore listen to the voice of Yahuah’s words. 
+<sup>2&#160;</sup>Yahuah of Armies says, ‘I remember what Amalek did to Israel, how he set himself against him on the way when he came up out of Egypt. 
 <sup>3&#160;</sup>Now go and strike Amalek, and utterly destroy all that they have, and don’t spare them; but kill both man and woman, infant and nursing baby, ox and sheep, camel and donkey.’&#160;” 
 </p><p>
 <sup>4&#160;</sup>Saul summoned the people, and counted them in Telaim, two hundred thousand footmen and ten thousand men of Judah. 
@@ -651,80 +651,80 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>He took Agag the king of the Amalekites alive, and utterly destroyed all the people with the edge of the sword. 
 <sup>9&#160;</sup>But Saul and the people spared Agag and the best of the sheep, of the cattle, of the fat calves, of the lambs, and all that was good, and were not willing to utterly destroy them; but everything that was vile and refuse, that they destroyed utterly. 
 </p><p>
-<sup>10&#160;</sup>Then Yahweh’s word came to Samuel, saying, 
-<sup>11&#160;</sup>“It grieves me that I have set up Saul to be king, for he has turned back from following me, and has not performed my commandments.” Samuel was angry; and he cried to Yahweh all night. 
+<sup>10&#160;</sup>Then Yahuah’s word came to Samuel, saying, 
+<sup>11&#160;</sup>“It grieves me that I have set up Saul to be king, for he has turned back from following me, and has not performed my commandments.” Samuel was angry; and he cried to Yahuah all night. 
 </p><p>
 <sup>12&#160;</sup>Samuel rose early to meet Saul in the morning; and Samuel was told, saying, “Saul came to Carmel, and behold, he set up a monument for himself, turned, passed on, and went down to Gilgal.” 
 </p><p>
-<sup>13&#160;</sup>Samuel came to Saul; and Saul said to him, “You are blessed by Yahweh! I have performed the commandment of Yahweh.” 
+<sup>13&#160;</sup>Samuel came to Saul; and Saul said to him, “You are blessed by Yahuah! I have performed the commandment of Yahuah.” 
 </p><p>
 <sup>14&#160;</sup>Samuel said, “Then what does this bleating of the sheep in my ears and the lowing of the cattle which I hear mean?” 
 </p><p>
-<sup>15&#160;</sup>Saul said, “They have brought them from the Amalekites; for the people spared the best of the sheep and of the cattle, to sacrifice to Yahweh your Elohim. We have utterly destroyed the rest.” 
+<sup>15&#160;</sup>Saul said, “They have brought them from the Amalekites; for the people spared the best of the sheep and of the cattle, to sacrifice to Yahuah your Elohim. We have utterly destroyed the rest.” 
 </p><p>
-<sup>16&#160;</sup>Then Samuel said to Saul, “Stay, and I will tell you what Yahweh said to me last night.” 
+<sup>16&#160;</sup>Then Samuel said to Saul, “Stay, and I will tell you what Yahuah said to me last night.” 
 </p><p>He said to him, “Say on.” 
 </p><p>
-<sup>17&#160;</sup>Samuel said, “Though you were little in your own sight, weren’t you made the head of the tribes of Israel? Yahweh anointed you king over Israel; 
-<sup>18&#160;</sup>and Yahweh sent you on a journey, and said, ‘Go, and utterly destroy the sinners the Amalekites, and fight against them until they are consumed.’ 
-<sup>19&#160;</sup>Why then didn’t you obey Yahweh’s voice, but took the plunder, and did that which was evil in Yahweh’s sight?” 
+<sup>17&#160;</sup>Samuel said, “Though you were little in your own sight, weren’t you made the head of the tribes of Israel? Yahuah anointed you king over Israel; 
+<sup>18&#160;</sup>and Yahuah sent you on a journey, and said, ‘Go, and utterly destroy the sinners the Amalekites, and fight against them until they are consumed.’ 
+<sup>19&#160;</sup>Why then didn’t you obey Yahuah’s voice, but took the plunder, and did that which was evil in Yahuah’s sight?” 
 </p><p>
-<sup>20&#160;</sup>Saul said to Samuel, “But I have obeyed Yahweh’s voice, and have gone the way which Yahweh sent me, and have brought Agag the king of Amalek, and have utterly destroyed the Amalekites. 
-<sup>21&#160;</sup>But the people took of the plunder, sheep and cattle, the best of the devoted things, to sacrifice to Yahweh your Elohim in Gilgal.” 
+<sup>20&#160;</sup>Saul said to Samuel, “But I have obeyed Yahuah’s voice, and have gone the way which Yahuah sent me, and have brought Agag the king of Amalek, and have utterly destroyed the Amalekites. 
+<sup>21&#160;</sup>But the people took of the plunder, sheep and cattle, the best of the devoted things, to sacrifice to Yahuah your Elohim in Gilgal.” 
 </p><p>
-<sup>22&#160;</sup>Samuel said, “Has Yahweh as great delight in burnt offerings and sacrifices, as in obeying Yahweh’s voice? Behold, to obey is better than sacrifice, and to listen than the fat of rams. 
-<sup>23&#160;</sup>For rebellion is as the sin of witchcraft, and stubbornness is as idolatry and teraphim. Because you have rejected Yahweh’s word, he has also rejected you from being king.” 
+<sup>22&#160;</sup>Samuel said, “Has Yahuah as great delight in burnt offerings and sacrifices, as in obeying Yahuah’s voice? Behold, to obey is better than sacrifice, and to listen than the fat of rams. 
+<sup>23&#160;</sup>For rebellion is as the sin of witchcraft, and stubbornness is as idolatry and teraphim. Because you have rejected Yahuah’s word, he has also rejected you from being king.” 
 </p><p>
-<sup>24&#160;</sup>Saul said to Samuel, “I have sinned; for I have transgressed the commandment of Yahweh and your words, because I feared the people and obeyed their voice. 
-<sup>25&#160;</sup>Now therefore, please pardon my sin, and turn again with me, that I may worship Yahweh.” 
+<sup>24&#160;</sup>Saul said to Samuel, “I have sinned; for I have transgressed the commandment of Yahuah and your words, because I feared the people and obeyed their voice. 
+<sup>25&#160;</sup>Now therefore, please pardon my sin, and turn again with me, that I may worship Yahuah.” 
 </p><p>
-<sup>26&#160;</sup>Samuel said to Saul, “I will not return with you; for you have rejected Yahweh’s word, and Yahweh has rejected you from being king over Israel.” 
+<sup>26&#160;</sup>Samuel said to Saul, “I will not return with you; for you have rejected Yahuah’s word, and Yahuah has rejected you from being king over Israel.” 
 <sup>27&#160;</sup>As Samuel turned around to go away, Saul grabbed the skirt of his robe, and it tore. 
-<sup>28&#160;</sup>Samuel said to him, “Yahweh has torn the kingdom of Israel from you today, and has given it to a neighbor of yours who is better than you. 
+<sup>28&#160;</sup>Samuel said to him, “Yahuah has torn the kingdom of Israel from you today, and has given it to a neighbor of yours who is better than you. 
 <sup>29&#160;</sup>Also the Strength of Israel will not lie nor repent; for he is not a man, that he should repent.” 
 </p><p>
-<sup>30&#160;</sup>Then he said, “I have sinned; yet please honor me now before the elders of my people and before Israel, and come back with me, that I may worship Yahweh your Elohim.” 
+<sup>30&#160;</sup>Then he said, “I have sinned; yet please honor me now before the elders of my people and before Israel, and come back with me, that I may worship Yahuah your Elohim.” 
 </p><p>
-<sup>31&#160;</sup>So Samuel went back with Saul; and Saul worshiped Yahweh. 
+<sup>31&#160;</sup>So Samuel went back with Saul; and Saul worshiped Yahuah. 
 <sup>32&#160;</sup>Then Samuel said, “Bring Agag the king of the Amalekites here to me!” 
 </p><p>Agag came to him cheerfully. Agag said, “Surely the bitterness of death is past.” 
 </p><p>
-<sup>33&#160;</sup>Samuel said, “As your sword has made women childless, so your mother will be childless among women!” Then Samuel cut Agag in pieces before Yahweh in Gilgal. 
+<sup>33&#160;</sup>Samuel said, “As your sword has made women childless, so your mother will be childless among women!” Then Samuel cut Agag in pieces before Yahuah in Gilgal. 
 </p><p>
 <sup>34&#160;</sup>Then Samuel went to Ramah; and Saul went up to his house to Gibeah of Saul. 
-<sup>35&#160;</sup>Samuel came no more to see Saul until the day of his death, but Samuel mourned for Saul. Yahweh grieved that he had made Saul king over Israel. 
+<sup>35&#160;</sup>Samuel came no more to see Saul until the day of his death, but Samuel mourned for Saul. Yahuah grieved that he had made Saul king over Israel. 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Samuel, “How long will you mourn for Saul, since I have rejected him from being king over Israel? Fill your horn with oil, and go. I will send you to Jesse the Bethlehemite, for I have provided a king for myself among his sons.” 
+<sup>1&#160;</sup>Yahuah said to Samuel, “How long will you mourn for Saul, since I have rejected him from being king over Israel? Fill your horn with oil, and go. I will send you to Jesse the Bethlehemite, for I have provided a king for myself among his sons.” 
 </p><p>
 <sup>2&#160;</sup>Samuel said, “How can I go? If Saul hears it, he will kill me.” 
-</p><p>Yahweh said, “Take a heifer with you, and say, ‘I have come to sacrifice to Yahweh.’ 
+</p><p>Yahuah said, “Take a heifer with you, and say, ‘I have come to sacrifice to Yahuah.’ 
 <sup>3&#160;</sup>Call Jesse to the sacrifice, and I will show you what you shall do. You shall anoint to me him whom I name to you.” 
 </p><p>
-<sup>4&#160;</sup>Samuel did that which Yahweh spoke, and came to Bethlehem. The elders of the city came to meet him trembling, and said, “Do you come peaceably?” 
+<sup>4&#160;</sup>Samuel did that which Yahuah spoke, and came to Bethlehem. The elders of the city came to meet him trembling, and said, “Do you come peaceably?” 
 </p><p>
-<sup>5&#160;</sup>He said, “Peaceably; I have come to sacrifice to Yahweh. Sanctify yourselves, and come with me to the sacrifice.” He sanctified Jesse and his sons, and called them to the sacrifice. 
-<sup>6&#160;</sup>When they had come, he looked at Eliab, and said, “Surely Yahweh’s anointed is before him.” 
+<sup>5&#160;</sup>He said, “Peaceably; I have come to sacrifice to Yahuah. Sanctify yourselves, and come with me to the sacrifice.” He sanctified Jesse and his sons, and called them to the sacrifice. 
+<sup>6&#160;</sup>When they had come, he looked at Eliab, and said, “Surely Yahuah’s anointed is before him.” 
 </p><p>
-<sup>7&#160;</sup>But Yahweh said to Samuel, “Don’t look on his face, or on the height of his stature, because I have rejected him; for I don’t see as man sees. For man looks at the outward appearance, but Yahweh looks at the heart.” 
+<sup>7&#160;</sup>But Yahuah said to Samuel, “Don’t look on his face, or on the height of his stature, because I have rejected him; for I don’t see as man sees. For man looks at the outward appearance, but Yahuah looks at the heart.” 
 </p><p>
-<sup>8&#160;</sup>Then Jesse called Abinadab, and made him pass before Samuel. He said, “Yahweh has not chosen this one, either.” 
-<sup>9&#160;</sup>Then Jesse made Shammah to pass by. He said, “Yahweh has not chosen this one, either.” 
-<sup>10&#160;</sup>Jesse made seven of his sons to pass before Samuel. Samuel said to Jesse, “Yahweh has not chosen these.” 
+<sup>8&#160;</sup>Then Jesse called Abinadab, and made him pass before Samuel. He said, “Yahuah has not chosen this one, either.” 
+<sup>9&#160;</sup>Then Jesse made Shammah to pass by. He said, “Yahuah has not chosen this one, either.” 
+<sup>10&#160;</sup>Jesse made seven of his sons to pass before Samuel. Samuel said to Jesse, “Yahuah has not chosen these.” 
 <sup>11&#160;</sup>Samuel said to Jesse, “Are all your children here?” 
 </p><p>He said, “There remains yet the youngest. Behold, he is keeping the sheep.” 
 </p><p>Samuel said to Jesse, “Send and get him, for we will not sit down until he comes here.” 
 </p><p>
-<sup>12&#160;</sup>He sent, and brought him in. Now he was ruddy, with a handsome face and good appearance. Yahweh said, “Arise! Anoint him, for this is he.” 
+<sup>12&#160;</sup>He sent, and brought him in. Now he was ruddy, with a handsome face and good appearance. Yahuah said, “Arise! Anoint him, for this is he.” 
 </p><p>
-<sup>13&#160;</sup>Then Samuel took the horn of oil and anointed him in the middle of his brothers. Then Yahweh’s Spirit came mightily on David from that day forward. So Samuel rose up and went to Ramah. 
-<sup>14&#160;</sup>Now Yahweh’s Spirit departed from Saul, and an evil spirit from Yahweh troubled him. 
+<sup>13&#160;</sup>Then Samuel took the horn of oil and anointed him in the middle of his brothers. Then Yahuah’s Spirit came mightily on David from that day forward. So Samuel rose up and went to Ramah. 
+<sup>14&#160;</sup>Now Yahuah’s Spirit departed from Saul, and an evil spirit from Yahuah troubled him. 
 <sup>15&#160;</sup>Saul’s servants said to him, “See now, an evil spirit from Elohim troubles you. 
 <sup>16&#160;</sup>Let our lord now command your servants who are in front of you to seek out a man who is a skillful player on the harp. Then when the evil spirit from Elohim is on you, he will play with his hand, and you will be well.” 
 </p><p>
 <sup>17&#160;</sup>Saul said to his servants, “Provide me now a man who can play well, and bring him to me.” 
 </p><p>
-<sup>18&#160;</sup>Then one of the young men answered and said, “Behold, I have seen a son of Jesse the Bethlehemite who is skillful in playing, a mighty man of valor, a man of war, prudent in speech, and a handsome person; and Yahweh is with him.” 
+<sup>18&#160;</sup>Then one of the young men answered and said, “Behold, I have seen a son of Jesse the Bethlehemite who is skillful in playing, a mighty man of valor, a man of war, prudent in speech, and a handsome person; and Yahuah is with him.” 
 </p><p>
 <sup>19&#160;</sup>Therefore Saul sent messengers to Jesse, and said, “Send me David your son, who is with the sheep.” 
 </p><p>
@@ -780,8 +780,8 @@ html[dir=ltr] .q2 {
 <sup>34&#160;</sup>David said to Saul, “Your servant was keeping his father’s sheep; and when a lion or a bear came and took a lamb out of the flock, 
 <sup>35&#160;</sup>I went out after him, struck him, and rescued it out of his mouth. When he arose against me, I caught him by his beard, struck him, and killed him. 
 <sup>36&#160;</sup>Your servant struck both the lion and the bear. This uncircumcised Philistine shall be as one of them, since he has defied the armies of the living Elohim.” 
-<sup>37&#160;</sup>David said, “Yahweh, who delivered me out of the paw of the lion and out of the paw of the bear, will deliver me out of the hand of this Philistine.” 
-</p><p>Saul said to David, “Go! Yahweh will be with you.” 
+<sup>37&#160;</sup>David said, “Yahuah, who delivered me out of the paw of the lion and out of the paw of the bear, will deliver me out of the hand of this Philistine.” 
+</p><p>Saul said to David, “Go! Yahuah will be with you.” 
 </p><p>
 <sup>38&#160;</sup>Saul dressed David with his clothing. He put a helmet of bronze on his head, and he clad him with a coat of mail. 
 <sup>39&#160;</sup>David strapped his sword on his clothing and he tried to move, for he had not tested it. David said to Saul, “I can’t go with these, for I have not tested them.” Then David took them off. 
@@ -792,9 +792,9 @@ html[dir=ltr] .q2 {
 <sup>43&#160;</sup>The Philistine said to David, “Am I a dog, that you come to me with sticks?” The Philistine cursed David by his elohims. 
 <sup>44&#160;</sup>The Philistine said to David, “Come to me, and I will give your flesh to the birds of the sky and to the animals of the field.” 
 </p><p>
-<sup>45&#160;</sup>Then David said to the Philistine, “You come to me with a sword, with a spear, and with a javelin; but I come to you in the name of Yahweh of Armies, the Elohim of the armies of Israel, whom you have defied. 
-<sup>46&#160;</sup>Today, Yahweh will deliver you into my hand. I will strike you and take your head from off you. I will give the dead bodies of the army of the Philistines today to the birds of the sky and to the wild animals of the earth, that all the earth may know that there is an Elohim in Israel, 
-<sup>47&#160;</sup>and that all this assembly may know that Yahweh doesn’t save with sword and spear; for the battle is Yahweh’s, and he will give you into our hand.” 
+<sup>45&#160;</sup>Then David said to the Philistine, “You come to me with a sword, with a spear, and with a javelin; but I come to you in the name of Yahuah of Armies, the Elohim of the armies of Israel, whom you have defied. 
+<sup>46&#160;</sup>Today, Yahuah will deliver you into my hand. I will strike you and take your head from off you. I will give the dead bodies of the army of the Philistines today to the birds of the sky and to the wild animals of the earth, that all the earth may know that there is an Elohim in Israel, 
+<sup>47&#160;</sup>and that all this assembly may know that Yahuah doesn’t save with sword and spear; for the battle is Yahuah’s, and he will give you into our hand.” 
 </p><p>
 <sup>48&#160;</sup>When the Philistine arose, and walked and came near to meet David, David hurried and ran toward the army to meet the Philistine. 
 <sup>49&#160;</sup>David put his hand in his bag, took a stone and slung it, and struck the Philistine in his forehead. The stone sank into his forehead, and he fell on his face to the earth. 
@@ -830,13 +830,13 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Saul watched David from that day and forward. 
 <sup>10&#160;</sup>On the next day, an evil spirit from Elohim came mightily on Saul, and he prophesied in the middle of the house. David played with his hand, as he did day by day. Saul had his spear in his hand; 
 <sup>11&#160;</sup>and Saul threw the spear, for he said, “I will pin David to the wall!” David escaped from his presence twice. 
-<sup>12&#160;</sup>Saul was afraid of David, because Yahweh was with him, and had departed from Saul. 
+<sup>12&#160;</sup>Saul was afraid of David, because Yahuah was with him, and had departed from Saul. 
 <sup>13&#160;</sup>Therefore Saul removed him from his presence, and made him his captain over a thousand; and he went out and came in before the people. 
 </p><p>
-<sup>14&#160;</sup>David behaved himself wisely in all his ways; and Yahweh was with him. 
+<sup>14&#160;</sup>David behaved himself wisely in all his ways; and Yahuah was with him. 
 <sup>15&#160;</sup>When Saul saw that he behaved himself very wisely, he stood in awe of him. 
 <sup>16&#160;</sup>But all Israel and Judah loved David; for he went out and came in before them. 
-<sup>17&#160;</sup>Saul said to David, “Behold, my elder daughter Merab. I will give her to you as woman. Only be valiant for me, and fight Yahweh’s battles.” For Saul said, “Don’t let my hand be on him, but let the hand of the Philistines be on him.” 
+<sup>17&#160;</sup>Saul said to David, “Behold, my elder daughter Merab. I will give her to you as woman. Only be valiant for me, and fight Yahuah’s battles.” For Saul said, “Don’t let my hand be on him, but let the hand of the Philistines be on him.” 
 </p><p>
 <sup>18&#160;</sup>David said to Saul, “Who am I, and what is my life, or my father’s family in Israel, that I should be son-in-law to the king?” 
 </p><p>
@@ -854,7 +854,7 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>Saul said, “Tell David, ‘The king desires no dowry except one hundred foreskins of the Philistines, to be avenged of the king’s enemies.’&#160;” Now Saul thought he would make David fall by the hand of the Philistines. 
 <sup>26&#160;</sup>When his servants told David these words, it pleased David well to be the king’s son-in-law. Before the deadline, 
 <sup>27&#160;</sup>David arose and went, he and his men, and killed two hundred men of the Philistines. Then David brought their foreskins, and they gave them in full number to the king, that he might be the king’s son-in-law. Then Saul gave him Michal his daughter as woman. 
-<sup>28&#160;</sup>Saul saw and knew that Yahweh was with David; and Michal, Saul’s daughter, loved him. 
+<sup>28&#160;</sup>Saul saw and knew that Yahuah was with David; and Michal, Saul’s daughter, loved him. 
 <sup>29&#160;</sup>Saul was even more afraid of David; and Saul was David’s enemy continually. 
 </p><p>
 <sup>30&#160;</sup>Then the princes of the Philistines went out; and as often as they went out, David behaved himself more wisely than all the servants of Saul, so that his name was highly esteemed. 
@@ -865,15 +865,15 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>I will go out and stand beside my father in the field where you are, and I will talk with my father about you; and if I see anything, I will tell you.” 
 </p><p>
 <sup>4&#160;</sup>Jonathan spoke good of David to Saul his father, and said to him, “Don’t let the king sin against his servant, against David; because he has not sinned against you, and because his works have been very good toward you; 
-<sup>5&#160;</sup>for he put his life in his hand and struck the Philistine, and Yahweh worked a great victory for all Israel. You saw it and rejoiced. Why then will you sin against innocent blood, to kill David without a cause?” 
+<sup>5&#160;</sup>for he put his life in his hand and struck the Philistine, and Yahuah worked a great victory for all Israel. You saw it and rejoiced. Why then will you sin against innocent blood, to kill David without a cause?” 
 </p><p>
-<sup>6&#160;</sup>Saul listened to the voice of Jonathan; and Saul swore, “As Yahweh lives, he shall not be put to death.” 
+<sup>6&#160;</sup>Saul listened to the voice of Jonathan; and Saul swore, “As Yahuah lives, he shall not be put to death.” 
 </p><p>
 <sup>7&#160;</sup>Jonathan called David, and Jonathan showed him all those things. Then Jonathan brought David to Saul, and he was in his presence as before. 
 </p><p>
 <sup>8&#160;</sup>There was war again. David went out and fought with the Philistines, and killed them with a great slaughter; and they fled before him. 
 </p><p>
-<sup>9&#160;</sup>An evil spirit from Yahweh was on Saul as he sat in his house with his spear in his hand; and David was playing music with his hand. 
+<sup>9&#160;</sup>An evil spirit from Yahuah was on Saul as he sat in his house with his spear in his hand; and David was playing music with his hand. 
 <sup>10&#160;</sup>Saul sought to pin David to the wall with the spear, but he slipped away out of Saul’s presence; and he stuck the spear into the wall. David fled and escaped that night. 
 <sup>11&#160;</sup>Saul sent messengers to David’s house to watch him and to kill him in the morning. Michal, David’s woman, told him, saying, “If you don’t save your life tonight, tomorrow you will be killed.” 
 <sup>12&#160;</sup>So Michal let David down through the window. He went away, fled, and escaped. 
@@ -902,33 +902,33 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>2&#160;</sup>He said to him, “Far from it; you will not die. Behold, my father does nothing either great or small, but that he discloses it to me. Why would my father hide this thing from me? It is not so.” 
 </p><p>
-<sup>3&#160;</sup>David swore moreover, and said, “Your father knows well that I have found favor in your eyes; and he says, ‘Don’t let Jonathan know this, lest he be grieved;’ but truly as Yahweh lives, and as your soul lives, there is but a step between me and death.” 
+<sup>3&#160;</sup>David swore moreover, and said, “Your father knows well that I have found favor in your eyes; and he says, ‘Don’t let Jonathan know this, lest he be grieved;’ but truly as Yahuah lives, and as your soul lives, there is but a step between me and death.” 
 </p><p>
 <sup>4&#160;</sup>Then Jonathan said to David, “Whatever your soul desires, I will even do it for you.” 
 </p><p>
 <sup>5&#160;</sup>David said to Jonathan, “Behold, tomorrow is the new moon, and I should not fail to dine with the king; but let me go, that I may hide myself in the field to the third day at evening. 
 <sup>6&#160;</sup>If your father misses me at all, then say, ‘David earnestly asked leave of me that he might run to Bethlehem, his city; for it is the yearly sacrifice there for all the family.’ 
 <sup>7&#160;</sup>If he says, ‘It is well,’ your servant shall have peace; but if he is angry, then know that evil is determined by him. 
-<sup>8&#160;</sup>Therefore deal kindly with your servant, for you have brought your servant into a covenant of Yahweh with you; but if there is iniquity in me, kill me yourself, for why should you bring me to your father?” 
+<sup>8&#160;</sup>Therefore deal kindly with your servant, for you have brought your servant into a covenant of Yahuah with you; but if there is iniquity in me, kill me yourself, for why should you bring me to your father?” 
 </p><p>
 <sup>9&#160;</sup>Jonathan said, “Far be it from you; for if I should at all know that evil were determined by my father to come on you, then wouldn’t I tell you that?” 
 </p><p>
 <sup>10&#160;</sup>Then David said to Jonathan, “Who will tell me if your father answers you roughly?” 
 </p><p>
 <sup>11&#160;</sup>Jonathan said to David, “Come! Let’s go out into the field.” They both went out into the field. 
-<sup>12&#160;</sup>Jonathan said to David, “By Yahweh, the Elohim of Israel, when I have sounded out my father about this time tomorrow, or the third day, behold, if there is good toward David, won’t I then send to you and disclose it to you? 
-<sup>13&#160;</sup>Yahweh do so to Jonathan and more also, should it please my father to do you evil, if I don’t disclose it to you and send you away, that you may go in peace. May Yahweh be with you as he has been with my father. 
-<sup>14&#160;</sup>You shall not only show me the loving kindness of Yahweh while I still live, that I not die; 
-<sup>15&#160;</sup>but you shall also not cut off your kindness from my house forever, no, not when Yahweh has cut off every one of the enemies of David from the surface of the earth.” 
-<sup>16&#160;</sup>So Jonathan made a covenant with David’s house, saying, “Yahweh will require it at the hand of David’s enemies.” 
+<sup>12&#160;</sup>Jonathan said to David, “By Yahuah, the Elohim of Israel, when I have sounded out my father about this time tomorrow, or the third day, behold, if there is good toward David, won’t I then send to you and disclose it to you? 
+<sup>13&#160;</sup>Yahuah do so to Jonathan and more also, should it please my father to do you evil, if I don’t disclose it to you and send you away, that you may go in peace. May Yahuah be with you as he has been with my father. 
+<sup>14&#160;</sup>You shall not only show me the loving kindness of Yahuah while I still live, that I not die; 
+<sup>15&#160;</sup>but you shall also not cut off your kindness from my house forever, no, not when Yahuah has cut off every one of the enemies of David from the surface of the earth.” 
+<sup>16&#160;</sup>So Jonathan made a covenant with David’s house, saying, “Yahuah will require it at the hand of David’s enemies.” 
 </p><p>
 <sup>17&#160;</sup>Jonathan caused David to swear again, for the love that he had to him; for he loved him as he loved his own soul. 
 <sup>18&#160;</sup>Then Jonathan said to him, “Tomorrow is the new moon, and you will be missed, because your seat will be empty. 
 <sup>19&#160;</sup>When you have stayed three days, go down quickly and come to the place where you hid yourself when this started, and remain by the stone Ezel. 
 <sup>20&#160;</sup>I will shoot three arrows on its side, as though I shot at a mark. 
-<sup>21&#160;</sup>Behold, I will send the boy, saying, ‘Go, find the arrows!’ If I tell the boy, ‘Behold, the arrows are on this side of you. Take them;’ then come, for there is peace to you and no danger, as Yahweh lives. 
-<sup>22&#160;</sup>But if I say this to the boy, ‘Behold, the arrows are beyond you,’ then go your way, for Yahweh has sent you away. 
-<sup>23&#160;</sup>Concerning the matter which you and I have spoken of, behold, Yahweh is between you and me forever.” 
+<sup>21&#160;</sup>Behold, I will send the boy, saying, ‘Go, find the arrows!’ If I tell the boy, ‘Behold, the arrows are on this side of you. Take them;’ then come, for there is peace to you and no danger, as Yahuah lives. 
+<sup>22&#160;</sup>But if I say this to the boy, ‘Behold, the arrows are beyond you,’ then go your way, for Yahuah has sent you away. 
+<sup>23&#160;</sup>Concerning the matter which you and I have spoken of, behold, Yahuah is between you and me forever.” 
 </p><p>
 <sup>24&#160;</sup>So David hid himself in the field. When the new moon had come, the king sat himself down to eat food. 
 <sup>25&#160;</sup>The king sat on his seat, as at other times, even on the seat by the wall; and Jonathan stood up, and Abner sat by Saul’s side, but David’s place was empty. 
@@ -955,7 +955,7 @@ html[dir=ltr] .q2 {
 <sup>40&#160;</sup>Jonathan gave his weapons to his boy, and said to him, “Go, carry them to the city.” 
 </p><p>
 <sup>41&#160;</sup>As soon as the boy was gone, David arose out of the south, and fell on his face to the ground, and bowed himself three times. They kissed one another and wept with one another, and David wept the most. 
-<sup>42&#160;</sup>Jonathan said to David, “Go in peace, because we have both sworn in Yahweh’s name, saying, ‘Yahweh is between me and you, and between my offspring and your offspring, forever.’&#160;” He arose and departed; and Jonathan went into the city. 
+<sup>42&#160;</sup>Jonathan said to David, “Go in peace, because we have both sworn in Yahuah’s name, saying, ‘Yahuah is between me and you, and between my offspring and your offspring, forever.’&#160;” He arose and departed; and Jonathan went into the city. 
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
 <sup>1&#160;</sup>Then David came to Nob to Ahimelech the priest. Ahimelech came to meet David trembling, and said to him, “Why are you alone, and no man with you?” 
@@ -965,9 +965,9 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>The priest answered David, and said, “I have no common bread, but there is set-apart bread; if only the young men have kept themselves from women.” 
 </p><p>
 <sup>5&#160;</sup>David answered the priest, and said to him, “Truly, women have been kept from us as usual these three days. When I came out, the vessels of the young men were set-apart, though it was only a common journey. How much more then today shall their vessels be set-apart?” 
-<sup>6&#160;</sup>So the priest gave him set-apart bread; for there was no bread there but the show bread that was taken from before Yahweh, to be replaced with hot bread in the day when it was taken away. 
+<sup>6&#160;</sup>So the priest gave him set-apart bread; for there was no bread there but the show bread that was taken from before Yahuah, to be replaced with hot bread in the day when it was taken away. 
 </p><p>
-<sup>7&#160;</sup>Now a certain man of the servants of Saul was there that day, detained before Yahweh; and his name was Doeg the Edomite, the best of the herdsmen who belonged to Saul. 
+<sup>7&#160;</sup>Now a certain man of the servants of Saul was there that day, detained before Yahuah; and his name was Doeg the Edomite, the best of the herdsmen who belonged to Saul. 
 </p><p>
 <sup>8&#160;</sup>David said to Ahimelech, “Isn’t there here under your hand spear or sword? For I haven’t brought my sword or my weapons with me, because the king’s business required haste.” 
 </p><p>
@@ -997,7 +997,7 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>Is that why all of you have conspired against me, and there is no one who discloses to me when my son makes a treaty with the son of Jesse, and there is none of you who is sorry for me, or discloses to me that my son has stirred up my servant against me, to lie in wait, as it is today?” 
 </p><p>
 <sup>9&#160;</sup>Then Doeg the Edomite, who stood by the servants of Saul, answered and said, “I saw the son of Jesse coming to Nob, to Ahimelech the son of Ahitub. 
-<sup>10&#160;</sup>He inquired of Yahweh for him, gave him food, and gave him the sword of Goliath the Philistine.” 
+<sup>10&#160;</sup>He inquired of Yahuah for him, gave him food, and gave him the sword of Goliath the Philistine.” 
 </p><p>
 <sup>11&#160;</sup>Then the king sent to call Ahimelech the priest, the son of Ahitub, and all his father’s house, the priests who were in Nob; and they all came to the king. 
 <sup>12&#160;</sup>Saul said, “Hear now, you son of Ahitub.” 
@@ -1009,13 +1009,13 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Have I today begun to inquire of Elohim for him? Be it far from me! Don’t let the king impute anything to his servant, nor to all the house of my father; for your servant knew nothing of all this, less or more.” 
 </p><p>
 <sup>16&#160;</sup>The king said, “You shall surely die, Ahimelech, you and all your father’s house.” 
-<sup>17&#160;</sup>The king said to the guard who stood about him, “Turn and kill the priests of Yahweh, because their hand also is with David, and because they knew that he fled and didn’t disclose it to me.” But the servants of the king wouldn’t put out their hand to fall on the priests of Yahweh. 
+<sup>17&#160;</sup>The king said to the guard who stood about him, “Turn and kill the priests of Yahuah, because their hand also is with David, and because they knew that he fled and didn’t disclose it to me.” But the servants of the king wouldn’t put out their hand to fall on the priests of Yahuah. 
 </p><p>
 <sup>18&#160;</sup>The king said to Doeg, “Turn and attack the priests!” 
 </p><p>Doeg the Edomite turned, and he attacked the priests, and he killed on that day eighty-five people who wore a linen ephod. 
 <sup>19&#160;</sup>He struck Nob, the city of the priests, with the edge of the sword—both men and women, children and nursing babies, and cattle, donkeys, and sheep, with the edge of the sword. 
 <sup>20&#160;</sup>One of the sons of Ahimelech the son of Ahitub, named Abiathar, escaped and fled after David. 
-<sup>21&#160;</sup>Abiathar told David that Saul had slain Yahweh’s priests. 
+<sup>21&#160;</sup>Abiathar told David that Saul had slain Yahuah’s priests. 
 </p><p>
 <sup>22&#160;</sup>David said to Abiathar, “I knew on that day, when Doeg the Edomite was there, that he would surely tell Saul. I am responsible for the death of all the persons of your father’s house. 
 <sup>23&#160;</sup>Stay with me. Don’t be afraid, for he who seeks my life seeks your life. You will be safe with me.” 
@@ -1023,12 +1023,12 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>David was told, “Behold, the Philistines are fighting against Keilah, and are robbing the threshing floors.” 
 </p><p>
-<sup>2&#160;</sup>Therefore David inquired of Yahweh, saying, “Shall I go and strike these Philistines?” 
-</p><p>Yahweh said to David, “Go strike the Philistines, and save Keilah.” 
+<sup>2&#160;</sup>Therefore David inquired of Yahuah, saying, “Shall I go and strike these Philistines?” 
+</p><p>Yahuah said to David, “Go strike the Philistines, and save Keilah.” 
 </p><p>
 <sup>3&#160;</sup>David’s men said to him, “Behold, we are afraid here in Judah. How much more then if we go to Keilah against the armies of the Philistines?” 
 </p><p>
-<sup>4&#160;</sup>Then David inquired of Yahweh yet again. Yahweh answered him, and said, “Arise, go down to Keilah; for I will deliver the Philistines into your hand.” 
+<sup>4&#160;</sup>Then David inquired of Yahuah yet again. Yahuah answered him, and said, “Arise, go down to Keilah; for I will deliver the Philistines into your hand.” 
 </p><p>
 <sup>5&#160;</sup>David and his men went to Keilah and fought with the Philistines, and brought away their livestock, and killed them with a great slaughter. So David saved the inhabitants of Keilah. 
 </p><p>
@@ -1037,12 +1037,12 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>Saul was told that David had come to Keilah. Saul said, “Elohim has delivered him into my hand, for he is shut in by entering into a town that has gates and bars.” 
 <sup>8&#160;</sup>Saul summoned all the people to war, to go down to Keilah to besiege David and his men. 
 <sup>9&#160;</sup>David knew that Saul was devising mischief against him. He said to Abiathar the priest, “Bring the ephod here.” 
-<sup>10&#160;</sup>Then David said, “O Yahweh, the Elohim of Israel, your servant has surely heard that Saul seeks to come to Keilah to destroy the city for my sake. 
-<sup>11&#160;</sup>Will the owners of Keilah deliver me up into his hand? Will Saul come down, as your servant has heard? Yahweh, the Elohim of Israel, I beg you, tell your servant.” 
-</p><p>Yahweh said, “He will come down.” 
+<sup>10&#160;</sup>Then David said, “O Yahuah, the Elohim of Israel, your servant has surely heard that Saul seeks to come to Keilah to destroy the city for my sake. 
+<sup>11&#160;</sup>Will the owners of Keilah deliver me up into his hand? Will Saul come down, as your servant has heard? Yahuah, the Elohim of Israel, I beg you, tell your servant.” 
+</p><p>Yahuah said, “He will come down.” 
 </p><p>
 <sup>12&#160;</sup>Then David said, “Will the owners of Keilah deliver me and my men into the hand of Saul?” 
-</p><p>Yahweh said, “They will deliver you up.” 
+</p><p>Yahuah said, “They will deliver you up.” 
 </p><p>
 <sup>13&#160;</sup>Then David and his men, who were about six hundred, arose and departed out of Keilah and went wherever they could go. Saul was told that David had escaped from Keilah; and he gave up going there. 
 <sup>14&#160;</sup>David stayed in the wilderness in the strongholds, and remained in the hill country in the wilderness of Ziph. Saul sought him every day, but Elohim didn’t deliver him into his hand. 
@@ -1050,12 +1050,12 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>16&#160;</sup>Jonathan, Saul’s son, arose and went to David into the woods, and strengthened his hand in Elohim. 
 <sup>17&#160;</sup>He said to him, “Don’t be afraid, for the hand of Saul my father won’t find you; and you will be king over Israel, and I will be next to you; and Saul my father knows that also.” 
-<sup>18&#160;</sup>They both made a covenant before Yahweh. Then David stayed in the woods and Jonathan went to his house. 
+<sup>18&#160;</sup>They both made a covenant before Yahuah. Then David stayed in the woods and Jonathan went to his house. 
 </p><p>
 <sup>19&#160;</sup>Then the Ziphites came up to Saul to Gibeah, saying, “Doesn’t David hide himself with us in the strongholds in the woods, in the hill of Hachilah, which is on the south of the desert? 
 <sup>20&#160;</sup>Now therefore, O king, come down. According to all the desire of your soul to come down; and our part will be to deliver him up into the king’s hand.” 
 </p><p>
-<sup>21&#160;</sup>Saul said, “You are blessed by Yahweh, for you have had compassion on me. 
+<sup>21&#160;</sup>Saul said, “You are blessed by Yahuah, for you have had compassion on me. 
 <sup>22&#160;</sup>Please go make yet more sure, and know and see his place where his haunt is, and who has seen him there; for I have been told that he is very cunning. 
 <sup>23&#160;</sup>See therefore, and take knowledge of all the lurking places where he hides himself; and come again to me with certainty, and I will go with you. It shall happen, if he is in the land, that I will search him out among all the thousands of Judah.” 
 </p><p>
@@ -1071,26 +1071,26 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>When Saul had returned from following the Philistines, he was told, “Behold, David is in the wilderness of En Gedi.” 
 <sup>2&#160;</sup>Then Saul took three thousand chosen men out of all Israel, and went to seek David and his men on the rocks of the wild goats. 
 <sup>3&#160;</sup>He came to the sheep pens by the way, where there was a cave; and Saul went in to relieve himself. Now David and his men were staying in the innermost parts of the cave. 
-<sup>4&#160;</sup>David’s men said to him, “Behold, the day of which Yahweh said to you, ‘Behold, I will deliver your enemy into your hand, and you shall do to him as it shall seem good to you.’&#160;” Then David arose and cut off the skirt of Saul’s robe secretly. 
+<sup>4&#160;</sup>David’s men said to him, “Behold, the day of which Yahuah said to you, ‘Behold, I will deliver your enemy into your hand, and you shall do to him as it shall seem good to you.’&#160;” Then David arose and cut off the skirt of Saul’s robe secretly. 
 <sup>5&#160;</sup>Afterward, David’s heart struck him because he had cut off Saul’s skirt. 
-<sup>6&#160;</sup>He said to his men, “Yahweh forbid that I should do this thing to my lord, Yahweh’s anointed, to stretch out my hand against him, since he is Yahweh’s anointed.” 
+<sup>6&#160;</sup>He said to his men, “Yahuah forbid that I should do this thing to my lord, Yahuah’s anointed, to stretch out my hand against him, since he is Yahuah’s anointed.” 
 <sup>7&#160;</sup>So David checked his men with these words, and didn’t allow them to rise against Saul. Saul rose up out of the cave, and went on his way. 
 <sup>8&#160;</sup>David also arose afterward, and went out of the cave and cried after Saul, saying, “My lord the king!” 
 </p><p>When Saul looked behind him, David bowed with his face to the earth, and showed respect. 
 <sup>9&#160;</sup>David said to Saul, “Why do you listen to men’s words, saying, ‘Behold, David seeks to harm you’? 
-<sup>10&#160;</sup>Behold, today your eyes have seen how Yahweh had delivered you today into my hand in the cave. Some urged me to kill you, but I spared you. I said, ‘I will not stretch out my hand against my lord, for he is Yahweh’s anointed.’ 
+<sup>10&#160;</sup>Behold, today your eyes have seen how Yahuah had delivered you today into my hand in the cave. Some urged me to kill you, but I spared you. I said, ‘I will not stretch out my hand against my lord, for he is Yahuah’s anointed.’ 
 <sup>11&#160;</sup>Moreover, my father, behold, yes, see the skirt of your robe in my hand; for in that I cut off the skirt of your robe and didn’t kill you, know and see that there is neither evil nor disobedience in my hand. I have not sinned against you, though you hunt for my life to take it. 
-<sup>12&#160;</sup>May Yahweh judge between me and you, and may Yahweh avenge me of you; but my hand will not be on you. 
+<sup>12&#160;</sup>May Yahuah judge between me and you, and may Yahuah avenge me of you; but my hand will not be on you. 
 <sup>13&#160;</sup>As the proverb of the ancients says, ‘Out of the wicked comes wickedness;’ but my hand will not be on you. 
 <sup>14&#160;</sup>Against whom has the king of Israel come out? Whom do you pursue? A dead dog? A flea? 
-<sup>15&#160;</sup>May Yahweh therefore be judge, and give sentence between me and you, and see, and plead my cause, and deliver me out of your hand.” 
+<sup>15&#160;</sup>May Yahuah therefore be judge, and give sentence between me and you, and see, and plead my cause, and deliver me out of your hand.” 
 </p><p>
 <sup>16&#160;</sup>It came to pass, when David had finished speaking these words to Saul, that Saul said, “Is that your voice, my son David?” Saul lifted up his voice and wept. 
 <sup>17&#160;</sup>He said to David, “You are more righteous than I; for you have done good to me, whereas I have done evil to you. 
-<sup>18&#160;</sup>You have declared today how you have dealt well with me, because when Yahweh had delivered me up into your hand, you didn’t kill me. 
-<sup>19&#160;</sup>For if a man finds his enemy, will he let him go away unharmed? Therefore may Yahweh reward you good for that which you have done to me today. 
+<sup>18&#160;</sup>You have declared today how you have dealt well with me, because when Yahuah had delivered me up into your hand, you didn’t kill me. 
+<sup>19&#160;</sup>For if a man finds his enemy, will he let him go away unharmed? Therefore may Yahuah reward you good for that which you have done to me today. 
 <sup>20&#160;</sup>Now, behold, I know that you will surely be king, and that the kingdom of Israel will be established in your hand. 
-<sup>21&#160;</sup>Swear now therefore to me by Yahweh that you will not cut off my offspring after me, and that you will not destroy my name out of my father’s house.” 
+<sup>21&#160;</sup>Swear now therefore to me by Yahuah that you will not cut off my offspring after me, and that you will not destroy my name out of my father’s house.” 
 </p><p>
 <sup>22&#160;</sup>David swore to Saul. Saul went home, but David and his men went up to the stronghold. 
 </p><h2 class="chapterlabel" id="25">25</h2>
@@ -1130,23 +1130,23 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>When Abigail saw David, she hurried and got off her donkey, and fell before David on her face and bowed herself to the ground. 
 <sup>24&#160;</sup>She fell at his feet and said, “On me, my lord, on me be the blame! Please let your servant speak in your ears. Hear the words of your servant. 
 <sup>25&#160;</sup>Please don’t let my lord pay attention to this worthless fellow, Nabal, for as his name is, so is he. Nabal is his name, and folly is with him; but I, your servant, didn’t see my lord’s young men whom you sent. 
-<sup>26&#160;</sup>Now therefore, my lord, as Yahweh lives and as your soul lives, since Yahweh has withheld you from blood guiltiness and from avenging yourself with your own hand, now therefore let your enemies and those who seek evil to my lord be as Nabal. 
+<sup>26&#160;</sup>Now therefore, my lord, as Yahuah lives and as your soul lives, since Yahuah has withheld you from blood guiltiness and from avenging yourself with your own hand, now therefore let your enemies and those who seek evil to my lord be as Nabal. 
 <sup>27&#160;</sup>Now this present which your servant has brought to my lord, let it be given to the young men who follow my lord. 
-<sup>28&#160;</sup>Please forgive the trespass of your servant. For Yahweh will certainly make my lord a sure house, because my lord fights Yahweh’s battles. Evil will not be found in you all your days. 
-<sup>29&#160;</sup>Though men may rise up to pursue you and to seek your soul, yet the soul of my lord will be bound in the bundle of life with Yahweh your Elohim. He will sling out the souls of your enemies as from a sling’s pocket. 
-<sup>30&#160;</sup>It will come to pass, when Yahweh has done to my lord according to all the good that he has spoken concerning you, and has appointed you prince over Israel, 
-<sup>31&#160;</sup>that this shall be no grief to you, nor offense of heart to my lord, either that you have shed blood without cause, or that my lord has avenged himself. When Yahweh has dealt well with my lord, then remember your servant.” 
+<sup>28&#160;</sup>Please forgive the trespass of your servant. For Yahuah will certainly make my lord a sure house, because my lord fights Yahuah’s battles. Evil will not be found in you all your days. 
+<sup>29&#160;</sup>Though men may rise up to pursue you and to seek your soul, yet the soul of my lord will be bound in the bundle of life with Yahuah your Elohim. He will sling out the souls of your enemies as from a sling’s pocket. 
+<sup>30&#160;</sup>It will come to pass, when Yahuah has done to my lord according to all the good that he has spoken concerning you, and has appointed you prince over Israel, 
+<sup>31&#160;</sup>that this shall be no grief to you, nor offense of heart to my lord, either that you have shed blood without cause, or that my lord has avenged himself. When Yahuah has dealt well with my lord, then remember your servant.” 
 </p><p>
-<sup>32&#160;</sup>David said to Abigail, “Blessed is Yahweh, the Elohim of Israel, who sent you today to meet me! 
+<sup>32&#160;</sup>David said to Abigail, “Blessed is Yahuah, the Elohim of Israel, who sent you today to meet me! 
 <sup>33&#160;</sup>Blessed is your discretion, and blessed are you, who have kept me today from blood guiltiness, and from avenging myself with my own hand. 
-<sup>34&#160;</sup>For indeed, as Yahweh the Elohim of Israel lives, who has withheld me from harming you, unless you had hurried and come to meet me, surely there wouldn’t have been left to Nabal by the morning light so much as one who urinates on a wall.” 
+<sup>34&#160;</sup>For indeed, as Yahuah the Elohim of Israel lives, who has withheld me from harming you, unless you had hurried and come to meet me, surely there wouldn’t have been left to Nabal by the morning light so much as one who urinates on a wall.” 
 </p><p>
 <sup>35&#160;</sup>So David received from her hand that which she had brought him. Then he said to her, “Go up in peace to your house. Behold, I have listened to your voice and have granted your request.” 
 </p><p>
 <sup>36&#160;</sup>Abigail came to Nabal; and behold, he held a feast in his house like the feast of a king. Nabal’s heart was merry within him, for he was very drunk. Therefore she told him nothing until the morning light. 
 <sup>37&#160;</sup>In the morning, when the wine had gone out of Nabal, his woman told him these things; and his heart died within him, and he became as a stone. 
-<sup>38&#160;</sup>About ten days later, Yahweh struck Nabal, so that he died. 
-<sup>39&#160;</sup>When David heard that Nabal was dead, he said, “Blessed is Yahweh, who has pleaded the cause of my reproach from the hand of Nabal, and has kept back his servant from evil. Yahweh has returned the evildoing of Nabal on his own head.” 
+<sup>38&#160;</sup>About ten days later, Yahuah struck Nabal, so that he died. 
+<sup>39&#160;</sup>When David heard that Nabal was dead, he said, “Blessed is Yahuah, who has pleaded the cause of my reproach from the hand of Nabal, and has kept back his servant from evil. Yahuah has returned the evildoing of Nabal on his own head.” 
 </p><p>David sent and spoke concerning Abigail, to take her to himself as woman. 
 <sup>40&#160;</sup>When David’s servants had come to Abigail to Carmel, they spoke to her, saying, “David has sent us to you, to take you to him as woman.” 
 </p><p>
@@ -1168,29 +1168,29 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>So David and Abishai came to the people by night; and, behold, Saul lay sleeping within the place of the wagons, with his spear stuck in the ground at his head; and Abner and the people lay around him. 
 <sup>8&#160;</sup>Then Abishai said to David, “Elohim has delivered up your enemy into your hand today. Now therefore please let me strike him with the spear to the earth at one stroke, and I will not strike him the second time.” 
 </p><p>
-<sup>9&#160;</sup>David said to Abishai, “Don’t destroy him, for who can stretch out his hand against Yahweh’s anointed, and be guiltless?” 
-<sup>10&#160;</sup>David said, “As Yahweh lives, Yahweh will strike him; or his day shall come to die, or he shall go down into battle and perish. 
-<sup>11&#160;</sup>Yahweh forbid that I should stretch out my hand against Yahweh’s anointed; but now please take the spear that is at his head and the jar of water, and let’s go.” 
+<sup>9&#160;</sup>David said to Abishai, “Don’t destroy him, for who can stretch out his hand against Yahuah’s anointed, and be guiltless?” 
+<sup>10&#160;</sup>David said, “As Yahuah lives, Yahuah will strike him; or his day shall come to die, or he shall go down into battle and perish. 
+<sup>11&#160;</sup>Yahuah forbid that I should stretch out my hand against Yahuah’s anointed; but now please take the spear that is at his head and the jar of water, and let’s go.” 
 </p><p>
-<sup>12&#160;</sup>So David took the spear and the jar of water from Saul’s head, and they went away. No man saw it, or knew it, nor did any awake; for they were all asleep, because a deep sleep from Yahweh had fallen on them. 
+<sup>12&#160;</sup>So David took the spear and the jar of water from Saul’s head, and they went away. No man saw it, or knew it, nor did any awake; for they were all asleep, because a deep sleep from Yahuah had fallen on them. 
 <sup>13&#160;</sup>Then David went over to the other side, and stood on the top of the mountain far away, a great space being between them; 
 <sup>14&#160;</sup>and David cried to the people, and to Abner the son of Ner, saying, “Don’t you answer, Abner?” 
 </p><p>Then Abner answered, “Who are you who calls to the king?” 
 </p><p>
 <sup>15&#160;</sup>David said to Abner, “Aren’t you a man? Who is like you in Israel? Why then have you not kept watch over your lord the king? For one of the people came in to destroy your lord the king. 
-<sup>16&#160;</sup>This thing isn’t good that you have done. As Yahweh lives, you are worthy to die, because you have not kept watch over your lord, Yahweh’s anointed. Now see where the king’s spear is, and the jar of water that was at his head.” 
+<sup>16&#160;</sup>This thing isn’t good that you have done. As Yahuah lives, you are worthy to die, because you have not kept watch over your lord, Yahuah’s anointed. Now see where the king’s spear is, and the jar of water that was at his head.” 
 </p><p>
 <sup>17&#160;</sup>Saul recognized David’s voice, and said, “Is this your voice, my son David?” 
 </p><p>David said, “It is my voice, my lord, O king.” 
 <sup>18&#160;</sup>He said, “Why does my lord pursue his servant? For what have I done? What evil is in my hand? 
-<sup>19&#160;</sup>Now therefore, please let my lord the king hear the words of his servant. If it is so that Yahweh has stirred you up against me, let him accept an offering. But if it is the children of men, they are cursed before Yahweh; for they have driven me out today that I shouldn’t cling to Yahweh’s inheritance, saying, ‘Go, serve other elohims!’ 
-<sup>20&#160;</sup>Now therefore, don’t let my blood fall to the earth away from the presence of Yahweh; for the king of Israel has come out to seek a flea, as when one hunts a partridge in the mountains.” 
+<sup>19&#160;</sup>Now therefore, please let my lord the king hear the words of his servant. If it is so that Yahuah has stirred you up against me, let him accept an offering. But if it is the children of men, they are cursed before Yahuah; for they have driven me out today that I shouldn’t cling to Yahuah’s inheritance, saying, ‘Go, serve other elohims!’ 
+<sup>20&#160;</sup>Now therefore, don’t let my blood fall to the earth away from the presence of Yahuah; for the king of Israel has come out to seek a flea, as when one hunts a partridge in the mountains.” 
 </p><p>
 <sup>21&#160;</sup>Then Saul said, “I have sinned. Return, my son David; for I will no more do you harm, because my life was precious in your eyes today. Behold, I have played the fool, and have erred exceedingly.” 
 </p><p>
 <sup>22&#160;</sup>David answered, “Behold the spear, O king! Let one of the young men come over and get it. 
-<sup>23&#160;</sup>Yahweh will render to every man his righteousness and his faithfulness; because Yahweh delivered you into my hand today, and I wouldn’t stretch out my hand against Yahweh’s anointed. 
-<sup>24&#160;</sup>Behold, as your life was respected today in my eyes, so let my life be respected in Yahweh’s eyes, and let him deliver me out of all oppression.” 
+<sup>23&#160;</sup>Yahuah will render to every man his righteousness and his faithfulness; because Yahuah delivered you into my hand today, and I wouldn’t stretch out my hand against Yahuah’s anointed. 
+<sup>24&#160;</sup>Behold, as your life was respected today in my eyes, so let my life be respected in Yahuah’s eyes, and let him deliver me out of all oppression.” 
 </p><p>
 <sup>25&#160;</sup>Then Saul said to David, “You are blessed, my son David. You will both do mightily, and will surely prevail.” 
 </p><p>So David went his way, and Saul returned to his place. 
@@ -1224,7 +1224,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>4&#160;</sup>The Philistines gathered themselves together, and came and encamped in Shunem; and Saul gathered all Israel together, and they encamped in Gilboa. 
 <sup>5&#160;</sup>When Saul saw the army of the Philistines, he was afraid, and his heart trembled greatly. 
-<sup>6&#160;</sup>When Saul inquired of Yahweh, Yahweh didn’t answer him by dreams, by Urim, or by prophets. 
+<sup>6&#160;</sup>When Saul inquired of Yahuah, Yahuah didn’t answer him by dreams, by Urim, or by prophets. 
 <sup>7&#160;</sup>Then Saul said to his servants, “Seek for me a woman who has a familiar spirit, that I may go to her and inquire of her.” 
 </p><p>His servants said to him, “Behold, there is a woman who has a familiar spirit at Endor.” 
 </p><p>
@@ -1232,7 +1232,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>9&#160;</sup>The woman said to him, “Behold, you know what Saul has done, how he has cut off those who have familiar spirits and the wizards out of the land. Why then do you lay a snare for my life, to cause me to die?” 
 </p><p>
-<sup>10&#160;</sup>Saul swore to her by Yahweh, saying, “As Yahweh lives, no punishment will happen to you for this thing.” 
+<sup>10&#160;</sup>Saul swore to her by Yahuah, saying, “As Yahuah lives, no punishment will happen to you for this thing.” 
 </p><p>
 <sup>11&#160;</sup>Then the woman said, “Whom shall I bring up to you?” 
 </p><p>He said, “Bring Samuel up for me.” 
@@ -1248,10 +1248,10 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Samuel said to Saul, “Why have you disturbed me, to bring me up?” 
 </p><p>Saul answered, “I am very distressed; for the Philistines make war against me, and Elohim has departed from me, and answers me no more, by prophets, or by dreams. Therefore I have called you, that you may make known to me what I shall do.” 
 </p><p>
-<sup>16&#160;</sup>Samuel said, “Why then do you ask me, since Yahweh has departed from you and has become your adversary? 
-<sup>17&#160;</sup>Yahweh has done to you as he spoke by me. Yahweh has torn the kingdom out of your hand and given it to your neighbor, even to David. 
-<sup>18&#160;</sup>Because you didn’t obey Yahweh’s voice, and didn’t execute his fierce wrath on Amalek, therefore Yahweh has done this thing to you today. 
-<sup>19&#160;</sup>Moreover Yahweh will deliver Israel also with you into the hand of the Philistines; and tomorrow you and your sons will be with me. Yahweh will deliver the army of Israel also into the hand of the Philistines.” 
+<sup>16&#160;</sup>Samuel said, “Why then do you ask me, since Yahuah has departed from you and has become your adversary? 
+<sup>17&#160;</sup>Yahuah has done to you as he spoke by me. Yahuah has torn the kingdom out of your hand and given it to your neighbor, even to David. 
+<sup>18&#160;</sup>Because you didn’t obey Yahuah’s voice, and didn’t execute his fierce wrath on Amalek, therefore Yahuah has done this thing to you today. 
+<sup>19&#160;</sup>Moreover Yahuah will deliver Israel also with you into the hand of the Philistines; and tomorrow you and your sons will be with me. Yahuah will deliver the army of Israel also into the hand of the Philistines.” 
 </p><p>
 <sup>20&#160;</sup>Then Saul fell immediately his full length on the earth, and was terrified, because of Samuel’s words. There was no strength in him, for he had eaten no bread all day long or all night long. 
 </p><p>
@@ -1274,7 +1274,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">‘Saul has slain his thousands, 
 </p><p class="q2">and David his ten thousands’?” 
 </p><p>
-<sup>6&#160;</sup>Then Achish called David and said to him, “As Yahweh lives, you have been upright, and your going out and your coming in with me in the army is good in my sight; for I have not found evil in you since the day of your coming to me to this day. Nevertheless, the lords don’t favor you. 
+<sup>6&#160;</sup>Then Achish called David and said to him, “As Yahuah lives, you have been upright, and your going out and your coming in with me in the army is good in my sight; for I have not found evil in you since the day of your coming to me to this day. Nevertheless, the lords don’t favor you. 
 <sup>7&#160;</sup>Therefore now return, and go in peace, that you not displease the lords of the Philistines.” 
 </p><p>
 <sup>8&#160;</sup>David said to Achish, “But what have I done? What have you found in your servant so long as I have been before you to this day, that I may not go and fight against the enemies of my lord the king?” 
@@ -1290,10 +1290,10 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>When David and his men came to the city, behold, it was burned with fire; and their women, their sons, and their daughters were taken captive. 
 <sup>4&#160;</sup>Then David and the people who were with him lifted up their voice and wept until they had no more power to weep. 
 <sup>5&#160;</sup>David’s two women were taken captive, Ahinoam the Jezreelitess, and Abigail the woman of Nabal the Carmelite. 
-<sup>6&#160;</sup>David was greatly distressed, for the people spoke of stoning him, because the souls of all the people were grieved, every man for his sons and for his daughters; but David strengthened himself in Yahweh his Elohim. 
+<sup>6&#160;</sup>David was greatly distressed, for the people spoke of stoning him, because the souls of all the people were grieved, every man for his sons and for his daughters; but David strengthened himself in Yahuah his Elohim. 
 <sup>7&#160;</sup>David said to Abiathar the priest, the son of Ahimelech, “Please bring the ephod here to me.” 
 </p><p>Abiathar brought the ephod to David. 
-<sup>8&#160;</sup>David inquired of Yahweh, saying, “If I pursue after this troop, will I overtake them?” 
+<sup>8&#160;</sup>David inquired of Yahuah, saying, “If I pursue after this troop, will I overtake them?” 
 </p><p>He answered him, “Pursue, for you will surely overtake them, and will without fail recover all.” 
 </p><p>
 <sup>9&#160;</sup>So David went, he and the six hundred men who were with him, and came to the brook Besor, where those who were left behind stayed. 
@@ -1316,11 +1316,11 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>David came to the two hundred men, who were so faint that they could not follow David, whom also they had made to stay at the brook Besor; and they went out to meet David, and to meet the people who were with him. When David came near to the people, he greeted them. 
 <sup>22&#160;</sup>Then all the wicked men and worthless fellows of those who went with David answered and said, “Because they didn’t go with us, we will not give them anything of the plunder that we have recovered, except to every man his woman and his children, that he may lead them away and depart.” 
 </p><p>
-<sup>23&#160;</sup>Then David said, “Do not do so, my brothers, with that which Yahweh has given to us, who has preserved us, and delivered the troop that came against us into our hand. 
+<sup>23&#160;</sup>Then David said, “Do not do so, my brothers, with that which Yahuah has given to us, who has preserved us, and delivered the troop that came against us into our hand. 
 <sup>24&#160;</sup>Who will listen to you in this matter? For as his share is who goes down to the battle, so shall his share be who stays with the baggage. They shall share alike.” 
 <sup>25&#160;</sup>It was so from that day forward that he made it a statute and an ordinance for Israel to this day. 
 </p><p>
-<sup>26&#160;</sup>When David came to Ziklag, he sent some of the plunder to the elders of Judah, even to his friends, saying, “Behold, a present for you from the plunder of Yahweh’s enemies.” 
+<sup>26&#160;</sup>When David came to Ziklag, he sent some of the plunder to the elders of Judah, even to his friends, saying, “Behold, a present for you from the plunder of Yahuah’s enemies.” 
 <sup>27&#160;</sup>He sent it to those who were in Bethel, to those who were in Ramoth of the South, to those who were in Jattir, 
 <sup>28&#160;</sup>to those who were in Aroer, to those who were in Siphmoth, to those who were in Eshtemoa, 
 <sup>29&#160;</sup>to those who were in Racal, to those who were in the cities of the Jerahmeelites, to those who were in the cities of the Kenites, 

--- a/book/2chronicles.html
+++ b/book/2chronicles.html
@@ -95,18 +95,18 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>Solomon the son of David was firmly established in his kingdom, and Yahweh his Elohim was with him, and made him exceedingly great. 
+<sup>1&#160;</sup>Solomon the son of David was firmly established in his kingdom, and Yahuah his Elohim was with him, and made him exceedingly great. 
 </p><p>
 <sup>2&#160;</sup>Solomon spoke to all Israel, to the captains of thousands and of hundreds, to the judges, and to every prince in all Israel, the heads of the fathers’ households. 
-<sup>3&#160;</sup>Then Solomon, and all the assembly with him, went to the high place that was at Gibeon; for Elohim’s Tent of Meeting was there, which Yahweh’s servant Moses had made in the wilderness. 
+<sup>3&#160;</sup>Then Solomon, and all the assembly with him, went to the high place that was at Gibeon; for Elohim’s Tent of Meeting was there, which Yahuah’s servant Moses had made in the wilderness. 
 <sup>4&#160;</sup>But David had brought Elohim’s ark up from Kiriath Jearim to the place that David had prepared for it; for he had pitched a tent for it at Jerusalem. 
-<sup>5&#160;</sup>Moreover the bronze altar that Bezalel the son of Uri, the son of Hur, had made was there before Yahweh’s tabernacle; and Solomon and the assembly were seeking counsel there. 
-<sup>6&#160;</sup>Solomon went up there to the bronze altar before Yahweh, which was at the Tent of Meeting, and offered one thousand burnt offerings on it. 
+<sup>5&#160;</sup>Moreover the bronze altar that Bezalel the son of Uri, the son of Hur, had made was there before Yahuah’s tabernacle; and Solomon and the assembly were seeking counsel there. 
+<sup>6&#160;</sup>Solomon went up there to the bronze altar before Yahuah, which was at the Tent of Meeting, and offered one thousand burnt offerings on it. 
 </p><p>
 <sup>7&#160;</sup>That night, Elohim appeared to Solomon and said to him, “Ask for what you want me to give you.” 
 </p><p>
 <sup>8&#160;</sup>Solomon said to Elohim, “You have shown great loving kindness to David my father, and have made me king in his place. 
-<sup>9&#160;</sup>Now, Yahweh Elohim, let your promise to David my father be established; for you have made me king over a people like the dust of the earth in multitude. 
+<sup>9&#160;</sup>Now, Yahuah Elohim, let your promise to David my father be established; for you have made me king over a people like the dust of the earth in multitude. 
 <sup>10&#160;</sup>Now give me wisdom and knowledge, that I may go out and come in before this people; for who can judge this great people of yours?” 
 </p><p>
 <sup>11&#160;</sup>Elohim said to Solomon, “Because this was in your heart, and you have not asked riches, wealth, honor, or the life of those who hate you, nor yet have you asked for long life; but have asked for wisdom and knowledge for yourself, that you may judge my people, over whom I have made you king, 
@@ -120,11 +120,11 @@ html[dir=ltr] .q2 {
 <sup>17&#160;</sup>They imported from Egypt then exported a chariot for six hundred pieces of silver and a horse for one hundred fifty. They also exported them to the Hittite kings and the Syrian kings. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>Now Solomon decided to build a house for Yahweh’s name, and a house for his kingdom. 
+<sup>1&#160;</sup>Now Solomon decided to build a house for Yahuah’s name, and a house for his kingdom. 
 <sup>2&#160;</sup>Solomon counted out seventy thousand men to bear burdens, eighty thousand men who were stone cutters in the mountains, and three thousand six hundred to oversee them. 
 </p><p>
 <sup>3&#160;</sup>Solomon sent to Huram the king of Tyre, saying, “As you dealt with David my father, and sent him cedars to build him a house in which to dwell, so deal with me. 
-<sup>4&#160;</sup>Behold, I am about to build a house for the name of Yahweh my Elohim, to dedicate it to him, to burn before him incense of sweet spices, for the continual show bread, and for the burnt offerings morning and evening, on the Sabbaths, on the new moons, and on the set feasts of Yahweh our Elohim. This is an ordinance forever to Israel. 
+<sup>4&#160;</sup>Behold, I am about to build a house for the name of Yahuah my Elohim, to dedicate it to him, to burn before him incense of sweet spices, for the continual show bread, and for the burnt offerings morning and evening, on the Sabbaths, on the new moons, and on the set feasts of Yahuah our Elohim. This is an ordinance forever to Israel. 
 </p><p>
 <sup>5&#160;</sup>“The house which I am building will be great, for our Elohim is greater than all elohims. 
 <sup>6&#160;</sup>But who is able to build him a house, since heaven and the heaven of heavens can’t contain him? Who am I then, that I should build him a house, except just to burn incense before him? 
@@ -135,8 +135,8 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>even to prepare me timber in abundance; for the house which I am about to build will be great and wonderful. 
 <sup>10&#160;</sup>Behold, I will give to your servants, the cutters who cut timber, twenty thousand cors of beaten wheat, twenty thousand baths of barley, twenty thousand baths of wine, and twenty thousand baths of oil.” 
 </p><p>
-<sup>11&#160;</sup>Then Huram the king of Tyre answered in writing, which he sent to Solomon, “Because Yahweh loves his people, he has made you king over them.” 
-<sup>12&#160;</sup>Huram continued, “Blessed be Yahweh, the Elohim of Israel, who made heaven and earth, who has given to David the king a wise son, endowed with discretion and understanding, who would build a house for Yahweh and a house for his kingdom. 
+<sup>11&#160;</sup>Then Huram the king of Tyre answered in writing, which he sent to Solomon, “Because Yahuah loves his people, he has made you king over them.” 
+<sup>12&#160;</sup>Huram continued, “Blessed be Yahuah, the Elohim of Israel, who made heaven and earth, who has given to David the king a wise son, endowed with discretion and understanding, who would build a house for Yahuah and a house for his kingdom. 
 </p><p>
 <sup>13&#160;</sup>Now I have sent a skillful man, endowed with understanding, Huram-abi, 
 <sup>14&#160;</sup>the son of a woman of the daughters of Dan; and his father was a man of Tyre. He is skillful to work in gold, in silver, in bronze, in iron, in stone, in timber, in purple, in blue, in fine linen, and in crimson, also to engrave any kind of engraving and to devise any device, that there may be a place appointed to him with your skillful men, and with the skillful men of my lord David your father. 
@@ -148,7 +148,7 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>He set seventy thousand of them to bear burdens, eighty thousand who were stone cutters in the mountains, and three thousand six hundred overseers to assign the people their work. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>Then Solomon began to build Yahweh’s house at Jerusalem on Mount Moriah, where Yahweh appeared to David his father, which he prepared in the place that David had appointed, on the threshing floor of Ornan the Jebusite. 
+<sup>1&#160;</sup>Then Solomon began to build Yahuah’s house at Jerusalem on Mount Moriah, where Yahuah appeared to David his father, which he prepared in the place that David had appointed, on the threshing floor of Ornan the Jebusite. 
 <sup>2&#160;</sup>He began to build in the second day of the second month, in the fourth year of his reign. 
 <sup>3&#160;</sup>Now these are the foundations which Solomon laid for the building of Elohim’s house: the length by cubits after the first measure was sixty cubits, and the width twenty cubits. 
 <sup>4&#160;</sup>The porch that was in front, its length, across the width of the house, was twenty cubits, and the height one hundred twenty; and he overlaid it within with pure gold. 
@@ -187,7 +187,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>the two pillars, the bowls, the two capitals which were on the top of the pillars, the two networks to cover the two bowls of the capitals that were on the top of the pillars, 
 <sup>13&#160;</sup>and the four hundred pomegranates for the two networks—two rows of pomegranates for each network, to cover the two bowls of the capitals that were on the pillars. 
 <sup>14&#160;</sup>He also made the bases, and he made the basins on the bases—<sup>15&#160;</sup>one sea, and the twelve oxen under it. 
-<sup>16&#160;</sup>Huram-abi also made the pots, the shovels, the forks, and all its vessels for King Solomon, for Yahweh’s house, of bright bronze. 
+<sup>16&#160;</sup>Huram-abi also made the pots, the shovels, the forks, and all its vessels for King Solomon, for Yahuah’s house, of bright bronze. 
 <sup>17&#160;</sup>The king cast them in the plain of the Jordan, in the clay ground between Succoth and Zeredah. 
 <sup>18&#160;</sup>Thus Solomon made all these vessels in great abundance, so that the weight of the bronze could not be determined. 
 </p><p>
@@ -197,52 +197,52 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>and the snuffers, the basins, the spoons, and the fire pans of pure gold. As for the entry of the house, its inner doors for the most set-apart place and the doors of the main hall of the temple were of gold. 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
-<sup>1&#160;</sup>Thus all the work that Solomon did for Yahweh’s house was finished. Solomon brought in the things that David his father had dedicated, even the silver, the gold, and all the vessels, and put them in the treasuries of Elohim’s house. 
+<sup>1&#160;</sup>Thus all the work that Solomon did for Yahuah’s house was finished. Solomon brought in the things that David his father had dedicated, even the silver, the gold, and all the vessels, and put them in the treasuries of Elohim’s house. 
 </p><p>
-<sup>2&#160;</sup>Then Solomon assembled the elders of Israel and all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to Jerusalem, to bring up the ark of Yahweh’s covenant out of David’s city, which is Zion. 
+<sup>2&#160;</sup>Then Solomon assembled the elders of Israel and all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to Jerusalem, to bring up the ark of Yahuah’s covenant out of David’s city, which is Zion. 
 <sup>3&#160;</sup>So all the men of Israel assembled themselves to the king at the feast, which was in the seventh month. 
 <sup>4&#160;</sup>All the elders of Israel came. The Levites took up the ark. 
 <sup>5&#160;</sup>They brought up the ark, the Tent of Meeting, and all the set-apart vessels that were in the Tent. The Levitical priests brought these up. 
 <sup>6&#160;</sup>King Solomon and all the congregation of Israel who were assembled to him were before the ark, sacrificing sheep and cattle that could not be counted or numbered for multitude. 
-<sup>7&#160;</sup>The priests brought in the ark of Yahweh’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the wings of the cherubim. 
+<sup>7&#160;</sup>The priests brought in the ark of Yahuah’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the wings of the cherubim. 
 <sup>8&#160;</sup>For the cherubim spread out their wings over the place of the ark, and the cherubim covered the ark and its poles above. 
 <sup>9&#160;</sup>The poles were so long that the ends of the poles were seen from the ark in front of the inner sanctuary, but they were not seen outside; and it is there to this day. 
-<sup>10&#160;</sup>There was nothing in the ark except the two tablets which Moses put there at Horeb, when Yahweh made a covenant with the children of Israel, when they came out of Egypt. 
+<sup>10&#160;</sup>There was nothing in the ark except the two tablets which Moses put there at Horeb, when Yahuah made a covenant with the children of Israel, when they came out of Egypt. 
 </p><p>
 <sup>11&#160;</sup>When the priests had come out of the set-apart place (for all the priests who were present had sanctified themselves, and didn’t keep their divisions; 
 <sup>12&#160;</sup>also the Levites who were the singers, all of them, even Asaph, Heman, Jeduthun, and their sons and their brothers, arrayed in fine linen, with cymbals and stringed instruments and harps, stood at the east end of the altar, and with them one hundred twenty priests sounding with trumpets); 
-<sup>13&#160;</sup>when the trumpeters and singers were as one, to make one sound to be heard in praising and thanking Yahweh; and when they lifted up their voice with the trumpets and cymbals and instruments of music, and praised Yahweh, saying, 
+<sup>13&#160;</sup>when the trumpeters and singers were as one, to make one sound to be heard in praising and thanking Yahuah; and when they lifted up their voice with the trumpets and cymbals and instruments of music, and praised Yahuah, saying, 
 </p><p class="q1">“For he is good, 
 </p><p class="q2">for his loving kindness endures forever!” 
-</p><p class="m">then the house was filled with a cloud, even Yahweh’s house, 
-<sup>14&#160;</sup>so that the priests could not stand to minister by reason of the cloud; for Yahweh’s glory filled Elohim’s house. 
+</p><p class="m">then the house was filled with a cloud, even Yahuah’s house, 
+<sup>14&#160;</sup>so that the priests could not stand to minister by reason of the cloud; for Yahuah’s glory filled Elohim’s house. 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>Then Solomon said, “Yahweh has said that he would dwell in the thick darkness. 
+<sup>1&#160;</sup>Then Solomon said, “Yahuah has said that he would dwell in the thick darkness. 
 <sup>2&#160;</sup>But I have built you a house and home, a place for you to dwell in forever.” 
 </p><p>
 <sup>3&#160;</sup>The king turned his face, and blessed all the assembly of Israel; and all the assembly of Israel stood. 
 </p><p>
-<sup>4&#160;</sup>He said, “Blessed be Yahweh, the Elohim of Israel, who spoke with his mouth to David my father, and has with his hands fulfilled it, saying, 
+<sup>4&#160;</sup>He said, “Blessed be Yahuah, the Elohim of Israel, who spoke with his mouth to David my father, and has with his hands fulfilled it, saying, 
 <sup>5&#160;</sup>‘Since the day that I brought my people out of the land of Egypt, I chose no city out of all the tribes of Israel to build a house in, that my name might be there, and I chose no man to be prince over my people Israel; 
 <sup>6&#160;</sup>but now I have chosen Jerusalem, that my name might be there; and I have chosen David to be over my people Israel.’ 
-<sup>7&#160;</sup>Now it was in the heart of David my father to build a house for the name of Yahweh, the Elohim of Israel. 
-<sup>8&#160;</sup>But Yahweh said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart; 
+<sup>7&#160;</sup>Now it was in the heart of David my father to build a house for the name of Yahuah, the Elohim of Israel. 
+<sup>8&#160;</sup>But Yahuah said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart; 
 <sup>9&#160;</sup>nevertheless you shall not build the house, but your son who will come out of your body, he shall build the house for my name.’ 
 </p><p>
-<sup>10&#160;</sup>“Yahweh has performed his word that he spoke; for I have risen up in the place of David my father, and sit on the throne of Israel, as Yahweh promised, and have built the house for the name of Yahweh, the Elohim of Israel. 
-<sup>11&#160;</sup>There I have set the ark, in which is Yahweh’s covenant, which he made with the children of Israel.” 
+<sup>10&#160;</sup>“Yahuah has performed his word that he spoke; for I have risen up in the place of David my father, and sit on the throne of Israel, as Yahuah promised, and have built the house for the name of Yahuah, the Elohim of Israel. 
+<sup>11&#160;</sup>There I have set the ark, in which is Yahuah’s covenant, which he made with the children of Israel.” 
 </p><p>
-<sup>12&#160;</sup>He stood before Yahweh’s altar in the presence of all the assembly of Israel, and spread out his hands 
+<sup>12&#160;</sup>He stood before Yahuah’s altar in the presence of all the assembly of Israel, and spread out his hands 
 <sup>13&#160;</sup>(for Solomon had made a bronze platform, five cubits long, five cubits wide, and three cubits high, and had set it in the middle of the court; and he stood on it, and knelt down on his knees before all the assembly of Israel, and spread out his hands toward heaven). 
-<sup>14&#160;</sup>Then he said, “Yahweh, the Elohim of Israel, there is no Elohim like you in heaven or on earth—you who keep covenant and loving kindness with your servants who walk before you with all their heart; 
+<sup>14&#160;</sup>Then he said, “Yahuah, the Elohim of Israel, there is no Elohim like you in heaven or on earth—you who keep covenant and loving kindness with your servants who walk before you with all their heart; 
 <sup>15&#160;</sup>who have kept with your servant David my father that which you promised him. Yes, you spoke with your mouth, and have fulfilled it with your hand, as it is today. 
 </p><p>
-<sup>16&#160;</sup>“Now therefore, Yahweh, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk in my law as you have walked before me.’ 
-<sup>17&#160;</sup>Now therefore, Yahweh, the Elohim of Israel, let your word be verified, which you spoke to your servant David. 
+<sup>16&#160;</sup>“Now therefore, Yahuah, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk in my law as you have walked before me.’ 
+<sup>17&#160;</sup>Now therefore, Yahuah, the Elohim of Israel, let your word be verified, which you spoke to your servant David. 
 </p><p>
 <sup>18&#160;</sup>“But will Elohim indeed dwell with men on the earth? Behold, heaven and the heaven of heavens can’t contain you; how much less this house which I have built! 
-<sup>19&#160;</sup>Yet have respect for the prayer of your servant and to his supplication, Yahweh my Elohim, to listen to the cry and to the prayer which your servant prays before you; 
+<sup>19&#160;</sup>Yet have respect for the prayer of your servant and to his supplication, Yahuah my Elohim, to listen to the cry and to the prayer which your servant prays before you; 
 <sup>20&#160;</sup>that your eyes may be open toward this house day and night, even toward the place where you have said that you would put your name, to listen to the prayer which your servant will pray toward this place. 
 <sup>21&#160;</sup>Listen to the petitions of your servant and of your people Israel, when they pray toward this place. Yes, hear from your dwelling place, even from heaven; and when you hear, forgive. 
 </p><p>
@@ -272,31 +272,31 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>40&#160;</sup>“Now, my Elohim, let, I beg you, your eyes be open, and let your ears be attentive to the prayer that is made in this place. 
 </p><p>
-<sup>41&#160;</sup>“Now therefore arise, Yahweh Elohim, into your resting place, you, and the ark of your strength. Let your priests, Yahweh Elohim, be clothed with salvation, and let your saints rejoice in goodness. 
+<sup>41&#160;</sup>“Now therefore arise, Yahuah Elohim, into your resting place, you, and the ark of your strength. Let your priests, Yahuah Elohim, be clothed with salvation, and let your saints rejoice in goodness. 
 </p><p>
-<sup>42&#160;</sup>“Yahweh Elohim, don’t turn away the face of your anointed. Remember your loving kindnesses to David your servant.” 
+<sup>42&#160;</sup>“Yahuah Elohim, don’t turn away the face of your anointed. Remember your loving kindnesses to David your servant.” 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>Now when Solomon had finished praying, fire came down from heaven and consumed the burnt offering and the sacrifices; and Yahweh’s glory filled the house. 
-<sup>2&#160;</sup>The priests could not enter into Yahweh’s house, because Yahweh’s glory filled Yahweh’s house. 
-<sup>3&#160;</sup>All the children of Israel looked on, when the fire came down, and Yahweh’s glory was on the house. They bowed themselves with their faces to the ground on the pavement, worshiped, and gave thanks to Yahweh, saying, 
+<sup>1&#160;</sup>Now when Solomon had finished praying, fire came down from heaven and consumed the burnt offering and the sacrifices; and Yahuah’s glory filled the house. 
+<sup>2&#160;</sup>The priests could not enter into Yahuah’s house, because Yahuah’s glory filled Yahuah’s house. 
+<sup>3&#160;</sup>All the children of Israel looked on, when the fire came down, and Yahuah’s glory was on the house. They bowed themselves with their faces to the ground on the pavement, worshiped, and gave thanks to Yahuah, saying, 
 </p><p class="q1">“For he is good, 
 </p><p class="q2">for his loving kindness endures forever!” 
 </p><p>
-<sup>4&#160;</sup>Then the king and all the people offered sacrifices before Yahweh. 
+<sup>4&#160;</sup>Then the king and all the people offered sacrifices before Yahuah. 
 <sup>5&#160;</sup>King Solomon offered a sacrifice of twenty-two thousand head of cattle and a hundred twenty thousand sheep. So the king and all the people dedicated Elohim’s house. 
-<sup>6&#160;</sup>The priests stood, according to their positions; the Levites also with instruments of music of Yahweh, which David the king had made to give thanks to Yahweh, when David praised by their ministry, saying “For his loving kindness endures forever.” The priests sounded trumpets before them; and all Israel stood. 
+<sup>6&#160;</sup>The priests stood, according to their positions; the Levites also with instruments of music of Yahuah, which David the king had made to give thanks to Yahuah, when David praised by their ministry, saying “For his loving kindness endures forever.” The priests sounded trumpets before them; and all Israel stood. 
 </p><p>
-<sup>7&#160;</sup>Moreover Solomon made the middle of the court that was before Yahweh’s house set-apart; for there he offered the burnt offerings and the fat of the peace offerings, because the bronze altar which Solomon had made was not able to receive the burnt offering, the meal offering, and the fat. 
+<sup>7&#160;</sup>Moreover Solomon made the middle of the court that was before Yahuah’s house set-apart; for there he offered the burnt offerings and the fat of the peace offerings, because the bronze altar which Solomon had made was not able to receive the burnt offering, the meal offering, and the fat. 
 </p><p>
 <sup>8&#160;</sup>So Solomon held the feast at that time for seven days, and all Israel with him, a very great assembly, from the entrance of Hamath to the brook of Egypt. 
 </p><p>
 <sup>9&#160;</sup>On the eighth day, they held a solemn assembly; for they kept the dedication of the altar seven days, and the feast seven days. 
-<sup>10&#160;</sup>On the twenty-third day of the seventh month, he sent the people away to their tents, joyful and glad of heart for the goodness that Yahweh had shown to David, to Solomon, and to Israel his people. 
+<sup>10&#160;</sup>On the twenty-third day of the seventh month, he sent the people away to their tents, joyful and glad of heart for the goodness that Yahuah had shown to David, to Solomon, and to Israel his people. 
 </p><p>
-<sup>11&#160;</sup>Thus Solomon finished Yahweh’s house and the king’s house; and he successfully completed all that came into Solomon’s heart to make in Yahweh’s house and in his own house. 
+<sup>11&#160;</sup>Thus Solomon finished Yahuah’s house and the king’s house; and he successfully completed all that came into Solomon’s heart to make in Yahuah’s house and in his own house. 
 </p><p>
-<sup>12&#160;</sup>Then Yahweh appeared to Solomon by night, and said to him, “I have heard your prayer, and have chosen this place for myself for a house of sacrifice. 
+<sup>12&#160;</sup>Then Yahuah appeared to Solomon by night, and said to him, “I have heard your prayer, and have chosen this place for myself for a house of sacrifice. 
 </p><p>
 <sup>13&#160;</sup>“If I shut up the sky so that there is no rain, or if I command the locust to devour the land, or if I send pestilence among my people, 
 <sup>14&#160;</sup>if my people who are called by my name will humble themselves, pray, seek my face, and turn from their wicked ways, then I will hear from heaven, will forgive their sin, and will heal their land. 
@@ -308,11 +308,11 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>19&#160;</sup>But if you turn away and forsake my statutes and my commandments which I have set before you, and go and serve other elohims and worship them, 
 <sup>20&#160;</sup>then I will pluck them up by the roots out of my land which I have given them; and this house, which I have made set-apart for my name, I will cast out of my sight, and I will make it a proverb and a byword among all peoples. 
-<sup>21&#160;</sup>This house, which is so high, everyone who passes by it will be astonished and say, ‘Why has Yahweh done this to this land and to this house?’ 
-<sup>22&#160;</sup>They shall answer, ‘Because they abandoned Yahweh, the Elohim of their fathers, who brought them out of the land of Egypt, and took other elohims, worshiped them, and served them. Therefore he has brought all this evil on them.’&#160;” 
+<sup>21&#160;</sup>This house, which is so high, everyone who passes by it will be astonished and say, ‘Why has Yahuah done this to this land and to this house?’ 
+<sup>22&#160;</sup>They shall answer, ‘Because they abandoned Yahuah, the Elohim of their fathers, who brought them out of the land of Egypt, and took other elohims, worshiped them, and served them. Therefore he has brought all this evil on them.’&#160;” 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>At the end of twenty years, in which Solomon had built Yahweh’s house and his own house, 
+<sup>1&#160;</sup>At the end of twenty years, in which Solomon had built Yahuah’s house and his own house, 
 <sup>2&#160;</sup>Solomon built the cities which Huram had given to Solomon, and caused the children of Israel to dwell there. 
 </p><p>
 <sup>3&#160;</sup>Solomon went to Hamath Zobah, and prevailed against it. 
@@ -324,15 +324,15 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>But of the children of Israel, Solomon made no servants for his work, but they were men of war, chief of his captains, and rulers of his chariots and of his horsemen. 
 <sup>10&#160;</sup>These were the chief officers of King Solomon, even two-hundred fifty, who ruled over the people. 
 </p><p>
-<sup>11&#160;</sup>Solomon brought up Pharaoh’s daughter out of David’s city to the house that he had built for her; for he said, “My woman shall not dwell in the house of David king of Israel, because the places where Yahweh’s ark has come are set-apart.” 
+<sup>11&#160;</sup>Solomon brought up Pharaoh’s daughter out of David’s city to the house that he had built for her; for he said, “My woman shall not dwell in the house of David king of Israel, because the places where Yahuah’s ark has come are set-apart.” 
 </p><p>
-<sup>12&#160;</sup>Then Solomon offered burnt offerings to Yahweh on Yahweh’s altar which he had built before the porch, 
+<sup>12&#160;</sup>Then Solomon offered burnt offerings to Yahuah on Yahuah’s altar which he had built before the porch, 
 <sup>13&#160;</sup>even as the duty of every day required, offering according to the commandment of Moses on the Sabbaths, on the new moons, and on the set feasts, three times per year, during the feast of unleavened bread, during the feast of weeks, and during the feast of booths. 
 </p><p>
 <sup>14&#160;</sup>He appointed, according to the ordinance of David his father, the divisions of the priests to their service, and the Levites to their offices, to praise and to minister before the priests, as the duty of every day required, the doorkeepers also by their divisions at every gate, for David the man of Elohim had so commanded. 
 <sup>15&#160;</sup>They didn’t depart from the commandment of the king to the priests and Levites concerning any matter or concerning the treasures. 
 </p><p>
-<sup>16&#160;</sup>Now all the work of Solomon was accomplished from the day of the foundation of Yahweh’s house until it was finished. So Yahweh’s house was completed. 
+<sup>16&#160;</sup>Now all the work of Solomon was accomplished from the day of the foundation of Yahuah’s house until it was finished. So Yahuah’s house was completed. 
 </p><p>
 <sup>17&#160;</sup>Then Solomon went to Ezion Geber and to Eloth, on the seashore in the land of Edom. 
 <sup>18&#160;</sup>Huram sent him ships and servants who had knowledge of the sea by the hands of his servants; and they came with the servants of Solomon to Ophir, and brought from there four hundred fifty talents of gold, and brought them to King Solomon. 
@@ -341,17 +341,17 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>When the queen of Sheba heard of the fame of Solomon, she came to test Solomon with hard questions at Jerusalem, with a very great caravan, including camels that bore spices, gold in abundance, and precious stones. When she had come to Solomon, she talked with him about all that was in her heart. 
 <sup>2&#160;</sup>Solomon answered all her questions. There wasn’t anything hidden from Solomon which he didn’t tell her. 
 <sup>3&#160;</sup>When the queen of Sheba had seen the wisdom of Solomon, the house that he had built, 
-<sup>4&#160;</sup>the food of his table, the seating of his servants, the attendance of his ministers, their clothing, his cup bearers and their clothing, and his ascent by which he went up to Yahweh’s house, there was no more spirit in her. 
+<sup>4&#160;</sup>the food of his table, the seating of his servants, the attendance of his ministers, their clothing, his cup bearers and their clothing, and his ascent by which he went up to Yahuah’s house, there was no more spirit in her. 
 </p><p>
 <sup>5&#160;</sup>She said to the king, “It was a true report that I heard in my own land of your acts and of your wisdom. 
 <sup>6&#160;</sup>However I didn’t believe their words until I came, and my eyes had seen it; and behold half of the greatness of your wisdom wasn’t told me. You exceed the fame that I heard! 
 <sup>7&#160;</sup>Happy are your men, and happy are these your servants, who stand continually before you and hear your wisdom. 
-<sup>8&#160;</sup>Blessed be Yahweh your Elohim, who delighted in you and set you on his throne to be king for Yahweh your Elohim, because your Elohim loved Israel, to establish them forever. Therefore he made you king over them, to do justice and righteousness.” 
+<sup>8&#160;</sup>Blessed be Yahuah your Elohim, who delighted in you and set you on his throne to be king for Yahuah your Elohim, because your Elohim loved Israel, to establish them forever. Therefore he made you king over them, to do justice and righteousness.” 
 </p><p>
 <sup>9&#160;</sup>She gave the king one hundred and twenty talents of gold, spices in great abundance, and precious stones. There was never before such spice as the queen of Sheba gave to King Solomon. 
 </p><p>
 <sup>10&#160;</sup>The servants of Huram and the servants of Solomon, who brought gold from Ophir, also brought algum trees and precious stones. 
-<sup>11&#160;</sup>The king used algum tree wood to make terraces for Yahweh’s house and for the king’s house, and harps and stringed instruments for the singers. There were none like these seen before in the land of Judah. 
+<sup>11&#160;</sup>The king used algum tree wood to make terraces for Yahuah’s house and for the king’s house, and harps and stringed instruments for the singers. There were none like these seen before in the land of Judah. 
 <sup>12&#160;</sup>King Solomon gave to the queen of Sheba all her desire, whatever she asked, more than that which she had brought to the king. So she turned and went to her own land, she and her servants. 
 </p><p>
 <sup>13&#160;</sup>Now the weight of gold that came to Solomon in one year was six hundred sixty-six talents of gold, 
@@ -399,7 +399,7 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>The king answered them roughly; and King Rehoboam abandoned the counsel of the old men, 
 <sup>14&#160;</sup>and spoke to them after the counsel of the young men, saying, “My father made your yoke heavy, but I will add to it. My father chastised you with whips, but I will chastise you with scorpions.” 
 </p><p>
-<sup>15&#160;</sup>So the king didn’t listen to the people; for it was brought about by Elohim, that Yahweh might establish his word, which he spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
+<sup>15&#160;</sup>So the king didn’t listen to the people; for it was brought about by Elohim, that Yahuah might establish his word, which he spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
 </p><p>
 <sup>16&#160;</sup>When all Israel saw that the king didn’t listen to them, the people answered the king, saying, “What portion do we have in David? We don’t have an inheritance in the son of Jesse! Every man to your tents, Israel! Now see to your own house, David.” So all Israel departed to their tents. 
 </p><p>
@@ -409,9 +409,9 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p>
 <sup>1&#160;</sup>When Rehoboam had come to Jerusalem, he assembled the house of Judah and Benjamin, one hundred eighty thousand chosen men who were warriors, to fight against Israel, to bring the kingdom again to Rehoboam. 
-<sup>2&#160;</sup>But Yahweh’s word came to Shemaiah the man of Elohim, saying, 
+<sup>2&#160;</sup>But Yahuah’s word came to Shemaiah the man of Elohim, saying, 
 <sup>3&#160;</sup>“Speak to Rehoboam the son of Solomon, king of Judah, and to all Israel in Judah and Benjamin, saying, 
-<sup>4&#160;</sup>‘Yahweh says, “You shall not go up, nor fight against your brothers! Every man return to his house; for this thing is of me.”&#160;’&#160;” So they listened to Yahweh’s words, and returned from going against Jeroboam. 
+<sup>4&#160;</sup>‘Yahuah says, “You shall not go up, nor fight against your brothers! Every man return to his house; for this thing is of me.”&#160;’&#160;” So they listened to Yahuah’s words, and returned from going against Jeroboam. 
 </p><p>
 <sup>5&#160;</sup>Rehoboam lived in Jerusalem, and built cities for defense in Judah. 
 <sup>6&#160;</sup>He built Bethlehem, Etam, Tekoa, 
@@ -423,9 +423,9 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>He put shields and spears in every city, and made them exceedingly strong. Judah and Benjamin belonged to him. 
 </p><p>
 <sup>13&#160;</sup>The priests and the Levites who were in all Israel stood with him out of all their territory. 
-<sup>14&#160;</sup>For the Levites left their pasture lands and their possessions, and came to Judah and Jerusalem; for Jeroboam and his sons cast them off, that they should not execute the priest’s office to Yahweh. 
+<sup>14&#160;</sup>For the Levites left their pasture lands and their possessions, and came to Judah and Jerusalem; for Jeroboam and his sons cast them off, that they should not execute the priest’s office to Yahuah. 
 <sup>15&#160;</sup>He himself appointed priests for the high places, for the male goat and calf idols which he had made. 
-<sup>16&#160;</sup>After them, out of all the tribes of Israel, those who set their hearts to seek Yahweh, the Elohim of Israel, came to Jerusalem to sacrifice to Yahweh, the Elohim of their fathers. 
+<sup>16&#160;</sup>After them, out of all the tribes of Israel, those who set their hearts to seek Yahuah, the Elohim of Israel, came to Jerusalem to sacrifice to Yahuah, the Elohim of their fathers. 
 <sup>17&#160;</sup>So they strengthened the kingdom of Judah and made Rehoboam the son of Solomon strong for three years, for they walked three years in the way of David and Solomon. 
 </p><p>
 <sup>18&#160;</sup>Rehoboam took a woman for himself, Mahalath the daughter of Jerimoth the son of David and of Abihail the daughter of Eliab the son of Jesse. 
@@ -436,24 +436,24 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>He dealt wisely, and dispersed some of his sons throughout all the lands of Judah and Benjamin, to every fortified city. He gave them food in abundance; and he sought many women for them. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
-<sup>1&#160;</sup>When the kingdom of Rehoboam was established and he was strong, he abandoned Yahweh’s law, and all Israel with him. 
-<sup>2&#160;</sup>In the fifth year of King Rehoboam, Shishak king of Egypt came up against Jerusalem, because they had trespassed against Yahweh, 
+<sup>1&#160;</sup>When the kingdom of Rehoboam was established and he was strong, he abandoned Yahuah’s law, and all Israel with him. 
+<sup>2&#160;</sup>In the fifth year of King Rehoboam, Shishak king of Egypt came up against Jerusalem, because they had trespassed against Yahuah, 
 <sup>3&#160;</sup>with twelve hundred chariots and sixty thousand horsemen. The people were without number who came with him out of Egypt: the Lubim, the Sukkiim, and the Ethiopians. 
 <sup>4&#160;</sup>He took the fortified cities which belonged to Judah, and came to Jerusalem. 
-<sup>5&#160;</sup>Now Shemaiah the prophet came to Rehoboam and to the princes of Judah, who were gathered together to Jerusalem because of Shishak, and said to them, “Yahweh says, ‘You have forsaken me, therefore I have also left you in the hand of Shishak.’&#160;” 
+<sup>5&#160;</sup>Now Shemaiah the prophet came to Rehoboam and to the princes of Judah, who were gathered together to Jerusalem because of Shishak, and said to them, “Yahuah says, ‘You have forsaken me, therefore I have also left you in the hand of Shishak.’&#160;” 
 </p><p>
-<sup>6&#160;</sup>Then the princes of Israel and the king humbled themselves; and they said, “Yahweh is righteous.” 
+<sup>6&#160;</sup>Then the princes of Israel and the king humbled themselves; and they said, “Yahuah is righteous.” 
 </p><p>
-<sup>7&#160;</sup>When Yahweh saw that they humbled themselves, Yahweh’s word came to Shemaiah, saying, “They have humbled themselves. I will not destroy them, but I will grant them some deliverance, and my wrath won’t be poured out on Jerusalem by the hand of Shishak. 
+<sup>7&#160;</sup>When Yahuah saw that they humbled themselves, Yahuah’s word came to Shemaiah, saying, “They have humbled themselves. I will not destroy them, but I will grant them some deliverance, and my wrath won’t be poured out on Jerusalem by the hand of Shishak. 
 <sup>8&#160;</sup>Nevertheless they will be his servants, that they may know my service, and the service of the kingdoms of the countries.” 
 </p><p>
-<sup>9&#160;</sup>So Shishak king of Egypt came up against Jerusalem and took away the treasures of Yahweh’s house and the treasures of the king’s house. He took it all away. He also took away the shields of gold which Solomon had made. 
+<sup>9&#160;</sup>So Shishak king of Egypt came up against Jerusalem and took away the treasures of Yahuah’s house and the treasures of the king’s house. He took it all away. He also took away the shields of gold which Solomon had made. 
 <sup>10&#160;</sup>King Rehoboam made shields of bronze in their place, and committed them to the hands of the captains of the guard, who kept the door of the king’s house. 
-<sup>11&#160;</sup>As often as the king entered into Yahweh’s house, the guard came and bore them, then brought them back into the guard room. 
-<sup>12&#160;</sup>When he humbled himself, Yahweh’s wrath turned from him, so as not to destroy him altogether. Moreover, there were good things found in Judah. 
+<sup>11&#160;</sup>As often as the king entered into Yahuah’s house, the guard came and bore them, then brought them back into the guard room. 
+<sup>12&#160;</sup>When he humbled himself, Yahuah’s wrath turned from him, so as not to destroy him altogether. Moreover, there were good things found in Judah. 
 </p><p>
-<sup>13&#160;</sup>So King Rehoboam strengthened himself in Jerusalem and reigned; for Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahweh had chosen out of all the tribes of Israel to put his name there. His mother’s name was Naamah the Ammonitess. 
-<sup>14&#160;</sup>He did that which was evil, because he didn’t set his heart to seek Yahweh. 
+<sup>13&#160;</sup>So King Rehoboam strengthened himself in Jerusalem and reigned; for Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahuah had chosen out of all the tribes of Israel to put his name there. His mother’s name was Naamah the Ammonitess. 
+<sup>14&#160;</sup>He did that which was evil, because he didn’t set his heart to seek Yahuah. 
 </p><p>
 <sup>15&#160;</sup>Now the acts of Rehoboam, first and last, aren’t they written in the histories of Shemaiah the prophet and of Iddo the seer, in the genealogies? There were wars between Rehoboam and Jeroboam continually. 
 <sup>16&#160;</sup>Rehoboam slept with his fathers, and was buried in David’s city; and Abijah his son reigned in his place. 
@@ -463,66 +463,66 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>He reigned three years in Jerusalem. His mother’s name was Micaiah the daughter of Uriel of Gibeah. There was war between Abijah and Jeroboam. 
 <sup>3&#160;</sup>Abijah joined battle with an army of valiant men of war, even four hundred thousand chosen men; and Jeroboam set the battle in array against him with eight hundred thousand chosen men, who were mighty men of valor. 
 <sup>4&#160;</sup>Abijah stood up on Mount Zemaraim, which is in the hill country of Ephraim, and said, “Hear me, Jeroboam and all Israel: 
-<sup>5&#160;</sup>Ought you not to know that Yahweh, the Elohim of Israel, gave the kingdom over Israel to David forever, even to him and to his sons by a covenant of salt? 
+<sup>5&#160;</sup>Ought you not to know that Yahuah, the Elohim of Israel, gave the kingdom over Israel to David forever, even to him and to his sons by a covenant of salt? 
 <sup>6&#160;</sup>Yet Jeroboam the son of Nebat, the servant of Solomon the son of David, rose up, and rebelled against his lord. 
 <sup>7&#160;</sup>Worthless men were gathered to him, wicked fellows who strengthened themselves against Rehoboam the son of Solomon, when Rehoboam was young and tender hearted, and could not withstand them. 
 </p><p>
-<sup>8&#160;</sup>“Now you intend to withstand the kingdom of Yahweh in the hand of the sons of David. You are a great multitude, and the golden calves which Jeroboam made you for elohims are with you. 
-<sup>9&#160;</sup>Haven’t you driven out the priests of Yahweh, the sons of Aaron, and the Levites, and made priests for yourselves according to the ways of the peoples of other lands? Whoever comes to consecrate himself with a young bull and seven rams may be a priest of those who are no elohims. 
+<sup>8&#160;</sup>“Now you intend to withstand the kingdom of Yahuah in the hand of the sons of David. You are a great multitude, and the golden calves which Jeroboam made you for elohims are with you. 
+<sup>9&#160;</sup>Haven’t you driven out the priests of Yahuah, the sons of Aaron, and the Levites, and made priests for yourselves according to the ways of the peoples of other lands? Whoever comes to consecrate himself with a young bull and seven rams may be a priest of those who are no elohims. 
 </p><p>
-<sup>10&#160;</sup>“But as for us, Yahweh is our Elohim, and we have not forsaken him. We have priests serving Yahweh, the sons of Aaron, and the Levites in their work. 
-<sup>11&#160;</sup>They burn to Yahweh every morning and every evening burnt offerings and sweet incense. They also set the show bread in order on the pure table, and care for the gold lamp stand with its lamps, to burn every evening; for we keep the instruction of Yahweh our Elohim, but you have forsaken him. 
-<sup>12&#160;</sup>Behold, Elohim is with us at our head, and his priests with the trumpets of alarm to sound an alarm against you. Children of Israel, don’t fight against Yahweh, the Elohim of your fathers; for you will not prosper.” 
+<sup>10&#160;</sup>“But as for us, Yahuah is our Elohim, and we have not forsaken him. We have priests serving Yahuah, the sons of Aaron, and the Levites in their work. 
+<sup>11&#160;</sup>They burn to Yahuah every morning and every evening burnt offerings and sweet incense. They also set the show bread in order on the pure table, and care for the gold lamp stand with its lamps, to burn every evening; for we keep the instruction of Yahuah our Elohim, but you have forsaken him. 
+<sup>12&#160;</sup>Behold, Elohim is with us at our head, and his priests with the trumpets of alarm to sound an alarm against you. Children of Israel, don’t fight against Yahuah, the Elohim of your fathers; for you will not prosper.” 
 </p><p>
 <sup>13&#160;</sup>But Jeroboam caused an ambush to come about behind them; so they were before Judah, and the ambush was behind them. 
-<sup>14&#160;</sup>When Judah looked back, behold, the battle was before and behind them; and they cried to Yahweh, and the priests sounded with the trumpets. 
+<sup>14&#160;</sup>When Judah looked back, behold, the battle was before and behind them; and they cried to Yahuah, and the priests sounded with the trumpets. 
 <sup>15&#160;</sup>Then the men of Judah gave a shout. As the men of Judah shouted, Elohim struck Jeroboam and all Israel before Abijah and Judah. 
 <sup>16&#160;</sup>The children of Israel fled before Judah, and Elohim delivered them into their hand. 
 <sup>17&#160;</sup>Abijah and his people killed them with a great slaughter, so five hundred thousand chosen men of Israel fell down slain. 
-<sup>18&#160;</sup>Thus the children of Israel were brought under at that time, and the children of Judah prevailed, because they relied on Yahweh, the Elohim of their fathers. 
+<sup>18&#160;</sup>Thus the children of Israel were brought under at that time, and the children of Judah prevailed, because they relied on Yahuah, the Elohim of their fathers. 
 <sup>19&#160;</sup>Abijah pursued Jeroboam, and took cities from him: Bethel with its villages, Jeshanah with its villages, and Ephron with its villages. 
 </p><p>
-<sup>20&#160;</sup>Jeroboam didn’t recover strength again in the days of Abijah. Yahweh struck him, and he died. 
+<sup>20&#160;</sup>Jeroboam didn’t recover strength again in the days of Abijah. Yahuah struck him, and he died. 
 <sup>21&#160;</sup>But Abijah grew mighty and took for himself fourteen women, and brought forth twenty-two sons and sixteen daughters. 
 <sup>22&#160;</sup>The rest of the acts of Abijah, his ways, and his sayings are written in the commentary of the prophet Iddo. 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
 <sup>1&#160;</sup>So Abijah slept with his fathers, and they buried him in David’s city; and Asa his son reigned in his place. In his days, the land was quiet ten years. 
-<sup>2&#160;</sup>Asa did that which was good and right in Yahweh his Elohim’s eyes, 
+<sup>2&#160;</sup>Asa did that which was good and right in Yahuah his Elohim’s eyes, 
 <sup>3&#160;</sup>for he took away the foreign altars and the high places, broke down the pillars, cut down the Asherah poles, 
-<sup>4&#160;</sup>and commanded Judah to seek Yahweh, the Elohim of their fathers, and to obey his law and command. 
+<sup>4&#160;</sup>and commanded Judah to seek Yahuah, the Elohim of their fathers, and to obey his law and command. 
 <sup>5&#160;</sup>Also he took away out of all the cities of Judah the high places and the sun images; and the kingdom was quiet before him. 
-<sup>6&#160;</sup>He built fortified cities in Judah; for the land was quiet, and he had no war in those years, because Yahweh had given him rest. 
-<sup>7&#160;</sup>For he said to Judah, “Let’s build these cities and make walls around them, with towers, gates, and bars. The land is yet before us, because we have sought Yahweh our Elohim. We have sought him, and he has given us rest on every side.” So they built and prospered. 
+<sup>6&#160;</sup>He built fortified cities in Judah; for the land was quiet, and he had no war in those years, because Yahuah had given him rest. 
+<sup>7&#160;</sup>For he said to Judah, “Let’s build these cities and make walls around them, with towers, gates, and bars. The land is yet before us, because we have sought Yahuah our Elohim. We have sought him, and he has given us rest on every side.” So they built and prospered. 
 </p><p>
 <sup>8&#160;</sup>Asa had an army of three hundred thousand out of Judah who bore bucklers and spears, and two hundred eighty thousand out of Benjamin who bore shields and drew bows. All these were mighty men of valor. 
 </p><p>
 <sup>9&#160;</sup>Zerah the Ethiopian came out against them with an army of a million troops and three hundred chariots, and he came to Mareshah. 
 <sup>10&#160;</sup>Then Asa went out to meet him, and they set the battle in array in the valley of Zephathah at Mareshah. 
-<sup>11&#160;</sup>Asa cried to Yahweh his Elohim, and said, “Yahweh, there is no one besides you to help, between the mighty and him who has no strength. Help us, Yahweh our Elohim; for we rely on you, and in your name are we come against this multitude. Yahweh, you are our Elohim. Don’t let man prevail against you.” 
+<sup>11&#160;</sup>Asa cried to Yahuah his Elohim, and said, “Yahuah, there is no one besides you to help, between the mighty and him who has no strength. Help us, Yahuah our Elohim; for we rely on you, and in your name are we come against this multitude. Yahuah, you are our Elohim. Don’t let man prevail against you.” 
 </p><p>
-<sup>12&#160;</sup>So Yahweh struck the Ethiopians before Asa and before Judah; and the Ethiopians fled. 
-<sup>13&#160;</sup>Asa and the people who were with him pursued them to Gerar. So many of the Ethiopians fell that they could not recover themselves, for they were destroyed before Yahweh and before his army. Judah’s army carried away very much booty. 
-<sup>14&#160;</sup>They struck all the cities around Gerar, for the fear of Yahweh came on them. They plundered all the cities, for there was much plunder in them. 
+<sup>12&#160;</sup>So Yahuah struck the Ethiopians before Asa and before Judah; and the Ethiopians fled. 
+<sup>13&#160;</sup>Asa and the people who were with him pursued them to Gerar. So many of the Ethiopians fell that they could not recover themselves, for they were destroyed before Yahuah and before his army. Judah’s army carried away very much booty. 
+<sup>14&#160;</sup>They struck all the cities around Gerar, for the fear of Yahuah came on them. They plundered all the cities, for there was much plunder in them. 
 <sup>15&#160;</sup>They also struck the tents of those who had livestock, and carried away sheep and camels in abundance, then returned to Jerusalem. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
 <sup>1&#160;</sup>The Spirit of Elohim came on Azariah the son of Oded. 
-<sup>2&#160;</sup>He went out to meet Asa, and said to him, “Hear me, Asa, and all Judah and Benjamin! Yahweh is with you while you are with him; and if you seek him, he will be found by you; but if you forsake him, he will forsake you. 
+<sup>2&#160;</sup>He went out to meet Asa, and said to him, “Hear me, Asa, and all Judah and Benjamin! Yahuah is with you while you are with him; and if you seek him, he will be found by you; but if you forsake him, he will forsake you. 
 <sup>3&#160;</sup>Now for a long time Israel was without the true Elohim, without a teaching priest, and without law. 
-<sup>4&#160;</sup>But when in their distress they turned to Yahweh, the Elohim of Israel, and sought him, he was found by them. 
+<sup>4&#160;</sup>But when in their distress they turned to Yahuah, the Elohim of Israel, and sought him, he was found by them. 
 <sup>5&#160;</sup>In those times there was no peace to him who went out, nor to him who came in; but great troubles were on all the inhabitants of the lands. 
 <sup>6&#160;</sup>They were broken in pieces, nation against nation, and city against city; for Elohim troubled them with all adversity. 
 <sup>7&#160;</sup>But you be strong! Don’t let your hands be slack, for your work will be rewarded.” 
 </p><p>
-<sup>8&#160;</sup>When Asa heard these words and the prophecy of Oded the prophet, he took courage, and put away the abominations out of all the land of Judah and Benjamin, and out of the cities which he had taken from the hill country of Ephraim; and he renewed Yahweh’s altar that was before Yahweh’s porch. 
-<sup>9&#160;</sup>He gathered all Judah and Benjamin, and those who lived with them out of Ephraim, Manasseh, and Simeon; for they came to him out of Israel in abundance when they saw that Yahweh his Elohim was with him. 
+<sup>8&#160;</sup>When Asa heard these words and the prophecy of Oded the prophet, he took courage, and put away the abominations out of all the land of Judah and Benjamin, and out of the cities which he had taken from the hill country of Ephraim; and he renewed Yahuah’s altar that was before Yahuah’s porch. 
+<sup>9&#160;</sup>He gathered all Judah and Benjamin, and those who lived with them out of Ephraim, Manasseh, and Simeon; for they came to him out of Israel in abundance when they saw that Yahuah his Elohim was with him. 
 <sup>10&#160;</sup>So they gathered themselves together at Jerusalem in the third month, in the fifteenth year of Asa’s reign. 
-<sup>11&#160;</sup>They sacrificed to Yahweh in that day, of the plunder which they had brought, seven hundred head of cattle and seven thousand sheep. 
-<sup>12&#160;</sup>They entered into the covenant to seek Yahweh, the Elohim of their fathers, with all their heart and with all their soul; 
-<sup>13&#160;</sup>and that whoever would not seek Yahweh, the Elohim of Israel, should be put to death, whether small or great, whether man or woman. 
-<sup>14&#160;</sup>They swore to Yahweh with a loud voice, with shouting, with trumpets, and with cornets. 
-<sup>15&#160;</sup>All Judah rejoiced at the oath, for they had sworn with all their heart and sought him with their whole desire; and he was found by them. Then Yahweh gave them rest all around. 
+<sup>11&#160;</sup>They sacrificed to Yahuah in that day, of the plunder which they had brought, seven hundred head of cattle and seven thousand sheep. 
+<sup>12&#160;</sup>They entered into the covenant to seek Yahuah, the Elohim of their fathers, with all their heart and with all their soul; 
+<sup>13&#160;</sup>and that whoever would not seek Yahuah, the Elohim of Israel, should be put to death, whether small or great, whether man or woman. 
+<sup>14&#160;</sup>They swore to Yahuah with a loud voice, with shouting, with trumpets, and with cornets. 
+<sup>15&#160;</sup>All Judah rejoiced at the oath, for they had sworn with all their heart and sought him with their whole desire; and he was found by them. Then Yahuah gave them rest all around. 
 </p><p>
 <sup>16&#160;</sup>Also Maacah, the mother of Asa the king, he removed from being queen mother, because she had made an abominable image for an Asherah; so Asa cut down her image, ground it into dust, and burned it at the brook Kidron. 
 <sup>17&#160;</sup>But the high places were not taken away out of Israel; nevertheless the heart of Asa was perfect all his days. 
@@ -531,43 +531,43 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
 <sup>1&#160;</sup>In the thirty-sixth year of Asa’s reign, Baasha king of Israel went up against Judah, and built Ramah, that he might not allow anyone to go out or come in to Asa king of Judah. 
-<sup>2&#160;</sup>Then Asa brought out silver and gold out of the treasures of Yahweh’s house and of the king’s house, and sent to Ben Hadad king of Syria, who lived at Damascus, saying, 
+<sup>2&#160;</sup>Then Asa brought out silver and gold out of the treasures of Yahuah’s house and of the king’s house, and sent to Ben Hadad king of Syria, who lived at Damascus, saying, 
 <sup>3&#160;</sup>“Let there be a treaty between me and you, as there was between my father and your father. Behold, I have sent you silver and gold. Go, break your treaty with Baasha king of Israel, that he may depart from me.” 
 </p><p>
 <sup>4&#160;</sup>Ben Hadad listened to King Asa, and sent the captains of his armies against the cities of Israel; and they struck Ijon, Dan, Abel Maim, and all the storage cities of Naphtali. 
 <sup>5&#160;</sup>When Baasha heard of it, he stopped building Ramah, and let his work cease. 
 <sup>6&#160;</sup>Then Asa the king took all Judah, and they carried away the stones and timber of Ramah, with which Baasha had built; and he built Geba and Mizpah with them. 
 </p><p>
-<sup>7&#160;</sup>At that time Hanani the seer came to Asa king of Judah, and said to him, “Because you have relied on the king of Syria, and have not relied on Yahweh your Elohim, therefore the army of the king of Syria has escaped out of your hand. 
-<sup>8&#160;</sup>Weren’t the Ethiopians and the Lubim a huge army, with chariots and exceedingly many horsemen? Yet, because you relied on Yahweh, he delivered them into your hand. 
-<sup>9&#160;</sup>For Yahweh’s eyes run back and forth throughout the whole earth, to show himself strong in the behalf of them whose heart is perfect toward him. You have done foolishly in this; for from now on you will have wars.” 
+<sup>7&#160;</sup>At that time Hanani the seer came to Asa king of Judah, and said to him, “Because you have relied on the king of Syria, and have not relied on Yahuah your Elohim, therefore the army of the king of Syria has escaped out of your hand. 
+<sup>8&#160;</sup>Weren’t the Ethiopians and the Lubim a huge army, with chariots and exceedingly many horsemen? Yet, because you relied on Yahuah, he delivered them into your hand. 
+<sup>9&#160;</sup>For Yahuah’s eyes run back and forth throughout the whole earth, to show himself strong in the behalf of them whose heart is perfect toward him. You have done foolishly in this; for from now on you will have wars.” 
 </p><p>
 <sup>10&#160;</sup>Then Asa was angry with the seer, and put him in the prison; for he was in a rage with him because of this thing. Asa oppressed some of the people at the same time. 
 </p><p>
 <sup>11&#160;</sup>Behold, the acts of Asa, first and last, behold, they are written in the book of the kings of Judah and Israel. 
-<sup>12&#160;</sup>In the thirty-ninth year of his reign, Asa was diseased in his feet. His disease was exceedingly great; yet in his disease he didn’t seek Yahweh, but just the physicians. 
+<sup>12&#160;</sup>In the thirty-ninth year of his reign, Asa was diseased in his feet. His disease was exceedingly great; yet in his disease he didn’t seek Yahuah, but just the physicians. 
 <sup>13&#160;</sup>Asa slept with his fathers, and died in the forty-first year of his reign. 
 <sup>14&#160;</sup>They buried him in his own tomb, which he had dug out for himself in David’s city, and laid him in the bed which was filled with sweet odors and various kinds of spices prepared by the perfumers’ art; and they made a very great fire for him. 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
 <sup>1&#160;</sup>Jehoshaphat his son reigned in his place, and strengthened himself against Israel. 
 <sup>2&#160;</sup>He placed forces in all the fortified cities of Judah, and set garrisons in the land of Judah and in the cities of Ephraim, which Asa his father had taken. 
-<sup>3&#160;</sup>Yahweh was with Jehoshaphat, because he walked in the first ways of his father David, and didn’t seek the Baals, 
+<sup>3&#160;</sup>Yahuah was with Jehoshaphat, because he walked in the first ways of his father David, and didn’t seek the Baals, 
 <sup>4&#160;</sup>but sought the Elohim of his father, and walked in his commandments, and not in the ways of Israel. 
-<sup>5&#160;</sup>Therefore Yahweh established the kingdom in his hand. All Judah brought tribute to Jehoshaphat, and he had riches and honor in abundance. 
-<sup>6&#160;</sup>His heart was lifted up in the ways of Yahweh. Furthermore, he took away the high places and the Asherah poles out of Judah. 
+<sup>5&#160;</sup>Therefore Yahuah established the kingdom in his hand. All Judah brought tribute to Jehoshaphat, and he had riches and honor in abundance. 
+<sup>6&#160;</sup>His heart was lifted up in the ways of Yahuah. Furthermore, he took away the high places and the Asherah poles out of Judah. 
 </p><p>
 <sup>7&#160;</sup>Also in the third year of his reign he sent his princes, even Ben Hail, Obadiah, Zechariah, Nethanel, and Micaiah, to teach in the cities of Judah; 
 <sup>8&#160;</sup>and with them Levites, even Shemaiah, Nethaniah, Zebadiah, Asahel, Shemiramoth, Jehonathan, Adonijah, Tobijah, and Tobadonijah, the Levites; and with them Elishama and Jehoram, the priests. 
-<sup>9&#160;</sup>They taught in Judah, having the book of Yahweh’s law with them. They went about throughout all the cities of Judah and taught among the people. 
+<sup>9&#160;</sup>They taught in Judah, having the book of Yahuah’s law with them. They went about throughout all the cities of Judah and taught among the people. 
 </p><p>
-<sup>10&#160;</sup>The fear of Yahweh fell on all the kingdoms of the lands that were around Judah, so that they made no war against Jehoshaphat. 
+<sup>10&#160;</sup>The fear of Yahuah fell on all the kingdoms of the lands that were around Judah, so that they made no war against Jehoshaphat. 
 <sup>11&#160;</sup>Some of the Philistines brought Jehoshaphat presents and silver for tribute. The Arabians also brought him flocks: seven thousand seven hundred rams and seven thousand seven hundred male goats. 
 <sup>12&#160;</sup>Jehoshaphat grew great exceedingly; and he built fortresses and store cities in Judah. 
 <sup>13&#160;</sup>He had many works in the cities of Judah; and men of war, mighty men of valor, in Jerusalem. 
 <sup>14&#160;</sup>This was the numbering of them according to their fathers’ houses: From Judah, the captains of thousands: Adnah the captain, and with him three hundred thousand mighty men of valor; 
 <sup>15&#160;</sup>and next to him Jehohanan the captain, and with him two hundred eighty thousand; 
-<sup>16&#160;</sup>and next to him Amasiah the son of Zichri, who willingly offered himself to Yahweh, and with him two hundred thousand mighty men of valor. 
+<sup>16&#160;</sup>and next to him Amasiah the son of Zichri, who willingly offered himself to Yahuah, and with him two hundred thousand mighty men of valor. 
 <sup>17&#160;</sup>From Benjamin: Eliada, a mighty man of valor, and with him two hundred thousand armed with bow and shield; 
 <sup>18&#160;</sup>and next to him Jehozabad, and with him one hundred eighty thousand ready and prepared for war. 
 <sup>19&#160;</sup>These were those who waited on the king, in addition to those whom the king put in the fortified cities throughout all Judah. 
@@ -577,87 +577,87 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>After some years, he went down to Ahab to Samaria. Ahab killed sheep and cattle for him in abundance, and for the people who were with him, and moved him to go up with him to Ramoth Gilead. 
 <sup>3&#160;</sup>Ahab king of Israel said to Jehoshaphat king of Judah, “Will you go with me to Ramoth Gilead?” 
 </p><p>He answered him, “I am as you are, and my people as your people. We will be with you in the war.” 
-<sup>4&#160;</sup>Jehoshaphat said to the king of Israel, “Please inquire first for Yahweh’s word.” 
+<sup>4&#160;</sup>Jehoshaphat said to the king of Israel, “Please inquire first for Yahuah’s word.” 
 </p><p>
 <sup>5&#160;</sup>Then the king of Israel gathered the prophets together, four hundred men, and said to them, “Shall we go to Ramoth Gilead to battle, or shall I forbear?” 
 </p><p>They said, “Go up, for Elohim will deliver it into the hand of the king.” 
 </p><p>
-<sup>6&#160;</sup>But Jehoshaphat said, “Isn’t there here a prophet of Yahweh besides, that we may inquire of him?” 
+<sup>6&#160;</sup>But Jehoshaphat said, “Isn’t there here a prophet of Yahuah besides, that we may inquire of him?” 
 </p><p>
-<sup>7&#160;</sup>The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahweh; but I hate him, for he never prophesies good concerning me, but always evil. He is Micaiah the son of Imla.” 
+<sup>7&#160;</sup>The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahuah; but I hate him, for he never prophesies good concerning me, but always evil. He is Micaiah the son of Imla.” 
 </p><p>Jehoshaphat said, “Don’t let the king say so.” 
 </p><p>
 <sup>8&#160;</sup>Then the king of Israel called an officer, and said, “Get Micaiah the son of Imla quickly.” 
 </p><p>
 <sup>9&#160;</sup>Now the king of Israel and Jehoshaphat the king of Judah each sat on his throne, arrayed in their robes, and they were sitting in an open place at the entrance of the gate of Samaria; and all the prophets were prophesying before them. 
-<sup>10&#160;</sup>Zedekiah the son of Chenaanah made himself horns of iron and said, “Yahweh says, ‘With these you shall push the Syrians, until they are consumed.’&#160;” 
+<sup>10&#160;</sup>Zedekiah the son of Chenaanah made himself horns of iron and said, “Yahuah says, ‘With these you shall push the Syrians, until they are consumed.’&#160;” 
 </p><p>
-<sup>11&#160;</sup>All the prophets prophesied so, saying, “Go up to Ramoth Gilead, and prosper; for Yahweh will deliver it into the hand of the king.” 
+<sup>11&#160;</sup>All the prophets prophesied so, saying, “Go up to Ramoth Gilead, and prosper; for Yahuah will deliver it into the hand of the king.” 
 </p><p>
 <sup>12&#160;</sup>The messenger who went to call Micaiah spoke to him, saying, “Behold, the words of the prophets declare good to the king with one mouth. Let your word therefore, please be like one of theirs, and speak good.” 
 </p><p>
-<sup>13&#160;</sup>Micaiah said, “As Yahweh lives, I will say what my Elohim says.” 
+<sup>13&#160;</sup>Micaiah said, “As Yahuah lives, I will say what my Elohim says.” 
 </p><p>
 <sup>14&#160;</sup>When he had come to the king, the king said to him, “Micaiah, shall we go to Ramoth Gilead to battle, or shall I forbear?” 
 </p><p>He said, “Go up, and prosper. They shall be delivered into your hand.” 
 </p><p>
-<sup>15&#160;</sup>The king said to him, “How many times shall I adjure you that you speak to me nothing but the truth in Yahweh’s name?” 
+<sup>15&#160;</sup>The king said to him, “How many times shall I adjure you that you speak to me nothing but the truth in Yahuah’s name?” 
 </p><p>
-<sup>16&#160;</sup>He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahweh said, ‘These have no master. Let them each return to his house in peace.’&#160;” 
+<sup>16&#160;</sup>He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahuah said, ‘These have no master. Let them each return to his house in peace.’&#160;” 
 </p><p>
 <sup>17&#160;</sup>The king of Israel said to Jehoshaphat, “Didn’t I tell you that he would not prophesy good concerning me, but evil?” 
 </p><p>
-<sup>18&#160;</sup>Micaiah said, “Therefore hear Yahweh’s word: I saw Yahweh sitting on his throne, and all the army of heaven standing on his right hand and on his left. 
-<sup>19&#160;</sup>Yahweh said, ‘Who will entice Ahab king of Israel, that he may go up and fall at Ramoth Gilead?’ One spoke saying in this way, and another saying in that way. 
-<sup>20&#160;</sup>A spirit came out, stood before Yahweh, and said, ‘I will entice him.’ 
-</p><p>“Yahweh said to him, ‘How?’ 
+<sup>18&#160;</sup>Micaiah said, “Therefore hear Yahuah’s word: I saw Yahuah sitting on his throne, and all the army of heaven standing on his right hand and on his left. 
+<sup>19&#160;</sup>Yahuah said, ‘Who will entice Ahab king of Israel, that he may go up and fall at Ramoth Gilead?’ One spoke saying in this way, and another saying in that way. 
+<sup>20&#160;</sup>A spirit came out, stood before Yahuah, and said, ‘I will entice him.’ 
+</p><p>“Yahuah said to him, ‘How?’ 
 </p><p>
 <sup>21&#160;</sup>“He said, ‘I will go, and will be a lying spirit in the mouth of all his prophets.’ 
 </p><p>“He said, ‘You will entice him, and will prevail also. Go and do so.’ 
 </p><p>
-<sup>22&#160;</sup>“Now therefore, behold, Yahweh has put a lying spirit in the mouth of these your prophets; and Yahweh has spoken evil concerning you.” 
+<sup>22&#160;</sup>“Now therefore, behold, Yahuah has put a lying spirit in the mouth of these your prophets; and Yahuah has spoken evil concerning you.” 
 </p><p>
-<sup>23&#160;</sup>Then Zedekiah the son of Chenaanah came near, and struck Micaiah on the cheek, and said, “Which way did Yahweh’s Spirit go from me to speak to you?” 
+<sup>23&#160;</sup>Then Zedekiah the son of Chenaanah came near, and struck Micaiah on the cheek, and said, “Which way did Yahuah’s Spirit go from me to speak to you?” 
 </p><p>
 <sup>24&#160;</sup>Micaiah said, “Behold, you shall see on that day, when you go into an inner room to hide yourself.” 
 </p><p>
 <sup>25&#160;</sup>The king of Israel said, “Take Micaiah, and carry him back to Amon the governor of the city, and to Joash the king’s son; 
 <sup>26&#160;</sup>and say, ‘The king says, “Put this fellow in the prison, and feed him with bread of affliction and with water of affliction, until I return in peace.”&#160;’&#160;” 
 </p><p>
-<sup>27&#160;</sup>Micaiah said, “If you return at all in peace, Yahweh has not spoken by me.” He said, “Listen, you people, all of you!” 
+<sup>27&#160;</sup>Micaiah said, “If you return at all in peace, Yahuah has not spoken by me.” He said, “Listen, you people, all of you!” 
 </p><p>
 <sup>28&#160;</sup>So the king of Israel and Jehoshaphat the king of Judah went up to Ramoth Gilead. 
 <sup>29&#160;</sup>The king of Israel said to Jehoshaphat, “I will disguise myself, and go into the battle; but you put on your robes.” So the king of Israel disguised himself; and they went into the battle. 
 <sup>30&#160;</sup>Now the king of Syria had commanded the captains of his chariots, saying, “Don’t fight with small nor great, except only with the king of Israel.” 
 </p><p>
-<sup>31&#160;</sup>When the captains of the chariots saw Jehoshaphat, they said, “It is the king of Israel!” Therefore they turned around to fight against him. But Jehoshaphat cried out, and Yahweh helped him; and Elohim moved them to depart from him. 
+<sup>31&#160;</sup>When the captains of the chariots saw Jehoshaphat, they said, “It is the king of Israel!” Therefore they turned around to fight against him. But Jehoshaphat cried out, and Yahuah helped him; and Elohim moved them to depart from him. 
 <sup>32&#160;</sup>When the captains of the chariots saw that it was not the king of Israel, they turned back from pursuing him. 
 <sup>33&#160;</sup>A certain man drew his bow at random, and struck the king of Israel between the joints of the armor. Therefore he said to the driver of the chariot, “Turn around and carry me out of the battle, for I am severely wounded.” 
 <sup>34&#160;</sup>The battle increased that day. However, the king of Israel propped himself up in his chariot against the Syrians until the evening; and at about sunset, he died. 
 </p><h2 class="chapterlabel" id="19">19</h2>
 <p>
 <sup>1&#160;</sup>Jehoshaphat the king of Judah returned to his house in peace to Jerusalem. 
-<sup>2&#160;</sup>Jehu the son of Hanani the seer went out to meet him, and said to King Jehoshaphat, “Should you help the wicked, and love those who hate Yahweh? Because of this, wrath is on you from before Yahweh. 
+<sup>2&#160;</sup>Jehu the son of Hanani the seer went out to meet him, and said to King Jehoshaphat, “Should you help the wicked, and love those who hate Yahuah? Because of this, wrath is on you from before Yahuah. 
 <sup>3&#160;</sup>Nevertheless there are good things found in you, in that you have put away the Asheroth out of the land, and have set your heart to seek Elohim.” 
 </p><p>
-<sup>4&#160;</sup>Jehoshaphat lived at Jerusalem; and he went out again among the people from Beersheba to the hill country of Ephraim, and brought them back to Yahweh, the Elohim of their fathers. 
+<sup>4&#160;</sup>Jehoshaphat lived at Jerusalem; and he went out again among the people from Beersheba to the hill country of Ephraim, and brought them back to Yahuah, the Elohim of their fathers. 
 <sup>5&#160;</sup>He set judges in the land throughout all the fortified cities of Judah, city by city, 
-<sup>6&#160;</sup>and said to the judges, “Consider what you do, for you don’t judge for man, but for Yahweh; and he is with you in the judgment. 
-<sup>7&#160;</sup>Now therefore let the fear of Yahweh be on you. Take heed and do it; for there is no iniquity with Yahweh our Elohim, nor respect of persons, nor taking of bribes.” 
+<sup>6&#160;</sup>and said to the judges, “Consider what you do, for you don’t judge for man, but for Yahuah; and he is with you in the judgment. 
+<sup>7&#160;</sup>Now therefore let the fear of Yahuah be on you. Take heed and do it; for there is no iniquity with Yahuah our Elohim, nor respect of persons, nor taking of bribes.” 
 </p><p>
-<sup>8&#160;</sup>Moreover in Jerusalem Jehoshaphat appointed certain Levites, priests, and heads of the fathers’ households of Israel to give judgment for Yahweh and for controversies. They returned to Jerusalem. 
-<sup>9&#160;</sup>He commanded them, saying, “You shall do this in the fear of Yahweh, faithfully, and with a perfect heart. 
-<sup>10&#160;</sup>Whenever any controversy comes to you from your brothers who dwell in their cities, between blood and blood, between law and commandment, statutes and ordinances, you must warn them, that they not be guilty toward Yahweh, and so wrath come on you and on your brothers. Do this, and you will not be guilty. 
-<sup>11&#160;</sup>Behold, Amariah the chief priest is over you in all matters of Yahweh; and Zebadiah the son of Ishmael, the ruler of the house of Judah, in all the king’s matters. Also the Levites shall be officers before you. Deal courageously, and may Yahweh be with the good.” 
+<sup>8&#160;</sup>Moreover in Jerusalem Jehoshaphat appointed certain Levites, priests, and heads of the fathers’ households of Israel to give judgment for Yahuah and for controversies. They returned to Jerusalem. 
+<sup>9&#160;</sup>He commanded them, saying, “You shall do this in the fear of Yahuah, faithfully, and with a perfect heart. 
+<sup>10&#160;</sup>Whenever any controversy comes to you from your brothers who dwell in their cities, between blood and blood, between law and commandment, statutes and ordinances, you must warn them, that they not be guilty toward Yahuah, and so wrath come on you and on your brothers. Do this, and you will not be guilty. 
+<sup>11&#160;</sup>Behold, Amariah the chief priest is over you in all matters of Yahuah; and Zebadiah the son of Ishmael, the ruler of the house of Judah, in all the king’s matters. Also the Levites shall be officers before you. Deal courageously, and may Yahuah be with the good.” 
 </p><h2 class="chapterlabel" id="20">20</h2>
 <p>
 <sup>1&#160;</sup>After this, the children of Moab, the children of Ammon, and with them some of the Ammonites, came against Jehoshaphat to battle. 
 <sup>2&#160;</sup>Then some came who told Jehoshaphat, saying, “A great multitude is coming against you from beyond the sea from Syria. Behold, they are in Hazazon Tamar” (that is, En Gedi). 
-<sup>3&#160;</sup>Jehoshaphat was alarmed, and set himself to seek to Yahweh. He proclaimed a fast throughout all Judah. 
-<sup>4&#160;</sup>Judah gathered themselves together to seek help from Yahweh. They came out of all the cities of Judah to seek Yahweh. 
+<sup>3&#160;</sup>Jehoshaphat was alarmed, and set himself to seek to Yahuah. He proclaimed a fast throughout all Judah. 
+<sup>4&#160;</sup>Judah gathered themselves together to seek help from Yahuah. They came out of all the cities of Judah to seek Yahuah. 
 </p><p>
-<sup>5&#160;</sup>Jehoshaphat stood in the assembly of Judah and Jerusalem, in Yahweh’s house, before the new court; 
-<sup>6&#160;</sup>and he said, “Yahweh, the Elohim of our fathers, aren’t you Elohim in heaven? Aren’t you ruler over all the kingdoms of the nations? Power and might are in your hand, so that no one is able to withstand you. 
+<sup>5&#160;</sup>Jehoshaphat stood in the assembly of Judah and Jerusalem, in Yahuah’s house, before the new court; 
+<sup>6&#160;</sup>and he said, “Yahuah, the Elohim of our fathers, aren’t you Elohim in heaven? Aren’t you ruler over all the kingdoms of the nations? Power and might are in your hand, so that no one is able to withstand you. 
 <sup>7&#160;</sup>Didn’t you, our Elohim, drive out the inhabitants of this land before your people Israel, and give it to the offspring of Abraham your friend forever? 
 <sup>8&#160;</sup>They lived in it, and have built you a sanctuary in it for your name, saying, 
 <sup>9&#160;</sup>‘If evil comes on us—the sword, judgment, pestilence, or famine—we will stand before this house, and before you (for your name is in this house), and cry to you in our affliction, and you will hear and save.’ 
@@ -665,39 +665,39 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>behold, how they reward us, to come to cast us out of your possession, which you have given us to inherit. 
 <sup>12&#160;</sup>Our Elohim, will you not judge them? For we have no might against this great company that comes against us. We don’t know what to do, but our eyes are on you.” 
 </p><p>
-<sup>13&#160;</sup>All Judah stood before Yahweh, with their little ones, their women, and their children. 
+<sup>13&#160;</sup>All Judah stood before Yahuah, with their little ones, their women, and their children. 
 </p><p>
-<sup>14&#160;</sup>Then Yahweh’s Spirit came on Jahaziel the son of Zechariah, the son of Benaiah, the son of Jeiel, the son of Mattaniah, the Levite, of the sons of Asaph, in the middle of the assembly; 
-<sup>15&#160;</sup>and he said, “Listen, all Judah, and you inhabitants of Jerusalem, and you, King Jehoshaphat. Yahweh says to you, ‘Don’t be afraid, and don’t be dismayed because of this great multitude; for the battle is not yours, but Elohim’s. 
+<sup>14&#160;</sup>Then Yahuah’s Spirit came on Jahaziel the son of Zechariah, the son of Benaiah, the son of Jeiel, the son of Mattaniah, the Levite, of the sons of Asaph, in the middle of the assembly; 
+<sup>15&#160;</sup>and he said, “Listen, all Judah, and you inhabitants of Jerusalem, and you, King Jehoshaphat. Yahuah says to you, ‘Don’t be afraid, and don’t be dismayed because of this great multitude; for the battle is not yours, but Elohim’s. 
 <sup>16&#160;</sup>Tomorrow, go down against them. Behold, they are coming up by the ascent of Ziz. You will find them at the end of the valley, before the wilderness of Jeruel. 
-<sup>17&#160;</sup>You will not need to fight this battle. Set yourselves, stand still, and see the salvation of Yahweh with you, O Judah and Jerusalem. Don’t be afraid, nor be dismayed. Go out against them tomorrow, for Yahweh is with you.’&#160;” 
+<sup>17&#160;</sup>You will not need to fight this battle. Set yourselves, stand still, and see the salvation of Yahuah with you, O Judah and Jerusalem. Don’t be afraid, nor be dismayed. Go out against them tomorrow, for Yahuah is with you.’&#160;” 
 </p><p>
-<sup>18&#160;</sup>Jehoshaphat bowed his head with his face to the ground; and all Judah and the inhabitants of Jerusalem fell down before Yahweh, worshiping Yahweh. 
-<sup>19&#160;</sup>The Levites, of the children of the Kohathites and of the children of the Korahites, stood up to praise Yahweh, the Elohim of Israel, with an exceedingly loud voice. 
+<sup>18&#160;</sup>Jehoshaphat bowed his head with his face to the ground; and all Judah and the inhabitants of Jerusalem fell down before Yahuah, worshiping Yahuah. 
+<sup>19&#160;</sup>The Levites, of the children of the Kohathites and of the children of the Korahites, stood up to praise Yahuah, the Elohim of Israel, with an exceedingly loud voice. 
 </p><p>
-<sup>20&#160;</sup>They rose early in the morning and went out into the wilderness of Tekoa. As they went out, Jehoshaphat stood and said, “Listen to me, Judah and you inhabitants of Jerusalem! Believe in Yahweh your Elohim, so you will be established! Believe his prophets, so you will prosper.” 
+<sup>20&#160;</sup>They rose early in the morning and went out into the wilderness of Tekoa. As they went out, Jehoshaphat stood and said, “Listen to me, Judah and you inhabitants of Jerusalem! Believe in Yahuah your Elohim, so you will be established! Believe his prophets, so you will prosper.” 
 </p><p>
-<sup>21&#160;</sup>When he had taken counsel with the people, he appointed those who were to sing to Yahweh and give praise in set-apart array as they go out before the army, and say, “Give thanks to Yahweh, for his loving kindness endures forever.” 
-<sup>22&#160;</sup>When they began to sing and to praise, Yahweh set ambushers against the children of Ammon, Moab, and Mount Seir, who had come against Judah; and they were struck. 
+<sup>21&#160;</sup>When he had taken counsel with the people, he appointed those who were to sing to Yahuah and give praise in set-apart array as they go out before the army, and say, “Give thanks to Yahuah, for his loving kindness endures forever.” 
+<sup>22&#160;</sup>When they began to sing and to praise, Yahuah set ambushers against the children of Ammon, Moab, and Mount Seir, who had come against Judah; and they were struck. 
 <sup>23&#160;</sup>For the children of Ammon and Moab stood up against the inhabitants of Mount Seir to utterly kill and destroy them. When they had finished the inhabitants of Seir, everyone helped to destroy each other. 
 </p><p>
 <sup>24&#160;</sup>When Judah came to the place overlooking the wilderness, they looked at the multitude; and behold, they were dead bodies fallen to the earth, and there were none who escaped. 
 <sup>25&#160;</sup>When Jehoshaphat and his people came to take their plunder, they found among them in abundance both riches and dead bodies with precious jewels, which they stripped off for themselves, more than they could carry away. They took plunder for three days, it was so much. 
-<sup>26&#160;</sup>On the fourth day, they assembled themselves in Beracah Valley, for there they blessed Yahweh. Therefore the name of that place was called “Beracah Valley” to this day. 
-<sup>27&#160;</sup>Then they returned, every man of Judah and Jerusalem, with Jehoshaphat in front of them, to go again to Jerusalem with joy; for Yahweh had made them to rejoice over their enemies. 
-<sup>28&#160;</sup>They came to Jerusalem with stringed instruments, harps, and trumpets to Yahweh’s house. 
-<sup>29&#160;</sup>The fear of Elohim was on all the kingdoms of the countries when they heard that Yahweh fought against the enemies of Israel. 
+<sup>26&#160;</sup>On the fourth day, they assembled themselves in Beracah Valley, for there they blessed Yahuah. Therefore the name of that place was called “Beracah Valley” to this day. 
+<sup>27&#160;</sup>Then they returned, every man of Judah and Jerusalem, with Jehoshaphat in front of them, to go again to Jerusalem with joy; for Yahuah had made them to rejoice over their enemies. 
+<sup>28&#160;</sup>They came to Jerusalem with stringed instruments, harps, and trumpets to Yahuah’s house. 
+<sup>29&#160;</sup>The fear of Elohim was on all the kingdoms of the countries when they heard that Yahuah fought against the enemies of Israel. 
 <sup>30&#160;</sup>So the realm of Jehoshaphat was quiet, for his Elohim gave him rest all around. 
 </p><p>
 <sup>31&#160;</sup>So Jehoshaphat reigned over Judah. He was thirty-five years old when he began to reign. He reigned twenty-five years in Jerusalem. His mother’s name was Azubah the daughter of Shilhi. 
-<sup>32&#160;</sup>He walked in the way of Asa his father, and didn’t turn away from it, doing that which was right in Yahweh’s eyes. 
+<sup>32&#160;</sup>He walked in the way of Asa his father, and didn’t turn away from it, doing that which was right in Yahuah’s eyes. 
 <sup>33&#160;</sup>However the high places were not taken away, and the people had still not set their hearts on the Elohim of their fathers. 
 </p><p>
 <sup>34&#160;</sup>Now the rest of the acts of Jehoshaphat, first and last, behold, they are written in the history of Jehu the son of Hanani, which is included in the book of the kings of Israel. 
 </p><p>
 <sup>35&#160;</sup>After this, Jehoshaphat king of Judah joined himself with Ahaziah king of Israel. The same did very wickedly. 
 <sup>36&#160;</sup>He joined himself with him to make ships to go to Tarshish. They made the ships in Ezion Geber. 
-<sup>37&#160;</sup>Then Eliezer the son of Dodavahu of Mareshah prophesied against Jehoshaphat, saying, “Because you have joined yourself with Ahaziah, Yahweh has destroyed your works.” The ships were wrecked, so that they were not able to go to Tarshish. 
+<sup>37&#160;</sup>Then Eliezer the son of Dodavahu of Mareshah prophesied against Jehoshaphat, saying, “Because you have joined yourself with Ahaziah, Yahuah has destroyed your works.” The ships were wrecked, so that they were not able to go to Tarshish. 
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
 <sup>1&#160;</sup>Jehoshaphat slept with his fathers, and was buried with his fathers in David’s city; and Jehoram his son reigned in his place. 
@@ -705,23 +705,23 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>Their father gave them great gifts of silver, of gold, and of precious things, with fortified cities in Judah; but he gave the kingdom to Jehoram, because he was the firstborn. 
 <sup>4&#160;</sup>Now when Jehoram had risen up over the kingdom of his father, and had strengthened himself, he killed all his brothers with the sword, and also some of the princes of Israel. 
 <sup>5&#160;</sup>Jehoram was thirty-two years old when he began to reign, and he reigned eight years in Jerusalem. 
-<sup>6&#160;</sup>He walked in the way of the kings of Israel, as did Ahab’s house, for he had Ahab’s daughter as his woman. He did that which was evil in Yahweh’s sight. 
-<sup>7&#160;</sup>However Yahweh would not destroy David’s house, because of the covenant that he had made with David, and as he promised to give a lamp to him and to his children always. 
+<sup>6&#160;</sup>He walked in the way of the kings of Israel, as did Ahab’s house, for he had Ahab’s daughter as his woman. He did that which was evil in Yahuah’s sight. 
+<sup>7&#160;</sup>However Yahuah would not destroy David’s house, because of the covenant that he had made with David, and as he promised to give a lamp to him and to his children always. 
 </p><p>
 <sup>8&#160;</sup>In his days Edom revolted from under the hand of Judah, and made a king over themselves. 
 <sup>9&#160;</sup>Then Jehoram went there with his captains and all his chariots with him. He rose up by night and struck the Edomites who surrounded him, along with the captains of the chariots. 
-<sup>10&#160;</sup>So Edom has been in revolt from under the hand of Judah to this day. Then Libnah revolted at the same time from under his hand, because he had forsaken Yahweh, the Elohim of his fathers. 
+<sup>10&#160;</sup>So Edom has been in revolt from under the hand of Judah to this day. Then Libnah revolted at the same time from under his hand, because he had forsaken Yahuah, the Elohim of his fathers. 
 </p><p>
 <sup>11&#160;</sup>Moreover he made high places in the mountains of Judah, and made the inhabitants of Jerusalem play the prostitute, and led Judah astray. 
-<sup>12&#160;</sup>A letter came to him from Elijah the prophet, saying, “Yahweh, the Elohim of David your father, says, ‘Because you have not walked in the ways of Jehoshaphat your father, nor in the ways of Asa king of Judah, 
+<sup>12&#160;</sup>A letter came to him from Elijah the prophet, saying, “Yahuah, the Elohim of David your father, says, ‘Because you have not walked in the ways of Jehoshaphat your father, nor in the ways of Asa king of Judah, 
 <sup>13&#160;</sup>but have walked in the way of the kings of Israel, and have made Judah and the inhabitants of Jerusalem to play the prostitute like Ahab’s house did, and also have slain your brothers of your father’s house, who were better than yourself, 
-<sup>14&#160;</sup>behold, Yahweh will strike your people with a great plague, including your children, your women, and all your possessions; 
+<sup>14&#160;</sup>behold, Yahuah will strike your people with a great plague, including your children, your women, and all your possessions; 
 <sup>15&#160;</sup>and you will have great sickness with a disease of your bowels, until your bowels fall out by reason of the sickness, day by day.’&#160;” 
 </p><p>
-<sup>16&#160;</sup>Yahweh stirred up against Jehoram the spirit of the Philistines and of the Arabians who are beside the Ethiopians; 
+<sup>16&#160;</sup>Yahuah stirred up against Jehoram the spirit of the Philistines and of the Arabians who are beside the Ethiopians; 
 <sup>17&#160;</sup>and they came up against Judah, broke into it, and carried away all the possessions that were found in the king’s house, including his sons and his women, so that there was no son left to him except Jehoahaz, the youngest of his sons. 
 </p><p>
-<sup>18&#160;</sup>After all this Yahweh struck him in his bowels with an incurable disease. 
+<sup>18&#160;</sup>After all this Yahuah struck him in his bowels with an incurable disease. 
 <sup>19&#160;</sup>In process of time, at the end of two years, his bowels fell out by reason of his sickness, and he died of severe diseases. His people made no burning for him, like the burning of his fathers. 
 <sup>20&#160;</sup>He was thirty-two years old when he began to reign, and he reigned in Jerusalem eight years. He departed with no one’s regret. They buried him in David’s city, but not in the tombs of the kings. 
 </p><h2 class="chapterlabel" id="22">22</h2>
@@ -729,13 +729,13 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>The inhabitants of Jerusalem made Ahaziah his youngest son king in his place, because the band of men who came with the Arabians to the camp had slain all the oldest. So Ahaziah the son of Jehoram king of Judah reigned. 
 <sup>2&#160;</sup>Ahaziah was forty-two years old when he began to reign, and he reigned one year in Jerusalem. His mother’s name was Athaliah the daughter of Omri. 
 <sup>3&#160;</sup>He also walked in the ways of Ahab’s house, because his mother was his counselor in acting wickedly. 
-<sup>4&#160;</sup>He did that which was evil in Yahweh’s sight, as did Ahab’s house, for they were his counselors after the death of his father, to his destruction. 
+<sup>4&#160;</sup>He did that which was evil in Yahuah’s sight, as did Ahab’s house, for they were his counselors after the death of his father, to his destruction. 
 <sup>5&#160;</sup>He also followed their counsel, and went with Jehoram the son of Ahab king of Israel to war against Hazael king of Syria at Ramoth Gilead; and the Syrians wounded Joram. 
 <sup>6&#160;</sup>He returned to be healed in Jezreel of the wounds which they had given him at Ramah, when he fought against Hazael king of Syria. Azariah the son of Jehoram, king of Judah, went down to see Jehoram the son of Ahab in Jezreel, because he was sick. 
 </p><p>
-<sup>7&#160;</sup>Now the destruction of Ahaziah was of Elohim, in that he went to Joram; for when he had come, he went out with Jehoram against Jehu the son of Nimshi, whom Yahweh had anointed to cut off Ahab’s house. 
+<sup>7&#160;</sup>Now the destruction of Ahaziah was of Elohim, in that he went to Joram; for when he had come, he went out with Jehoram against Jehu the son of Nimshi, whom Yahuah had anointed to cut off Ahab’s house. 
 <sup>8&#160;</sup>When Jehu was executing judgment on Ahab’s house, he found the princes of Judah and the sons of the brothers of Ahaziah serving Ahaziah, and killed them. 
-<sup>9&#160;</sup>He sought Ahaziah, and they caught him (now he was hiding in Samaria), and they brought him to Jehu and killed him; and they buried him, for they said, “He is the son of Jehoshaphat, who sought Yahweh with all his heart.” The house of Ahaziah had no power to hold the kingdom. 
+<sup>9&#160;</sup>He sought Ahaziah, and they caught him (now he was hiding in Samaria), and they brought him to Jehu and killed him; and they buried him, for they said, “He is the son of Jehoshaphat, who sought Yahuah with all his heart.” The house of Ahaziah had no power to hold the kingdom. 
 </p><p>
 <sup>10&#160;</sup>Now when Athaliah the mother of Ahaziah saw that her son was dead, she arose and destroyed all the royal offspring of the house of Judah. 
 <sup>11&#160;</sup>But Jehoshabeath, the king’s daughter, took Joash the son of Ahaziah, and stealthily rescued him from among the king’s sons who were slain, and put him and his nurse in the bedroom. So Jehoshabeath, the daughter of King Jehoram, the woman of Jehoiada the priest (for she was the sister of Ahaziah), hid him from Athaliah, so that she didn’t kill him. 
@@ -744,10 +744,10 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>In the seventh year, Jehoiada strengthened himself, and took the captains of hundreds—Azariah the son of Jeroham, Ishmael the son of Jehohanan, Azariah the son of Obed, Maaseiah the son of Adaiah, and Elishaphat the son of Zichri—into a covenant with him. 
 <sup>2&#160;</sup>They went around in Judah and gathered the Levites out of all the cities of Judah, and the heads of fathers’ households of Israel, and they came to Jerusalem. 
-<sup>3&#160;</sup>All the assembly made a covenant with the king in Elohim’s house. Jehoiada said to them, “Behold, the king’s son must reign, as Yahweh has spoken concerning the sons of David. 
+<sup>3&#160;</sup>All the assembly made a covenant with the king in Elohim’s house. Jehoiada said to them, “Behold, the king’s son must reign, as Yahuah has spoken concerning the sons of David. 
 <sup>4&#160;</sup>This is the thing that you must do: a third part of you, who come in on the Sabbath, of the priests and of the Levites, shall be gatekeepers of the thresholds. 
-<sup>5&#160;</sup>A third part shall be at the king’s house; and a third part at the gate of the foundation. All the people will be in the courts of Yahweh’s house. 
-<sup>6&#160;</sup>But let no one come into Yahweh’s house except the priests and those who minister of the Levites. They shall come in, for they are set-apart, but all the people shall follow Yahweh’s instructions. 
+<sup>5&#160;</sup>A third part shall be at the king’s house; and a third part at the gate of the foundation. All the people will be in the courts of Yahuah’s house. 
+<sup>6&#160;</sup>But let no one come into Yahuah’s house except the priests and those who minister of the Levites. They shall come in, for they are set-apart, but all the people shall follow Yahuah’s instructions. 
 <sup>7&#160;</sup>The Levites shall surround the king, every man with his weapons in his hand. Whoever comes into the house, let him be slain. Be with the king when he comes in and when he goes out.” 
 </p><p>
 <sup>8&#160;</sup>So the Levites and all Judah did according to all that Jehoiada the priest commanded. They each took his men, those who were to come in on the Sabbath, with those who were to go out on the Sabbath, for Jehoiada the priest didn’t dismiss the shift. 
@@ -755,51 +755,51 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>He set all the people, every man with his weapon in his hand, from the right side of the house to the left side of the house, near the altar and the house, around the king. 
 <sup>11&#160;</sup>Then they brought out the king’s son, put the crown on him, gave him the covenant, and made him king. Jehoiada and his sons anointed him, and they said, “Long live the king!” 
 </p><p>
-<sup>12&#160;</sup>When Athaliah heard the noise of the people running and praising the king, she came to the people into Yahweh’s house. 
+<sup>12&#160;</sup>When Athaliah heard the noise of the people running and praising the king, she came to the people into Yahuah’s house. 
 <sup>13&#160;</sup>Then she looked, and behold, the king stood by his pillar at the entrance, with the captains and the trumpeters by the king. All the people of the land rejoiced and blew trumpets. The singers also played musical instruments, and led the singing of praise. Then Athaliah tore her clothes, and said, “Treason! treason!” 
 </p><p>
-<sup>14&#160;</sup>Jehoiada the priest brought out the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks; and whoever follows her, let him be slain with the sword.” For the priest said, “Don’t kill her in Yahweh’s house.” 
+<sup>14&#160;</sup>Jehoiada the priest brought out the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks; and whoever follows her, let him be slain with the sword.” For the priest said, “Don’t kill her in Yahuah’s house.” 
 <sup>15&#160;</sup>So they made way for her. She went to the entrance of the horse gate to the king’s house; and they killed her there. 
 </p><p>
-<sup>16&#160;</sup>Jehoiada made a covenant between himself, all the people, and the king, that they should be Yahweh’s people. 
+<sup>16&#160;</sup>Jehoiada made a covenant between himself, all the people, and the king, that they should be Yahuah’s people. 
 <sup>17&#160;</sup>All the people went to the house of Baal, broke it down, broke his altars and his images in pieces, and killed Mattan the priest of Baal before the altars. 
-<sup>18&#160;</sup>Jehoiada appointed the officers of Yahweh’s house under the hand of the Levitical priests, whom David had distributed in Yahweh’s house, to offer the burnt offerings of Yahweh, as it is written in the law of Moses, with rejoicing and with singing, as David had ordered. 
-<sup>19&#160;</sup>He set the gatekeepers at the gates of Yahweh’s house, that no one who was unclean in anything should enter in. 
-<sup>20&#160;</sup>He took the captains of hundreds, the nobles, the governors of the people, and all the people of the land, and brought the king down from Yahweh’s house. They came through the upper gate to the king’s house, and set the king on the throne of the kingdom. 
+<sup>18&#160;</sup>Jehoiada appointed the officers of Yahuah’s house under the hand of the Levitical priests, whom David had distributed in Yahuah’s house, to offer the burnt offerings of Yahuah, as it is written in the law of Moses, with rejoicing and with singing, as David had ordered. 
+<sup>19&#160;</sup>He set the gatekeepers at the gates of Yahuah’s house, that no one who was unclean in anything should enter in. 
+<sup>20&#160;</sup>He took the captains of hundreds, the nobles, the governors of the people, and all the people of the land, and brought the king down from Yahuah’s house. They came through the upper gate to the king’s house, and set the king on the throne of the kingdom. 
 <sup>21&#160;</sup>So all the people of the land rejoiced, and the city was quiet. They had slain Athaliah with the sword. 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
 <sup>1&#160;</sup>Joash was seven years old when he began to reign, and he reigned forty years in Jerusalem. His mother’s name was Zibiah, of Beersheba. 
-<sup>2&#160;</sup>Joash did that which was right in Yahweh’s eyes all the days of Jehoiada the priest. 
+<sup>2&#160;</sup>Joash did that which was right in Yahuah’s eyes all the days of Jehoiada the priest. 
 <sup>3&#160;</sup>Jehoiada took for him two women, and he brought forth sons and daughters. 
 </p><p>
-<sup>4&#160;</sup>After this, Joash intended to restore Yahweh’s house. 
+<sup>4&#160;</sup>After this, Joash intended to restore Yahuah’s house. 
 <sup>5&#160;</sup>He gathered together the priests and the Levites, and said to them, “Go out to the cities of Judah, and gather money to repair the house of your Elohim from all Israel from year to year. See that you expedite this matter.” However the Levites didn’t do it right away. 
-<sup>6&#160;</sup>The king called for Jehoiada the chief, and said to him, “Why haven’t you required of the Levites to bring in the tax of Moses the servant of Yahweh, and of the assembly of Israel, out of Judah and out of Jerusalem, for the Tent of the Testimony?” 
-<sup>7&#160;</sup>For the sons of Athaliah, that wicked woman, had broken up Elohim’s house; and they also gave all the dedicated things of Yahweh’s house to the Baals. 
+<sup>6&#160;</sup>The king called for Jehoiada the chief, and said to him, “Why haven’t you required of the Levites to bring in the tax of Moses the servant of Yahuah, and of the assembly of Israel, out of Judah and out of Jerusalem, for the Tent of the Testimony?” 
+<sup>7&#160;</sup>For the sons of Athaliah, that wicked woman, had broken up Elohim’s house; and they also gave all the dedicated things of Yahuah’s house to the Baals. 
 </p><p>
-<sup>8&#160;</sup>So the king commanded, and they made a chest, and set it outside at the gate of Yahweh’s house. 
-<sup>9&#160;</sup>They made a proclamation through Judah and Jerusalem, to bring in for Yahweh the tax that Moses the servant of Elohim laid on Israel in the wilderness. 
+<sup>8&#160;</sup>So the king commanded, and they made a chest, and set it outside at the gate of Yahuah’s house. 
+<sup>9&#160;</sup>They made a proclamation through Judah and Jerusalem, to bring in for Yahuah the tax that Moses the servant of Elohim laid on Israel in the wilderness. 
 <sup>10&#160;</sup>All the princes and all the people rejoiced, and brought in, and cast into the chest, until they had filled it. 
 <sup>11&#160;</sup>Whenever the chest was brought to the king’s officers by the hand of the Levites, and when they saw that there was much money, the king’s scribe and the chief priest’s officer came and emptied the chest, and took it, and carried it to its place again. Thus they did day by day, and gathered money in abundance. 
-<sup>12&#160;</sup>The king and Jehoiada gave it to those who did the work of the service of Yahweh’s house. They hired masons and carpenters to restore Yahweh’s house, and also those who worked iron and bronze to repair Yahweh’s house. 
+<sup>12&#160;</sup>The king and Jehoiada gave it to those who did the work of the service of Yahuah’s house. They hired masons and carpenters to restore Yahuah’s house, and also those who worked iron and bronze to repair Yahuah’s house. 
 <sup>13&#160;</sup>So the workmen worked, and the work of repairing went forward in their hands. They set up Elohim’s house as it was designed, and strengthened it. 
-<sup>14&#160;</sup>When they had finished, they brought the rest of the money before the king and Jehoiada, from which were made vessels for Yahweh’s house, even vessels with which to minister and to offer, including spoons and vessels of gold and silver. They offered burnt offerings in Yahweh’s house continually all the days of Jehoiada. 
+<sup>14&#160;</sup>When they had finished, they brought the rest of the money before the king and Jehoiada, from which were made vessels for Yahuah’s house, even vessels with which to minister and to offer, including spoons and vessels of gold and silver. They offered burnt offerings in Yahuah’s house continually all the days of Jehoiada. 
 </p><p>
 <sup>15&#160;</sup>But Jehoiada grew old and was full of days, and he died. He was one hundred thirty years old when he died. 
 <sup>16&#160;</sup>They buried him in David’s city among the kings, because he had done good in Israel, and toward Elohim and his house. 
 </p><p>
 <sup>17&#160;</sup>Now after the death of Jehoiada, the princes of Judah came and bowed down to the king. Then the king listened to them. 
-<sup>18&#160;</sup>They abandoned the house of Yahweh, the Elohim of their fathers, and served the Asherah poles and the idols, so wrath came on Judah and Jerusalem for this their guiltiness. 
-<sup>19&#160;</sup>Yet he sent prophets to them to bring them again to Yahweh, and they testified against them; but they would not listen. 
+<sup>18&#160;</sup>They abandoned the house of Yahuah, the Elohim of their fathers, and served the Asherah poles and the idols, so wrath came on Judah and Jerusalem for this their guiltiness. 
+<sup>19&#160;</sup>Yet he sent prophets to them to bring them again to Yahuah, and they testified against them; but they would not listen. 
 </p><p>
-<sup>20&#160;</sup>The Spirit of Elohim came on Zechariah the son of Jehoiada the priest; and he stood above the people, and said to them, “Elohim says, ‘Why do you disobey Yahweh’s commandments, so that you can’t prosper? Because you have forsaken Yahweh, he has also forsaken you.’&#160;” 
+<sup>20&#160;</sup>The Spirit of Elohim came on Zechariah the son of Jehoiada the priest; and he stood above the people, and said to them, “Elohim says, ‘Why do you disobey Yahuah’s commandments, so that you can’t prosper? Because you have forsaken Yahuah, he has also forsaken you.’&#160;” 
 </p><p>
-<sup>21&#160;</sup>They conspired against him, and stoned him with stones at the commandment of the king in the court of Yahweh’s house. 
-<sup>22&#160;</sup>Thus Joash the king didn’t remember the kindness which Jehoiada his father had done to him, but killed his son. When he died, he said, “May Yahweh look at it, and repay it.” 
+<sup>21&#160;</sup>They conspired against him, and stoned him with stones at the commandment of the king in the court of Yahuah’s house. 
+<sup>22&#160;</sup>Thus Joash the king didn’t remember the kindness which Jehoiada his father had done to him, but killed his son. When he died, he said, “May Yahuah look at it, and repay it.” 
 </p><p>
 <sup>23&#160;</sup>At the end of the year, the army of the Syrians came up against him. They came to Judah and Jerusalem, and destroyed all the princes of the people from among the people, and sent all their plunder to the king of Damascus. 
-<sup>24&#160;</sup>For the army of the Syrians came with a small company of men; and Yahweh delivered a very great army into their hand, because they had forsaken Yahweh, the Elohim of their fathers. So they executed judgment on Joash. 
+<sup>24&#160;</sup>For the army of the Syrians came with a small company of men; and Yahuah delivered a very great army into their hand, because they had forsaken Yahuah, the Elohim of their fathers. So they executed judgment on Joash. 
 </p><p>
 <sup>25&#160;</sup>When they had departed from him (for they left him seriously wounded), his own servants conspired against him for the blood of the sons of Jehoiada the priest, and killed him on his bed, and he died. They buried him in David’s city, but they didn’t bury him in the tombs of the kings. 
 <sup>26&#160;</sup>These are those who conspired against him: Zabad the son of Shimeath the Ammonitess and Jehozabad the son of Shimrith the Moabitess. 
@@ -807,17 +807,17 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="25">25</h2>
 <p>
 <sup>1&#160;</sup>Amaziah was twenty-five years old when he began to reign, and he reigned twenty-nine years in Jerusalem. His mother’s name was Jehoaddan, of Jerusalem. 
-<sup>2&#160;</sup>He did that which was right in Yahweh’s eyes, but not with a perfect heart. 
+<sup>2&#160;</sup>He did that which was right in Yahuah’s eyes, but not with a perfect heart. 
 <sup>3&#160;</sup>Now when the kingdom was established to him, he killed his servants who had killed his father the king. 
-<sup>4&#160;</sup>But he didn’t put their children to death, but did according to that which is written in the law in the book of Moses, as Yahweh commanded, saying, “The fathers shall not die for the children, neither shall the children die for the fathers; but every man shall die for his own sin.” 
+<sup>4&#160;</sup>But he didn’t put their children to death, but did according to that which is written in the law in the book of Moses, as Yahuah commanded, saying, “The fathers shall not die for the children, neither shall the children die for the fathers; but every man shall die for his own sin.” 
 </p><p>
 <sup>5&#160;</sup>Moreover Amaziah gathered Judah together and ordered them according to their fathers’ houses, under captains of thousands and captains of hundreds, even all Judah and Benjamin. He counted them from twenty years old and upward, and found that there were three hundred thousand chosen men, able to go out to war, who could handle spear and shield. 
 <sup>6&#160;</sup>He also hired one hundred thousand mighty men of valor out of Israel for one hundred talents of silver. 
-<sup>7&#160;</sup>A man of Elohim came to him, saying, “O king, don’t let the army of Israel go with you, for Yahweh is not with Israel, with all the children of Ephraim. 
+<sup>7&#160;</sup>A man of Elohim came to him, saying, “O king, don’t let the army of Israel go with you, for Yahuah is not with Israel, with all the children of Ephraim. 
 <sup>8&#160;</sup>But if you will go, take action, and be strong for the battle. Elohim will overthrow you before the enemy; for Elohim has power to help, and to overthrow.” 
 </p><p>
 <sup>9&#160;</sup>Amaziah said to the man of Elohim, “But what shall we do for the hundred talents which I have given to the army of Israel?” 
-</p><p>The man of Elohim answered, “Yahweh is able to give you much more than this.” 
+</p><p>The man of Elohim answered, “Yahuah is able to give you much more than this.” 
 </p><p>
 <sup>10&#160;</sup>Then Amaziah separated them, the army that had come to him out of Ephraim, to go home again. Therefore their anger was greatly kindled against Judah, and they returned home in fierce anger. 
 </p><p>
@@ -826,7 +826,7 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>But the men of the army whom Amaziah sent back, that they should not go with him to battle, fell on the cities of Judah from Samaria even to Beth Horon, and struck of them three thousand, and took much plunder. 
 </p><p>
 <sup>14&#160;</sup>Now after Amaziah had come from the slaughter of the Edomites, he brought the elohims of the children of Seir, and set them up to be his elohims, and bowed down himself before them and burned incense to them. 
-<sup>15&#160;</sup>Therefore Yahweh’s anger burned against Amaziah, and he sent to him a prophet who said to him, “Why have you sought after the elohims of the people, which have not delivered their own people out of your hand?” 
+<sup>15&#160;</sup>Therefore Yahuah’s anger burned against Amaziah, and he sent to him a prophet who said to him, “Why have you sought after the elohims of the people, which have not delivered their own people out of your hand?” 
 </p><p>
 <sup>16&#160;</sup>As he talked with him, the king said to him, “Have we made you one of the king’s counselors? Stop! Why should you be struck down?” 
 </p><p>Then the prophet stopped, and said, “I know that Elohim has determined to destroy you, because you have done this and have not listened to my counsel.” 
@@ -845,15 +845,15 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>25&#160;</sup>Amaziah the son of Joash, king of Judah, lived for fifteen years after the death of Joash, son of Jehoahaz, king of Israel. 
 <sup>26&#160;</sup>Now the rest of the acts of Amaziah, first and last, behold, aren’t they written in the book of the kings of Judah and Israel? 
-<sup>27&#160;</sup>Now from the time that Amaziah turned away from following Yahweh, they made a conspiracy against him in Jerusalem. He fled to Lachish, but they sent after him to Lachish and killed him there. 
+<sup>27&#160;</sup>Now from the time that Amaziah turned away from following Yahuah, they made a conspiracy against him in Jerusalem. He fled to Lachish, but they sent after him to Lachish and killed him there. 
 <sup>28&#160;</sup>They brought him on horses and buried him with his fathers in the City of Judah. 
 </p><h2 class="chapterlabel" id="26">26</h2>
 <p>
 <sup>1&#160;</sup>All the people of Judah took Uzziah, who was sixteen years old, and made him king in the place of his father Amaziah. 
 <sup>2&#160;</sup>He built Eloth and restored it to Judah. After that the king slept with his fathers. 
 <sup>3&#160;</sup>Uzziah was sixteen years old when he began to reign; and he reigned fifty-two years in Jerusalem. His mother’s name was Jechiliah, of Jerusalem. 
-<sup>4&#160;</sup>He did that which was right in Yahweh’s eyes, according to all that his father Amaziah had done. 
-<sup>5&#160;</sup>He set himself to seek Elohim in the days of Zechariah, who had understanding in the vision of Elohim; and as long as he sought Yahweh, Elohim made him prosper. 
+<sup>4&#160;</sup>He did that which was right in Yahuah’s eyes, according to all that his father Amaziah had done. 
+<sup>5&#160;</sup>He set himself to seek Elohim in the days of Zechariah, who had understanding in the vision of Elohim; and as long as he sought Yahuah, Elohim made him prosper. 
 </p><p>
 <sup>6&#160;</sup>He went out and fought against the Philistines, and broke down the wall of Gath, the wall of Jabneh, and the wall of Ashdod; and he built cities in the country of Ashdod, and among the Philistines. 
 <sup>7&#160;</sup>Elohim helped him against the Philistines, and against the Arabians who lived in Gur Baal, and the Meunim. 
@@ -866,43 +866,43 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>Uzziah prepared for them, even for all the army, shields, spears, helmets, coats of mail, bows, and stones for slinging. 
 <sup>15&#160;</sup>In Jerusalem, he made devices, invented by skillful men, to be on the towers and on the battlements, with which to shoot arrows and great stones. His name spread far abroad, because he was marvelously helped until he was strong. 
 </p><p>
-<sup>16&#160;</sup>But when he was strong, his heart was lifted up, so that he did corruptly and he trespassed against Yahweh his Elohim, for he went into Yahweh’s temple to burn incense on the altar of incense. 
-<sup>17&#160;</sup>Azariah the priest went in after him, and with him eighty priests of Yahweh, who were valiant men. 
-<sup>18&#160;</sup>They resisted Uzziah the king, and said to him, “It isn’t for you, Uzziah, to burn incense to Yahweh, but for the priests the sons of Aaron, who are consecrated to burn incense. Go out of the sanctuary, for you have trespassed. It will not be for your honor from Yahweh Elohim.” 
+<sup>16&#160;</sup>But when he was strong, his heart was lifted up, so that he did corruptly and he trespassed against Yahuah his Elohim, for he went into Yahuah’s temple to burn incense on the altar of incense. 
+<sup>17&#160;</sup>Azariah the priest went in after him, and with him eighty priests of Yahuah, who were valiant men. 
+<sup>18&#160;</sup>They resisted Uzziah the king, and said to him, “It isn’t for you, Uzziah, to burn incense to Yahuah, but for the priests the sons of Aaron, who are consecrated to burn incense. Go out of the sanctuary, for you have trespassed. It will not be for your honor from Yahuah Elohim.” 
 </p><p>
-<sup>19&#160;</sup>Then Uzziah was angry. He had a censer in his hand to burn incense, and while he was angry with the priests, the leprosy broke out on his forehead before the priests in Yahweh’s house, beside the altar of incense. 
-<sup>20&#160;</sup>Azariah the chief priest and all the priests looked at him, and behold, he was leprous in his forehead; and they thrust him out quickly from there. Indeed, he himself also hurried to go out, because Yahweh had struck him. 
-<sup>21&#160;</sup>Uzziah the king was a leper to the day of his death, and lived in a separate house, being a leper; for he was cut off from Yahweh’s house. Jotham his son was over the king’s house, judging the people of the land. 
+<sup>19&#160;</sup>Then Uzziah was angry. He had a censer in his hand to burn incense, and while he was angry with the priests, the leprosy broke out on his forehead before the priests in Yahuah’s house, beside the altar of incense. 
+<sup>20&#160;</sup>Azariah the chief priest and all the priests looked at him, and behold, he was leprous in his forehead; and they thrust him out quickly from there. Indeed, he himself also hurried to go out, because Yahuah had struck him. 
+<sup>21&#160;</sup>Uzziah the king was a leper to the day of his death, and lived in a separate house, being a leper; for he was cut off from Yahuah’s house. Jotham his son was over the king’s house, judging the people of the land. 
 </p><p>
 <sup>22&#160;</sup>Now the rest of the acts of Uzziah, first and last, Isaiah the prophet, the son of Amoz, wrote. 
 <sup>23&#160;</sup>So Uzziah slept with his fathers; and they buried him with his fathers in the field of burial which belonged to the kings, for they said, “He is a leper.” Jotham his son reigned in his place. 
 </p><h2 class="chapterlabel" id="27">27</h2>
 <p>
 <sup>1&#160;</sup>Jotham was twenty-five years old when he began to reign, and he reigned sixteen years in Jerusalem. His mother’s name was Jerushah the daughter of Zadok. 
-<sup>2&#160;</sup>He did that which was right in Yahweh’s eyes, according to all that his father Uzziah had done. However he didn’t enter into Yahweh’s temple. The people still acted corruptly. 
-<sup>3&#160;</sup>He built the upper gate of Yahweh’s house, and he built much on the wall of Ophel. 
+<sup>2&#160;</sup>He did that which was right in Yahuah’s eyes, according to all that his father Uzziah had done. However he didn’t enter into Yahuah’s temple. The people still acted corruptly. 
+<sup>3&#160;</sup>He built the upper gate of Yahuah’s house, and he built much on the wall of Ophel. 
 <sup>4&#160;</sup>Moreover he built cities in the hill country of Judah, and in the forests he built fortresses and towers. 
 <sup>5&#160;</sup>He also fought with the king of the children of Ammon, and prevailed against them. The children of Ammon gave him the same year one hundred talents of silver, ten thousand cors of wheat, and ten thousand cors of barley. The children of Ammon also gave that much to him in the second year, and in the third. 
-<sup>6&#160;</sup>So Jotham became mighty, because he ordered his ways before Yahweh his Elohim. 
+<sup>6&#160;</sup>So Jotham became mighty, because he ordered his ways before Yahuah his Elohim. 
 <sup>7&#160;</sup>Now the rest of the acts of Jotham, and all his wars and his ways, behold, they are written in the book of the kings of Israel and Judah. 
 <sup>8&#160;</sup>He was twenty-five years old when he began to reign, and reigned sixteen years in Jerusalem. 
 <sup>9&#160;</sup>Jotham slept with his fathers, and they buried him in David’s city; and Ahaz his son reigned in his place. 
 </p><h2 class="chapterlabel" id="28">28</h2>
 <p>
-<sup>1&#160;</sup>Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahweh’s eyes, like David his father, 
+<sup>1&#160;</sup>Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahuah’s eyes, like David his father, 
 <sup>2&#160;</sup>but he walked in the ways of the kings of Israel, and also made molten images for the Baals. 
-<sup>3&#160;</sup>Moreover he burned incense in the valley of the son of Hinnom, and burned his children in the fire, according to the abominations of the nations whom Yahweh cast out before the children of Israel. 
+<sup>3&#160;</sup>Moreover he burned incense in the valley of the son of Hinnom, and burned his children in the fire, according to the abominations of the nations whom Yahuah cast out before the children of Israel. 
 <sup>4&#160;</sup>He sacrificed and burned incense in the high places, and on the hills, and under every green tree. 
 </p><p>
-<sup>5&#160;</sup>Therefore Yahweh his Elohim delivered him into the hand of the king of Syria. They struck him, and carried away from him a great multitude of captives, and brought them to Damascus. He was also delivered into the hand of the king of Israel, who struck him with a great slaughter. 
-<sup>6&#160;</sup>For Pekah the son of Remaliah killed in Judah one hundred twenty thousand in one day, all of them valiant men, because they had forsaken Yahweh, the Elohim of their fathers. 
+<sup>5&#160;</sup>Therefore Yahuah his Elohim delivered him into the hand of the king of Syria. They struck him, and carried away from him a great multitude of captives, and brought them to Damascus. He was also delivered into the hand of the king of Israel, who struck him with a great slaughter. 
+<sup>6&#160;</sup>For Pekah the son of Remaliah killed in Judah one hundred twenty thousand in one day, all of them valiant men, because they had forsaken Yahuah, the Elohim of their fathers. 
 <sup>7&#160;</sup>Zichri, a mighty man of Ephraim, killed Maaseiah the king’s son, Azrikam the ruler of the house, and Elkanah who was next to the king. 
 <sup>8&#160;</sup>The children of Israel carried away captive of their brothers two hundred thousand women, sons, and daughters, and also took away much plunder from them, and brought the plunder to Samaria. 
-<sup>9&#160;</sup>But a prophet of Yahweh was there, whose name was Oded; and he went out to meet the army that came to Samaria, and said to them, “Behold, because Yahweh, the Elohim of your fathers, was angry with Judah, he has delivered them into your hand, and you have slain them in a rage which has reached up to heaven. 
-<sup>10&#160;</sup>Now you intend to degrade the children of Judah and Jerusalem as male and female slaves for yourselves. Aren’t there even with you trespasses of your own against Yahweh your Elohim? 
-<sup>11&#160;</sup>Now hear me therefore, and send back the captives that you have taken captive from your brothers, for the fierce wrath of Yahweh is on you.” 
+<sup>9&#160;</sup>But a prophet of Yahuah was there, whose name was Oded; and he went out to meet the army that came to Samaria, and said to them, “Behold, because Yahuah, the Elohim of your fathers, was angry with Judah, he has delivered them into your hand, and you have slain them in a rage which has reached up to heaven. 
+<sup>10&#160;</sup>Now you intend to degrade the children of Judah and Jerusalem as male and female slaves for yourselves. Aren’t there even with you trespasses of your own against Yahuah your Elohim? 
+<sup>11&#160;</sup>Now hear me therefore, and send back the captives that you have taken captive from your brothers, for the fierce wrath of Yahuah is on you.” 
 <sup>12&#160;</sup>Then some of the heads of the children of Ephraim, Azariah the son of Johanan, Berechiah the son of Meshillemoth, Jehizkiah the son of Shallum, and Amasa the son of Hadlai, stood up against those who came from the war, 
-<sup>13&#160;</sup>and said to them, “You must not bring in the captives here, for you intend that which will bring on us a trespass against Yahweh, to add to our sins and to our guilt; for our guilt is great, and there is fierce wrath against Israel.” 
+<sup>13&#160;</sup>and said to them, “You must not bring in the captives here, for you intend that which will bring on us a trespass against Yahuah, to add to our sins and to our guilt; for our guilt is great, and there is fierce wrath against Israel.” 
 </p><p>
 <sup>14&#160;</sup>So the armed men left the captives and the plunder before the princes and all the assembly. 
 <sup>15&#160;</sup>The men who have been mentioned by name rose up and took the captives, and with the plunder clothed all who were naked among them, dressed them, gave them sandals, gave them something to eat and to drink, anointed them, carried all the feeble of them on donkeys, and brought them to Jericho, the city of palm trees, to their brothers. Then they returned to Samaria. 
@@ -910,88 +910,88 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>At that time King Ahaz sent to the kings of Assyria to help him. 
 <sup>17&#160;</sup>For again the Edomites had come and struck Judah, and carried away captives. 
 <sup>18&#160;</sup>The Philistines also had invaded the cities of the lowland and of the South of Judah, and had taken Beth Shemesh, Aijalon, Gederoth, Soco with its villages, Timnah with its villages, and also Gimzo and its villages; and they lived there. 
-<sup>19&#160;</sup>For Yahweh brought Judah low because of Ahaz king of Israel, because he acted without restraint in Judah and trespassed severely against Yahweh. 
+<sup>19&#160;</sup>For Yahuah brought Judah low because of Ahaz king of Israel, because he acted without restraint in Judah and trespassed severely against Yahuah. 
 <sup>20&#160;</sup>Tilgath-pilneser king of Assyria came to him and gave him trouble, but didn’t strengthen him. 
-<sup>21&#160;</sup>For Ahaz took away a portion out of Yahweh’s house, and out of the house of the king and of the princes, and gave it to the king of Assyria; but it didn’t help him. 
+<sup>21&#160;</sup>For Ahaz took away a portion out of Yahuah’s house, and out of the house of the king and of the princes, and gave it to the king of Assyria; but it didn’t help him. 
 </p><p>
-<sup>22&#160;</sup>In the time of his distress, he trespassed yet more against Yahweh, this same King Ahaz. 
+<sup>22&#160;</sup>In the time of his distress, he trespassed yet more against Yahuah, this same King Ahaz. 
 <sup>23&#160;</sup>For he sacrificed to the elohims of Damascus which had defeated him. He said, “Because the elohims of the kings of Syria helped them, I will sacrifice to them, that they may help me.” But they were the ruin of him and of all Israel. 
-<sup>24&#160;</sup>Ahaz gathered together the vessels of Elohim’s house, cut the vessels of Elohim’s house in pieces, and shut up the doors of Yahweh’s house; and he made himself altars in every corner of Jerusalem. 
-<sup>25&#160;</sup>In every city of Judah he made high places to burn incense to other elohims, and provoked Yahweh, the Elohim of his fathers, to anger. 
+<sup>24&#160;</sup>Ahaz gathered together the vessels of Elohim’s house, cut the vessels of Elohim’s house in pieces, and shut up the doors of Yahuah’s house; and he made himself altars in every corner of Jerusalem. 
+<sup>25&#160;</sup>In every city of Judah he made high places to burn incense to other elohims, and provoked Yahuah, the Elohim of his fathers, to anger. 
 </p><p>
 <sup>26&#160;</sup>Now the rest of his acts, and all his ways, first and last, behold, they are written in the book of the kings of Judah and Israel. 
 <sup>27&#160;</sup>Ahaz slept with his fathers, and they buried him in the city, even in Jerusalem, because they didn’t bring him into the tombs of the kings of Israel; and Hezekiah his son reigned in his place. 
 </p><h2 class="chapterlabel" id="29">29</h2>
 <p>
 <sup>1&#160;</sup>Hezekiah began to reign when he was twenty-five years old, and he reigned twenty-nine years in Jerusalem. His mother’s name was Abijah, the daughter of Zechariah. 
-<sup>2&#160;</sup>He did that which was right in Yahweh’s eyes, according to all that David his father had done. 
-<sup>3&#160;</sup>In the first year of his reign, in the first month, he opened the doors of Yahweh’s house and repaired them. 
+<sup>2&#160;</sup>He did that which was right in Yahuah’s eyes, according to all that David his father had done. 
+<sup>3&#160;</sup>In the first year of his reign, in the first month, he opened the doors of Yahuah’s house and repaired them. 
 <sup>4&#160;</sup>He brought in the priests and the Levites and gathered them together into the wide place on the east, 
-<sup>5&#160;</sup>and said to them, “Listen to me, you Levites! Now sanctify yourselves, and sanctify the house of Yahweh, the Elohim of your fathers, and carry the filthiness out of the set-apart place. 
-<sup>6&#160;</sup>For our fathers were unfaithful, and have done that which was evil in Yahweh our Elohim’s sight, and have forsaken him, and have turned away their faces from the habitation of Yahweh, and turned their backs. 
+<sup>5&#160;</sup>and said to them, “Listen to me, you Levites! Now sanctify yourselves, and sanctify the house of Yahuah, the Elohim of your fathers, and carry the filthiness out of the set-apart place. 
+<sup>6&#160;</sup>For our fathers were unfaithful, and have done that which was evil in Yahuah our Elohim’s sight, and have forsaken him, and have turned away their faces from the habitation of Yahuah, and turned their backs. 
 <sup>7&#160;</sup>Also they have shut up the doors of the porch, and put out the lamps, and have not burned incense nor offered burnt offerings in the set-apart place to the Elohim of Israel. 
-<sup>8&#160;</sup>Therefore Yahweh’s wrath was on Judah and Jerusalem, and he has delivered them to be tossed back and forth, to be an astonishment and a hissing, as you see with your eyes. 
+<sup>8&#160;</sup>Therefore Yahuah’s wrath was on Judah and Jerusalem, and he has delivered them to be tossed back and forth, to be an astonishment and a hissing, as you see with your eyes. 
 <sup>9&#160;</sup>For behold, our fathers have fallen by the sword, and our sons and our daughters and our women are in captivity for this. 
-<sup>10&#160;</sup>Now it is in my heart to make a covenant with Yahweh, the Elohim of Israel, that his fierce anger may turn away from us. 
-<sup>11&#160;</sup>My sons, don’t be negligent now; for Yahweh has chosen you to stand before him, to minister to him, and that you should be his ministers and burn incense.” 
+<sup>10&#160;</sup>Now it is in my heart to make a covenant with Yahuah, the Elohim of Israel, that his fierce anger may turn away from us. 
+<sup>11&#160;</sup>My sons, don’t be negligent now; for Yahuah has chosen you to stand before him, to minister to him, and that you should be his ministers and burn incense.” 
 </p><p>
 <sup>12&#160;</sup>Then the Levites arose: Mahath, the son of Amasai, and Joel the son of Azariah, of the sons of the Kohathites; and of the sons of Merari, Kish the son of Abdi, and Azariah the son of Jehallelel; and of the Gershonites, Joah the son of Zimmah, and Eden the son of Joah; 
 <sup>13&#160;</sup>and of the sons of Elizaphan, Shimri and Jeuel; and of the sons of Asaph, Zechariah and Mattaniah; 
 <sup>14&#160;</sup>and of the sons of Heman, Jehuel and Shimei; and of the sons of Jeduthun, Shemaiah and Uzziel. 
-<sup>15&#160;</sup>They gathered their brothers, sanctified themselves, and went in, according to the commandment of the king by Yahweh’s words, to cleanse Yahweh’s house. 
-<sup>16&#160;</sup>The priests went into the inner part of Yahweh’s house to cleanse it, and brought out all the uncleanness that they found in Yahweh’s temple into the court of Yahweh’s house. The Levites took it from there to carry it out to the brook Kidron. 
-<sup>17&#160;</sup>Now they began on the first day of the first month to sanctify, and on the eighth day of the month they came to Yahweh’s porch. They sanctified Yahweh’s house in eight days, and on the sixteenth day of the first month they finished. 
-<sup>18&#160;</sup>Then they went in to Hezekiah the king within the palace and said, “We have cleansed all Yahweh’s house, including the altar of burnt offering with all its vessels, and the table of show bread with all its vessels. 
-<sup>19&#160;</sup>Moreover, we have prepared and sanctified all the vessels which King Ahaz threw away in his reign when he was unfaithful. Behold, they are before Yahweh’s altar.” 
+<sup>15&#160;</sup>They gathered their brothers, sanctified themselves, and went in, according to the commandment of the king by Yahuah’s words, to cleanse Yahuah’s house. 
+<sup>16&#160;</sup>The priests went into the inner part of Yahuah’s house to cleanse it, and brought out all the uncleanness that they found in Yahuah’s temple into the court of Yahuah’s house. The Levites took it from there to carry it out to the brook Kidron. 
+<sup>17&#160;</sup>Now they began on the first day of the first month to sanctify, and on the eighth day of the month they came to Yahuah’s porch. They sanctified Yahuah’s house in eight days, and on the sixteenth day of the first month they finished. 
+<sup>18&#160;</sup>Then they went in to Hezekiah the king within the palace and said, “We have cleansed all Yahuah’s house, including the altar of burnt offering with all its vessels, and the table of show bread with all its vessels. 
+<sup>19&#160;</sup>Moreover, we have prepared and sanctified all the vessels which King Ahaz threw away in his reign when he was unfaithful. Behold, they are before Yahuah’s altar.” 
 </p><p>
-<sup>20&#160;</sup>Then Hezekiah the king arose early, gathered the princes of the city, and went up to Yahweh’s house. 
-<sup>21&#160;</sup>They brought seven bulls, seven rams, seven lambs, and seven male goats, for a sin offering for the kingdom, for the sanctuary, and for Judah. He commanded the priests the sons of Aaron to offer them on Yahweh’s altar. 
+<sup>20&#160;</sup>Then Hezekiah the king arose early, gathered the princes of the city, and went up to Yahuah’s house. 
+<sup>21&#160;</sup>They brought seven bulls, seven rams, seven lambs, and seven male goats, for a sin offering for the kingdom, for the sanctuary, and for Judah. He commanded the priests the sons of Aaron to offer them on Yahuah’s altar. 
 <sup>22&#160;</sup>So they killed the bulls, and the priests received the blood and sprinkled it on the altar. They killed the rams and sprinkled the blood on the altar. They also killed the lambs and sprinkled the blood on the altar. 
 <sup>23&#160;</sup>They brought near the male goats for the sin offering before the king and the assembly; and they laid their hands on them. 
 <sup>24&#160;</sup>Then the priests killed them, and they made a sin offering with their blood on the altar, to make atonement for all Israel; for the king commanded that the burnt offering and the sin offering should be made for all Israel. 
 </p><p>
-<sup>25&#160;</sup>He set the Levites in Yahweh’s house with cymbals, with stringed instruments, and with harps, according to the commandment of David, of Gad the king’s seer, and Nathan the prophet; for the commandment was from Yahweh by his prophets. 
+<sup>25&#160;</sup>He set the Levites in Yahuah’s house with cymbals, with stringed instruments, and with harps, according to the commandment of David, of Gad the king’s seer, and Nathan the prophet; for the commandment was from Yahuah by his prophets. 
 <sup>26&#160;</sup>The Levites stood with David’s instruments, and the priests with the trumpets. 
-<sup>27&#160;</sup>Hezekiah commanded them to offer the burnt offering on the altar. When the burnt offering began, Yahweh’s song also began, along with the trumpets and instruments of David king of Israel. 
+<sup>27&#160;</sup>Hezekiah commanded them to offer the burnt offering on the altar. When the burnt offering began, Yahuah’s song also began, along with the trumpets and instruments of David king of Israel. 
 <sup>28&#160;</sup>All the assembly worshiped, the singers sang, and the trumpeters sounded. All this continued until the burnt offering was finished. 
 </p><p>
 <sup>29&#160;</sup>When they had finished offering, the king and all who were present with him bowed themselves and worshiped. 
-<sup>30&#160;</sup>Moreover Hezekiah the king and the princes commanded the Levites to sing praises to Yahweh with the words of David, and of Asaph the seer. They sang praises with gladness, and they bowed their heads and worshiped. 
+<sup>30&#160;</sup>Moreover Hezekiah the king and the princes commanded the Levites to sing praises to Yahuah with the words of David, and of Asaph the seer. They sang praises with gladness, and they bowed their heads and worshiped. 
 </p><p>
-<sup>31&#160;</sup>Then Hezekiah answered, “Now you have consecrated yourselves to Yahweh. Come near and bring sacrifices and thank offerings into Yahweh’s house.” The assembly brought in sacrifices and thank offerings, and as many as were of a willing heart brought burnt offerings. 
-<sup>32&#160;</sup>The number of the burnt offerings which the assembly brought was seventy bulls, one hundred rams, and two hundred lambs. All these were for a burnt offering to Yahweh. 
+<sup>31&#160;</sup>Then Hezekiah answered, “Now you have consecrated yourselves to Yahuah. Come near and bring sacrifices and thank offerings into Yahuah’s house.” The assembly brought in sacrifices and thank offerings, and as many as were of a willing heart brought burnt offerings. 
+<sup>32&#160;</sup>The number of the burnt offerings which the assembly brought was seventy bulls, one hundred rams, and two hundred lambs. All these were for a burnt offering to Yahuah. 
 <sup>33&#160;</sup>The consecrated things were six hundred head of cattle and three thousand sheep. 
 <sup>34&#160;</sup>But the priests were too few, so that they could not skin all the burnt offerings. Therefore their brothers the Levites helped them until the work was ended, and until the priests had sanctified themselves, for the Levites were more upright in heart to sanctify themselves than the priests. 
-<sup>35&#160;</sup>Also the burnt offerings were in abundance, with the fat of the peace offerings and with the drink offerings for every burnt offering. So the service of Yahweh’s house was set in order. 
+<sup>35&#160;</sup>Also the burnt offerings were in abundance, with the fat of the peace offerings and with the drink offerings for every burnt offering. So the service of Yahuah’s house was set in order. 
 <sup>36&#160;</sup>Hezekiah and all the people rejoiced because of that which Elohim had prepared for the people; for the thing was done suddenly. 
 </p><h2 class="chapterlabel" id="30">30</h2>
 <p>
-<sup>1&#160;</sup>Hezekiah sent to all Israel and Judah, and wrote letters also to Ephraim and Manasseh, that they should come to Yahweh’s house at Jerusalem, to keep the Passover to Yahweh, the Elohim of Israel. 
+<sup>1&#160;</sup>Hezekiah sent to all Israel and Judah, and wrote letters also to Ephraim and Manasseh, that they should come to Yahuah’s house at Jerusalem, to keep the Passover to Yahuah, the Elohim of Israel. 
 <sup>2&#160;</sup>For the king had taken counsel with his princes and all the assembly in Jerusalem to keep the Passover in the second month. 
 <sup>3&#160;</sup>For they could not keep it at that time, because the priests had not sanctified themselves in sufficient number, and the people had not gathered themselves together to Jerusalem. 
 <sup>4&#160;</sup>The thing was right in the eyes of the king and of all the assembly. 
-<sup>5&#160;</sup>So they established a decree to make proclamation throughout all Israel, from Beersheba even to Dan, that they should come to keep the Passover to Yahweh, the Elohim of Israel, at Jerusalem, for they had not kept it in great numbers in the way it is written. 
+<sup>5&#160;</sup>So they established a decree to make proclamation throughout all Israel, from Beersheba even to Dan, that they should come to keep the Passover to Yahuah, the Elohim of Israel, at Jerusalem, for they had not kept it in great numbers in the way it is written. 
 </p><p>
-<sup>6&#160;</sup>So the couriers went with the letters from the king and his princes throughout all Israel and Judah, according to the commandment of the king, saying, “You children of Israel, turn again to Yahweh, the Elohim of Abraham, Isaac, and Israel, that he may return to the remnant of you that have escaped out of the hand of the kings of Assyria. 
-<sup>7&#160;</sup>Don’t be like your fathers and like your brothers, who trespassed against Yahweh, the Elohim of their fathers, so that he gave them up to desolation, as you see. 
-<sup>8&#160;</sup>Now don’t be stiff-necked, as your fathers were, but yield yourselves to Yahweh, and enter into his sanctuary, which he has sanctified forever, and serve Yahweh your Elohim, that his fierce anger may turn away from you. 
-<sup>9&#160;</sup>For if you turn again to Yahweh, your brothers and your children will find compassion with those who led them captive, and will come again into this land, because Yahweh your Elohim is gracious and merciful, and will not turn away his face from you if you return to him.” 
+<sup>6&#160;</sup>So the couriers went with the letters from the king and his princes throughout all Israel and Judah, according to the commandment of the king, saying, “You children of Israel, turn again to Yahuah, the Elohim of Abraham, Isaac, and Israel, that he may return to the remnant of you that have escaped out of the hand of the kings of Assyria. 
+<sup>7&#160;</sup>Don’t be like your fathers and like your brothers, who trespassed against Yahuah, the Elohim of their fathers, so that he gave them up to desolation, as you see. 
+<sup>8&#160;</sup>Now don’t be stiff-necked, as your fathers were, but yield yourselves to Yahuah, and enter into his sanctuary, which he has sanctified forever, and serve Yahuah your Elohim, that his fierce anger may turn away from you. 
+<sup>9&#160;</sup>For if you turn again to Yahuah, your brothers and your children will find compassion with those who led them captive, and will come again into this land, because Yahuah your Elohim is gracious and merciful, and will not turn away his face from you if you return to him.” 
 </p><p>
 <sup>10&#160;</sup>So the couriers passed from city to city through the country of Ephraim and Manasseh, even to Zebulun, but people ridiculed them and mocked them. 
 <sup>11&#160;</sup>Nevertheless some men of Asher, Manasseh, and Zebulun humbled themselves and came to Jerusalem. 
-<sup>12&#160;</sup>Also the hand of Elohim came on Judah to give them one heart, to do the commandment of the king and of the princes by Yahweh’s word. 
+<sup>12&#160;</sup>Also the hand of Elohim came on Judah to give them one heart, to do the commandment of the king and of the princes by Yahuah’s word. 
 </p><p>
 <sup>13&#160;</sup>Many people assembled at Jerusalem to keep the feast of unleavened bread in the second month, a very great assembly. 
 <sup>14&#160;</sup>They arose and took away the altars that were in Jerusalem, and they took away all the altars for incense and threw them into the brook Kidron. 
-<sup>15&#160;</sup>Then they killed the Passover on the fourteenth day of the second month. The priests and the Levites were ashamed, and sanctified themselves, and brought burnt offerings into Yahweh’s house. 
+<sup>15&#160;</sup>Then they killed the Passover on the fourteenth day of the second month. The priests and the Levites were ashamed, and sanctified themselves, and brought burnt offerings into Yahuah’s house. 
 <sup>16&#160;</sup>They stood in their place after their order, according to the law of Moses the man of Elohim. The priests sprinkled the blood which they received of the hand of the Levites. 
-<sup>17&#160;</sup>For there were many in the assembly who had not sanctified themselves; therefore the Levites were in charge of killing the Passovers for everyone who was not clean, to sanctify them to Yahweh. 
-<sup>18&#160;</sup>For a multitude of the people, even many of Ephraim, Manasseh, Issachar, and Zebulun, had not cleansed themselves, yet they ate the Passover other than the way it is written. For Hezekiah had prayed for them, saying, “May the good Yahweh pardon everyone 
-<sup>19&#160;</sup>who sets his heart to seek Elohim, Yahweh, the Elohim of his fathers, even if they aren’t clean according to the purification of the sanctuary.” 
+<sup>17&#160;</sup>For there were many in the assembly who had not sanctified themselves; therefore the Levites were in charge of killing the Passovers for everyone who was not clean, to sanctify them to Yahuah. 
+<sup>18&#160;</sup>For a multitude of the people, even many of Ephraim, Manasseh, Issachar, and Zebulun, had not cleansed themselves, yet they ate the Passover other than the way it is written. For Hezekiah had prayed for them, saying, “May the good Yahuah pardon everyone 
+<sup>19&#160;</sup>who sets his heart to seek Elohim, Yahuah, the Elohim of his fathers, even if they aren’t clean according to the purification of the sanctuary.” 
 </p><p>
-<sup>20&#160;</sup>Yahweh listened to Hezekiah, and healed the people. 
-<sup>21&#160;</sup>The children of Israel who were present at Jerusalem kept the feast of unleavened bread seven days with great gladness. The Levites and the priests praised Yahweh day by day, singing with loud instruments to Yahweh. 
-<sup>22&#160;</sup>Hezekiah spoke encouragingly to all the Levites who had good understanding in the service of Yahweh. So they ate throughout the feast for the seven days, offering sacrifices of peace offerings and making confession to Yahweh, the Elohim of their fathers. 
+<sup>20&#160;</sup>Yahuah listened to Hezekiah, and healed the people. 
+<sup>21&#160;</sup>The children of Israel who were present at Jerusalem kept the feast of unleavened bread seven days with great gladness. The Levites and the priests praised Yahuah day by day, singing with loud instruments to Yahuah. 
+<sup>22&#160;</sup>Hezekiah spoke encouragingly to all the Levites who had good understanding in the service of Yahuah. So they ate throughout the feast for the seven days, offering sacrifices of peace offerings and making confession to Yahuah, the Elohim of their fathers. 
 </p><p>
 <sup>23&#160;</sup>The whole assembly took counsel to keep another seven days, and they kept another seven days with gladness. 
 <sup>24&#160;</sup>For Hezekiah king of Judah gave to the assembly for offerings one thousand bulls and seven thousand sheep; and the princes gave to the assembly a thousand bulls and ten thousand sheep; and a great number of priests sanctified themselves. 
@@ -1002,28 +1002,28 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Now when all this was finished, all Israel who were present went out to the cities of Judah and broke the pillars in pieces, cut down the Asherah poles, and broke down the high places and the altars out of all Judah and Benjamin, also in Ephraim and Manasseh, until they had destroyed them all. Then all the children of Israel returned, every man to his possession, into their own cities. 
 </p><p>
-<sup>2&#160;</sup>Hezekiah appointed the divisions of the priests and the Levites after their divisions, every man according to his service, both the priests and the Levites, for burnt offerings and for peace offerings, to minister, to give thanks, and to praise in the gates of Yahweh’s camp. 
-<sup>3&#160;</sup>He also appointed the king’s portion of his possessions for the burnt offerings: for the morning and evening burnt offerings, and the burnt offerings for the Sabbaths, for the new moons, and for the set feasts, as it is written in Yahweh’s law. 
-<sup>4&#160;</sup>Moreover he commanded the people who lived in Jerusalem to give the portion of the priests and the Levites, that they might give themselves to Yahweh’s law. 
+<sup>2&#160;</sup>Hezekiah appointed the divisions of the priests and the Levites after their divisions, every man according to his service, both the priests and the Levites, for burnt offerings and for peace offerings, to minister, to give thanks, and to praise in the gates of Yahuah’s camp. 
+<sup>3&#160;</sup>He also appointed the king’s portion of his possessions for the burnt offerings: for the morning and evening burnt offerings, and the burnt offerings for the Sabbaths, for the new moons, and for the set feasts, as it is written in Yahuah’s law. 
+<sup>4&#160;</sup>Moreover he commanded the people who lived in Jerusalem to give the portion of the priests and the Levites, that they might give themselves to Yahuah’s law. 
 <sup>5&#160;</sup>As soon as the commandment went out, the children of Israel gave in abundance the first fruits of grain, new wine, oil, honey, and of all the increase of the field; and they brought in the tithe of all things abundantly. 
-<sup>6&#160;</sup>The children of Israel and Judah, who lived in the cities of Judah, also brought in the tithe of cattle and sheep, and the tithe of dedicated things which were consecrated to Yahweh their Elohim, and laid them in heaps. 
+<sup>6&#160;</sup>The children of Israel and Judah, who lived in the cities of Judah, also brought in the tithe of cattle and sheep, and the tithe of dedicated things which were consecrated to Yahuah their Elohim, and laid them in heaps. 
 </p><p>
 <sup>7&#160;</sup>In the third month, they began to lay the foundation of the heaps, and finished them in the seventh month. 
-<sup>8&#160;</sup>When Hezekiah and the princes came and saw the heaps, they blessed Yahweh and his people Israel. 
+<sup>8&#160;</sup>When Hezekiah and the princes came and saw the heaps, they blessed Yahuah and his people Israel. 
 <sup>9&#160;</sup>Then Hezekiah questioned the priests and the Levites about the heaps. 
-<sup>10&#160;</sup>Azariah the chief priest, of the house of Zadok, answered him and said, “Since people began to bring the offerings into Yahweh’s house, we have eaten and had enough, and have plenty left over, for Yahweh has blessed his people; and that which is left is this great store.” 
+<sup>10&#160;</sup>Azariah the chief priest, of the house of Zadok, answered him and said, “Since people began to bring the offerings into Yahuah’s house, we have eaten and had enough, and have plenty left over, for Yahuah has blessed his people; and that which is left is this great store.” 
 </p><p>
-<sup>11&#160;</sup>Then Hezekiah commanded them to prepare rooms in Yahweh’s house, and they prepared them. 
+<sup>11&#160;</sup>Then Hezekiah commanded them to prepare rooms in Yahuah’s house, and they prepared them. 
 <sup>12&#160;</sup>They brought in the offerings, the tithes, and the dedicated things faithfully. Conaniah the Levite was ruler over them, and Shimei his brother was second. 
 <sup>13&#160;</sup>Jehiel, Azaziah, Nahath, Asahel, Jerimoth, Jozabad, Eliel, Ismachiah, Mahath, and Benaiah were overseers under the hand of Conaniah and Shimei his brother, by the appointment of Hezekiah the king and Azariah the ruler of Elohim’s house. 
-<sup>14&#160;</sup>Kore the son of Imnah the Levite, the gatekeeper at the east gate, was over the free will offerings of Elohim, to distribute Yahweh’s offerings and the most set-apart things. 
+<sup>14&#160;</sup>Kore the son of Imnah the Levite, the gatekeeper at the east gate, was over the free will offerings of Elohim, to distribute Yahuah’s offerings and the most set-apart things. 
 <sup>15&#160;</sup>Under him were Eden, Miniamin, Jeshua, Shemaiah, Amariah, and Shecaniah, in the cities of the priests, in their office of trust, to give to their brothers by divisions, to the great as well as to the small; 
-<sup>16&#160;</sup>in addition to those who were listed by genealogy of males, from three years old and upward, even everyone who entered into Yahweh’s house, as the duty of every day required, for their service in their offices according to their divisions; 
+<sup>16&#160;</sup>in addition to those who were listed by genealogy of males, from three years old and upward, even everyone who entered into Yahuah’s house, as the duty of every day required, for their service in their offices according to their divisions; 
 <sup>17&#160;</sup>and those who were listed by genealogy of the priests by their fathers’ houses, and the Levites from twenty years old and upward, in their offices by their divisions; 
 <sup>18&#160;</sup>and those who were listed by genealogy of all their little ones, their women, their sons, and their daughters, through all the congregation; for in their office of trust they sanctified themselves in set-apartness. 
 <sup>19&#160;</sup>Also for the sons of Aaron the priests, who were in the fields of the pasture lands of their cities, in every city, there were men who were mentioned by name to give portions to all the males among the priests and to all who were listed by genealogy among the Levites. 
 </p><p>
-<sup>20&#160;</sup>Hezekiah did so throughout all Judah; and he did that which was good, right, and faithful before Yahweh his Elohim. 
+<sup>20&#160;</sup>Hezekiah did so throughout all Judah; and he did that which was good, right, and faithful before Yahuah his Elohim. 
 <sup>21&#160;</sup>In every work that he began in the service of Elohim’s house, in the law, and in the commandments, to seek his Elohim, he did it with all his heart and prospered. 
 </p><h2 class="chapterlabel" id="32">32</h2>
 <p>
@@ -1035,30 +1035,30 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>He took courage, built up all the wall that was broken down, and raised it up to the towers, with the other wall outside, and strengthened Millo in David’s city, and made weapons and shields in abundance. 
 <sup>6&#160;</sup>He set captains of war over the people, gathered them together to him in the wide place at the gate of the city, and spoke encouragingly to them, saying, 
 <sup>7&#160;</sup>“Be strong and courageous. Don’t be afraid or dismayed because of the king of Assyria, nor for all the multitude who is with him; for there is a greater one with us than with him. 
-<sup>8&#160;</sup>An arm of flesh is with him, but Yahweh our Elohim is with us to help us and to fight our battles.” The people rested themselves on the words of Hezekiah king of Judah. 
+<sup>8&#160;</sup>An arm of flesh is with him, but Yahuah our Elohim is with us to help us and to fight our battles.” The people rested themselves on the words of Hezekiah king of Judah. 
 </p><p>
 <sup>9&#160;</sup>After this, Sennacherib king of Assyria sent his servants to Jerusalem, (now he was attacking Lachish, and all his forces were with him), to Hezekiah king of Judah, and to all Judah who were at Jerusalem, saying, 
 <sup>10&#160;</sup>Sennacherib king of Assyria says, “In whom do you trust, that you remain under siege in Jerusalem? 
-<sup>11&#160;</sup>Doesn’t Hezekiah persuade you to give you over to die by famine and by thirst, saying, ‘Yahweh our Elohim will deliver us out of the hand of the king of Assyria’? 
+<sup>11&#160;</sup>Doesn’t Hezekiah persuade you to give you over to die by famine and by thirst, saying, ‘Yahuah our Elohim will deliver us out of the hand of the king of Assyria’? 
 <sup>12&#160;</sup>Hasn’t the same Hezekiah taken away his high places and his altars, and commanded Judah and Jerusalem, saying, ‘You shall worship before one altar, and you shall burn incense on it’? 
 <sup>13&#160;</sup>Don’t you know what I and my fathers have done to all the peoples of the lands? Were the elohims of the nations of those lands in any way able to deliver their land out of my hand? 
 <sup>14&#160;</sup>Who was there among all the elohims of those nations which my fathers utterly destroyed that could deliver his people out of my hand, that your Elohim should be able to deliver you out of my hand? 
 <sup>15&#160;</sup>Now therefore don’t let Hezekiah deceive you nor persuade you in this way. Don’t believe him, for no elohim of any nation or kingdom was able to deliver his people out of my hand, and out of the hand of my fathers. How much less will your Elohim deliver you out of my hand?” 
 </p><p>
-<sup>16&#160;</sup>His servants spoke yet more against Yahweh Elohim and against his servant Hezekiah. 
-<sup>17&#160;</sup>He also wrote letters insulting Yahweh, the Elohim of Israel, and speaking against him, saying, “As the elohims of the nations of the lands, which have not delivered their people out of my hand, so shall the Elohim of Hezekiah not deliver his people out of my hand.” 
+<sup>16&#160;</sup>His servants spoke yet more against Yahuah Elohim and against his servant Hezekiah. 
+<sup>17&#160;</sup>He also wrote letters insulting Yahuah, the Elohim of Israel, and speaking against him, saying, “As the elohims of the nations of the lands, which have not delivered their people out of my hand, so shall the Elohim of Hezekiah not deliver his people out of my hand.” 
 <sup>18&#160;</sup>They called out with a loud voice in the Jews’ language to the people of Jerusalem who were on the wall, to frighten them and to trouble them, that they might take the city. 
 <sup>19&#160;</sup>They spoke of the Elohim of Jerusalem as of the elohims of the peoples of the earth, which are the work of men’s hands. 
 </p><p>
 <sup>20&#160;</sup>Hezekiah the king and Isaiah the prophet, the son of Amoz, prayed because of this, and cried to heaven. 
 </p><p>
-<sup>21&#160;</sup>Yahweh sent an angel, who cut off all the mighty men of valor, the leaders, and captains in the camp of the king of Assyria. So he returned with shame of face to his own land. When he had come into the house of his elohim, those who came out of his own body killed him there with the sword. 
-<sup>22&#160;</sup>Thus Yahweh saved Hezekiah and the inhabitants of Jerusalem from the hand of Sennacherib the king of Assyria and from the hand of all others, and guided them on every side. 
-<sup>23&#160;</sup>Many brought gifts to Yahweh to Jerusalem, and precious things to Hezekiah king of Judah, so that he was exalted in the sight of all nations from then on. 
+<sup>21&#160;</sup>Yahuah sent an angel, who cut off all the mighty men of valor, the leaders, and captains in the camp of the king of Assyria. So he returned with shame of face to his own land. When he had come into the house of his elohim, those who came out of his own body killed him there with the sword. 
+<sup>22&#160;</sup>Thus Yahuah saved Hezekiah and the inhabitants of Jerusalem from the hand of Sennacherib the king of Assyria and from the hand of all others, and guided them on every side. 
+<sup>23&#160;</sup>Many brought gifts to Yahuah to Jerusalem, and precious things to Hezekiah king of Judah, so that he was exalted in the sight of all nations from then on. 
 </p><p>
-<sup>24&#160;</sup>In those days Hezekiah was terminally ill, and he prayed to Yahweh; and he spoke to him, and gave him a sign. 
+<sup>24&#160;</sup>In those days Hezekiah was terminally ill, and he prayed to Yahuah; and he spoke to him, and gave him a sign. 
 <sup>25&#160;</sup>But Hezekiah didn’t reciprocate appropriate to the benefit done for him, because his heart was lifted up. Therefore there was wrath on him, Judah, and Jerusalem. 
-<sup>26&#160;</sup>However, Hezekiah humbled himself for the pride of his heart, both he and the inhabitants of Jerusalem, so that Yahweh’s wrath didn’t come on them in the days of Hezekiah. 
+<sup>26&#160;</sup>However, Hezekiah humbled himself for the pride of his heart, both he and the inhabitants of Jerusalem, so that Yahuah’s wrath didn’t come on them in the days of Hezekiah. 
 </p><p>
 <sup>27&#160;</sup>Hezekiah had exceedingly great riches and honor. He provided himself with treasuries for silver, for gold, for precious stones, for spices, for shields, and for all kinds of valuable vessels; 
 <sup>28&#160;</sup>also storehouses for the increase of grain, new wine, and oil; and stalls for all kinds of animals, and flocks in folds. 
@@ -1072,86 +1072,86 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="33">33</h2>
 <p>
 <sup>1&#160;</sup>Manasseh was twelve years old when he began to reign, and he reigned fifty-five years in Jerusalem. 
-<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, after the abominations of the nations whom Yahweh cast out before the children of Israel. 
+<sup>2&#160;</sup>He did that which was evil in Yahuah’s sight, after the abominations of the nations whom Yahuah cast out before the children of Israel. 
 <sup>3&#160;</sup>For he built again the high places which Hezekiah his father had broken down; and he raised up altars for the Baals, made Asheroth, and worshiped all the army of the sky, and served them. 
-<sup>4&#160;</sup>He built altars in Yahweh’s house, of which Yahweh said, “My name shall be in Jerusalem forever.” 
-<sup>5&#160;</sup>He built altars for all the army of the sky in the two courts of Yahweh’s house. 
-<sup>6&#160;</sup>He also made his children to pass through the fire in the valley of the son of Hinnom. He practiced sorcery, divination, and witchcraft, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahweh’s sight, to provoke him to anger. 
+<sup>4&#160;</sup>He built altars in Yahuah’s house, of which Yahuah said, “My name shall be in Jerusalem forever.” 
+<sup>5&#160;</sup>He built altars for all the army of the sky in the two courts of Yahuah’s house. 
+<sup>6&#160;</sup>He also made his children to pass through the fire in the valley of the son of Hinnom. He practiced sorcery, divination, and witchcraft, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahuah’s sight, to provoke him to anger. 
 <sup>7&#160;</sup>He set the engraved image of the idol, which he had made, in Elohim’s house, of which Elohim said to David and to Solomon his son, “In this house, and in Jerusalem, which I have chosen out of all the tribes of Israel, I will put my name forever. 
 <sup>8&#160;</sup>I will not any more remove the foot of Israel from off the land which I have appointed for your fathers, if only they will observe to do all that I have commanded them, even all the law, the statutes, and the ordinances given by Moses.” 
-<sup>9&#160;</sup>Manasseh seduced Judah and the inhabitants of Jerusalem, so that they did more evil than did the nations whom Yahweh destroyed before the children of Israel. 
+<sup>9&#160;</sup>Manasseh seduced Judah and the inhabitants of Jerusalem, so that they did more evil than did the nations whom Yahuah destroyed before the children of Israel. 
 </p><p>
-<sup>10&#160;</sup>Yahweh spoke to Manasseh and to his people, but they didn’t listen. 
-<sup>11&#160;</sup>Therefore Yahweh brought on them the captains of the army of the king of Assyria, who took Manasseh in chains, bound him with fetters, and carried him to Babylon. 
+<sup>10&#160;</sup>Yahuah spoke to Manasseh and to his people, but they didn’t listen. 
+<sup>11&#160;</sup>Therefore Yahuah brought on them the captains of the army of the king of Assyria, who took Manasseh in chains, bound him with fetters, and carried him to Babylon. 
 </p><p>
-<sup>12&#160;</sup>When he was in distress, he begged Yahweh his Elohim, and humbled himself greatly before the Elohim of his fathers. 
-<sup>13&#160;</sup>He prayed to him; and he was entreated by him, and heard his supplication, and brought him again to Jerusalem into his kingdom. Then Manasseh knew that Yahweh was Elohim. 
+<sup>12&#160;</sup>When he was in distress, he begged Yahuah his Elohim, and humbled himself greatly before the Elohim of his fathers. 
+<sup>13&#160;</sup>He prayed to him; and he was entreated by him, and heard his supplication, and brought him again to Jerusalem into his kingdom. Then Manasseh knew that Yahuah was Elohim. 
 </p><p>
 <sup>14&#160;</sup>Now after this, he built an outer wall to David’s city on the west side of Gihon, in the valley, even to the entrance at the fish gate. He encircled Ophel with it, and raised it up to a very great height; and he put valiant captains in all the fortified cities of Judah. 
-<sup>15&#160;</sup>He took away the foreign elohims and the idol out of Yahweh’s house, and all the altars that he had built in the mountain of Yahweh’s house and in Jerusalem, and cast them out of the city. 
-<sup>16&#160;</sup>He built up Yahweh’s altar, and offered sacrifices of peace offerings and of thanksgiving on it, and commanded Judah to serve Yahweh, the Elohim of Israel. 
-<sup>17&#160;</sup>Nevertheless the people still sacrificed in the high places, but only to Yahweh their Elohim. 
+<sup>15&#160;</sup>He took away the foreign elohims and the idol out of Yahuah’s house, and all the altars that he had built in the mountain of Yahuah’s house and in Jerusalem, and cast them out of the city. 
+<sup>16&#160;</sup>He built up Yahuah’s altar, and offered sacrifices of peace offerings and of thanksgiving on it, and commanded Judah to serve Yahuah, the Elohim of Israel. 
+<sup>17&#160;</sup>Nevertheless the people still sacrificed in the high places, but only to Yahuah their Elohim. 
 </p><p>
-<sup>18&#160;</sup>Now the rest of the acts of Manasseh, and his prayer to his Elohim, and the words of the seers who spoke to him in the name of Yahweh, the Elohim of Israel, behold, they are written among the acts of the kings of Israel. 
+<sup>18&#160;</sup>Now the rest of the acts of Manasseh, and his prayer to his Elohim, and the words of the seers who spoke to him in the name of Yahuah, the Elohim of Israel, behold, they are written among the acts of the kings of Israel. 
 <sup>19&#160;</sup>His prayer also, and how Elohim listened to his request, and all his sin and his trespass, and the places in which he built high places and set up the Asherah poles and the engraved images before he humbled himself: behold, they are written in the history of Hozai. 
 <sup>20&#160;</sup>So Manasseh slept with his fathers, and they buried him in his own house; and Amon his son reigned in his place. 
 </p><p>
 <sup>21&#160;</sup>Amon was twenty-two years old when he began to reign; and he reigned two years in Jerusalem. 
-<sup>22&#160;</sup>He did that which was evil in Yahweh’s sight, as did Manasseh his father; and Amon sacrificed to all the engraved images which Manasseh his father had made, and served them. 
-<sup>23&#160;</sup>He didn’t humble himself before Yahweh, as Manasseh his father had humbled himself; but this same Amon trespassed more and more. 
+<sup>22&#160;</sup>He did that which was evil in Yahuah’s sight, as did Manasseh his father; and Amon sacrificed to all the engraved images which Manasseh his father had made, and served them. 
+<sup>23&#160;</sup>He didn’t humble himself before Yahuah, as Manasseh his father had humbled himself; but this same Amon trespassed more and more. 
 <sup>24&#160;</sup>His servants conspired against him, and put him to death in his own house. 
 <sup>25&#160;</sup>But the people of the land killed all those who had conspired against King Amon; and the people of the land made Josiah his son king in his place. 
 </p><h2 class="chapterlabel" id="34">34</h2>
 <p>
 <sup>1&#160;</sup>Josiah was eight years old when he began to reign, and he reigned thirty-one years in Jerusalem. 
-<sup>2&#160;</sup>He did that which was right in Yahweh’s eyes, and walked in the ways of David his father, and didn’t turn away to the right hand or to the left. 
+<sup>2&#160;</sup>He did that which was right in Yahuah’s eyes, and walked in the ways of David his father, and didn’t turn away to the right hand or to the left. 
 <sup>3&#160;</sup>For in the eighth year of his reign, while he was yet young, he began to seek after the Elohim of David his father; and in the twelfth year he began to purge Judah and Jerusalem from the high places, the Asherah poles, the engraved images, and the molten images. 
 <sup>4&#160;</sup>They broke down the altars of the Baals in his presence; and he cut down the incense altars that were on high above them. He broke the Asherah poles, the engraved images, and the molten images in pieces, made dust of them, and scattered it on the graves of those who had sacrificed to them. 
 <sup>5&#160;</sup>He burned the bones of the priests on their altars, and purged Judah and Jerusalem. 
 <sup>6&#160;</sup>He did this in the cities of Manasseh, Ephraim, and Simeon, even to Naphtali, around in their ruins. 
 <sup>7&#160;</sup>He broke down the altars, beat the Asherah poles and the engraved images into powder, and cut down all the incense altars throughout all the land of Israel, then returned to Jerusalem. 
 </p><p>
-<sup>8&#160;</sup>Now in the eighteenth year of his reign, when he had purged the land and the house, he sent Shaphan the son of Azaliah, Maaseiah the governor of the city, and Joah the son of Joahaz the recorder to repair the house of Yahweh his Elohim. 
+<sup>8&#160;</sup>Now in the eighteenth year of his reign, when he had purged the land and the house, he sent Shaphan the son of Azaliah, Maaseiah the governor of the city, and Joah the son of Joahaz the recorder to repair the house of Yahuah his Elohim. 
 <sup>9&#160;</sup>They came to Hilkiah the high priest and delivered the money that was brought into Elohim’s house, which the Levites, the keepers of the threshold, had gathered from the hands of Manasseh, Ephraim, of all the remnant of Israel, of all Judah and Benjamin, and of the inhabitants of Jerusalem. 
-<sup>10&#160;</sup>They delivered it into the hands of the workmen who had the oversight of Yahweh’s house; and the workmen who labored in Yahweh’s house gave it to mend and repair the house. 
+<sup>10&#160;</sup>They delivered it into the hands of the workmen who had the oversight of Yahuah’s house; and the workmen who labored in Yahuah’s house gave it to mend and repair the house. 
 <sup>11&#160;</sup>They gave it to the carpenters and to the builders to buy cut stone and timber for couplings, and to make beams for the houses which the kings of Judah had destroyed. 
 <sup>12&#160;</sup>The men did the work faithfully. Their overseers were Jahath and Obadiah the Levites, of the sons of Merari; and Zechariah and Meshullam, of the sons of the Kohathites, to give direction; and others of the Levites, who were all skillful with musical instruments. 
 <sup>13&#160;</sup>Also they were over the bearers of burdens, and directed all who did the work in every kind of service. Of the Levites, there were scribes, officials, and gatekeepers. 
 </p><p>
-<sup>14&#160;</sup>When they brought out the money that was brought into Yahweh’s house, Hilkiah the priest found the book of Yahweh’s law given by Moses. 
-<sup>15&#160;</sup>Hilkiah answered Shaphan the scribe, “I have found the book of the law in Yahweh’s house.” So Hilkiah delivered the book to Shaphan. 
+<sup>14&#160;</sup>When they brought out the money that was brought into Yahuah’s house, Hilkiah the priest found the book of Yahuah’s law given by Moses. 
+<sup>15&#160;</sup>Hilkiah answered Shaphan the scribe, “I have found the book of the law in Yahuah’s house.” So Hilkiah delivered the book to Shaphan. 
 </p><p>
 <sup>16&#160;</sup>Shaphan carried the book to the king, and moreover brought back word to the king, saying, “All that was committed to your servants, they are doing. 
-<sup>17&#160;</sup>They have emptied out the money that was found in Yahweh’s house, and have delivered it into the hand of the overseers and into the hand of the workmen.” 
+<sup>17&#160;</sup>They have emptied out the money that was found in Yahuah’s house, and have delivered it into the hand of the overseers and into the hand of the workmen.” 
 <sup>18&#160;</sup>Shaphan the scribe told the king, saying, “Hilkiah the priest has delivered me a book.” Shaphan read from it to the king. 
 </p><p>
 <sup>19&#160;</sup>When the king had heard the words of the law, he tore his clothes. 
 <sup>20&#160;</sup>The king commanded Hilkiah, Ahikam the son of Shaphan, Abdon the son of Micah, Shaphan the scribe, and Asaiah the king’s servant, saying, 
-<sup>21&#160;</sup>“Go inquire of Yahweh for me, and for those who are left in Israel and in Judah, concerning the words of the book that is found; for great is Yahweh’s wrath that is poured out on us, because our fathers have not kept Yahweh’s word, to do according to all that is written in this book.” 
+<sup>21&#160;</sup>“Go inquire of Yahuah for me, and for those who are left in Israel and in Judah, concerning the words of the book that is found; for great is Yahuah’s wrath that is poured out on us, because our fathers have not kept Yahuah’s word, to do according to all that is written in this book.” 
 </p><p>
 <sup>22&#160;</sup>So Hilkiah and those whom the king had commanded went to Huldah the prophetess, the woman of Shallum the son of Tokhath, the son of Hasrah, keeper of the wardrobe (now she lived in Jerusalem in the second quarter), and they spoke to her to that effect. 
 </p><p>
-<sup>23&#160;</sup>She said to them, “Yahweh, the Elohim of Israel says: ‘Tell the man who sent you to me, 
-<sup>24&#160;</sup>“Yahweh says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the curses that are written in the book which they have read before the king of Judah. 
+<sup>23&#160;</sup>She said to them, “Yahuah, the Elohim of Israel says: ‘Tell the man who sent you to me, 
+<sup>24&#160;</sup>“Yahuah says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the curses that are written in the book which they have read before the king of Judah. 
 <sup>25&#160;</sup>Because they have forsaken me, and have burned incense to other elohims, that they might provoke me to anger with all the works of their hands, therefore my wrath is poured out on this place, and it will not be quenched.’&#160;”&#160;’ 
-<sup>26&#160;</sup>But to the king of Judah, who sent you to inquire of Yahweh, you shall tell him this, ‘Yahweh, the Elohim of Israel says: “About the words which you have heard, 
-<sup>27&#160;</sup>because your heart was tender, and you humbled yourself before Elohim when you heard his words against this place and against its inhabitants, and have humbled yourself before me, and have torn your clothes and wept before me, I also have heard you,” says Yahweh. 
+<sup>26&#160;</sup>But to the king of Judah, who sent you to inquire of Yahuah, you shall tell him this, ‘Yahuah, the Elohim of Israel says: “About the words which you have heard, 
+<sup>27&#160;</sup>because your heart was tender, and you humbled yourself before Elohim when you heard his words against this place and against its inhabitants, and have humbled yourself before me, and have torn your clothes and wept before me, I also have heard you,” says Yahuah. 
 <sup>28&#160;</sup>“Behold, I will gather you to your fathers, and you will be gathered to your grave in peace. Your eyes won’t see all the evil that I will bring on this place and on its inhabitants.”&#160;’&#160;” 
 </p><p>They brought back this message to the king. 
 </p><p>
 <sup>29&#160;</sup>Then the king sent and gathered together all the elders of Judah and Jerusalem. 
-<sup>30&#160;</sup>The king went up to Yahweh’s house with all the men of Judah and the inhabitants of Jerusalem—the priests, the Levites, and all the people, both great and small—and he read in their hearing all the words of the book of the covenant that was found in Yahweh’s house. 
-<sup>31&#160;</sup>The king stood in his place and made a covenant before Yahweh, to walk after Yahweh, and to keep his commandments, his testimonies, and his statutes with all his heart and with all his soul, to perform the words of the covenant that were written in this book. 
+<sup>30&#160;</sup>The king went up to Yahuah’s house with all the men of Judah and the inhabitants of Jerusalem—the priests, the Levites, and all the people, both great and small—and he read in their hearing all the words of the book of the covenant that was found in Yahuah’s house. 
+<sup>31&#160;</sup>The king stood in his place and made a covenant before Yahuah, to walk after Yahuah, and to keep his commandments, his testimonies, and his statutes with all his heart and with all his soul, to perform the words of the covenant that were written in this book. 
 <sup>32&#160;</sup>He caused all who were found in Jerusalem and Benjamin to stand. The inhabitants of Jerusalem did according to the covenant of Elohim, the Elohim of their fathers. 
-<sup>33&#160;</sup>Josiah took away all the abominations out of all the countries that belonged to the children of Israel, and made all who were found in Israel to serve, even to serve Yahweh their Elohim. All his days they didn’t depart from following Yahweh, the Elohim of their fathers. 
+<sup>33&#160;</sup>Josiah took away all the abominations out of all the countries that belonged to the children of Israel, and made all who were found in Israel to serve, even to serve Yahuah their Elohim. All his days they didn’t depart from following Yahuah, the Elohim of their fathers. 
 </p><h2 class="chapterlabel" id="35">35</h2>
 <p>
-<sup>1&#160;</sup>Josiah kept a Passover to Yahweh in Jerusalem. They killed the Passover on the fourteenth day of the first month. 
-<sup>2&#160;</sup>He set the priests in their offices and encouraged them in the service of Yahweh’s house. 
-<sup>3&#160;</sup>He said to the Levites who taught all Israel, who were set-apart to Yahweh, “Put the set-apart ark in the house which Solomon the son of David king of Israel built. It will no longer be a burden on your shoulders. Now serve Yahweh your Elohim and his people Israel. 
+<sup>1&#160;</sup>Josiah kept a Passover to Yahuah in Jerusalem. They killed the Passover on the fourteenth day of the first month. 
+<sup>2&#160;</sup>He set the priests in their offices and encouraged them in the service of Yahuah’s house. 
+<sup>3&#160;</sup>He said to the Levites who taught all Israel, who were set-apart to Yahuah, “Put the set-apart ark in the house which Solomon the son of David king of Israel built. It will no longer be a burden on your shoulders. Now serve Yahuah your Elohim and his people Israel. 
 <sup>4&#160;</sup>Prepare yourselves after your fathers’ houses by your divisions, according to the writing of David king of Israel, and according to the writing of Solomon his son. 
 <sup>5&#160;</sup>Stand in the set-apart place according to the divisions of the fathers’ houses of your brothers the children of the people, and let there be for each a portion of a fathers’ house of the Levites. 
-<sup>6&#160;</sup>Kill the Passover lamb, sanctify yourselves, and prepare for your brothers, to do according to Yahweh’s word by Moses.” 
+<sup>6&#160;</sup>Kill the Passover lamb, sanctify yourselves, and prepare for your brothers, to do according to Yahuah’s word by Moses.” 
 </p><p>
 <sup>7&#160;</sup>Josiah gave to the children of the people, of the flock, lambs and young goats, all of them for the Passover offerings, to all who were present, to the number of thirty thousand, and three thousand bulls. These were of the king’s substance. 
 <sup>8&#160;</sup>His princes gave a free will offering to the people, to the priests, and to the Levites. Hilkiah, Zechariah, and Jehiel, the rulers of Elohim’s house, gave to the priests for the Passover offerings two thousand six hundred small livestock, and three hundred head of cattle. 
@@ -1159,12 +1159,12 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>10&#160;</sup>So the service was prepared, and the priests stood in their place, and the Levites by their divisions, according to the king’s commandment. 
 <sup>11&#160;</sup>They killed the Passover lambs, and the priests sprinkled the blood which they received from their hands, and the Levites skinned them. 
-<sup>12&#160;</sup>They removed the burnt offerings, that they might give them according to the divisions of the fathers’ houses of the children of the people, to offer to Yahweh, as it is written in the book of Moses. They did the same with the cattle. 
+<sup>12&#160;</sup>They removed the burnt offerings, that they might give them according to the divisions of the fathers’ houses of the children of the people, to offer to Yahuah, as it is written in the book of Moses. They did the same with the cattle. 
 <sup>13&#160;</sup>They roasted the Passover with fire according to the ordinance. They boiled the set-apart offerings in pots, in cauldrons, and in pans, and carried them quickly to all the children of the people. 
 <sup>14&#160;</sup>Afterward they prepared for themselves and for the priests, because the priests the sons of Aaron were busy with offering the burnt offerings and the fat until night. Therefore the Levites prepared for themselves and for the priests the sons of Aaron. 
 <sup>15&#160;</sup>The singers, the sons of Asaph, were in their place, according to the commandment of David, Asaph, Heman, and Jeduthun the king’s seer; and the gatekeepers were at every gate. They didn’t need to depart from their service, because their brothers the Levites prepared for them. 
 </p><p>
-<sup>16&#160;</sup>So all the service of Yahweh was prepared the same day, to keep the Passover, and to offer burnt offerings on Yahweh’s altar, according to the commandment of King Josiah. 
+<sup>16&#160;</sup>So all the service of Yahuah was prepared the same day, to keep the Passover, and to offer burnt offerings on Yahuah’s altar, according to the commandment of King Josiah. 
 <sup>17&#160;</sup>The children of Israel who were present kept the Passover at that time, and the feast of unleavened bread seven days. 
 <sup>18&#160;</sup>There was no Passover like that kept in Israel from the days of Samuel the prophet, nor did any of the kings of Israel keep such a Passover as Josiah kept—with the priests, the Levites, and all Judah and Israel who were present, and the inhabitants of Jerusalem. 
 <sup>19&#160;</sup>This Passover was kept in the eighteenth year of the reign of Josiah. 
@@ -1177,7 +1177,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>24&#160;</sup>So his servants took him out of the chariot, and put him in the second chariot that he had, and brought him to Jerusalem; and he died, and was buried in the tombs of his fathers. All Judah and Jerusalem mourned for Josiah. 
 <sup>25&#160;</sup>Jeremiah lamented for Josiah, and all the singing men and singing women spoke of Josiah in their lamentations to this day; and they made them an ordinance in Israel. Behold, they are written in the lamentations. 
-<sup>26&#160;</sup>Now the rest of the acts of Josiah and his good deeds, according to that which is written in Yahweh’s law, 
+<sup>26&#160;</sup>Now the rest of the acts of Josiah and his good deeds, according to that which is written in Yahuah’s law, 
 <sup>27&#160;</sup>and his acts, first and last, behold, they are written in the book of the kings of Israel and Judah. 
 </p><h2 class="chapterlabel" id="36">36</h2>
 <p>
@@ -1186,27 +1186,27 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>The king of Egypt removed him from office at Jerusalem, and fined the land one hundred talents of silver and a talent of gold. 
 <sup>4&#160;</sup>The king of Egypt made Eliakim his brother king over Judah and Jerusalem, and changed his name to Jehoiakim. Neco took Joahaz his brother, and carried him to Egypt. 
 </p><p>
-<sup>5&#160;</sup>Jehoiakim was twenty-five years old when he began to reign, and he reigned eleven years in Jerusalem. He did that which was evil in Yahweh his Elohim’s sight. 
+<sup>5&#160;</sup>Jehoiakim was twenty-five years old when he began to reign, and he reigned eleven years in Jerusalem. He did that which was evil in Yahuah his Elohim’s sight. 
 <sup>6&#160;</sup>Nebuchadnezzar king of Babylon came up against him, and bound him in fetters to carry him to Babylon. 
-<sup>7&#160;</sup>Nebuchadnezzar also carried some of the vessels of Yahweh’s house to Babylon, and put them in his temple at Babylon. 
+<sup>7&#160;</sup>Nebuchadnezzar also carried some of the vessels of Yahuah’s house to Babylon, and put them in his temple at Babylon. 
 <sup>8&#160;</sup>Now the rest of the acts of Jehoiakim, and his abominations which he did, and that which was found in him, behold, they are written in the book of the kings of Israel and Judah; and Jehoiachin his son reigned in his place. 
 </p><p>
-<sup>9&#160;</sup>Jehoiachin was eight years old when he began to reign, and he reigned three months and ten days in Jerusalem. He did that which was evil in Yahweh’s sight. 
-<sup>10&#160;</sup>At the return of the year, King Nebuchadnezzar sent and brought him to Babylon, with the valuable vessels of Yahweh’s house, and made Zedekiah his brother king over Judah and Jerusalem. 
+<sup>9&#160;</sup>Jehoiachin was eight years old when he began to reign, and he reigned three months and ten days in Jerusalem. He did that which was evil in Yahuah’s sight. 
+<sup>10&#160;</sup>At the return of the year, King Nebuchadnezzar sent and brought him to Babylon, with the valuable vessels of Yahuah’s house, and made Zedekiah his brother king over Judah and Jerusalem. 
 </p><p>
 <sup>11&#160;</sup>Zedekiah was twenty-one years old when he began to reign, and he reigned eleven years in Jerusalem. 
-<sup>12&#160;</sup>He did that which was evil in Yahweh his Elohim’s sight. He didn’t humble himself before Jeremiah the prophet speaking from Yahweh’s mouth. 
-<sup>13&#160;</sup>He also rebelled against King Nebuchadnezzar, who had made him swear by Elohim; but he stiffened his neck, and hardened his heart against turning to Yahweh, the Elohim of Israel. 
-<sup>14&#160;</sup>Moreover all the chiefs of the priests and the people trespassed very greatly after all the abominations of the nations; and they polluted Yahweh’s house which he had made set-apart in Jerusalem. 
+<sup>12&#160;</sup>He did that which was evil in Yahuah his Elohim’s sight. He didn’t humble himself before Jeremiah the prophet speaking from Yahuah’s mouth. 
+<sup>13&#160;</sup>He also rebelled against King Nebuchadnezzar, who had made him swear by Elohim; but he stiffened his neck, and hardened his heart against turning to Yahuah, the Elohim of Israel. 
+<sup>14&#160;</sup>Moreover all the chiefs of the priests and the people trespassed very greatly after all the abominations of the nations; and they polluted Yahuah’s house which he had made set-apart in Jerusalem. 
 </p><p>
-<sup>15&#160;</sup>Yahweh, the Elohim of their fathers, sent to them by his messengers, rising up early and sending, because he had compassion on his people and on his dwelling place; 
-<sup>16&#160;</sup>but they mocked the messengers of Elohim, despised his words, and scoffed at his prophets, until Yahweh’s wrath arose against his people, until there was no remedy. 
+<sup>15&#160;</sup>Yahuah, the Elohim of their fathers, sent to them by his messengers, rising up early and sending, because he had compassion on his people and on his dwelling place; 
+<sup>16&#160;</sup>but they mocked the messengers of Elohim, despised his words, and scoffed at his prophets, until Yahuah’s wrath arose against his people, until there was no remedy. 
 </p><p>
 <sup>17&#160;</sup>Therefore he brought on them the king of the Chaldeans, who killed their young men with the sword in the house of their sanctuary, and had no compassion on young man or virgin, old man or infirm. He gave them all into his hand. 
-<sup>18&#160;</sup>All the vessels of Elohim’s house, great and small, and the treasures of Yahweh’s house, and the treasures of the king and of his princes, all these he brought to Babylon. 
+<sup>18&#160;</sup>All the vessels of Elohim’s house, great and small, and the treasures of Yahuah’s house, and the treasures of the king and of his princes, all these he brought to Babylon. 
 <sup>19&#160;</sup>They burned Elohim’s house, broke down the wall of Jerusalem, burned all its palaces with fire, and destroyed all of its valuable vessels. 
 <sup>20&#160;</sup>He carried those who had escaped from the sword away to Babylon, and they were servants to him and his sons until the reign of the kingdom of Persia, 
-<sup>21&#160;</sup>to fulfill Yahweh’s word by Jeremiah’s mouth, until the land had enjoyed its Sabbaths. As long as it lay desolate, it kept Sabbath, to fulfill seventy years. 
+<sup>21&#160;</sup>to fulfill Yahuah’s word by Jeremiah’s mouth, until the land had enjoyed its Sabbaths. As long as it lay desolate, it kept Sabbath, to fulfill seventy years. 
 </p><p>
-<sup>22&#160;</sup>Now in the first year of Cyrus king of Persia, that Yahweh’s word by the mouth of Jeremiah might be accomplished, Yahweh stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
-<sup>23&#160;</sup>“Cyrus king of Persia says, ‘Yahweh, the Elohim of heaven, has given all the kingdoms of the earth to me; and he has commanded me to build him a house in Jerusalem, which is in Judah. Whoever there is among you of all his people, Yahweh his Elohim be with him, and let him go up.’&#160;” </p></div><script src="../main.js"></script></body></html>
+<sup>22&#160;</sup>Now in the first year of Cyrus king of Persia, that Yahuah’s word by the mouth of Jeremiah might be accomplished, Yahuah stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
+<sup>23&#160;</sup>“Cyrus king of Persia says, ‘Yahuah, the Elohim of heaven, has given all the kingdoms of the earth to me; and he has commanded me to build him a house in Jerusalem, which is in Judah. Whoever there is among you of all his people, Yahuah his Elohim be with him, and let him go up.’&#160;” </p></div><script src="../main.js"></script></body></html>

--- a/book/2kings.html
+++ b/book/2kings.html
@@ -88,12 +88,12 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>2&#160;</sup>Ahaziah fell down through the lattice in his upper room that was in Samaria, and was sick. So he sent messengers, and said to them, “Go, inquire of Baal Zebub, the elohim of Ekron, whether I will recover of this sickness.” 
 </p><p>
-<sup>3&#160;</sup>But Yahweh’s angel said to Elijah the Tishbite, “Arise, go up to meet the messengers of the king of Samaria, and tell them, ‘Is it because there is no Elohim in Israel that you go to inquire of Baal Zebub, the elohim of Ekron? 
-<sup>4&#160;</sup>Now therefore Yahweh says, “You will not come down from the bed where you have gone up, but you will surely die.”&#160;’&#160;” Then Elijah departed. 
+<sup>3&#160;</sup>But Yahuah’s angel said to Elijah the Tishbite, “Arise, go up to meet the messengers of the king of Samaria, and tell them, ‘Is it because there is no Elohim in Israel that you go to inquire of Baal Zebub, the elohim of Ekron? 
+<sup>4&#160;</sup>Now therefore Yahuah says, “You will not come down from the bed where you have gone up, but you will surely die.”&#160;’&#160;” Then Elijah departed. 
 </p><p>
 <sup>5&#160;</sup>The messengers returned to him, and he said to them, “Why is it that you have returned?” 
 </p><p>
-<sup>6&#160;</sup>They said to him, “A man came up to meet us, and said to us, ‘Go, return to the king who sent you, and tell him, “Yahweh says, ‘Is it because there is no Elohim in Israel that you send to inquire of Baal Zebub, the elohim of Ekron? Therefore you will not come down from the bed where you have gone up, but you will surely die.’&#160;”&#160;’&#160;” 
+<sup>6&#160;</sup>They said to him, “A man came up to meet us, and said to us, ‘Go, return to the king who sent you, and tell him, “Yahuah says, ‘Is it because there is no Elohim in Israel that you send to inquire of Baal Zebub, the elohim of Ekron? Therefore you will not come down from the bed where you have gone up, but you will surely die.’&#160;”&#160;’&#160;” 
 </p><p>
 <sup>7&#160;</sup>He said to them, “What kind of man was he who came up to meet you and told you these words?” 
 </p><p>
@@ -111,29 +111,29 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>Again he sent the captain of a third fifty with his fifty. The third captain of fifty went up, and came and fell on his knees before Elijah, and begged him, and said to him, “Man of Elohim, please let my life and the life of these fifty of your servants be precious in your sight. 
 <sup>14&#160;</sup>Behold, fire came down from the sky and consumed the last two captains of fifty with their fifties. But now let my life be precious in your sight.” 
 </p><p>
-<sup>15&#160;</sup>Yahweh’s angel said to Elijah, “Go down with him. Don’t be afraid of him.” 
+<sup>15&#160;</sup>Yahuah’s angel said to Elijah, “Go down with him. Don’t be afraid of him.” 
 </p><p>Then he arose and went down with him to the king. 
-<sup>16&#160;</sup>He said to him, “Yahweh says, ‘Because you have sent messengers to inquire of Baal Zebub, the elohim of Ekron, is it because there is no Elohim in Israel to inquire of his word? Therefore you will not come down from the bed where you have gone up, but you will surely die.’&#160;” 
+<sup>16&#160;</sup>He said to him, “Yahuah says, ‘Because you have sent messengers to inquire of Baal Zebub, the elohim of Ekron, is it because there is no Elohim in Israel to inquire of his word? Therefore you will not come down from the bed where you have gone up, but you will surely die.’&#160;” 
 </p><p>
-<sup>17&#160;</sup>So he died according to Yahweh’s word which Elijah had spoken. Jehoram began to reign in his place in the second year of Jehoram the son of Jehoshaphat king of Judah, because he had no son. 
+<sup>17&#160;</sup>So he died according to Yahuah’s word which Elijah had spoken. Jehoram began to reign in his place in the second year of Jehoram the son of Jehoshaphat king of Judah, because he had no son. 
 <sup>18&#160;</sup>Now the rest of the acts of Ahaziah which he did, aren’t they written in the book of the chronicles of the kings of Israel? 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>When Yahweh was about to take Elijah up by a whirlwind into heaven, Elijah went with Elisha from Gilgal. 
-<sup>2&#160;</sup>Elijah said to Elisha, “Please wait here, for Yahweh has sent me as far as Bethel.” 
-</p><p>Elisha said, “As Yahweh lives, and as your soul lives, I will not leave you.” So they went down to Bethel. 
+<sup>1&#160;</sup>When Yahuah was about to take Elijah up by a whirlwind into heaven, Elijah went with Elisha from Gilgal. 
+<sup>2&#160;</sup>Elijah said to Elisha, “Please wait here, for Yahuah has sent me as far as Bethel.” 
+</p><p>Elisha said, “As Yahuah lives, and as your soul lives, I will not leave you.” So they went down to Bethel. 
 </p><p>
-<sup>3&#160;</sup>The sons of the prophets who were at Bethel came out to Elisha, and said to him, “Do you know that Yahweh will take away your master from over you today?” 
+<sup>3&#160;</sup>The sons of the prophets who were at Bethel came out to Elisha, and said to him, “Do you know that Yahuah will take away your master from over you today?” 
 </p><p>He said, “Yes, I know it. Hold your peace.” 
 </p><p>
-<sup>4&#160;</sup>Elijah said to him, “Elisha, please wait here, for Yahweh has sent me to Jericho.” 
-</p><p>He said, “As Yahweh lives, and as your soul lives, I will not leave you.” So they came to Jericho. 
+<sup>4&#160;</sup>Elijah said to him, “Elisha, please wait here, for Yahuah has sent me to Jericho.” 
+</p><p>He said, “As Yahuah lives, and as your soul lives, I will not leave you.” So they came to Jericho. 
 </p><p>
-<sup>5&#160;</sup>The sons of the prophets who were at Jericho came near to Elisha, and said to him, “Do you know that Yahweh will take away your master from over you today?” 
+<sup>5&#160;</sup>The sons of the prophets who were at Jericho came near to Elisha, and said to him, “Do you know that Yahuah will take away your master from over you today?” 
 </p><p>He answered, “Yes, I know it. Hold your peace.” 
 </p><p>
-<sup>6&#160;</sup>Elijah said to him, “Please wait here, for Yahweh has sent me to the Jordan.” 
-</p><p>He said, “As Yahweh lives, and as your soul lives, I will not leave you.” Then they both went on. 
+<sup>6&#160;</sup>Elijah said to him, “Please wait here, for Yahuah has sent me to the Jordan.” 
+</p><p>He said, “As Yahuah lives, and as your soul lives, I will not leave you.” Then they both went on. 
 <sup>7&#160;</sup>Fifty men of the sons of the prophets went and stood opposite them at a distance; and they both stood by the Jordan. 
 <sup>8&#160;</sup>Elijah took his mantle, and rolled it up, and struck the waters; and they were divided here and there, so that they both went over on dry ground. 
 <sup>9&#160;</sup>When they had gone over, Elijah said to Elisha, “Ask what I shall do for you, before I am taken from you.” 
@@ -145,10 +145,10 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Elisha saw it, and he cried, “My father, my father, the chariots of Israel and its horsemen!” 
 </p><p>He saw him no more. Then he took hold of his own clothes and tore them in two pieces. 
 <sup>13&#160;</sup>He also took up Elijah’s mantle that fell from him, and went back and stood by the bank of the Jordan. 
-<sup>14&#160;</sup>He took Elijah’s mantle that fell from him, and struck the waters, and said, “Where is Yahweh, the Elohim of Elijah?” When he also had struck the waters, they were divided apart, and Elisha went over. 
+<sup>14&#160;</sup>He took Elijah’s mantle that fell from him, and struck the waters, and said, “Where is Yahuah, the Elohim of Elijah?” When he also had struck the waters, they were divided apart, and Elisha went over. 
 </p><p>
 <sup>15&#160;</sup>When the sons of the prophets who were at Jericho facing him saw him, they said, “The spirit of Elijah rests on Elisha.” They came to meet him, and bowed themselves to the ground before him. 
-<sup>16&#160;</sup>They said to him, “See now, there are with your servants fifty strong men. Please let them go and seek your master. Perhaps Yahweh’s Spirit has taken him up, and put him on some mountain or into some valley.” 
+<sup>16&#160;</sup>They said to him, “See now, there are with your servants fifty strong men. Please let them go and seek your master. Perhaps Yahuah’s Spirit has taken him up, and put him on some mountain or into some valley.” 
 </p><p>He said, “Don’t send them.” 
 </p><p>
 <sup>17&#160;</sup>When they urged him until he was ashamed, he said, “Send them.” 
@@ -158,16 +158,16 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>The men of the city said to Elisha, “Behold, please, the situation of this city is pleasant, as my lord sees; but the water is bad, and the land is barren.” 
 </p><p>
 <sup>20&#160;</sup>He said, “Bring me a new jar, and put salt in it.” Then they brought it to him. 
-<sup>21&#160;</sup>He went out to the spring of the waters, and threw salt into it, and said, “Yahweh says, ‘I have healed these waters. There shall not be from there any more death or barren wasteland.’&#160;” 
+<sup>21&#160;</sup>He went out to the spring of the waters, and threw salt into it, and said, “Yahuah says, ‘I have healed these waters. There shall not be from there any more death or barren wasteland.’&#160;” 
 <sup>22&#160;</sup>So the waters were healed to this day, according to Elisha’s word which he spoke. 
 </p><p>
 <sup>23&#160;</sup>He went up from there to Bethel. As he was going up by the way, some youths came out of the city and mocked him, and said to him, “Go up, you baldy! Go up, you baldy!” 
-<sup>24&#160;</sup>He looked behind him and saw them, and cursed them in Yahweh’s name. Then two female bears came out of the woods and mauled forty-two of those youths. 
+<sup>24&#160;</sup>He looked behind him and saw them, and cursed them in Yahuah’s name. Then two female bears came out of the woods and mauled forty-two of those youths. 
 <sup>25&#160;</sup>He went from there to Mount Carmel, and from there he returned to Samaria. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
 <sup>1&#160;</sup>Now Jehoram the son of Ahab began to reign over Israel in Samaria in the eighteenth year of Jehoshaphat king of Judah, and reigned twelve years. 
-<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, but not like his father and like his mother, for he put away the pillar of Baal that his father had made. 
+<sup>2&#160;</sup>He did that which was evil in Yahuah’s sight, but not like his father and like his mother, for he put away the pillar of Baal that his father had made. 
 <sup>3&#160;</sup>Nevertheless he held to the sins of Jeroboam the son of Nebat, with which he made Israel to sin. He didn’t depart from them. 
 </p><p>
 <sup>4&#160;</sup>Now Mesha king of Moab was a sheep breeder; and he supplied the king of Israel with one hundred thousand lambs and the wool of one hundred thousand rams. 
@@ -179,21 +179,21 @@ html[dir=ltr] .q2 {
 </p><p>Jehoram answered, “The way of the wilderness of Edom.” 
 </p><p>
 <sup>9&#160;</sup>So the king of Israel went with the king of Judah and the king of Edom, and they marched for seven days along a circuitous route. There was no water for the army or for the animals that followed them. 
-<sup>10&#160;</sup>The king of Israel said, “Alas! For Yahweh has called these three kings together to deliver them into the hand of Moab.” 
+<sup>10&#160;</sup>The king of Israel said, “Alas! For Yahuah has called these three kings together to deliver them into the hand of Moab.” 
 </p><p>
-<sup>11&#160;</sup>But Jehoshaphat said, “Isn’t there a prophet of Yahweh here, that we may inquire of Yahweh by him?” 
+<sup>11&#160;</sup>But Jehoshaphat said, “Isn’t there a prophet of Yahuah here, that we may inquire of Yahuah by him?” 
 </p><p>One of the king of Israel’s servants answered, “Elisha the son of Shaphat, who poured water on the hands of Elijah, is here.” 
 </p><p>
-<sup>12&#160;</sup>Jehoshaphat said, “Yahweh’s word is with him.” So the king of Israel and Jehoshaphat and the king of Edom went down to him. 
+<sup>12&#160;</sup>Jehoshaphat said, “Yahuah’s word is with him.” So the king of Israel and Jehoshaphat and the king of Edom went down to him. 
 </p><p>
 <sup>13&#160;</sup>Elisha said to the king of Israel, “What have I to do with you? Go to the prophets of your father, and to the prophets of your mother.” 
-</p><p>The king of Israel said to him, “No, for Yahweh has called these three kings together to deliver them into the hand of Moab.” 
+</p><p>The king of Israel said to him, “No, for Yahuah has called these three kings together to deliver them into the hand of Moab.” 
 </p><p>
-<sup>14&#160;</sup>Elisha said, “As Yahweh of Armies lives, before whom I stand, surely, were it not that I respect the presence of Jehoshaphat the king of Judah, I would not look toward you, nor see you. 
-<sup>15&#160;</sup>But now bring me a musician.” When the musician played, Yahweh’s hand came on him. 
-<sup>16&#160;</sup>He said, “Yahweh says, ‘Make this valley full of trenches.’ 
-<sup>17&#160;</sup>For Yahweh says, ‘You will not see wind, neither will you see rain, yet that valley will be filled with water, and you will drink, both you and your livestock and your other animals. 
-<sup>18&#160;</sup>This is an easy thing in Yahweh’s sight. He will also deliver the Moabites into your hand. 
+<sup>14&#160;</sup>Elisha said, “As Yahuah of Armies lives, before whom I stand, surely, were it not that I respect the presence of Jehoshaphat the king of Judah, I would not look toward you, nor see you. 
+<sup>15&#160;</sup>But now bring me a musician.” When the musician played, Yahuah’s hand came on him. 
+<sup>16&#160;</sup>He said, “Yahuah says, ‘Make this valley full of trenches.’ 
+<sup>17&#160;</sup>For Yahuah says, ‘You will not see wind, neither will you see rain, yet that valley will be filled with water, and you will drink, both you and your livestock and your other animals. 
+<sup>18&#160;</sup>This is an easy thing in Yahuah’s sight. He will also deliver the Moabites into your hand. 
 <sup>19&#160;</sup>You shall strike every fortified city and every choice city, and shall fell every good tree, and stop all springs of water, and mar every good piece of land with stones.’&#160;” 
 </p><p>
 <sup>20&#160;</sup>In the morning, about the time of offering the sacrifice, behold, water came by the way of Edom, and the country was filled with water. 
@@ -208,7 +208,7 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>Then he took his oldest son who would have reigned in his place, and offered him for a burnt offering on the wall. There was great wrath against Israel; and they departed from him, and returned to their own land. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>Now a certain woman of the women of the sons of the prophets cried out to Elisha, saying, “Your servant my man is dead. You know that your servant feared Yahweh. Now the creditor has come to take for himself my two children to be slaves.” 
+<sup>1&#160;</sup>Now a certain woman of the women of the sons of the prophets cried out to Elisha, saying, “Your servant my man is dead. You know that your servant feared Yahuah. Now the creditor has come to take for himself my two children to be slaves.” 
 </p><p>
 <sup>2&#160;</sup>Elisha said to her, “What should I do for you? Tell me, what do you have in the house?” 
 </p><p>She said, “Your servant has nothing in the house, except a pot of oil.” 
@@ -256,19 +256,19 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>Please run now to meet her, and ask her, ‘Is it well with you? Is it well with your man? Is it well with your child?’&#160;” 
 </p><p>She answered, “It is well.” 
 </p><p>
-<sup>27&#160;</sup>When she came to the man of Elohim to the hill, she caught hold of his feet. Gehazi came near to thrust her away; but the man of Elohim said, “Leave her alone, for her soul is troubled within her; and Yahweh has hidden it from me, and has not told me.” 
+<sup>27&#160;</sup>When she came to the man of Elohim to the hill, she caught hold of his feet. Gehazi came near to thrust her away; but the man of Elohim said, “Leave her alone, for her soul is troubled within her; and Yahuah has hidden it from me, and has not told me.” 
 </p><p>
 <sup>28&#160;</sup>Then she said, “Did I ask you for a son, my lord? Didn’t I say, ‘Do not deceive me’?” 
 </p><p>
 <sup>29&#160;</sup>Then he said to Gehazi, “Tuck your cloak into your belt, take my staff in your hand, and go your way. If you meet any man, don’t greet him; and if anyone greets you, don’t answer him again. Then lay my staff on the child’s face.” 
 </p><p>
-<sup>30&#160;</sup>The child’s mother said, “As Yahweh lives, and as your soul lives, I will not leave you.” 
+<sup>30&#160;</sup>The child’s mother said, “As Yahuah lives, and as your soul lives, I will not leave you.” 
 </p><p>So he arose, and followed her. 
 </p><p>
 <sup>31&#160;</sup>Gehazi went ahead of them, and laid the staff on the child’s face; but there was no voice and no hearing. Therefore he returned to meet him, and told him, “The child has not awakened.” 
 </p><p>
 <sup>32&#160;</sup>When Elisha had come into the house, behold, the child was dead, and lying on his bed. 
-<sup>33&#160;</sup>He went in therefore, and shut the door on them both, and prayed to Yahweh. 
+<sup>33&#160;</sup>He went in therefore, and shut the door on them both, and prayed to Yahuah. 
 <sup>34&#160;</sup>He went up and lay on the child, and put his mouth on his mouth, and his eyes on his eyes, and his hands on his hands. He stretched himself on him; and the child’s flesh grew warm. 
 <sup>35&#160;</sup>Then he returned, and walked in the house once back and forth, then went up and stretched himself out on him. Then the child sneezed seven times, and the child opened his eyes. 
 <sup>36&#160;</sup>He called Gehazi, and said, “Call this Shunammite!” So he called her. 
@@ -286,12 +286,12 @@ html[dir=ltr] .q2 {
 <sup>42&#160;</sup>A man from Baal Shalishah came, and brought the man of Elohim some bread of the first fruits: twenty loaves of barley and fresh ears of grain in his sack. Elisha said, “Give to the people, that they may eat.” 
 </p><p>
 <sup>43&#160;</sup>His servant said, “What, should I set this before a hundred men?” 
-</p><p>But he said, “Give it to the people, that they may eat; for Yahweh says, ‘They will eat, and will have some left over.’&#160;” 
+</p><p>But he said, “Give it to the people, that they may eat; for Yahuah says, ‘They will eat, and will have some left over.’&#160;” 
 </p><p>
-<sup>44&#160;</sup>So he set it before them and they ate and had some left over, according to Yahweh’s word. 
+<sup>44&#160;</sup>So he set it before them and they ate and had some left over, according to Yahuah’s word. 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
-<sup>1&#160;</sup>Now Naaman, captain of the army of the king of Syria, was a great man with his master, and honorable, because by him Yahweh had given victory to Syria; he was also a mighty man of valor, but he was a leper. 
+<sup>1&#160;</sup>Now Naaman, captain of the army of the king of Syria, was a great man with his master, and honorable, because by him Yahuah had given victory to Syria; he was also a mighty man of valor, but he was a leper. 
 <sup>2&#160;</sup>The Syrians had gone out in bands, and had brought away captive out of the land of Israel a little girl, and she waited on Naaman’s woman. 
 <sup>3&#160;</sup>She said to her mistress, “I wish that my lord were with the prophet who is in Samaria! Then he would heal him of his leprosy.” 
 </p><p>
@@ -308,7 +308,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>So Naaman came with his horses and with his chariots, and stood at the door of the house of Elisha. 
 <sup>10&#160;</sup>Elisha sent a messenger to him, saying, “Go and wash in the Jordan seven times, and your flesh shall come again to you, and you shall be clean.” 
 </p><p>
-<sup>11&#160;</sup>But Naaman was angry, and went away and said, “Behold, I thought, ‘He will surely come out to me, and stand, and call on the name of Yahweh his Elohim, and wave his hand over the place, and heal the leper.’ 
+<sup>11&#160;</sup>But Naaman was angry, and went away and said, “Behold, I thought, ‘He will surely come out to me, and stand, and call on the name of Yahuah his Elohim, and wave his hand over the place, and heal the leper.’ 
 <sup>12&#160;</sup>Aren’t Abanah and Pharpar, the rivers of Damascus, better than all the waters of Israel? Couldn’t I wash in them and be clean?” So he turned and went away in a rage. 
 </p><p>
 <sup>13&#160;</sup>His servants came near and spoke to him, and said, “My father, if the prophet had asked you do some great thing, wouldn’t you have done it? How much rather then, when he says to you, ‘Wash, and be clean’?” 
@@ -316,14 +316,14 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>Then went he down and dipped himself seven times in the Jordan, according to the saying of the man of Elohim; and his flesh was restored like the flesh of a little child, and he was clean. 
 <sup>15&#160;</sup>He returned to the man of Elohim, he and all his company, and came, and stood before him; and he said, “See now, I know that there is no Elohim in all the earth, but in Israel. Now therefore, please take a gift from your servant.” 
 </p><p>
-<sup>16&#160;</sup>But he said, “As Yahweh lives, before whom I stand, I will receive none.” 
+<sup>16&#160;</sup>But he said, “As Yahuah lives, before whom I stand, I will receive none.” 
 </p><p>He urged him to take it; but he refused. 
-<sup>17&#160;</sup>Naaman said, “If not, then, please let two mules’ load of earth be given to your servant; for your servant will from now on offer neither burnt offering nor sacrifice to other elohims, but to Yahweh. 
-<sup>18&#160;</sup>In this thing may Yahweh pardon your servant: when my master goes into the house of Rimmon to worship there, and he leans on my hand, and I bow myself in the house of Rimmon. When I bow myself in the house of Rimmon, may Yahweh pardon your servant in this thing.” 
+<sup>17&#160;</sup>Naaman said, “If not, then, please let two mules’ load of earth be given to your servant; for your servant will from now on offer neither burnt offering nor sacrifice to other elohims, but to Yahuah. 
+<sup>18&#160;</sup>In this thing may Yahuah pardon your servant: when my master goes into the house of Rimmon to worship there, and he leans on my hand, and I bow myself in the house of Rimmon. When I bow myself in the house of Rimmon, may Yahuah pardon your servant in this thing.” 
 </p><p>
 <sup>19&#160;</sup>He said to him, “Go in peace.” 
 </p><p>So he departed from him a little way. 
-<sup>20&#160;</sup>But Gehazi the servant of Elisha the man of Elohim, said, “Behold, my master has spared this Naaman the Syrian, in not receiving at his hands that which he brought. As Yahweh lives, I will run after him, and take something from him.” 
+<sup>20&#160;</sup>But Gehazi the servant of Elisha the man of Elohim, said, “Behold, my master has spared this Naaman the Syrian, in not receiving at his hands that which he brought. As Yahuah lives, I will run after him, and take something from him.” 
 </p><p>
 <sup>21&#160;</sup>So Gehazi followed after Naaman. When Naaman saw one running after him, he came down from the chariot to meet him, and said, “Is all well?” 
 </p><p>
@@ -366,13 +366,13 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>When the servant of the man of Elohim had risen early and gone out, behold, an army with horses and chariots was around the city. His servant said to him, “Alas, my master! What shall we do?” 
 </p><p>
 <sup>16&#160;</sup>He answered, “Don’t be afraid, for those who are with us are more than those who are with them.” 
-<sup>17&#160;</sup>Elisha prayed, and said, “Yahweh, please open his eyes, that he may see.” Yahweh opened the young man’s eyes, and he saw; and behold, the mountain was full of horses and chariots of fire around Elisha. 
-<sup>18&#160;</sup>When they came down to him, Elisha prayed to Yahweh, and said, “Please strike this people with blindness.” 
+<sup>17&#160;</sup>Elisha prayed, and said, “Yahuah, please open his eyes, that he may see.” Yahuah opened the young man’s eyes, and he saw; and behold, the mountain was full of horses and chariots of fire around Elisha. 
+<sup>18&#160;</sup>When they came down to him, Elisha prayed to Yahuah, and said, “Please strike this people with blindness.” 
 </p><p>He struck them with blindness according to Elisha’s word. 
 </p><p>
 <sup>19&#160;</sup>Elisha said to them, “This is not the way, neither is this the city. Follow me, and I will bring you to the man whom you seek.” He led them to Samaria. 
-<sup>20&#160;</sup>When they had come into Samaria, Elisha said, “Yahweh, open these men’s eyes, that they may see.” 
-</p><p>Yahweh opened their eyes, and they saw; and behold, they were in the middle of Samaria. 
+<sup>20&#160;</sup>When they had come into Samaria, Elisha said, “Yahuah, open these men’s eyes, that they may see.” 
+</p><p>Yahuah opened their eyes, and they saw; and behold, they were in the middle of Samaria. 
 </p><p>
 <sup>21&#160;</sup>The king of Israel said to Elisha, when he saw them, “My father, shall I strike them? Shall I strike them?” 
 </p><p>
@@ -384,7 +384,7 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>There was a great famine in Samaria. Behold, they besieged it until a donkey’s head was sold for eighty pieces of silver, and the fourth part of a kab of dove’s dung for five pieces of silver. 
 <sup>26&#160;</sup>As the king of Israel was passing by on the wall, a woman cried to him, saying, “Help, my lord, O king!” 
 </p><p>
-<sup>27&#160;</sup>He said, “If Yahweh doesn’t help you, where could I get help for you? From the threshing floor, or from the wine press?” 
+<sup>27&#160;</sup>He said, “If Yahuah doesn’t help you, where could I get help for you? From the threshing floor, or from the wine press?” 
 <sup>28&#160;</sup>Then the king asked her, “What is your problem?” 
 </p><p>She answered, “This woman said to me, ‘Give your son, that we may eat him today, and we will eat my son tomorrow.’ 
 <sup>29&#160;</sup>So we boiled my son and ate him; and I said to her on the next day, ‘Give up your son, that we may eat him;’ and she has hidden her son.” 
@@ -394,12 +394,12 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>32&#160;</sup>But Elisha was sitting in his house, and the elders were sitting with him. Then the king sent a man from before him; but before the messenger came to him, he said to the elders, “Do you see how this son of a murderer has sent to take away my head? Behold, when the messenger comes, shut the door, and hold the door shut against him. Isn’t the sound of his master’s feet behind him?” 
 </p><p>
-<sup>33&#160;</sup>While he was still talking with them, behold, the messenger came down to him. Then he said, “Behold, this evil is from Yahweh. Why should I wait for Yahweh any longer?” 
+<sup>33&#160;</sup>While he was still talking with them, behold, the messenger came down to him. Then he said, “Behold, this evil is from Yahuah. Why should I wait for Yahuah any longer?” 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>Elisha said, “Hear Yahweh’s word. Yahweh says, ‘Tomorrow about this time a seah of fine flour will be sold for a shekel, and two seahs of barley for a shekel, in the gate of Samaria.’&#160;” 
+<sup>1&#160;</sup>Elisha said, “Hear Yahuah’s word. Yahuah says, ‘Tomorrow about this time a seah of fine flour will be sold for a shekel, and two seahs of barley for a shekel, in the gate of Samaria.’&#160;” 
 </p><p>
-<sup>2&#160;</sup>Then the captain on whose hand the king leaned answered the man of Elohim, and said, “Behold, if Yahweh made windows in heaven, could this thing be?” 
+<sup>2&#160;</sup>Then the captain on whose hand the king leaned answered the man of Elohim, and said, “Behold, if Yahuah made windows in heaven, could this thing be?” 
 </p><p>He said, “Behold, you will see it with your eyes, but will not eat of it.” 
 </p><p>
 <sup>3&#160;</sup>Now there were four leprous men at the entrance of the gate. They said to one another, “Why do we sit here until we die? 
@@ -422,14 +422,14 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>Therefore they took two chariots with horses; and the king sent them out to the Syrian army, saying, “Go and see.” 
 </p><p>
 <sup>15&#160;</sup>They went after them to the Jordan; and behold, all the path was full of garments and equipment which the Syrians had cast away in their haste. The messengers returned and told the king. 
-<sup>16&#160;</sup>The people went out and plundered the camp of the Syrians. So a seah of fine flour was sold for a shekel, and two measures of barley for a shekel, according to Yahweh’s word. 
+<sup>16&#160;</sup>The people went out and plundered the camp of the Syrians. So a seah of fine flour was sold for a shekel, and two measures of barley for a shekel, according to Yahuah’s word. 
 <sup>17&#160;</sup>The king had appointed the captain on whose hand he leaned to be in charge of the gate; and the people trampled over him in the gate, and he died as the man of Elohim had said, who spoke when the king came down to him. 
 <sup>18&#160;</sup>It happened as the man of Elohim had spoken to the king, saying, “Two seahs of barley for a shekel, and a seah of fine flour for a shekel, shall be tomorrow about this time in the gate of Samaria;” 
-<sup>19&#160;</sup>and that captain answered the man of Elohim, and said, “Now, behold, if Yahweh made windows in heaven, might such a thing be?” and he said, “Behold, you will see it with your eyes, but will not eat of it.” 
+<sup>19&#160;</sup>and that captain answered the man of Elohim, and said, “Now, behold, if Yahuah made windows in heaven, might such a thing be?” and he said, “Behold, you will see it with your eyes, but will not eat of it.” 
 <sup>20&#160;</sup>It happened like that to him, for the people trampled over him in the gate, and he died. 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>Now Elisha had spoken to the woman whose son he had restored to life, saying, “Arise, and go, you and your household, and stay for a while wherever you can; for Yahweh has called for a famine. It will also come on the land for seven years.” 
+<sup>1&#160;</sup>Now Elisha had spoken to the woman whose son he had restored to life, saying, “Arise, and go, you and your household, and stay for a while wherever you can; for Yahuah has called for a famine. It will also come on the land for seven years.” 
 </p><p>
 <sup>2&#160;</sup>The woman arose, and did according to the man of Elohim’s word. She went with her household, and lived in the land of the Philistines for seven years. 
 <sup>3&#160;</sup>At the end of seven years, the woman returned from the land of the Philistines. Then she went out to beg the king for her house and for her land. 
@@ -440,18 +440,18 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>7&#160;</sup>Elisha came to Damascus; and Benhadad the king of Syria was sick. He was told, “The man of Elohim has come here.” 
 </p><p>
-<sup>8&#160;</sup>The king said to Hazael, “Take a present in your hand, and go meet the man of Elohim, and inquire of Yahweh by him, saying, ‘Will I recover from this sickness?’&#160;” 
+<sup>8&#160;</sup>The king said to Hazael, “Take a present in your hand, and go meet the man of Elohim, and inquire of Yahuah by him, saying, ‘Will I recover from this sickness?’&#160;” 
 </p><p>
 <sup>9&#160;</sup>So Hazael went to meet him and took a present with him, even of every good thing of Damascus, forty camels’ burden, and came and stood before him and said, “Your son Benhadad king of Syria has sent me to you, saying, ‘Will I recover from this sickness?’&#160;” 
 </p><p>
-<sup>10&#160;</sup>Elisha said to him, “Go, tell him, ‘You will surely recover;’ however Yahweh has shown me that he will surely die.” 
+<sup>10&#160;</sup>Elisha said to him, “Go, tell him, ‘You will surely recover;’ however Yahuah has shown me that he will surely die.” 
 <sup>11&#160;</sup>He settled his gaze steadfastly on him, until he was ashamed. Then the man of Elohim wept. 
 </p><p>
 <sup>12&#160;</sup>Hazael said, “Why do you weep, my lord?” 
 </p><p>He answered, “Because I know the evil that you will do to the children of Israel. You will set their strongholds on fire, and you will kill their young men with the sword, and will dash their little ones in pieces, and rip up their pregnant women.” 
 </p><p>
 <sup>13&#160;</sup>Hazael said, “But what is your servant, who is but a dog, that he could do this great thing?” 
-</p><p>Elisha answered, “Yahweh has shown me that you will be king over Syria.” 
+</p><p>Elisha answered, “Yahuah has shown me that you will be king over Syria.” 
 </p><p>
 <sup>14&#160;</sup>Then he departed from Elisha, and came to his master, who said to him, “What did Elisha say to you?” 
 </p><p>He answered, “He told me that you would surely recover.” 
@@ -460,8 +460,8 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>16&#160;</sup>In the fifth year of Joram the son of Ahab king of Israel, Jehoshaphat being king of Judah then, Jehoram the son of Jehoshaphat king of Judah began to reign. 
 <sup>17&#160;</sup>He was thirty-two years old when he began to reign. He reigned eight years in Jerusalem. 
-<sup>18&#160;</sup>He walked in the way of the kings of Israel, as did Ahab’s house, for he took to himself Ahab’s daughter. He did that which was evil in Yahweh’s sight. 
-<sup>19&#160;</sup>However, Yahweh would not destroy Judah, for David his servant’s sake, as he promised him to give to him a lamp for his children always. 
+<sup>18&#160;</sup>He walked in the way of the kings of Israel, as did Ahab’s house, for he took to himself Ahab’s daughter. He did that which was evil in Yahuah’s sight. 
+<sup>19&#160;</sup>However, Yahuah would not destroy Judah, for David his servant’s sake, as he promised him to give to him a lamp for his children always. 
 </p><p>
 <sup>20&#160;</sup>In his days Edom revolted from under the hand of Judah, and made a king over themselves. 
 <sup>21&#160;</sup>Then Joram crossed over to Zair, and all his chariots with him; and he rose up by night and struck the Edomites who surrounded him with the captains of the chariots; and the people fled to their tents. 
@@ -471,7 +471,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>25&#160;</sup>In the twelfth year of Joram the son of Ahab king of Israel, Ahaziah the son of Jehoram king of Judah began to reign. 
 <sup>26&#160;</sup>Ahaziah was twenty-two years old when he began to reign; and he reigned one year in Jerusalem. His mother’s name was Athaliah the daughter of Omri king of Israel. 
-<sup>27&#160;</sup>He walked in the way of Ahab’s house and did that which was evil in Yahweh’s sight, as did Ahab’s house, for he was the son-in-law of Ahab’s house. 
+<sup>27&#160;</sup>He walked in the way of Ahab’s house and did that which was evil in Yahuah’s sight, as did Ahab’s house, for he was the son-in-law of Ahab’s house. 
 </p><p>
 <sup>28&#160;</sup>He went with Joram the son of Ahab to war against Hazael king of Syria at Ramoth Gilead, and the Syrians wounded Joram. 
 <sup>29&#160;</sup>King Joram returned to be healed in Jezreel from the wounds which the Syrians had given him at Ramah, when he fought against Hazael king of Syria. Ahaziah the son of Jehoram, king of Judah, went down to see Joram the son of Ahab in Jezreel, because he was sick. 
@@ -479,14 +479,14 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Elisha the prophet called one of the sons of the prophets, and said to him, “Put your belt on your waist, take this vial of oil in your hand, and go to Ramoth Gilead. 
 <sup>2&#160;</sup>When you come there, find Jehu the son of Jehoshaphat the son of Nimshi, and go in and make him rise up from among his brothers, and take him to an inner room. 
-<sup>3&#160;</sup>Then take the vial of oil, and pour it on his head, and say, ‘Yahweh says, “I have anointed you king over Israel.”&#160;’ Then open the door, flee, and don’t wait.” 
+<sup>3&#160;</sup>Then take the vial of oil, and pour it on his head, and say, ‘Yahuah says, “I have anointed you king over Israel.”&#160;’ Then open the door, flee, and don’t wait.” 
 </p><p>
 <sup>4&#160;</sup>So the young man, the young prophet, went to Ramoth Gilead. 
 <sup>5&#160;</sup>When he came, behold, the captains of the army were sitting. Then he said, “I have a message for you, captain.” 
 </p><p>Jehu said, “To which one of us?” 
 </p><p>He said, “To you, O captain.” 
-<sup>6&#160;</sup>He arose, and went into the house. Then he poured the oil on his head, and said to him, “Yahweh, the Elohim of Israel, says, ‘I have anointed you king over the people of Yahweh, even over Israel. 
-<sup>7&#160;</sup>You must strike your master Ahab’s house, that I may avenge the blood of my servants the prophets, and the blood of all the servants of Yahweh, at the hand of Jezebel. 
+<sup>6&#160;</sup>He arose, and went into the house. Then he poured the oil on his head, and said to him, “Yahuah, the Elohim of Israel, says, ‘I have anointed you king over the people of Yahuah, even over Israel. 
+<sup>7&#160;</sup>You must strike your master Ahab’s house, that I may avenge the blood of my servants the prophets, and the blood of all the servants of Yahuah, at the hand of Jezebel. 
 <sup>8&#160;</sup>For the whole house of Ahab will perish. I will cut off from Ahab everyone who urinates against a wall, both him who is shut up and him who is left at large in Israel. 
 <sup>9&#160;</sup>I will make Ahab’s house like the house of Jeroboam the son of Nebat, and like the house of Baasha the son of Ahijah. 
 <sup>10&#160;</sup>The dogs will eat Jezebel on the plot of ground of Jezreel, and there shall be no one to bury her.’&#160;” Then he opened the door and fled. 
@@ -495,7 +495,7 @@ html[dir=ltr] .q2 {
 </p><p>He said to them, “You know the man and how he talks.” 
 </p><p>
 <sup>12&#160;</sup>They said, “That is a lie. Tell us now.” 
-</p><p>He said, “He said to me, ‘Yahweh says, I have anointed you king over Israel.’&#160;” 
+</p><p>He said, “He said to me, ‘Yahuah says, I have anointed you king over Israel.’&#160;” 
 </p><p>
 <sup>13&#160;</sup>Then they hurried, and each man took his cloak, and put it under him on the top of the stairs, and blew the trumpet, saying, “Jehu is king.” 
 </p><p>
@@ -522,8 +522,8 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>Joram turned his hands and fled, and said to Ahaziah, “This is treason, Ahaziah!” 
 </p><p>
 <sup>24&#160;</sup>Jehu drew his bow with his full strength, and struck Joram between his arms; and the arrow went out at his heart, and he sunk down in his chariot. 
-<sup>25&#160;</sup>Then Jehu said to Bidkar his captain, “Pick him up, and throw him in the plot of the field of Naboth the Jezreelite; for remember how, when you and I rode together after Ahab his father, Yahweh laid this burden on him: 
-<sup>26&#160;</sup>‘Surely I have seen yesterday the blood of Naboth, and the blood of his sons,’ says Yahweh; ‘and I will repay you in this plot of ground,’ says Yahweh. Now therefore take and cast him onto the plot of ground, according to Yahweh’s word.” 
+<sup>25&#160;</sup>Then Jehu said to Bidkar his captain, “Pick him up, and throw him in the plot of the field of Naboth the Jezreelite; for remember how, when you and I rode together after Ahab his father, Yahuah laid this burden on him: 
+<sup>26&#160;</sup>‘Surely I have seen yesterday the blood of Naboth, and the blood of his sons,’ says Yahuah; ‘and I will repay you in this plot of ground,’ says Yahuah. Now therefore take and cast him onto the plot of ground, according to Yahuah’s word.” 
 </p><p>
 <sup>27&#160;</sup>But when Ahaziah the king of Judah saw this, he fled by the way of the garden house. Jehu followed after him, and said, “Strike him also in the chariot!” They struck him at the ascent of Gur, which is by Ibleam. He fled to Megiddo, and died there. 
 <sup>28&#160;</sup>His servants carried him in a chariot to Jerusalem, and buried him in his tomb with his fathers in David’s city. 
@@ -541,7 +541,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>35&#160;</sup>They went to bury her, but they found no more of her than the skull, the feet, and the palms of her hands. 
 <sup>36&#160;</sup>Therefore they came back, and told him. 
-</p><p>He said, “This is Yahweh’s word, which he spoke by his servant Elijah the Tishbite, saying, ‘The dogs will eat the flesh of Jezebel on the plot of Jezreel, 
+</p><p>He said, “This is Yahuah’s word, which he spoke by his servant Elijah the Tishbite, saying, ‘The dogs will eat the flesh of Jezebel on the plot of Jezreel, 
 <sup>37&#160;</sup>and the body of Jezebel will be as dung on the surface of the field on Jezreel’s land, so that they won’t say, “This is Jezebel.”&#160;’&#160;” 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p>
@@ -558,7 +558,7 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>A messenger came and told him, “They have brought the heads of the king’s sons.” 
 </p><p>He said, “Lay them in two heaps at the entrance of the gate until the morning.” 
 <sup>9&#160;</sup>In the morning, he went out and stood, and said to all the people, “You are righteous. Behold, I conspired against my master and killed him, but who killed all these? 
-<sup>10&#160;</sup>Know now that nothing will fall to the earth of Yahweh’s word, which Yahweh spoke concerning Ahab’s house. For Yahweh has done that which he spoke by his servant Elijah.” 
+<sup>10&#160;</sup>Know now that nothing will fall to the earth of Yahuah’s word, which Yahuah spoke concerning Ahab’s house. For Yahuah has done that which he spoke by his servant Elijah.” 
 </p><p>
 <sup>11&#160;</sup>So Jehu struck all that remained of Ahab’s house in Jezreel, with all his great men, his familiar friends, and his priests, until he left him no one remaining. 
 </p><p>
@@ -572,8 +572,8 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>When he had departed from there, he met Jehonadab the son of Rechab coming to meet him. He greeted him, and said to him, “Is your heart right, as my heart is with your heart?” 
 </p><p>Jehonadab answered, “It is.” 
 </p><p>“If it is, give me your hand.” He gave him his hand; and he took him up to him into the chariot. 
-<sup>16&#160;</sup>He said, “Come with me, and see my zeal for Yahweh.” So they made him ride in his chariot. 
-<sup>17&#160;</sup>When he came to Samaria, he struck all who remained to Ahab in Samaria, until he had destroyed them, according to Yahweh’s word which he spoke to Elijah. 
+<sup>16&#160;</sup>He said, “Come with me, and see my zeal for Yahuah.” So they made him ride in his chariot. 
+<sup>17&#160;</sup>When he came to Samaria, he struck all who remained to Ahab in Samaria, until he had destroyed them, according to Yahuah’s word which he spoke to Elijah. 
 </p><p>
 <sup>18&#160;</sup>Jehu gathered all the people together, and said to them, “Ahab served Baal a little, but Jehu will serve him much. 
 <sup>19&#160;</sup>Now therefore call to me all the prophets of Baal, all of his worshipers, and all of his priests. Let no one be absent, for I have a great sacrifice to Baal. Whoever is absent, he shall not live.” But Jehu did deceptively, intending to destroy the worshipers of Baal. 
@@ -583,7 +583,7 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>Jehu sent through all Israel; and all the worshipers of Baal came, so that there was not a man left that didn’t come. They came into the house of Baal; and the house of Baal was filled from one end to another. 
 <sup>22&#160;</sup>He said to him who kept the wardrobe, “Bring out robes for all the worshipers of Baal!” 
 </p><p>So he brought robes out to them. 
-<sup>23&#160;</sup>Jehu went with Jehonadab the son of Rechab into the house of Baal. Then he said to the worshipers of Baal, “Search, and see that none of the servants of Yahweh are here with you, but only the worshipers of Baal.” 
+<sup>23&#160;</sup>Jehu went with Jehonadab the son of Rechab into the house of Baal. Then he said to the worshipers of Baal, “Search, and see that none of the servants of Yahuah are here with you, but only the worshipers of Baal.” 
 </p><p>
 <sup>24&#160;</sup>So they went in to offer sacrifices and burnt offerings. Now Jehu had appointed for himself eighty men outside, and said, “If any of the men whom I bring into your hands escape, he who lets him go, his life shall be for the life of him.” 
 </p><p>
@@ -593,11 +593,11 @@ html[dir=ltr] .q2 {
 <sup>28&#160;</sup>Thus Jehu destroyed Baal out of Israel. 
 </p><p>
 <sup>29&#160;</sup>However, Jehu didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin—the golden calves that were in Bethel and that were in Dan. 
-<sup>30&#160;</sup>Yahweh said to Jehu, “Because you have done well in executing that which is right in my eyes, and have done to Ahab’s house according to all that was in my heart, your descendants shall sit on the throne of Israel to the fourth generation.” 
+<sup>30&#160;</sup>Yahuah said to Jehu, “Because you have done well in executing that which is right in my eyes, and have done to Ahab’s house according to all that was in my heart, your descendants shall sit on the throne of Israel to the fourth generation.” 
 </p><p>
-<sup>31&#160;</sup>But Jehu took no heed to walk in the law of Yahweh, the Elohim of Israel, with all his heart. He didn’t depart from the sins of Jeroboam, with which he made Israel to sin. 
+<sup>31&#160;</sup>But Jehu took no heed to walk in the law of Yahuah, the Elohim of Israel, with all his heart. He didn’t depart from the sins of Jeroboam, with which he made Israel to sin. 
 </p><p>
-<sup>32&#160;</sup>In those days Yahweh began to cut away parts of Israel; and Hazael struck them in all the borders of Israel 
+<sup>32&#160;</sup>In those days Yahuah began to cut away parts of Israel; and Hazael struck them in all the borders of Israel 
 <sup>33&#160;</sup>from the Jordan eastward, all the land of Gilead, the Gadites, and the Reubenites, and the Manassites, from Aroer, which is by the valley of the Arnon, even Gilead and Bashan. 
 <sup>34&#160;</sup>Now the rest of the acts of Jehu, and all that he did, and all his might, aren’t they written in the book of the chronicles of the kings of Israel? 
 <sup>35&#160;</sup>Jehu slept with his fathers; and they buried him in Samaria. Jehoahaz his son reigned in his place. 
@@ -606,55 +606,55 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Now when Athaliah the mother of Ahaziah saw that her son was dead, she arose and destroyed all the royal offspring. 
 <sup>2&#160;</sup>But Jehosheba, the daughter of King Joram, sister of Ahaziah, took Joash the son of Ahaziah, and stole him away from among the king’s sons who were slain, even him and his nurse, and put them in the bedroom; and they hid him from Athaliah, so that he was not slain. 
-<sup>3&#160;</sup>He was with her hidden in Yahweh’s house six years while Athaliah reigned over the land. 
+<sup>3&#160;</sup>He was with her hidden in Yahuah’s house six years while Athaliah reigned over the land. 
 </p><p>
-<sup>4&#160;</sup>In the seventh year Jehoiada sent and fetched the captains over hundreds of the Carites and of the guard, and brought them to him into Yahweh’s house; and he made a covenant with them, and made a covenant with them in Yahweh’s house, and showed them the king’s son. 
+<sup>4&#160;</sup>In the seventh year Jehoiada sent and fetched the captains over hundreds of the Carites and of the guard, and brought them to him into Yahuah’s house; and he made a covenant with them, and made a covenant with them in Yahuah’s house, and showed them the king’s son. 
 <sup>5&#160;</sup>He commanded them, saying, “This is what you must do: a third of you, who come in on the Sabbath, shall be keepers of the watch of the king’s house; 
 <sup>6&#160;</sup>a third of you shall be at the gate Sur; and a third of you at the gate behind the guard. So you shall keep the watch of the house, and be a barrier. 
-<sup>7&#160;</sup>The two companies of you, even all who go out on the Sabbath, shall keep the watch of Yahweh’s house around the king. 
+<sup>7&#160;</sup>The two companies of you, even all who go out on the Sabbath, shall keep the watch of Yahuah’s house around the king. 
 <sup>8&#160;</sup>You shall surround the king, every man with his weapons in his hand; and he who comes within the ranks, let him be slain. Be with the king when he goes out, and when he comes in.” 
 </p><p>
 <sup>9&#160;</sup>The captains over hundreds did according to all that Jehoiada the priest commanded; and they each took his men, those who were to come in on the Sabbath with those who were to go out on the Sabbath, and came to Jehoiada the priest. 
-<sup>10&#160;</sup>The priest delivered to the captains over hundreds the spears and shields that had been King David’s, which were in Yahweh’s house. 
+<sup>10&#160;</sup>The priest delivered to the captains over hundreds the spears and shields that had been King David’s, which were in Yahuah’s house. 
 <sup>11&#160;</sup>The guard stood, every man with his weapons in his hand, from the right side of the house to the left side of the house, along by the altar and the house, around the king. 
 <sup>12&#160;</sup>Then he brought out the king’s son, and put the crown on him, and gave him the covenant; and they made him king and anointed him; and they clapped their hands, and said, “Long live the king!” 
 </p><p>
-<sup>13&#160;</sup>When Athaliah heard the noise of the guard and of the people, she came to the people into Yahweh’s house; 
+<sup>13&#160;</sup>When Athaliah heard the noise of the guard and of the people, she came to the people into Yahuah’s house; 
 <sup>14&#160;</sup>and she looked, and behold, the king stood by the pillar, as the tradition was, with the captains and the trumpets by the king; and all the people of the land rejoiced, and blew trumpets. Then Athaliah tore her clothes and cried, “Treason! Treason!” 
 </p><p>
-<sup>15&#160;</sup>Jehoiada the priest commanded the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks. Kill anyone who follows her with the sword.” For the priest said, “Don’t let her be slain in Yahweh’s house.” 
+<sup>15&#160;</sup>Jehoiada the priest commanded the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks. Kill anyone who follows her with the sword.” For the priest said, “Don’t let her be slain in Yahuah’s house.” 
 <sup>16&#160;</sup>So they seized her; and she went by the way of the horses’ entry to the king’s house, and she was slain there. 
 </p><p>
-<sup>17&#160;</sup>Jehoiada made a covenant between Yahweh and the king and the people, that they should be Yahweh’s people; also between the king and the people. 
-<sup>18&#160;</sup>All the people of the land went to the house of Baal, and broke it down. They broke his altars and his images in pieces thoroughly, and killed Mattan the priest of Baal before the altars. The priest appointed officers over Yahweh’s house. 
-<sup>19&#160;</sup>He took the captains over hundreds, and the Carites, and the guard, and all the people of the land; and they brought down the king from Yahweh’s house, and came by the way of the gate of the guard to the king’s house. He sat on the throne of the kings. 
+<sup>17&#160;</sup>Jehoiada made a covenant between Yahuah and the king and the people, that they should be Yahuah’s people; also between the king and the people. 
+<sup>18&#160;</sup>All the people of the land went to the house of Baal, and broke it down. They broke his altars and his images in pieces thoroughly, and killed Mattan the priest of Baal before the altars. The priest appointed officers over Yahuah’s house. 
+<sup>19&#160;</sup>He took the captains over hundreds, and the Carites, and the guard, and all the people of the land; and they brought down the king from Yahuah’s house, and came by the way of the gate of the guard to the king’s house. He sat on the throne of the kings. 
 <sup>20&#160;</sup>So all the people of the land rejoiced, and the city was quiet. They had slain Athaliah with the sword at the king’s house. 
 </p><p>
 <sup>21&#160;</sup>Jehoash was seven years old when he began to reign. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
 <sup>1&#160;</sup>Jehoash began to reign in the seventh year of Jehu, and he reigned forty years in Jerusalem. His mother’s name was Zibiah of Beersheba. 
-<sup>2&#160;</sup>Jehoash did that which was right in Yahweh’s eyes all his days in which Jehoiada the priest instructed him. 
+<sup>2&#160;</sup>Jehoash did that which was right in Yahuah’s eyes all his days in which Jehoiada the priest instructed him. 
 <sup>3&#160;</sup>However, the high places were not taken away. The people still sacrificed and burned incense in the high places. 
 </p><p>
-<sup>4&#160;</sup>Jehoash said to the priests, “All the money of the set-apart things that is brought into Yahweh’s house, in current money, the money of the people for whom each man is evaluated, and all the money that it comes into any man’s heart to bring into Yahweh’s house, 
+<sup>4&#160;</sup>Jehoash said to the priests, “All the money of the set-apart things that is brought into Yahuah’s house, in current money, the money of the people for whom each man is evaluated, and all the money that it comes into any man’s heart to bring into Yahuah’s house, 
 <sup>5&#160;</sup>let the priests take it to them, each man from his donor; and they shall repair the damage to the house, wherever any damage is found.” 
 </p><p>
 <sup>6&#160;</sup>But it was so, that in the twenty-third year of King Jehoash the priests had not repaired the damage to the house. 
 <sup>7&#160;</sup>Then King Jehoash called for Jehoiada the priest, and for the other priests, and said to them, “Why aren’t you repairing the damage to the house? Now therefore take no more money from your treasurers, but deliver it for repair of the damage to the house.” 
 </p><p>
 <sup>8&#160;</sup>The priests consented that they should take no more money from the people, and not repair the damage to the house. 
-<sup>9&#160;</sup>But Jehoiada the priest took a chest and bored a hole in its lid, and set it beside the altar, on the right side as one comes into Yahweh’s house; and the priests who kept the threshold put all the money that was brought into Yahweh’s house into it. 
-<sup>10&#160;</sup>When they saw that there was much money in the chest, the king’s scribe and the high priest came up, and they put it in bags and counted the money that was found in Yahweh’s house. 
-<sup>11&#160;</sup>They gave the money that was weighed out into the hands of those who did the work, who had the oversight of Yahweh’s house; and they paid it out to the carpenters and the builders who worked on Yahweh’s house, 
-<sup>12&#160;</sup>and to the masons and the stone cutters, and for buying timber and cut stone to repair the damage to Yahweh’s house, and for all that was laid out for the house to repair it. 
-<sup>13&#160;</sup>But there were not made for Yahweh’s house cups of silver, snuffers, basins, trumpets, any vessels of gold or vessels of silver, of the money that was brought into Yahweh’s house; 
-<sup>14&#160;</sup>for they gave that to those who did the work, and repaired Yahweh’s house with it. 
+<sup>9&#160;</sup>But Jehoiada the priest took a chest and bored a hole in its lid, and set it beside the altar, on the right side as one comes into Yahuah’s house; and the priests who kept the threshold put all the money that was brought into Yahuah’s house into it. 
+<sup>10&#160;</sup>When they saw that there was much money in the chest, the king’s scribe and the high priest came up, and they put it in bags and counted the money that was found in Yahuah’s house. 
+<sup>11&#160;</sup>They gave the money that was weighed out into the hands of those who did the work, who had the oversight of Yahuah’s house; and they paid it out to the carpenters and the builders who worked on Yahuah’s house, 
+<sup>12&#160;</sup>and to the masons and the stone cutters, and for buying timber and cut stone to repair the damage to Yahuah’s house, and for all that was laid out for the house to repair it. 
+<sup>13&#160;</sup>But there were not made for Yahuah’s house cups of silver, snuffers, basins, trumpets, any vessels of gold or vessels of silver, of the money that was brought into Yahuah’s house; 
+<sup>14&#160;</sup>for they gave that to those who did the work, and repaired Yahuah’s house with it. 
 <sup>15&#160;</sup>Moreover they didn’t demand an accounting from the men into whose hand they delivered the money to give to those who did the work; for they dealt faithfully. 
-<sup>16&#160;</sup>The money for the trespass offerings and the money for the sin offerings was not brought into Yahweh’s house. It was the priests’. 
+<sup>16&#160;</sup>The money for the trespass offerings and the money for the sin offerings was not brought into Yahuah’s house. It was the priests’. 
 </p><p>
 <sup>17&#160;</sup>Then Hazael king of Syria went up and fought against Gath, and took it; and Hazael set his face to go up to Jerusalem. 
-<sup>18&#160;</sup>Jehoash king of Judah took all the set-apart things that Jehoshaphat and Jehoram and Ahaziah, his fathers, kings of Judah, had dedicated, and his own set-apart things, and all the gold that was found in the treasures of Yahweh’s house, and of the king’s house, and sent it to Hazael king of Syria; and he went away from Jerusalem. 
+<sup>18&#160;</sup>Jehoash king of Judah took all the set-apart things that Jehoshaphat and Jehoram and Ahaziah, his fathers, kings of Judah, had dedicated, and his own set-apart things, and all the gold that was found in the treasures of Yahuah’s house, and of the king’s house, and sent it to Hazael king of Syria; and he went away from Jerusalem. 
 </p><p>
 <sup>19&#160;</sup>Now the rest of the acts of Joash, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 <sup>20&#160;</sup>His servants arose and made a conspiracy, and struck Joash at the house of Millo, on the way that goes down to Silla. 
@@ -662,17 +662,17 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
 <sup>1&#160;</sup>In the twenty-third year of Joash the son of Ahaziah, king of Judah, Jehoahaz the son of Jehu began to reign over Israel in Samaria for seventeen years. 
-<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, and followed the sins of Jeroboam the son of Nebat, with which he made Israel to sin. He didn’t depart from it. 
-<sup>3&#160;</sup>Yahweh’s anger burned against Israel, and he delivered them into the hand of Hazael king of Syria, and into the hand of Benhadad the son of Hazael, continually. 
-<sup>4&#160;</sup>Jehoahaz begged Yahweh, and Yahweh listened to him; for he saw the oppression of Israel, how the king of Syria oppressed them. 
-<sup>5&#160;</sup>(Yahweh gave Israel a savior, so that they went out from under the hand of the Syrians; and the children of Israel lived in their tents as before. 
+<sup>2&#160;</sup>He did that which was evil in Yahuah’s sight, and followed the sins of Jeroboam the son of Nebat, with which he made Israel to sin. He didn’t depart from it. 
+<sup>3&#160;</sup>Yahuah’s anger burned against Israel, and he delivered them into the hand of Hazael king of Syria, and into the hand of Benhadad the son of Hazael, continually. 
+<sup>4&#160;</sup>Jehoahaz begged Yahuah, and Yahuah listened to him; for he saw the oppression of Israel, how the king of Syria oppressed them. 
+<sup>5&#160;</sup>(Yahuah gave Israel a savior, so that they went out from under the hand of the Syrians; and the children of Israel lived in their tents as before. 
 <sup>6&#160;</sup>Nevertheless they didn’t depart from the sins of the house of Jeroboam, with which he made Israel to sin, but walked in them; and the Asherah also remained in Samaria.) 
 <sup>7&#160;</sup>For he didn’t leave to Jehoahaz of the people any more than fifty horsemen, and ten chariots, and ten thousand footmen; for the king of Syria destroyed them and made them like the dust in threshing. 
 <sup>8&#160;</sup>Now the rest of the acts of Jehoahaz, and all that he did, and his might, aren’t they written in the book of the chronicles of the kings of Israel? 
 <sup>9&#160;</sup>Jehoahaz slept with his fathers; and they buried him in Samaria; and Joash his son reigned in his place. 
 </p><p>
 <sup>10&#160;</sup>In the thirty-seventh year of Joash king of Judah, Jehoash the son of Jehoahaz began to reign over Israel in Samaria for sixteen years. 
-<sup>11&#160;</sup>He did that which was evil in Yahweh’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin; but he walked in them. 
+<sup>11&#160;</sup>He did that which was evil in Yahuah’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin; but he walked in them. 
 <sup>12&#160;</sup>Now the rest of the acts of Joash, and all that he did, and his might with which he fought against Amaziah king of Judah, aren’t they written in the book of the chronicles of the kings of Israel? 
 <sup>13&#160;</sup>Joash slept with his fathers; and Jeroboam sat on his throne. Joash was buried in Samaria with the kings of Israel. 
 </p><p>
@@ -680,7 +680,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>15&#160;</sup>Elisha said to him, “Take bow and arrows;” and he took bow and arrows for himself. 
 <sup>16&#160;</sup>He said to the king of Israel, “Put your hand on the bow;” and he put his hand on it. Elisha laid his hands on the king’s hands. 
-<sup>17&#160;</sup>He said, “Open the window eastward;” and he opened it. Then Elisha said, “Shoot!” and he shot. He said, “Yahweh’s arrow of victory, even the arrow of victory over Syria; for you will strike the Syrians in Aphek until you have consumed them.” 
+<sup>17&#160;</sup>He said, “Open the window eastward;” and he opened it. Then Elisha said, “Shoot!” and he shot. He said, “Yahuah’s arrow of victory, even the arrow of victory over Syria; for you will strike the Syrians in Aphek until you have consumed them.” 
 </p><p>
 <sup>18&#160;</sup>He said, “Take the arrows;” and he took them. He said to the king of Israel, “Strike the ground;” and he struck three times, and stopped. 
 <sup>19&#160;</sup>The man of Elohim was angry with him, and said, “You should have struck five or six times. Then you would have struck Syria until you had consumed it, but now you will strike Syria just three times.” 
@@ -690,7 +690,7 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>As they were burying a man, behold, they saw a band of raiders; and they threw the man into Elisha’s tomb. As soon as the man touched Elisha’s bones, he revived, and stood up on his feet. 
 </p><p>
 <sup>22&#160;</sup>Hazael king of Syria oppressed Israel all the days of Jehoahaz. 
-<sup>23&#160;</sup>But Yahweh was gracious to them, and had compassion on them, and favored them because of his covenant with Abraham, Isaac, and Jacob, and would not destroy them and he didn’t cast them from his presence as yet. 
+<sup>23&#160;</sup>But Yahuah was gracious to them, and had compassion on them, and favored them because of his covenant with Abraham, Isaac, and Jacob, and would not destroy them and he didn’t cast them from his presence as yet. 
 </p><p>
 <sup>24&#160;</sup>Hazael king of Syria died; and Benhadad his son reigned in his place. 
 <sup>25&#160;</sup>Jehoash the son of Jehoahaz took again out of the hand of Benhadad the son of Hazael the cities which he had taken out of the hand of Jehoahaz his father by war. Joash struck him three times, and recovered the cities of Israel. 
@@ -698,10 +698,10 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>In the second year of Joash, son of Joahaz, king of Israel, Amaziah the son of Joash king of Judah began to reign. 
 <sup>2&#160;</sup>He was twenty-five years old when he began to reign; and he reigned twenty-nine years in Jerusalem. His mother’s name was Jehoaddin of Jerusalem. 
-<sup>3&#160;</sup>He did that which was right in Yahweh’s eyes, yet not like David his father. He did according to all that Joash his father had done. 
+<sup>3&#160;</sup>He did that which was right in Yahuah’s eyes, yet not like David his father. He did according to all that Joash his father had done. 
 <sup>4&#160;</sup>However the high places were not taken away. The people still sacrificed and burned incense in the high places. 
 <sup>5&#160;</sup>As soon as the kingdom was established in his hand, he killed his servants who had slain the king his father, 
-<sup>6&#160;</sup>but the children of the murderers he didn’t put to death, according to that which is written in the book of the law of Moses, as Yahweh commanded, saying, “The fathers shall not be put to death for the children, nor the children be put to death for the fathers; but every man shall die for his own sin.” 
+<sup>6&#160;</sup>but the children of the murderers he didn’t put to death, according to that which is written in the book of the law of Moses, as Yahuah commanded, saying, “The fathers shall not be put to death for the children, nor the children be put to death for the fathers; but every man shall die for his own sin.” 
 </p><p>
 <sup>7&#160;</sup>He killed ten thousand Edomites in the Valley of Salt, and took Sela by war, and called its name Joktheel, to this day. 
 <sup>8&#160;</sup>Then Amaziah sent messengers to Jehoash, the son of Jehoahaz son of Jehu, king of Israel, saying, “Come, let’s look one another in the face.” 
@@ -712,7 +712,7 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>But Amaziah would not listen. So Jehoash king of Israel went up; and he and Amaziah king of Judah looked one another in the face at Beth Shemesh, which belongs to Judah. 
 <sup>12&#160;</sup>Judah was defeated by Israel; and each man fled to his tent. 
 <sup>13&#160;</sup>Jehoash king of Israel took Amaziah king of Judah, the son of Jehoash the son of Ahaziah, at Beth Shemesh and came to Jerusalem, then broke down the wall of Jerusalem from the gate of Ephraim to the corner gate, four hundred cubits. 
-<sup>14&#160;</sup>He took all the gold and silver and all the vessels that were found in Yahweh’s house and in the treasures of the king’s house, the hostages also, and returned to Samaria. 
+<sup>14&#160;</sup>He took all the gold and silver and all the vessels that were found in Yahuah’s house and in the treasures of the king’s house, the hostages also, and returned to Samaria. 
 </p><p>
 <sup>15&#160;</sup>Now the rest of the acts of Jehoash which he did, and his might, and how he fought with Amaziah king of Judah, aren’t they written in the book of the chronicles of the kings of Israel? 
 <sup>16&#160;</sup>Jehoash slept with his fathers, and was buried in Samaria with the kings of Israel; and Jeroboam his son reigned in his place. 
@@ -726,27 +726,27 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>He built Elath and restored it to Judah. After that the king slept with his fathers. 
 </p><p>
 <sup>23&#160;</sup>In the fifteenth year of Amaziah the son of Joash king of Judah, Jeroboam the son of Joash king of Israel began to reign in Samaria for forty-one years. 
-<sup>24&#160;</sup>He did that which was evil in Yahweh’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
-<sup>25&#160;</sup>He restored the border of Israel from the entrance of Hamath to the sea of the Arabah, according to Yahweh, the Elohim of Israel’s word, which he spoke by his servant Jonah the son of Amittai, the prophet, who was from Gath Hepher. 
-<sup>26&#160;</sup>For Yahweh saw the affliction of Israel, that it was very bitter for all, slave and free; and there was no helper for Israel. 
-<sup>27&#160;</sup>Yahweh didn’t say that he would blot out the name of Israel from under the sky; but he saved them by the hand of Jeroboam the son of Joash. 
+<sup>24&#160;</sup>He did that which was evil in Yahuah’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+<sup>25&#160;</sup>He restored the border of Israel from the entrance of Hamath to the sea of the Arabah, according to Yahuah, the Elohim of Israel’s word, which he spoke by his servant Jonah the son of Amittai, the prophet, who was from Gath Hepher. 
+<sup>26&#160;</sup>For Yahuah saw the affliction of Israel, that it was very bitter for all, slave and free; and there was no helper for Israel. 
+<sup>27&#160;</sup>Yahuah didn’t say that he would blot out the name of Israel from under the sky; but he saved them by the hand of Jeroboam the son of Joash. 
 <sup>28&#160;</sup>Now the rest of the acts of Jeroboam, and all that he did, and his might, how he fought, and how he recovered Damascus, and Hamath, which had belonged to Judah, for Israel, aren’t they written in the book of the chronicles of the kings of Israel? 
 <sup>29&#160;</sup>Jeroboam slept with his fathers, even with the kings of Israel; and Zechariah his son reigned in his place. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
 <sup>1&#160;</sup>In the twenty-seventh year of Jeroboam king of Israel, Azariah son of Amaziah king of Judah began to reign. 
 <sup>2&#160;</sup>He was sixteen years old when he began to reign, and he reigned fifty-two years in Jerusalem. His mother’s name was Jecoliah of Jerusalem. 
-<sup>3&#160;</sup>He did that which was right in Yahweh’s eyes, according to all that his father Amaziah had done. 
+<sup>3&#160;</sup>He did that which was right in Yahuah’s eyes, according to all that his father Amaziah had done. 
 <sup>4&#160;</sup>However, the high places were not taken away. The people still sacrificed and burned incense in the high places. 
-<sup>5&#160;</sup>Yahweh struck the king, so that he was a leper to the day of his death, and lived in a separate house. Jotham, the king’s son, was over the household, judging the people of the land. 
+<sup>5&#160;</sup>Yahuah struck the king, so that he was a leper to the day of his death, and lived in a separate house. Jotham, the king’s son, was over the household, judging the people of the land. 
 <sup>6&#160;</sup>Now the rest of the acts of Azariah, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 <sup>7&#160;</sup>Azariah slept with his fathers; and they buried him with his fathers in David’s city; and Jotham his son reigned in his place. 
 </p><p>
 <sup>8&#160;</sup>In the thirty-eighth year of Azariah king of Judah, Zechariah the son of Jeroboam reigned over Israel in Samaria six months. 
-<sup>9&#160;</sup>He did that which was evil in Yahweh’s sight, as his fathers had done. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+<sup>9&#160;</sup>He did that which was evil in Yahuah’s sight, as his fathers had done. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
 <sup>10&#160;</sup>Shallum the son of Jabesh conspired against him, and struck him before the people and killed him, and reigned in his place. 
 <sup>11&#160;</sup>Now the rest of the acts of Zechariah, behold, they are written in the book of the chronicles of the kings of Israel. 
-<sup>12&#160;</sup>This was Yahweh’s word which he spoke to Jehu, saying, “Your sons to the fourth generation shall sit on the throne of Israel.” So it came to pass. 
+<sup>12&#160;</sup>This was Yahuah’s word which he spoke to Jehu, saying, “Your sons to the fourth generation shall sit on the throne of Israel.” So it came to pass. 
 </p><p>
 <sup>13&#160;</sup>Shallum the son of Jabesh began to reign in the thirty-ninth year of Uzziah king of Judah, and he reigned for a month in Samaria. 
 <sup>14&#160;</sup>Menahem the son of Gadi went up from Tirzah, came to Samaria, struck Shallum the son of Jabesh in Samaria, killed him, and reigned in his place. 
@@ -755,135 +755,135 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>Then Menahem attacked Tiphsah and all who were in it and its border areas, from Tirzah. He attacked it because they didn’t open their gates to him, and he ripped up all their women who were with child. 
 </p><p>
 <sup>17&#160;</sup>In the thirty ninth year of Azariah king of Judah, Menahem the son of Gadi began to reign over Israel for ten years in Samaria. 
-<sup>18&#160;</sup>He did that which was evil in Yahweh’s sight. He didn’t depart all his days from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+<sup>18&#160;</sup>He did that which was evil in Yahuah’s sight. He didn’t depart all his days from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
 <sup>19&#160;</sup>Pul the king of Assyria came against the land, and Menahem gave Pul one thousand talents of silver, that his hand might be with him to confirm the kingdom in his hand. 
 <sup>20&#160;</sup>Menahem exacted the money from Israel, even from all the mighty men of wealth, from each man fifty shekels of silver, to give to the king of Assyria. So the king of Assyria turned back, and didn’t stay there in the land. 
 <sup>21&#160;</sup>Now the rest of the acts of Menahem, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
 <sup>22&#160;</sup>Menahem slept with his fathers, and Pekahiah his son reigned in his place. 
 </p><p>
 <sup>23&#160;</sup>In the fiftieth year of Azariah king of Judah, Pekahiah the son of Menahem began to reign over Israel in Samaria for two years. 
-<sup>24&#160;</sup>He did that which was evil in Yahweh’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+<sup>24&#160;</sup>He did that which was evil in Yahuah’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
 <sup>25&#160;</sup>Pekah the son of Remaliah, his captain, conspired against him and attacked him in Samaria, in the fortress of the king’s house, with Argob and Arieh; and with him were fifty men of the Gileadites. He killed him, and reigned in his place. 
 <sup>26&#160;</sup>Now the rest of the acts of Pekahiah, and all that he did, behold, they are written in the book of the chronicles of the kings of Israel. 
 </p><p>
 <sup>27&#160;</sup>In the fifty-second year of Azariah king of Judah, Pekah the son of Remaliah began to reign over Israel in Samaria for twenty years. 
-<sup>28&#160;</sup>He did that which was evil in Yahweh’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+<sup>28&#160;</sup>He did that which was evil in Yahuah’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
 <sup>29&#160;</sup>In the days of Pekah king of Israel, Tiglath Pileser king of Assyria came and took Ijon, Abel Beth Maacah, Janoah, Kedesh, Hazor, Gilead, and Galilee, all the land of Naphtali; and he carried them captive to Assyria. 
 <sup>30&#160;</sup>Hoshea the son of Elah made a conspiracy against Pekah the son of Remaliah, attacked him, killed him, and reigned in his place, in the twentieth year of Jotham the son of Uzziah. 
 <sup>31&#160;</sup>Now the rest of the acts of Pekah, and all that he did, behold, they are written in the book of the chronicles of the kings of Israel. 
 </p><p>
 <sup>32&#160;</sup>In the second year of Pekah the son of Remaliah king of Israel, Jotham the son of Uzziah king of Judah began to reign. 
 <sup>33&#160;</sup>He was twenty-five years old when he began to reign, and he reigned sixteen years in Jerusalem. His mother’s name was Jerusha the daughter of Zadok. 
-<sup>34&#160;</sup>He did that which was right in Yahweh’s eyes. He did according to all that his father Uzziah had done. 
-<sup>35&#160;</sup>However the high places were not taken away. The people still sacrificed and burned incense in the high places. He built the upper gate of Yahweh’s house. 
+<sup>34&#160;</sup>He did that which was right in Yahuah’s eyes. He did according to all that his father Uzziah had done. 
+<sup>35&#160;</sup>However the high places were not taken away. The people still sacrificed and burned incense in the high places. He built the upper gate of Yahuah’s house. 
 <sup>36&#160;</sup>Now the rest of the acts of Jotham, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-<sup>37&#160;</sup>In those days, Yahweh began to send Rezin the king of Syria and Pekah the son of Remaliah against Judah. 
+<sup>37&#160;</sup>In those days, Yahuah began to send Rezin the king of Syria and Pekah the son of Remaliah against Judah. 
 <sup>38&#160;</sup>Jotham slept with his fathers, and was buried with his fathers in his father David’s city; and Ahaz his son reigned in his place. 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
 <sup>1&#160;</sup>In the seventeenth year of Pekah the son of Remaliah, Ahaz the son of Jotham king of Judah began to reign. 
-<sup>2&#160;</sup>Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahweh his Elohim’s eyes, like David his father. 
-<sup>3&#160;</sup>But he walked in the way of the kings of Israel, and even made his son to pass through the fire, according to the abominations of the nations whom Yahweh cast out from before the children of Israel. 
+<sup>2&#160;</sup>Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahuah his Elohim’s eyes, like David his father. 
+<sup>3&#160;</sup>But he walked in the way of the kings of Israel, and even made his son to pass through the fire, according to the abominations of the nations whom Yahuah cast out from before the children of Israel. 
 <sup>4&#160;</sup>He sacrificed and burned incense in the high places, on the hills, and under every green tree. 
 </p><p>
 <sup>5&#160;</sup>Then Rezin king of Syria and Pekah son of Remaliah king of Israel came up to Jerusalem to wage war. They besieged Ahaz, but could not overcome him. 
 <sup>6&#160;</sup>At that time Rezin king of Syria recovered Elath to Syria, and drove the Jews from Elath; and the Syrians came to Elath, and lived there to this day. 
 <sup>7&#160;</sup>So Ahaz sent messengers to Tiglath Pileser king of Assyria, saying, “I am your servant and your son. Come up and save me out of the hand of the king of Syria and out of the hand of the king of Israel, who rise up against me.” 
-<sup>8&#160;</sup>Ahaz took the silver and gold that was found in Yahweh’s house, and in the treasures of the king’s house, and sent it for a present to the king of Assyria. 
+<sup>8&#160;</sup>Ahaz took the silver and gold that was found in Yahuah’s house, and in the treasures of the king’s house, and sent it for a present to the king of Assyria. 
 <sup>9&#160;</sup>The king of Assyria listened to him; and the king of Assyria went up against Damascus and took it, and carried its people captive to Kir, and killed Rezin. 
 </p><p>
 <sup>10&#160;</sup>King Ahaz went to Damascus to meet Tiglath Pileser king of Assyria, and saw the altar that was at Damascus; and King Ahaz sent to Urijah the priest a drawing of the altar and plans to build it. 
 <sup>11&#160;</sup>Urijah the priest built an altar. According to all that King Ahaz had sent from Damascus, so Urijah the priest made it for the coming of King Ahaz from Damascus. 
 <sup>12&#160;</sup>When the king had come from Damascus, the king saw the altar; and the king came near to the altar, and offered on it. 
 <sup>13&#160;</sup>He burned his burnt offering and his meal offering, poured his drink offering, and sprinkled the blood of his peace offerings on the altar. 
-<sup>14&#160;</sup>The bronze altar, which was before Yahweh, he brought from the front of the house, from between his altar and Yahweh’s house, and put it on the north side of his altar. 
+<sup>14&#160;</sup>The bronze altar, which was before Yahuah, he brought from the front of the house, from between his altar and Yahuah’s house, and put it on the north side of his altar. 
 <sup>15&#160;</sup>King Ahaz commanded Urijah the priest, saying, “On the great altar burn the morning burnt offering, the evening meal offering, the king’s burnt offering and his meal offering, with the burnt offering of all the people of the land, their meal offering, and their drink offerings; and sprinkle on it all the blood of the burnt offering, and all the blood of the sacrifice; but the bronze altar will be for me to inquire by.” 
 <sup>16&#160;</sup>Urijah the priest did so, according to all that King Ahaz commanded. 
 </p><p>
 <sup>17&#160;</sup>King Ahaz cut off the panels of the bases, and removed the basin from off them, and took down the sea from off the bronze oxen that were under it, and put it on a pavement of stone. 
-<sup>18&#160;</sup>He removed the covered way for the Sabbath that they had built in the house, and the king’s outer entrance to Yahweh’s house, because of the king of Assyria. 
+<sup>18&#160;</sup>He removed the covered way for the Sabbath that they had built in the house, and the king’s outer entrance to Yahuah’s house, because of the king of Assyria. 
 <sup>19&#160;</sup>Now the rest of the acts of Ahaz which he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 <sup>20&#160;</sup>Ahaz slept with his fathers, and was buried with his fathers in David’s city; and Hezekiah his son reigned in his place. 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
 <sup>1&#160;</sup>In the twelfth year of Ahaz king of Judah, Hoshea the son of Elah began to reign in Samaria over Israel for nine years. 
-<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, yet not as the kings of Israel who were before him. 
+<sup>2&#160;</sup>He did that which was evil in Yahuah’s sight, yet not as the kings of Israel who were before him. 
 <sup>3&#160;</sup>Shalmaneser king of Assyria came up against him; and Hoshea became his servant, and brought him tribute. 
 <sup>4&#160;</sup>The king of Assyria discovered a conspiracy in Hoshea; for he had sent messengers to So king of Egypt, and offered no tribute to the king of Assyria, as he had done year by year. Therefore the king of Assyria seized him, and bound him in prison. 
 <sup>5&#160;</sup>Then the king of Assyria came up throughout all the land, went up to Samaria, and besieged it three years. 
 <sup>6&#160;</sup>In the ninth year of Hoshea the king of Assyria took Samaria and carried Israel away to Assyria, and placed them in Halah, and on the Habor, the river of Gozan, and in the cities of the Medes. 
 </p><p>
-<sup>7&#160;</sup>It was so because the children of Israel had sinned against Yahweh their Elohim, who brought them up out of the land of Egypt from under the hand of Pharaoh king of Egypt, and had feared other elohims, 
-<sup>8&#160;</sup>and walked in the statutes of the nations whom Yahweh cast out from before the children of Israel, and of the kings of Israel, which they made. 
-<sup>9&#160;</sup>The children of Israel secretly did things that were not right against Yahweh their Elohim; and they built high places for themselves in all their cities, from the tower of the watchmen to the fortified city; 
+<sup>7&#160;</sup>It was so because the children of Israel had sinned against Yahuah their Elohim, who brought them up out of the land of Egypt from under the hand of Pharaoh king of Egypt, and had feared other elohims, 
+<sup>8&#160;</sup>and walked in the statutes of the nations whom Yahuah cast out from before the children of Israel, and of the kings of Israel, which they made. 
+<sup>9&#160;</sup>The children of Israel secretly did things that were not right against Yahuah their Elohim; and they built high places for themselves in all their cities, from the tower of the watchmen to the fortified city; 
 <sup>10&#160;</sup>and they set up for themselves pillars and Asherah poles on every high hill and under every green tree; 
-<sup>11&#160;</sup>and there they burned incense in all the high places, as the nations whom Yahweh carried away before them did; and they did wicked things to provoke Yahweh to anger; 
-<sup>12&#160;</sup>and they served idols, of which Yahweh had said to them, “You shall not do this thing.” 
-<sup>13&#160;</sup>Yet Yahweh testified to Israel and to Judah, by every prophet and every seer, saying, “Turn from your evil ways, and keep my commandments and my statutes, according to all the law which I commanded your fathers, and which I sent to you by my servants the prophets.” 
-<sup>14&#160;</sup>Notwithstanding, they would not listen, but hardened their neck like the neck of their fathers who didn’t believe in Yahweh their Elohim. 
-<sup>15&#160;</sup>They rejected his statutes and his covenant that he made with their fathers, and his testimonies which he testified to them; and they followed vanity, and became vain, and followed the nations that were around them, concerning whom Yahweh had commanded them that they should not do like them. 
-<sup>16&#160;</sup>They abandoned all the commandments of Yahweh their Elohim, and made molten images for themselves, even two calves, and made an Asherah, and worshiped all the army of the sky, and served Baal. 
-<sup>17&#160;</sup>They caused their sons and their daughters to pass through the fire, used divination and enchantments, and sold themselves to do that which was evil in Yahweh’s sight, to provoke him to anger. 
-<sup>18&#160;</sup>Therefore Yahweh was very angry with Israel, and removed them out of his sight. There was none left but the tribe of Judah only. 
+<sup>11&#160;</sup>and there they burned incense in all the high places, as the nations whom Yahuah carried away before them did; and they did wicked things to provoke Yahuah to anger; 
+<sup>12&#160;</sup>and they served idols, of which Yahuah had said to them, “You shall not do this thing.” 
+<sup>13&#160;</sup>Yet Yahuah testified to Israel and to Judah, by every prophet and every seer, saying, “Turn from your evil ways, and keep my commandments and my statutes, according to all the law which I commanded your fathers, and which I sent to you by my servants the prophets.” 
+<sup>14&#160;</sup>Notwithstanding, they would not listen, but hardened their neck like the neck of their fathers who didn’t believe in Yahuah their Elohim. 
+<sup>15&#160;</sup>They rejected his statutes and his covenant that he made with their fathers, and his testimonies which he testified to them; and they followed vanity, and became vain, and followed the nations that were around them, concerning whom Yahuah had commanded them that they should not do like them. 
+<sup>16&#160;</sup>They abandoned all the commandments of Yahuah their Elohim, and made molten images for themselves, even two calves, and made an Asherah, and worshiped all the army of the sky, and served Baal. 
+<sup>17&#160;</sup>They caused their sons and their daughters to pass through the fire, used divination and enchantments, and sold themselves to do that which was evil in Yahuah’s sight, to provoke him to anger. 
+<sup>18&#160;</sup>Therefore Yahuah was very angry with Israel, and removed them out of his sight. There was none left but the tribe of Judah only. 
 </p><p>
-<sup>19&#160;</sup>Also Judah didn’t keep the commandments of Yahweh their Elohim, but walked in the statutes of Israel which they made. 
-<sup>20&#160;</sup>Yahweh rejected all the offspring of Israel, afflicted them, and delivered them into the hands of raiders, until he had cast them out of his sight. 
-<sup>21&#160;</sup>For he tore Israel from David’s house; and they made Jeroboam the son of Nebat king; and Jeroboam drove Israel from following Yahweh, and made them sin a great sin. 
+<sup>19&#160;</sup>Also Judah didn’t keep the commandments of Yahuah their Elohim, but walked in the statutes of Israel which they made. 
+<sup>20&#160;</sup>Yahuah rejected all the offspring of Israel, afflicted them, and delivered them into the hands of raiders, until he had cast them out of his sight. 
+<sup>21&#160;</sup>For he tore Israel from David’s house; and they made Jeroboam the son of Nebat king; and Jeroboam drove Israel from following Yahuah, and made them sin a great sin. 
 <sup>22&#160;</sup>The children of Israel walked in all the sins of Jeroboam which he did; they didn’t depart from them 
-<sup>23&#160;</sup>until Yahweh removed Israel out of his sight, as he said by all his servants the prophets. So Israel was carried away out of their own land to Assyria to this day. 
+<sup>23&#160;</sup>until Yahuah removed Israel out of his sight, as he said by all his servants the prophets. So Israel was carried away out of their own land to Assyria to this day. 
 </p><p>
 <sup>24&#160;</sup>The king of Assyria brought people from Babylon, from Cuthah, from Avva, and from Hamath and Sepharvaim, and placed them in the cities of Samaria instead of the children of Israel; and they possessed Samaria and lived in its cities. 
-<sup>25&#160;</sup>So it was, at the beginning of their dwelling there, that they didn’t fear Yahweh. Therefore Yahweh sent lions among them, which killed some of them. 
+<sup>25&#160;</sup>So it was, at the beginning of their dwelling there, that they didn’t fear Yahuah. Therefore Yahuah sent lions among them, which killed some of them. 
 <sup>26&#160;</sup>Therefore they spoke to the king of Assyria, saying, “The nations which you have carried away and placed in the cities of Samaria don’t know the law of the elohim of the land. Therefore he has sent lions among them; and behold, they kill them, because they don’t know the law of the elohim of the land.” 
 </p><p>
 <sup>27&#160;</sup>Then the king of Assyria commanded, saying, “Carry there one of the priests whom you brought from there; and let him go and dwell there, and let him teach them the law of the elohim of the land.” 
 </p><p>
-<sup>28&#160;</sup>So one of the priests whom they had carried away from Samaria came and lived in Bethel, and taught them how they should fear Yahweh. 
+<sup>28&#160;</sup>So one of the priests whom they had carried away from Samaria came and lived in Bethel, and taught them how they should fear Yahuah. 
 </p><p>
 <sup>29&#160;</sup>However every nation made elohims of their own, and put them in the houses of the high places which the Samaritans had made, every nation in their cities in which they lived. 
 <sup>30&#160;</sup>The men of Babylon made Succoth Benoth, and the men of Cuth made Nergal, and the men of Hamath made Ashima, 
 <sup>31&#160;</sup>and the Avvites made Nibhaz and Tartak; and the Sepharvites burned their children in the fire to Adrammelech and Anammelech, the elohims of Sepharvaim. 
-<sup>32&#160;</sup>So they feared Yahweh, and also made from among themselves priests of the high places for themselves, who sacrificed for them in the houses of the high places. 
-<sup>33&#160;</sup>They feared Yahweh, and also served their own elohims, after the ways of the nations from among whom they had been carried away. 
-<sup>34&#160;</sup>To this day they do what they did before. They don’t fear Yahweh, and they do not follow the statutes, or the ordinances, or the law, or the commandment which Yahweh commanded the children of Jacob, whom he named Israel; 
-<sup>35&#160;</sup>with whom Yahweh had made a covenant and commanded them, saying, “You shall not fear other elohims, nor bow yourselves to them, nor serve them, nor sacrifice to them; 
-<sup>36&#160;</sup>but you shall fear Yahweh, who brought you up out of the land of Egypt with great power and with an outstretched arm, and you shall bow yourselves to him, and you shall sacrifice to him. 
+<sup>32&#160;</sup>So they feared Yahuah, and also made from among themselves priests of the high places for themselves, who sacrificed for them in the houses of the high places. 
+<sup>33&#160;</sup>They feared Yahuah, and also served their own elohims, after the ways of the nations from among whom they had been carried away. 
+<sup>34&#160;</sup>To this day they do what they did before. They don’t fear Yahuah, and they do not follow the statutes, or the ordinances, or the law, or the commandment which Yahuah commanded the children of Jacob, whom he named Israel; 
+<sup>35&#160;</sup>with whom Yahuah had made a covenant and commanded them, saying, “You shall not fear other elohims, nor bow yourselves to them, nor serve them, nor sacrifice to them; 
+<sup>36&#160;</sup>but you shall fear Yahuah, who brought you up out of the land of Egypt with great power and with an outstretched arm, and you shall bow yourselves to him, and you shall sacrifice to him. 
 <sup>37&#160;</sup>The statutes and the ordinances, and the law and the commandment which he wrote for you, you shall observe to do forever more. You shall not fear other elohims. 
 <sup>38&#160;</sup>You shall not forget the covenant that I have made with you. You shall not fear other elohims. 
-<sup>39&#160;</sup>But you shall fear Yahweh your Elohim, and he will deliver you out of the hand of all your enemies.” 
+<sup>39&#160;</sup>But you shall fear Yahuah your Elohim, and he will deliver you out of the hand of all your enemies.” 
 </p><p>
 <sup>40&#160;</sup>However they didn’t listen, but they did what they did before. 
-<sup>41&#160;</sup>So these nations feared Yahweh, and also served their engraved images. Their children did likewise, and so did their children’s children. They do as their fathers did to this day. 
+<sup>41&#160;</sup>So these nations feared Yahuah, and also served their engraved images. Their children did likewise, and so did their children’s children. They do as their fathers did to this day. 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
 <sup>1&#160;</sup>Now in the third year of Hoshea son of Elah king of Israel, Hezekiah the son of Ahaz king of Judah began to reign. 
 <sup>2&#160;</sup>He was twenty-five years old when he began to reign, and he reigned twenty-nine years in Jerusalem. His mother’s name was Abi the daughter of Zechariah. 
-<sup>3&#160;</sup>He did that which was right in Yahweh’s eyes, according to all that David his father had done. 
+<sup>3&#160;</sup>He did that which was right in Yahuah’s eyes, according to all that David his father had done. 
 <sup>4&#160;</sup>He removed the high places, broke the pillars, and cut down the Asherah. He also broke in pieces the bronze serpent that Moses had made, because in those days the children of Israel burned incense to it; and he called it Nehushtan. 
-<sup>5&#160;</sup>He trusted in Yahweh, the Elohim of Israel, so that after him was no one like him among all the kings of Judah, nor among them that were before him. 
-<sup>6&#160;</sup>For he joined with Yahweh. He didn’t depart from following him, but kept his commandments, which Yahweh commanded Moses. 
-<sup>7&#160;</sup>Yahweh was with him. Wherever he went, he prospered. He rebelled against the king of Assyria, and didn’t serve him. 
+<sup>5&#160;</sup>He trusted in Yahuah, the Elohim of Israel, so that after him was no one like him among all the kings of Judah, nor among them that were before him. 
+<sup>6&#160;</sup>For he joined with Yahuah. He didn’t depart from following him, but kept his commandments, which Yahuah commanded Moses. 
+<sup>7&#160;</sup>Yahuah was with him. Wherever he went, he prospered. He rebelled against the king of Assyria, and didn’t serve him. 
 <sup>8&#160;</sup>He struck the Philistines to Gaza and its borders, from the tower of the watchmen to the fortified city. 
 </p><p>
 <sup>9&#160;</sup>In the fourth year of King Hezekiah, which was the seventh year of Hoshea son of Elah king of Israel, Shalmaneser king of Assyria came up against Samaria and besieged it. 
 <sup>10&#160;</sup>At the end of three years they took it. In the sixth year of Hezekiah, which was the ninth year of Hoshea king of Israel, Samaria was taken. 
 <sup>11&#160;</sup>The king of Assyria carried Israel away to Assyria, and put them in Halah, and on the Habor, the river of Gozan, and in the cities of the Medes, 
-<sup>12&#160;</sup>because they didn’t obey Yahweh their Elohim’s voice, but transgressed his covenant, even all that Moses the servant of Yahweh commanded, and would not hear it or do it. 
+<sup>12&#160;</sup>because they didn’t obey Yahuah their Elohim’s voice, but transgressed his covenant, even all that Moses the servant of Yahuah commanded, and would not hear it or do it. 
 </p><p>
 <sup>13&#160;</sup>Now in the fourteenth year of King Hezekiah, Sennacherib king of Assyria came up against all the fortified cities of Judah and took them. 
 <sup>14&#160;</sup>Hezekiah king of Judah sent to the king of Assyria at Lachish, saying, “I have offended you. Withdraw from me. That which you put on me, I will bear.” The king of Assyria appointed to Hezekiah king of Judah three hundred talents of silver and thirty talents of gold. 
-<sup>15&#160;</sup>Hezekiah gave him all the silver that was found in Yahweh’s house and in the treasures of the king’s house. 
-<sup>16&#160;</sup>At that time, Hezekiah cut off the gold from the doors of Yahweh’s temple, and from the pillars which Hezekiah king of Judah had overlaid, and gave it to the king of Assyria. 
+<sup>15&#160;</sup>Hezekiah gave him all the silver that was found in Yahuah’s house and in the treasures of the king’s house. 
+<sup>16&#160;</sup>At that time, Hezekiah cut off the gold from the doors of Yahuah’s temple, and from the pillars which Hezekiah king of Judah had overlaid, and gave it to the king of Assyria. 
 </p><p>
 <sup>17&#160;</sup>The king of Assyria sent Tartan, Rabsaris, and Rabshakeh from Lachish to King Hezekiah with a great army to Jerusalem. They went up and came to Jerusalem. When they had come up, they came and stood by the conduit of the upper pool, which is in the highway of the fuller’s field. 
 <sup>18&#160;</sup>When they had called to the king, Eliakim the son of Hilkiah, who was over the household, and Shebnah the scribe, and Joah the son of Asaph the recorder came out to them. 
 <sup>19&#160;</sup>Rabshakeh said to them, “Say now to Hezekiah, ‘The great king, the king of Assyria, says, “What confidence is this in which you trust? 
 <sup>20&#160;</sup>You say (but they are but vain words), ‘There is counsel and strength for war.’ Now on whom do you trust, that you have rebelled against me? 
 <sup>21&#160;</sup>Now, behold, you trust in the staff of this bruised reed, even in Egypt. If a man leans on it, it will go into his hand and pierce it. So is Pharaoh king of Egypt to all who trust on him. 
-<sup>22&#160;</sup>But if you tell me, ‘We trust in Yahweh our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar in Jerusalem’? 
+<sup>22&#160;</sup>But if you tell me, ‘We trust in Yahuah our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar in Jerusalem’? 
 <sup>23&#160;</sup>Now therefore, please give pledges to my master the king of Assyria, and I will give you two thousand horses if you are able on your part to set riders on them. 
 <sup>24&#160;</sup>How then can you turn away the face of one captain of the least of my master’s servants, and put your trust on Egypt for chariots and for horsemen? 
-<sup>25&#160;</sup>Have I now come up without Yahweh against this place to destroy it? Yahweh said to me, ‘Go up against this land, and destroy it.’&#160;”&#160;’&#160;” 
+<sup>25&#160;</sup>Have I now come up without Yahuah against this place to destroy it? Yahuah said to me, ‘Go up against this land, and destroy it.’&#160;”&#160;’&#160;” 
 </p><p>
 <sup>26&#160;</sup>Then Eliakim the son of Hilkiah, Shebnah, and Joah, said to Rabshakeh, “Please speak to your servants in the Syrian language, for we understand it. Don’t speak with us in the Jews’ language, in the hearing of the people who are on the wall.” 
 </p><p>
@@ -891,24 +891,24 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>28&#160;</sup>Then Rabshakeh stood and cried with a loud voice in the Jews’ language, and spoke, saying, “Hear the word of the great king, the king of Assyria. 
 <sup>29&#160;</sup>The king says, ‘Don’t let Hezekiah deceive you, for he will not be able to deliver you out of his hand. 
-<sup>30&#160;</sup>Don’t let Hezekiah make you trust in Yahweh, saying, “Yahweh will surely deliver us, and this city shall not be given into the hand of the king of Assyria.” 
+<sup>30&#160;</sup>Don’t let Hezekiah make you trust in Yahuah, saying, “Yahuah will surely deliver us, and this city shall not be given into the hand of the king of Assyria.” 
 <sup>31&#160;</sup>Don’t listen to Hezekiah.’ For the king of Assyria says, ‘Make your peace with me, and come out to me; and everyone of you eat from his own vine, and everyone from his own fig tree, and everyone drink water from his own cistern; 
-<sup>32&#160;</sup>until I come and take you away to a land like your own land, a land of grain and new wine, a land of bread and vineyards, a land of olive trees and of honey, that you may live and not die. Don’t listen to Hezekiah when he persuades you, saying, “Yahweh will deliver us.” 
+<sup>32&#160;</sup>until I come and take you away to a land like your own land, a land of grain and new wine, a land of bread and vineyards, a land of olive trees and of honey, that you may live and not die. Don’t listen to Hezekiah when he persuades you, saying, “Yahuah will deliver us.” 
 <sup>33&#160;</sup>Has any of the elohims of the nations ever delivered his land out of the hand of the king of Assyria? 
 <sup>34&#160;</sup>Where are the elohims of Hamath and of Arpad? Where are the elohims of Sepharvaim, of Hena, and Ivvah? Have they delivered Samaria out of my hand? 
-<sup>35&#160;</sup>Who are they among all the elohims of the countries, that have delivered their country out of my hand, that Yahweh should deliver Jerusalem out of my hand?’&#160;” 
+<sup>35&#160;</sup>Who are they among all the elohims of the countries, that have delivered their country out of my hand, that Yahuah should deliver Jerusalem out of my hand?’&#160;” 
 </p><p>
 <sup>36&#160;</sup>But the people stayed quiet, and answered him not a word; for the king’s commandment was, “Don’t answer him.” 
 <sup>37&#160;</sup>Then Eliakim the son of Hilkiah, who was over the household, came with Shebna the scribe and Joah the son of Asaph the recorder to Hezekiah with their clothes torn, and told him Rabshakeh’s words. 
 </p><h2 class="chapterlabel" id="19">19</h2>
 <p>
-<sup>1&#160;</sup>When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahweh’s house. 
+<sup>1&#160;</sup>When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahuah’s house. 
 <sup>2&#160;</sup>He sent Eliakim, who was over the household, Shebna the scribe, and the elders of the priests, covered with sackcloth, to Isaiah the prophet the son of Amoz. 
 <sup>3&#160;</sup>They said to him, “Hezekiah says, ‘Today is a day of trouble, of rebuke, and of rejection; for the children have come to the point of birth, and there is no strength to deliver them. 
-<sup>4&#160;</sup>It may be Yahweh your Elohim will hear all the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahweh your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’&#160;” 
+<sup>4&#160;</sup>It may be Yahuah your Elohim will hear all the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahuah your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’&#160;” 
 </p><p>
 <sup>5&#160;</sup>So the servants of King Hezekiah came to Isaiah. 
-<sup>6&#160;</sup>Isaiah said to them, “Tell your master this: ‘Yahweh says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
+<sup>6&#160;</sup>Isaiah said to them, “Tell your master this: ‘Yahuah says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
 <sup>7&#160;</sup>Behold, I will put a spirit in him, and he will hear news, and will return to his own land. I will cause him to fall by the sword in his own land.”&#160;’&#160;” 
 </p><p>
 <sup>8&#160;</sup>So Rabshakeh returned and found the king of Assyria warring against Libnah; for he had heard that he had departed from Lachish. 
@@ -918,15 +918,15 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Have the elohims of the nations delivered them, which my fathers have destroyed—Gozan, Haran, Rezeph, and the children of Eden who were in Telassar? 
 <sup>13&#160;</sup>Where is the king of Hamath, the king of Arpad, and the king of the city of Sepharvaim, of Hena, and Ivvah?’&#160;” 
 </p><p>
-<sup>14&#160;</sup>Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahweh’s house, and spread it before Yahweh. 
-<sup>15&#160;</sup>Hezekiah prayed before Yahweh, and said, “Yahweh, the Elohim of Israel, who are enthroned above the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
-<sup>16&#160;</sup>Incline your ear, Yahweh, and hear. Open your eyes, Yahweh, and see. Hear the words of Sennacherib, which he has sent to defy the living Elohim. 
-<sup>17&#160;</sup>Truly, Yahweh, the kings of Assyria have laid waste the nations and their lands, 
+<sup>14&#160;</sup>Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahuah’s house, and spread it before Yahuah. 
+<sup>15&#160;</sup>Hezekiah prayed before Yahuah, and said, “Yahuah, the Elohim of Israel, who are enthroned above the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
+<sup>16&#160;</sup>Incline your ear, Yahuah, and hear. Open your eyes, Yahuah, and see. Hear the words of Sennacherib, which he has sent to defy the living Elohim. 
+<sup>17&#160;</sup>Truly, Yahuah, the kings of Assyria have laid waste the nations and their lands, 
 <sup>18&#160;</sup>and have cast their elohims into the fire; for they were no elohims, but the work of men’s hands, wood and stone. Therefore they have destroyed them. 
-<sup>19&#160;</sup>Now therefore, Yahweh our Elohim, save us, I beg you, out of his hand, that all the kingdoms of the earth may know that you, Yahweh, are Elohim alone.” 
+<sup>19&#160;</sup>Now therefore, Yahuah our Elohim, save us, I beg you, out of his hand, that all the kingdoms of the earth may know that you, Yahuah, are Elohim alone.” 
 </p><p>
-<sup>20&#160;</sup>Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahweh, the Elohim of Israel, says ‘You have prayed to me against Sennacherib king of Assyria, and I have heard you. 
-<sup>21&#160;</sup>This is the word that Yahweh has spoken concerning him: ‘The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
+<sup>20&#160;</sup>Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahuah, the Elohim of Israel, says ‘You have prayed to me against Sennacherib king of Assyria, and I have heard you. 
+<sup>21&#160;</sup>This is the word that Yahuah has spoken concerning him: ‘The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
 <sup>22&#160;</sup>Whom have you defied and blasphemed? Against whom have you exalted your voice and lifted up your eyes on high? Against the Set-Apart One of Israel! 
 <sup>23&#160;</sup>By your messengers, you have defied the Lord, and have said, “With the multitude of my chariots, I have come up to the height of the mountains, to the innermost parts of Lebanon, and I will cut down its tall cedars and its choice cypress trees; and I will enter into his farthest lodging place, the forest of his fruitful field. 
 <sup>24&#160;</sup>I have dug and drunk strange waters, and I will dry up all the rivers of Egypt with the sole of my feet.” 
@@ -937,36 +937,36 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>29&#160;</sup>“This will be the sign to you: This year, you will eat that which grows of itself, and in the second year that which springs from that; and in the third year sow and reap, and plant vineyards and eat their fruit. 
 <sup>30&#160;</sup>The remnant that has escaped of the house of Judah will again take root downward, and bear fruit upward. 
-<sup>31&#160;</sup>For out of Jerusalem a remnant will go out, and out of Mount Zion those who shall escape. Yahweh’s zeal will perform this. 
+<sup>31&#160;</sup>For out of Jerusalem a remnant will go out, and out of Mount Zion those who shall escape. Yahuah’s zeal will perform this. 
 </p><p>
-<sup>32&#160;</sup>“Therefore Yahweh says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there. He will not come before it with shield, nor cast up a mound against it. 
-<sup>33&#160;</sup>He will return the same way that he came, and he will not come to this city,’ says Yahweh. 
+<sup>32&#160;</sup>“Therefore Yahuah says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there. He will not come before it with shield, nor cast up a mound against it. 
+<sup>33&#160;</sup>He will return the same way that he came, and he will not come to this city,’ says Yahuah. 
 <sup>34&#160;</sup>‘For I will defend this city to save it, for my own sake and for my servant David’s sake.’&#160;” 
 </p><p>
-<sup>35&#160;</sup>That night, Yahweh’s angel went out and struck one hundred eighty-five thousand in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
+<sup>35&#160;</sup>That night, Yahuah’s angel went out and struck one hundred eighty-five thousand in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
 <sup>36&#160;</sup>So Sennacherib king of Assyria departed, went home, and lived at Nineveh. 
 <sup>37&#160;</sup>As he was worshiping in the house of Nisroch his elohim, Adrammelech and Sharezer struck him with the sword; and they escaped into the land of Ararat. Esar Haddon his son reigned in his place. 
 </p><h2 class="chapterlabel" id="20">20</h2>
 <p>
-<sup>1&#160;</sup>In those days Hezekiah was sick and dying. Isaiah the prophet the son of Amoz came to him, and said to him, “Yahweh says, ‘Set your house in order; for you will die, and not live.’&#160;” 
+<sup>1&#160;</sup>In those days Hezekiah was sick and dying. Isaiah the prophet the son of Amoz came to him, and said to him, “Yahuah says, ‘Set your house in order; for you will die, and not live.’&#160;” 
 </p><p>
-<sup>2&#160;</sup>Then he turned his face to the wall, and prayed to Yahweh, saying, 
-<sup>3&#160;</sup>“Remember now, Yahweh, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” And Hezekiah wept bitterly. 
+<sup>2&#160;</sup>Then he turned his face to the wall, and prayed to Yahuah, saying, 
+<sup>3&#160;</sup>“Remember now, Yahuah, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” And Hezekiah wept bitterly. 
 </p><p>
-<sup>4&#160;</sup>Before Isaiah had gone out into the middle part of the city, Yahweh’s word came to him, saying, 
-<sup>5&#160;</sup>“Turn back, and tell Hezekiah the prince of my people, ‘Yahweh, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will heal you. On the third day, you will go up to Yahweh’s house. 
+<sup>4&#160;</sup>Before Isaiah had gone out into the middle part of the city, Yahuah’s word came to him, saying, 
+<sup>5&#160;</sup>“Turn back, and tell Hezekiah the prince of my people, ‘Yahuah, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will heal you. On the third day, you will go up to Yahuah’s house. 
 <sup>6&#160;</sup>I will add to your days fifteen years. I will deliver you and this city out of the hand of the king of Assyria. I will defend this city for my own sake, and for my servant David’s sake.”&#160;’&#160;” 
 </p><p>
 <sup>7&#160;</sup>Isaiah said, “Take a cake of figs.” 
 </p><p>They took and laid it on the boil, and he recovered. 
 </p><p>
-<sup>8&#160;</sup>Hezekiah said to Isaiah, “What will be the sign that Yahweh will heal me, and that I will go up to Yahweh’s house the third day?” 
+<sup>8&#160;</sup>Hezekiah said to Isaiah, “What will be the sign that Yahuah will heal me, and that I will go up to Yahuah’s house the third day?” 
 </p><p>
-<sup>9&#160;</sup>Isaiah said, “This will be the sign to you from Yahweh, that Yahweh will do the thing that he has spoken: should the shadow go forward ten steps, or go back ten steps?” 
+<sup>9&#160;</sup>Isaiah said, “This will be the sign to you from Yahuah, that Yahuah will do the thing that he has spoken: should the shadow go forward ten steps, or go back ten steps?” 
 </p><p>
 <sup>10&#160;</sup>Hezekiah answered, “It is a light thing for the shadow to go forward ten steps. No, but let the shadow return backward ten steps.” 
 </p><p>
-<sup>11&#160;</sup>Isaiah the prophet cried to Yahweh; and he brought the shadow ten steps backward, by which it had gone down on the sundial of Ahaz. 
+<sup>11&#160;</sup>Isaiah the prophet cried to Yahuah; and he brought the shadow ten steps backward, by which it had gone down on the sundial of Ahaz. 
 </p><p>
 <sup>12&#160;</sup>At that time Berodach Baladan the son of Baladan, king of Babylon, sent letters and a present to Hezekiah, for he had heard that Hezekiah had been sick. 
 <sup>13&#160;</sup>Hezekiah listened to them, and showed them all the storehouse of his precious things—the silver, the gold, the spices, and the precious oil, and the house of his armor, and all that was found in his treasures. There was nothing in his house, or in all his dominion, that Hezekiah didn’t show them. 
@@ -977,42 +977,42 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>He said, “What have they seen in your house?” 
 </p><p>Hezekiah answered, “They have seen all that is in my house. There is nothing among my treasures that I have not shown them.” 
 </p><p>
-<sup>16&#160;</sup>Isaiah said to Hezekiah, “Hear Yahweh’s word. 
-<sup>17&#160;</sup>‘Behold, the days come that all that is in your house, and that which your fathers have laid up in store to this day, will be carried to Babylon. Nothing will be left,’ says Yahweh. 
+<sup>16&#160;</sup>Isaiah said to Hezekiah, “Hear Yahuah’s word. 
+<sup>17&#160;</sup>‘Behold, the days come that all that is in your house, and that which your fathers have laid up in store to this day, will be carried to Babylon. Nothing will be left,’ says Yahuah. 
 <sup>18&#160;</sup>‘They will take away some of your sons who will issue from you, whom you will father; and they will be eunuchs in the palace of the king of Babylon.’&#160;” 
 </p><p>
-<sup>19&#160;</sup>Then Hezekiah said to Isaiah, “Yahweh’s word which you have spoken is good.” He said moreover, “Isn’t it so, if peace and truth will be in my days?” 
+<sup>19&#160;</sup>Then Hezekiah said to Isaiah, “Yahuah’s word which you have spoken is good.” He said moreover, “Isn’t it so, if peace and truth will be in my days?” 
 </p><p>
 <sup>20&#160;</sup>Now the rest of the acts of Hezekiah, and all his might, and how he made the pool, and the conduit, and brought water into the city, aren’t they written in the book of the chronicles of the kings of Judah? 
 <sup>21&#160;</sup>Hezekiah slept with his fathers, and Manasseh his son reigned in his place. 
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
 <sup>1&#160;</sup>Manasseh was twelve years old when he began to reign, and he reigned fifty-five years in Jerusalem. His mother’s name was Hephzibah. 
-<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, after the abominations of the nations whom Yahweh cast out before the children of Israel. 
+<sup>2&#160;</sup>He did that which was evil in Yahuah’s sight, after the abominations of the nations whom Yahuah cast out before the children of Israel. 
 <sup>3&#160;</sup>For he built again the high places which Hezekiah his father had destroyed; and he raised up altars for Baal, and made an Asherah, as Ahab king of Israel did, and worshiped all the army of the sky, and served them. 
-<sup>4&#160;</sup>He built altars in Yahweh’s house, of which Yahweh said, “I will put my name in Jerusalem.” 
-<sup>5&#160;</sup>He built altars for all the army of the sky in the two courts of Yahweh’s house. 
-<sup>6&#160;</sup>He made his son to pass through the fire, practiced sorcery, used enchantments, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahweh’s sight, to provoke him to anger. 
-<sup>7&#160;</sup>He set the engraved image of Asherah that he had made in the house of which Yahweh said to David and to Solomon his son, “In this house, and in Jerusalem, which I have chosen out of all the tribes of Israel, I will put my name forever; 
+<sup>4&#160;</sup>He built altars in Yahuah’s house, of which Yahuah said, “I will put my name in Jerusalem.” 
+<sup>5&#160;</sup>He built altars for all the army of the sky in the two courts of Yahuah’s house. 
+<sup>6&#160;</sup>He made his son to pass through the fire, practiced sorcery, used enchantments, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahuah’s sight, to provoke him to anger. 
+<sup>7&#160;</sup>He set the engraved image of Asherah that he had made in the house of which Yahuah said to David and to Solomon his son, “In this house, and in Jerusalem, which I have chosen out of all the tribes of Israel, I will put my name forever; 
 <sup>8&#160;</sup>I will not cause the feet of Israel to wander any more out of the land which I gave their fathers, if only they will observe to do according to all that I have commanded them, and according to all the law that my servant Moses commanded them.” 
-<sup>9&#160;</sup>But they didn’t listen, and Manasseh seduced them to do that which is evil more than the nations did whom Yahweh destroyed before the children of Israel. 
+<sup>9&#160;</sup>But they didn’t listen, and Manasseh seduced them to do that which is evil more than the nations did whom Yahuah destroyed before the children of Israel. 
 </p><p>
-<sup>10&#160;</sup>Yahweh spoke by his servants the prophets, saying, 
+<sup>10&#160;</sup>Yahuah spoke by his servants the prophets, saying, 
 <sup>11&#160;</sup>“Because Manasseh king of Judah has done these abominations, and has done wickedly above all that the Amorites did, who were before him, and has also made Judah to sin with his idols; 
-<sup>12&#160;</sup>therefore Yahweh the Elohim of Israel says, ‘Behold, I will bring such evil on Jerusalem and Judah that whoever hears of it, both his ears will tingle. 
+<sup>12&#160;</sup>therefore Yahuah the Elohim of Israel says, ‘Behold, I will bring such evil on Jerusalem and Judah that whoever hears of it, both his ears will tingle. 
 <sup>13&#160;</sup>I will stretch over Jerusalem the line of Samaria, and the plumb line of Ahab’s house; and I will wipe Jerusalem as a man wipes a dish, wiping it and turning it upside down. 
 <sup>14&#160;</sup>I will cast off the remnant of my inheritance and deliver them into the hands of their enemies. They will become a prey and a plunder to all their enemies, 
 <sup>15&#160;</sup>because they have done that which is evil in my sight, and have provoked me to anger since the day their fathers came out of Egypt, even to this day.’&#160;” 
 </p><p>
-<sup>16&#160;</sup>Moreover Manasseh shed innocent blood very much, until he had filled Jerusalem from one end to another; in addition to his sin with which he made Judah to sin, in doing that which was evil in Yahweh’s sight. 
+<sup>16&#160;</sup>Moreover Manasseh shed innocent blood very much, until he had filled Jerusalem from one end to another; in addition to his sin with which he made Judah to sin, in doing that which was evil in Yahuah’s sight. 
 </p><p>
 <sup>17&#160;</sup>Now the rest of the acts of Manasseh, and all that he did, and his sin that he sinned, aren’t they written in the book of the chronicles of the kings of Judah? 
 <sup>18&#160;</sup>Manasseh slept with his fathers, and was buried in the garden of his own house, in the garden of Uzza; and Amon his son reigned in his place. 
 </p><p>
 <sup>19&#160;</sup>Amon was twenty-two years old when he began to reign; and he reigned two years in Jerusalem. His mother’s name was Meshullemeth the daughter of Haruz of Jotbah. 
-<sup>20&#160;</sup>He did that which was evil in Yahweh’s sight, as Manasseh his father did. 
+<sup>20&#160;</sup>He did that which was evil in Yahuah’s sight, as Manasseh his father did. 
 <sup>21&#160;</sup>He walked in all the ways that his father walked in, and served the idols that his father served, and worshiped them; 
-<sup>22&#160;</sup>and he abandoned Yahweh, the Elohim of his fathers, and didn’t walk in the way of Yahweh. 
+<sup>22&#160;</sup>and he abandoned Yahuah, the Elohim of his fathers, and didn’t walk in the way of Yahuah. 
 <sup>23&#160;</sup>The servants of Amon conspired against him, and put the king to death in his own house. 
 <sup>24&#160;</sup>But the people of the land killed all those who had conspired against King Amon; and the people of the land made Josiah his son king in his place. 
 <sup>25&#160;</sup>Now the rest of the acts of Amon which he did, aren’t they written in the book of the chronicles of the kings of Judah? 
@@ -1020,101 +1020,101 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
 <sup>1&#160;</sup>Josiah was eight years old when he began to reign, and he reigned thirty-one years in Jerusalem. His mother’s name was Jedidah the daughter of Adaiah of Bozkath. 
-<sup>2&#160;</sup>He did that which was right in Yahweh’s eyes, and walked in all the ways of David his father, and didn’t turn away to the right hand or to the left. 
+<sup>2&#160;</sup>He did that which was right in Yahuah’s eyes, and walked in all the ways of David his father, and didn’t turn away to the right hand or to the left. 
 </p><p>
-<sup>3&#160;</sup>In the eighteenth year of King Josiah, the king sent Shaphan, the son of Azaliah the son of Meshullam, the scribe, to Yahweh’s house, saying, 
-<sup>4&#160;</sup>“Go up to Hilkiah the high priest, that he may count the money which is brought into Yahweh’s house, which the keepers of the threshold have gathered of the people. 
-<sup>5&#160;</sup>Let them deliver it into the hand of the workers who have the oversight of Yahweh’s house; and let them give it to the workers who are in Yahweh’s house, to repair the damage to the house, 
+<sup>3&#160;</sup>In the eighteenth year of King Josiah, the king sent Shaphan, the son of Azaliah the son of Meshullam, the scribe, to Yahuah’s house, saying, 
+<sup>4&#160;</sup>“Go up to Hilkiah the high priest, that he may count the money which is brought into Yahuah’s house, which the keepers of the threshold have gathered of the people. 
+<sup>5&#160;</sup>Let them deliver it into the hand of the workers who have the oversight of Yahuah’s house; and let them give it to the workers who are in Yahuah’s house, to repair the damage to the house, 
 <sup>6&#160;</sup>to the carpenters, and to the builders, and to the masons, and for buying timber and cut stone to repair the house. 
 <sup>7&#160;</sup>However, no accounting shall be asked of them for the money delivered into their hand, for they deal faithfully.” 
 </p><p>
-<sup>8&#160;</sup>Hilkiah the high priest said to Shaphan the scribe, “I have found the book of the law in Yahweh’s house.” Hilkiah delivered the book to Shaphan, and he read it. 
-<sup>9&#160;</sup>Shaphan the scribe came to the king, and brought the king word again, and said, “Your servants have emptied out the money that was found in the house, and have delivered it into the hands of the workmen who have the oversight of Yahweh’s house.” 
+<sup>8&#160;</sup>Hilkiah the high priest said to Shaphan the scribe, “I have found the book of the law in Yahuah’s house.” Hilkiah delivered the book to Shaphan, and he read it. 
+<sup>9&#160;</sup>Shaphan the scribe came to the king, and brought the king word again, and said, “Your servants have emptied out the money that was found in the house, and have delivered it into the hands of the workmen who have the oversight of Yahuah’s house.” 
 <sup>10&#160;</sup>Shaphan the scribe told the king, saying, “Hilkiah the priest has delivered a book to me.” Then Shaphan read it before the king. 
 </p><p>
 <sup>11&#160;</sup>When the king had heard the words of the book of the law, he tore his clothes. 
 <sup>12&#160;</sup>The king commanded Hilkiah the priest, Ahikam the son of Shaphan, Achbor the son of Micaiah, Shaphan the scribe, and Asaiah the king’s servant, saying, 
-<sup>13&#160;</sup>“Go inquire of Yahweh for me, and for the people, and for all Judah, concerning the words of this book that is found; for great is Yahweh’s wrath that is kindled against us, because our fathers have not listened to the words of this book, to do according to all that which is written concerning us.” 
+<sup>13&#160;</sup>“Go inquire of Yahuah for me, and for the people, and for all Judah, concerning the words of this book that is found; for great is Yahuah’s wrath that is kindled against us, because our fathers have not listened to the words of this book, to do according to all that which is written concerning us.” 
 </p><p>
 <sup>14&#160;</sup>So Hilkiah the priest, Ahikam, Achbor, Shaphan, and Asaiah went to Huldah the prophetess, the woman of Shallum the son of Tikvah, the son of Harhas, keeper of the wardrobe (now she lived in Jerusalem in the second quarter); and they talked with her. 
-<sup>15&#160;</sup>She said to them, “Yahweh the Elohim of Israel says, ‘Tell the man who sent you to me, 
-<sup>16&#160;</sup>“Yahweh says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the words of the book which the king of Judah has read. 
+<sup>15&#160;</sup>She said to them, “Yahuah the Elohim of Israel says, ‘Tell the man who sent you to me, 
+<sup>16&#160;</sup>“Yahuah says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the words of the book which the king of Judah has read. 
 <sup>17&#160;</sup>Because they have forsaken me and have burned incense to other elohims, that they might provoke me to anger with all the work of their hands, therefore my wrath shall be kindled against this place, and it will not be quenched.’&#160;” 
-<sup>18&#160;</sup>But to the king of Judah, who sent you to inquire of Yahweh, tell him, “Yahweh the Elohim of Israel says, ‘Concerning the words which you have heard, 
-<sup>19&#160;</sup>because your heart was tender, and you humbled yourself before Yahweh when you heard what I spoke against this place and against its inhabitants, that they should become a desolation and a curse, and have torn your clothes and wept before me, I also have heard you,’ says Yahweh. 
+<sup>18&#160;</sup>But to the king of Judah, who sent you to inquire of Yahuah, tell him, “Yahuah the Elohim of Israel says, ‘Concerning the words which you have heard, 
+<sup>19&#160;</sup>because your heart was tender, and you humbled yourself before Yahuah when you heard what I spoke against this place and against its inhabitants, that they should become a desolation and a curse, and have torn your clothes and wept before me, I also have heard you,’ says Yahuah. 
 <sup>20&#160;</sup>‘Therefore behold, I will gather you to your fathers, and you will be gathered to your grave in peace. Your eyes will not see all the evil which I will bring on this place.’&#160;”&#160;’&#160;” So they brought this message back to the king. 
 </p><h2 class="chapterlabel" id="23">23</h2>
 <p>
 <sup>1&#160;</sup>The king sent, and they gathered to him all the elders of Judah and of Jerusalem. 
-<sup>2&#160;</sup>The king went up to Yahweh’s house, and all the men of Judah and all the inhabitants of Jerusalem with him—with the priests, the prophets, and all the people, both small and great; and he read in their hearing all the words of the book of the covenant which was found in Yahweh’s house. 
-<sup>3&#160;</sup>The king stood by the pillar and made a covenant before Yahweh to walk after Yahweh and to keep his commandments, his testimonies, and his statutes with all his heart and all his soul, to confirm the words of this covenant that were written in this book; and all the people agreed to the covenant. 
+<sup>2&#160;</sup>The king went up to Yahuah’s house, and all the men of Judah and all the inhabitants of Jerusalem with him—with the priests, the prophets, and all the people, both small and great; and he read in their hearing all the words of the book of the covenant which was found in Yahuah’s house. 
+<sup>3&#160;</sup>The king stood by the pillar and made a covenant before Yahuah to walk after Yahuah and to keep his commandments, his testimonies, and his statutes with all his heart and all his soul, to confirm the words of this covenant that were written in this book; and all the people agreed to the covenant. 
 </p><p>
-<sup>4&#160;</sup>The king commanded Hilkiah the high priest, and the priests of the second order, and the keepers of the threshold, to bring out of Yahweh’s temple all the vessels that were made for Baal, for the Asherah, and for all the army of the sky; and he burned them outside of Jerusalem in the fields of the Kidron, and carried their ashes to Bethel. 
+<sup>4&#160;</sup>The king commanded Hilkiah the high priest, and the priests of the second order, and the keepers of the threshold, to bring out of Yahuah’s temple all the vessels that were made for Baal, for the Asherah, and for all the army of the sky; and he burned them outside of Jerusalem in the fields of the Kidron, and carried their ashes to Bethel. 
 <sup>5&#160;</sup>He got rid of the idolatrous priests whom the kings of Judah had ordained to burn incense in the high places in the cities of Judah and in the places around Jerusalem; those also who burned incense to Baal, to the sun, to the moon, to the planets, and to all the army of the sky. 
-<sup>6&#160;</sup>He brought out the Asherah from Yahweh’s house, outside of Jerusalem, to the brook Kidron, and burned it at the brook Kidron, and beat it to dust, and cast its dust on the graves of the common people. 
-<sup>7&#160;</sup>He broke down the houses of the male shrine prostitutes that were in Yahweh’s house, where the women wove hangings for the Asherah. 
+<sup>6&#160;</sup>He brought out the Asherah from Yahuah’s house, outside of Jerusalem, to the brook Kidron, and burned it at the brook Kidron, and beat it to dust, and cast its dust on the graves of the common people. 
+<sup>7&#160;</sup>He broke down the houses of the male shrine prostitutes that were in Yahuah’s house, where the women wove hangings for the Asherah. 
 <sup>8&#160;</sup>He brought all the priests out of the cities of Judah, and defiled the high places where the priests had burned incense, from Geba to Beersheba; and he broke down the high places of the gates that were at the entrance of the gate of Joshua the governor of the city, which were on a man’s left hand at the gate of the city. 
-<sup>9&#160;</sup>Nevertheless the priests of the high places didn’t come up to Yahweh’s altar in Jerusalem, but they ate unleavened bread among their brothers. 
+<sup>9&#160;</sup>Nevertheless the priests of the high places didn’t come up to Yahuah’s altar in Jerusalem, but they ate unleavened bread among their brothers. 
 <sup>10&#160;</sup>He defiled Topheth, which is in the valley of the children of Hinnom, that no man might make his son or his daughter to pass through the fire to Molech. 
-<sup>11&#160;</sup>He took away the horses that the kings of Judah had dedicated to the sun, at the entrance of Yahweh’s house, by the room of Nathan Melech the officer who was in the court; and he burned the chariots of the sun with fire. 
-<sup>12&#160;</sup>The king broke down the altars that were on the roof of the upper room of Ahaz, which the kings of Judah had made, and the altars which Manasseh had made in the two courts of Yahweh’s house, and beat them down from there, and cast their dust into the brook Kidron. 
+<sup>11&#160;</sup>He took away the horses that the kings of Judah had dedicated to the sun, at the entrance of Yahuah’s house, by the room of Nathan Melech the officer who was in the court; and he burned the chariots of the sun with fire. 
+<sup>12&#160;</sup>The king broke down the altars that were on the roof of the upper room of Ahaz, which the kings of Judah had made, and the altars which Manasseh had made in the two courts of Yahuah’s house, and beat them down from there, and cast their dust into the brook Kidron. 
 <sup>13&#160;</sup>The king defiled the high places that were before Jerusalem, which were on the right hand of the mountain of corruption, which Solomon the king of Israel had built for Ashtoreth the abomination of the Sidonians, and for Chemosh the abomination of Moab, and for Milcom the abomination of the children of Ammon. 
 <sup>14&#160;</sup>He broke in pieces the pillars, cut down the Asherah poles, and filled their places with men’s bones. 
 </p><p>
 <sup>15&#160;</sup>Moreover the altar that was at Bethel and the high place which Jeroboam the son of Nebat, who made Israel to sin, had made, even that altar and the high place he broke down; and he burned the high place and beat it to dust, and burned the Asherah. 
-<sup>16&#160;</sup>As Josiah turned himself, he spied the tombs that were there in the mountain; and he sent, and took the bones out of the tombs, and burned them on the altar, and defiled it, according to Yahweh’s word which the man of Elohim proclaimed, who proclaimed these things. 
+<sup>16&#160;</sup>As Josiah turned himself, he spied the tombs that were there in the mountain; and he sent, and took the bones out of the tombs, and burned them on the altar, and defiled it, according to Yahuah’s word which the man of Elohim proclaimed, who proclaimed these things. 
 <sup>17&#160;</sup>Then he said, “What monument is that which I see?” 
 </p><p>The men of the city told him, “It is the tomb of the man of Elohim who came from Judah and proclaimed these things that you have done against the altar of Bethel.” 
 </p><p>
 <sup>18&#160;</sup>He said, “Let him be! Let no one move his bones.” So they let his bones alone, with the bones of the prophet who came out of Samaria. 
-<sup>19&#160;</sup>All the houses also of the high places that were in the cities of Samaria, which the kings of Israel had made to provoke Yahweh to anger, Josiah took away, and did to them according to all the acts that he had done in Bethel. 
+<sup>19&#160;</sup>All the houses also of the high places that were in the cities of Samaria, which the kings of Israel had made to provoke Yahuah to anger, Josiah took away, and did to them according to all the acts that he had done in Bethel. 
 <sup>20&#160;</sup>He killed all the priests of the high places that were there, on the altars, and burned men’s bones on them; and he returned to Jerusalem. 
 </p><p>
-<sup>21&#160;</sup>The king commanded all the people, saying, “Keep the Passover to Yahweh your Elohim, as it is written in this book of the covenant.” 
+<sup>21&#160;</sup>The king commanded all the people, saying, “Keep the Passover to Yahuah your Elohim, as it is written in this book of the covenant.” 
 <sup>22&#160;</sup>Surely there was not kept such a Passover from the days of the judges who judged Israel, nor in all the days of the kings of Israel, nor of the kings of Judah; 
-<sup>23&#160;</sup>but in the eighteenth year of King Josiah, this Passover was kept to Yahweh in Jerusalem. 
+<sup>23&#160;</sup>but in the eighteenth year of King Josiah, this Passover was kept to Yahuah in Jerusalem. 
 </p><p>
-<sup>24&#160;</sup>Moreover, Josiah removed those who had familiar spirits, the wizards, and the teraphim, and the idols, and all the abominations that were seen in the land of Judah and in Jerusalem, that he might confirm the words of the law which were written in the book that Hilkiah the priest found in Yahweh’s house. 
-<sup>25&#160;</sup>There was no king like him before him, who turned to Yahweh with all his heart, and with all his soul, and with all his might, according to all the law of Moses; and there was none like him who arose after him. 
-<sup>26&#160;</sup>Notwithstanding, Yahweh didn’t turn from the fierceness of his great wrath, with which his anger burned against Judah, because of all the provocation with which Manasseh had provoked him. 
-<sup>27&#160;</sup>Yahweh said, “I will also remove Judah out of my sight, as I have removed Israel; and I will cast off this city which I have chosen, even Jerusalem, and the house of which I said, ‘My name shall be there.’&#160;” 
+<sup>24&#160;</sup>Moreover, Josiah removed those who had familiar spirits, the wizards, and the teraphim, and the idols, and all the abominations that were seen in the land of Judah and in Jerusalem, that he might confirm the words of the law which were written in the book that Hilkiah the priest found in Yahuah’s house. 
+<sup>25&#160;</sup>There was no king like him before him, who turned to Yahuah with all his heart, and with all his soul, and with all his might, according to all the law of Moses; and there was none like him who arose after him. 
+<sup>26&#160;</sup>Notwithstanding, Yahuah didn’t turn from the fierceness of his great wrath, with which his anger burned against Judah, because of all the provocation with which Manasseh had provoked him. 
+<sup>27&#160;</sup>Yahuah said, “I will also remove Judah out of my sight, as I have removed Israel; and I will cast off this city which I have chosen, even Jerusalem, and the house of which I said, ‘My name shall be there.’&#160;” 
 </p><p>
 <sup>28&#160;</sup>Now the rest of the acts of Josiah, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 <sup>29&#160;</sup>In his days Pharaoh Necoh king of Egypt went up against the king of Assyria to the river Euphrates; and King Josiah went against him, but Pharaoh Necoh killed him at Megiddo when he saw him. 
 <sup>30&#160;</sup>His servants carried him dead in a chariot from Megiddo, brought him to Jerusalem, and buried him in his own tomb. The people of the land took Jehoahaz the son of Josiah, and anointed him, and made him king in his father’s place. 
 </p><p>
 <sup>31&#160;</sup>Jehoahaz was twenty-three years old when he began to reign; and he reigned three months in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
-<sup>32&#160;</sup>He did that which was evil in Yahweh’s sight, according to all that his fathers had done. 
+<sup>32&#160;</sup>He did that which was evil in Yahuah’s sight, according to all that his fathers had done. 
 <sup>33&#160;</sup>Pharaoh Necoh put him in bonds at Riblah in the land of Hamath, that he might not reign in Jerusalem; and put the land to a tribute of one hundred talents of silver and a talent of gold. 
 <sup>34&#160;</sup>Pharaoh Necoh made Eliakim the son of Josiah king in the place of Josiah his father, and changed his name to Jehoiakim; but he took Jehoahaz away, and he came to Egypt and died there. 
 <sup>35&#160;</sup>Jehoiakim gave the silver and the gold to Pharaoh; but he taxed the land to give the money according to the commandment of Pharaoh. He exacted the silver and the gold of the people of the land, from everyone according to his assessment, to give it to Pharaoh Necoh. 
 <sup>36&#160;</sup>Jehoiakim was twenty-five years old when he began to reign, and he reigned eleven years in Jerusalem. His mother’s name was Zebidah the daughter of Pedaiah of Rumah. 
-<sup>37&#160;</sup>He did that which was evil in Yahweh’s sight, according to all that his fathers had done. 
+<sup>37&#160;</sup>He did that which was evil in Yahuah’s sight, according to all that his fathers had done. 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
 <sup>1&#160;</sup>In his days Nebuchadnezzar king of Babylon came up, and Jehoiakim became his servant three years. Then he turned and rebelled against him. 
-<sup>2&#160;</sup>Yahweh sent against him bands of the Chaldeans, bands of the Syrians, bands of the Moabites, and bands of the children of Ammon, and sent them against Judah to destroy it, according to Yahweh’s word which he spoke by his servants the prophets. 
-<sup>3&#160;</sup>Surely at the commandment of Yahweh this came on Judah, to remove them out of his sight for the sins of Manasseh, according to all that he did, 
-<sup>4&#160;</sup>and also for the innocent blood that he shed; for he filled Jerusalem with innocent blood, and Yahweh would not pardon. 
+<sup>2&#160;</sup>Yahuah sent against him bands of the Chaldeans, bands of the Syrians, bands of the Moabites, and bands of the children of Ammon, and sent them against Judah to destroy it, according to Yahuah’s word which he spoke by his servants the prophets. 
+<sup>3&#160;</sup>Surely at the commandment of Yahuah this came on Judah, to remove them out of his sight for the sins of Manasseh, according to all that he did, 
+<sup>4&#160;</sup>and also for the innocent blood that he shed; for he filled Jerusalem with innocent blood, and Yahuah would not pardon. 
 <sup>5&#160;</sup>Now the rest of the acts of Jehoiakim, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 <sup>6&#160;</sup>So Jehoiakim slept with his fathers, and Jehoiachin his son reigned in his place. 
 </p><p>
 <sup>7&#160;</sup>The king of Egypt didn’t come out of his land any more; for the king of Babylon had taken, from the brook of Egypt to the river Euphrates, all that belonged to the king of Egypt. 
 </p><p>
 <sup>8&#160;</sup>Jehoiachin was eighteen years old when he began to reign, and he reigned in Jerusalem three months. His mother’s name was Nehushta the daughter of Elnathan of Jerusalem. 
-<sup>9&#160;</sup>He did that which was evil in Yahweh’s sight, according to all that his father had done. 
+<sup>9&#160;</sup>He did that which was evil in Yahuah’s sight, according to all that his father had done. 
 <sup>10&#160;</sup>At that time the servants of Nebuchadnezzar king of Babylon came up to Jerusalem, and the city was besieged. 
 <sup>11&#160;</sup>Nebuchadnezzar king of Babylon came to the city while his servants were besieging it, 
 <sup>12&#160;</sup>and Jehoiachin the king of Judah went out to the king of Babylon—he, his mother, his servants, his princes, and his officers; and the king of Babylon captured him in the eighth year of his reign. 
-<sup>13&#160;</sup>He carried out from there all the treasures of Yahweh’s house and the treasures of the king’s house, and cut in pieces all the vessels of gold which Solomon king of Israel had made in Yahweh’s temple, as Yahweh had said. 
+<sup>13&#160;</sup>He carried out from there all the treasures of Yahuah’s house and the treasures of the king’s house, and cut in pieces all the vessels of gold which Solomon king of Israel had made in Yahuah’s temple, as Yahuah had said. 
 <sup>14&#160;</sup>He carried away all Jerusalem, and all the princes, and all the mighty men of valor, even ten thousand captives, and all the craftsmen and the smiths. No one remained except the poorest people of the land. 
 <sup>15&#160;</sup>He carried away Jehoiachin to Babylon, with the king’s mother, the king’s women, his officers, and the chief men of the land. He carried them into captivity from Jerusalem to Babylon. 
 <sup>16&#160;</sup>All the men of might, even seven thousand, and the craftsmen and the smiths one thousand, all of them strong and fit for war, even them the king of Babylon brought captive to Babylon. 
 <sup>17&#160;</sup>The king of Babylon made Mattaniah, Jehoiachin’s father’s brother, king in his place, and changed his name to Zedekiah. 
 </p><p>
 <sup>18&#160;</sup>Zedekiah was twenty-one years old when he began to reign, and he reigned eleven years in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
-<sup>19&#160;</sup>He did that which was evil in Yahweh’s sight, according to all that Jehoiakim had done. 
-<sup>20&#160;</sup>For through the anger of Yahweh, this happened in Jerusalem and Judah, until he had cast them out from his presence. 
+<sup>19&#160;</sup>He did that which was evil in Yahuah’s sight, according to all that Jehoiakim had done. 
+<sup>20&#160;</sup>For through the anger of Yahuah, this happened in Jerusalem and Judah, until he had cast them out from his presence. 
 </p><p>Then Zedekiah rebelled against the king of Babylon. 
 </p><h2 class="chapterlabel" id="25">25</h2>
 <p>
@@ -1127,15 +1127,15 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>They killed Zedekiah’s sons before his eyes, then put out Zedekiah’s eyes, bound him in fetters, and carried him to Babylon. 
 </p><p>
 <sup>8&#160;</sup>Now in the fifth month, on the seventh day of the month, which was the nineteenth year of King Nebuchadnezzar king of Babylon, Nebuzaradan the captain of the guard, a servant of the king of Babylon, came to Jerusalem. 
-<sup>9&#160;</sup>He burned Yahweh’s house, the king’s house, and all the houses of Jerusalem. He burned every great house with fire. 
+<sup>9&#160;</sup>He burned Yahuah’s house, the king’s house, and all the houses of Jerusalem. He burned every great house with fire. 
 <sup>10&#160;</sup>All the army of the Chaldeans, who were with the captain of the guard, broke down the walls around Jerusalem. 
 <sup>11&#160;</sup>Nebuzaradan the captain of the guard carried away captive the rest of the people who were left in the city and those who had deserted to the king of Babylon—all the rest of the multitude. 
 <sup>12&#160;</sup>But the captain of the guard left some of the poorest of the land to work the vineyards and fields. 
 </p><p>
-<sup>13&#160;</sup>The Chaldeans broke up the pillars of bronze that were in Yahweh’s house and the bases and the bronze sea that were in Yahweh’s house, and carried the bronze pieces to Babylon. 
+<sup>13&#160;</sup>The Chaldeans broke up the pillars of bronze that were in Yahuah’s house and the bases and the bronze sea that were in Yahuah’s house, and carried the bronze pieces to Babylon. 
 <sup>14&#160;</sup>They took away the pots, the shovels, the snuffers, the spoons, and all the vessels of bronze with which they ministered. 
 <sup>15&#160;</sup>The captain of the guard took away the fire pans, the basins, that which was of gold, for gold, and that which was of silver, for silver. 
-<sup>16&#160;</sup>The two pillars, the one sea, and the bases, which Solomon had made for Yahweh’s house, the bronze of all these vessels was not weighed. 
+<sup>16&#160;</sup>The two pillars, the one sea, and the bases, which Solomon had made for Yahuah’s house, the bronze of all these vessels was not weighed. 
 <sup>17&#160;</sup>The height of the one pillar was eighteen cubits, and a capital of bronze was on it. The height of the capital was three cubits, with network and pomegranates on the capital around it, all of bronze; and the second pillar with its network was like these. 
 </p><p>
 <sup>18&#160;</sup>The captain of the guard took Seraiah the chief priest, Zephaniah the second priest, and the three keepers of the threshold; 

--- a/book/2samuel.html
+++ b/book/2samuel.html
@@ -101,14 +101,14 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>So I stood beside him and killed him, because I was sure that he could not live after he had fallen. I took the crown that was on his head and the bracelet that was on his arm, and have brought them here to my lord.” 
 </p><p>
 <sup>11&#160;</sup>Then David took hold on his clothes and tore them; and all the men who were with him did likewise. 
-<sup>12&#160;</sup>They mourned, wept, and fasted until evening for Saul and for Jonathan his son, and for the people of Yahweh, and for the house of Israel, because they had fallen by the sword. 
+<sup>12&#160;</sup>They mourned, wept, and fasted until evening for Saul and for Jonathan his son, and for the people of Yahuah, and for the house of Israel, because they had fallen by the sword. 
 </p><p>
 <sup>13&#160;</sup>David said to the young man who told him, “Where are you from?” 
 </p><p>He answered, “I am the son of a foreigner, an Amalekite.” 
 </p><p>
-<sup>14&#160;</sup>David said to him, “Why were you not afraid to stretch out your hand to destroy Yahweh’s anointed?” 
+<sup>14&#160;</sup>David said to him, “Why were you not afraid to stretch out your hand to destroy Yahuah’s anointed?” 
 <sup>15&#160;</sup>David called one of the young men and said, “Go near, and cut him down!” He struck him so that he died. 
-<sup>16&#160;</sup>David said to him, “Your blood be on your head, for your mouth has testified against you, saying, ‘I have slain Yahweh’s anointed.’&#160;” 
+<sup>16&#160;</sup>David said to him, “Your blood be on your head, for your mouth has testified against you, saying, ‘I have slain Yahuah’s anointed.’&#160;” 
 </p><p>
 <sup>17&#160;</sup>David lamented with this lamentation over Saul and over Jonathan his son 
 <sup>18&#160;</sup>(and he commanded them to teach the children of Judah the song of the bow; behold, it is written in the book of Jashar): 
@@ -152,16 +152,16 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and the weapons of war have perished!” 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>After this, David inquired of Yahweh, saying, “Shall I go up into any of the cities of Judah?” 
-</p><p>Yahweh said to him, “Go up.” 
+<sup>1&#160;</sup>After this, David inquired of Yahuah, saying, “Shall I go up into any of the cities of Judah?” 
+</p><p>Yahuah said to him, “Go up.” 
 </p><p>David said, “Where shall I go up?” 
 </p><p>He said, “To Hebron.” 
 </p><p>
 <sup>2&#160;</sup>So David went up there with his two women, Ahinoam the Jezreelitess, and Abigail the woman of Nabal the Carmelite. 
 <sup>3&#160;</sup>David brought up his men who were with him, every man with his household. They lived in the cities of Hebron. 
 <sup>4&#160;</sup>The men of Judah came, and there they anointed David king over the house of Judah. They told David, “The men of Jabesh Gilead were those who buried Saul.” 
-<sup>5&#160;</sup>David sent messengers to the men of Jabesh Gilead, and said to them, “Blessed are you by Yahweh, that you have shown this kindness to your lord, even to Saul, and have buried him. 
-<sup>6&#160;</sup>Now may Yahweh show loving kindness and truth to you. I also will reward you for this kindness, because you have done this thing. 
+<sup>5&#160;</sup>David sent messengers to the men of Jabesh Gilead, and said to them, “Blessed are you by Yahuah, that you have shown this kindness to your lord, even to Saul, and have buried him. 
+<sup>6&#160;</sup>Now may Yahuah show loving kindness and truth to you. I also will reward you for this kindness, because you have done this thing. 
 <sup>7&#160;</sup>Now therefore let your hands be strong, and be valiant; for Saul your lord is dead, and also the house of Judah have anointed me king over them.” 
 </p><p>
 <sup>8&#160;</sup>Now Abner the son of Ner, captain of Saul’s army, had taken Ishbosheth the son of Saul and brought him over to Mahanaim. 
@@ -209,7 +209,7 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>Now Saul had a concubine, whose name was Rizpah, the daughter of Aiah; and Ishbosheth said to Abner, “Why have you gone in to my father’s concubine?” 
 </p><p>
 <sup>8&#160;</sup>Then Abner was very angry about Ishbosheth’s words, and said, “Am I a dog’s head that belongs to Judah? Today I show kindness to your father Saul’s house, to his brothers, and to his friends, and have not delivered you into the hand of David; and yet you charge me today with a fault concerning this woman! 
-<sup>9&#160;</sup>Elohim do so to Abner, and more also, if, as Yahweh has sworn to David, I don’t do even so to him: 
+<sup>9&#160;</sup>Elohim do so to Abner, and more also, if, as Yahuah has sworn to David, I don’t do even so to him: 
 <sup>10&#160;</sup>to transfer the kingdom from Saul’s house, and to set up David’s throne over Israel and over Judah, from Dan even to Beersheba.” 
 </p><p>
 <sup>11&#160;</sup>He could not answer Abner another word, because he was afraid of him. 
@@ -223,7 +223,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>Her man went with her, weeping as he went, and followed her to Bahurim. Then Abner said to him, “Go! Return!” and he returned. 
 </p><p>
 <sup>17&#160;</sup>Abner had communication with the elders of Israel, saying, “In times past, you sought for David to be king over you. 
-<sup>18&#160;</sup>Now then do it! For Yahweh has spoken of David, saying, ‘By the hand of my servant David, I will save my people Israel out of the hand of the Philistines, and out of the hand of all their enemies.’&#160;” 
+<sup>18&#160;</sup>Now then do it! For Yahuah has spoken of David, saying, ‘By the hand of my servant David, I will save my people Israel out of the hand of the Philistines, and out of the hand of all their enemies.’&#160;” 
 </p><p>
 <sup>19&#160;</sup>Abner also spoke in the ears of Benjamin; and Abner went also to speak in the ears of David in Hebron all that seemed good to Israel and to the whole house of Benjamin. 
 <sup>20&#160;</sup>So Abner came to David to Hebron, and twenty men with him. David made Abner and the men who were with him a feast. 
@@ -237,7 +237,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>26&#160;</sup>When Joab had come out from David, he sent messengers after Abner, and they brought him back from the well of Sirah; but David didn’t know it. 
 <sup>27&#160;</sup>When Abner had returned to Hebron, Joab took him aside into the middle of the gate to speak with him quietly, and struck him there in the body, so that he died for the blood of Asahel his brother. 
-<sup>28&#160;</sup>Afterward, when David heard it, he said, “I and my kingdom are guiltless before Yahweh forever of the blood of Abner the son of Ner. 
+<sup>28&#160;</sup>Afterward, when David heard it, he said, “I and my kingdom are guiltless before Yahuah forever of the blood of Abner the son of Ner. 
 <sup>29&#160;</sup>Let it fall on the head of Joab and on all his father’s house. Let there not fail from the house of Joab one who has a discharge, or who is a leper, or who leans on a staff, or who falls by the sword, or who lacks bread.” 
 <sup>30&#160;</sup>So Joab and Abishai his brother killed Abner, because he had killed their brother Asahel at Gibeon in the battle. 
 </p><p>
@@ -251,7 +251,7 @@ html[dir=ltr] .q2 {
 <sup>36&#160;</sup>All the people took notice of it, and it pleased them, as whatever the king did pleased all the people. 
 <sup>37&#160;</sup>So all the people and all Israel understood that day that it was not of the king to kill Abner the son of Ner. 
 <sup>38&#160;</sup>The king said to his servants, “Don’t you know that a prince and a great man has fallen today in Israel? 
-<sup>39&#160;</sup>I am weak today, though anointed king. These men, the sons of Zeruiah are too hard for me. May Yahweh reward the evildoer according to his wickedness.” 
+<sup>39&#160;</sup>I am weak today, though anointed king. These men, the sons of Zeruiah are too hard for me. May Yahuah reward the evildoer according to his wickedness.” 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
 <sup>1&#160;</sup>When Saul’s son heard that Abner was dead in Hebron, his hands became feeble, and all the Israelites were troubled. 
@@ -263,17 +263,17 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>The sons of Rimmon the Beerothite, Rechab and Baanah, went out and came at about the heat of the day to the house of Ishbosheth as he took his rest at noon. 
 <sup>6&#160;</sup>They came there into the middle of the house as though they would have fetched wheat, and they struck him in the body; and Rechab and Baanah his brother escaped. 
 <sup>7&#160;</sup>Now when they came into the house as he lay on his bed in his bedroom, they struck him, killed him, beheaded him, and took his head, and went by the way of the Arabah all night. 
-<sup>8&#160;</sup>They brought the head of Ishbosheth to David to Hebron, and said to the king, “Behold, the head of Ishbosheth, the son of Saul, your enemy, who sought your life! Yahweh has avenged my lord the king today of Saul and of his offspring.” 
+<sup>8&#160;</sup>They brought the head of Ishbosheth to David to Hebron, and said to the king, “Behold, the head of Ishbosheth, the son of Saul, your enemy, who sought your life! Yahuah has avenged my lord the king today of Saul and of his offspring.” 
 </p><p>
-<sup>9&#160;</sup>David answered Rechab and Baanah his brother, the sons of Rimmon the Beerothite, and said to them, “As Yahweh lives, who has redeemed my soul out of all adversity, 
+<sup>9&#160;</sup>David answered Rechab and Baanah his brother, the sons of Rimmon the Beerothite, and said to them, “As Yahuah lives, who has redeemed my soul out of all adversity, 
 <sup>10&#160;</sup>when someone told me, ‘Behold, Saul is dead,’ thinking that he brought good news, I seized him and killed him in Ziklag, which was the reward I gave him for his news. 
 <sup>11&#160;</sup>How much more, when wicked men have slain a righteous person in his own house on his bed, should I not now require his blood from your hand, and rid the earth of you?” 
 <sup>12&#160;</sup>David commanded his young men, and they killed them, cut off their hands and their feet, and hanged them up beside the pool in Hebron. But they took the head of Ishbosheth and buried it in Abner’s grave in Hebron. 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
 <sup>1&#160;</sup>Then all the tribes of Israel came to David at Hebron and spoke, saying, “Behold, we are your bone and your flesh. 
-<sup>2&#160;</sup>In times past, when Saul was king over us, it was you who led Israel out and in. Yahweh said to you, ‘You will be shepherd of my people Israel, and you will be prince over Israel.’&#160;” 
-<sup>3&#160;</sup>So all the elders of Israel came to the king to Hebron, and King David made a covenant with them in Hebron before Yahweh; and they anointed David king over Israel. 
+<sup>2&#160;</sup>In times past, when Saul was king over us, it was you who led Israel out and in. Yahuah said to you, ‘You will be shepherd of my people Israel, and you will be prince over Israel.’&#160;” 
+<sup>3&#160;</sup>So all the elders of Israel came to the king to Hebron, and King David made a covenant with them in Hebron before Yahuah; and they anointed David king over Israel. 
 </p><p>
 <sup>4&#160;</sup>David was thirty years old when he began to reign, and he reigned forty years. 
 <sup>5&#160;</sup>In Hebron he reigned over Judah seven years and six months, and in Jerusalem he reigned thirty-three years over all Israel and Judah. 
@@ -283,9 +283,9 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>David said on that day, “Whoever strikes the Jebusites, let him go up to the watercourse and strike those lame and blind, who are hated by David’s soul.” Therefore they say, “The blind and the lame can’t come into the house.” 
 </p><p>
 <sup>9&#160;</sup>David lived in the stronghold, and called it David’s city. David built around from Millo and inward. 
-<sup>10&#160;</sup>David grew greater and greater, for Yahweh, the Elohim of Armies, was with him. 
+<sup>10&#160;</sup>David grew greater and greater, for Yahuah, the Elohim of Armies, was with him. 
 <sup>11&#160;</sup>Hiram king of Tyre sent messengers to David, with cedar trees, carpenters, and masons; and they built David a house. 
-<sup>12&#160;</sup>David perceived that Yahweh had established him king over Israel, and that he had exalted his kingdom for his people Israel’s sake. 
+<sup>12&#160;</sup>David perceived that Yahuah had established him king over Israel, and that he had exalted his kingdom for his people Israel’s sake. 
 </p><p>
 <sup>13&#160;</sup>David took more concubines and women for himself out of Jerusalem, after he had come from Hebron; and more sons and daughters were born to David. 
 <sup>14&#160;</sup>These are the names of those who were born to him in Jerusalem: Shammua, Shobab, Nathan, Solomon, 
@@ -294,63 +294,63 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>17&#160;</sup>When the Philistines heard that they had anointed David king over Israel, all the Philistines went up to seek David, but David heard about it and went down to the stronghold. 
 <sup>18&#160;</sup>Now the Philistines had come and spread themselves in the valley of Rephaim. 
-<sup>19&#160;</sup>David inquired of Yahweh, saying, “Shall I go up against the Philistines? Will you deliver them into my hand?” 
-</p><p>Yahweh said to David, “Go up; for I will certainly deliver the Philistines into your hand.” 
+<sup>19&#160;</sup>David inquired of Yahuah, saying, “Shall I go up against the Philistines? Will you deliver them into my hand?” 
+</p><p>Yahuah said to David, “Go up; for I will certainly deliver the Philistines into your hand.” 
 </p><p>
-<sup>20&#160;</sup>David came to Baal Perazim, and David struck them there. Then he said, “Yahweh has broken my enemies before me, like the breach of waters.” Therefore he called the name of that place Baal Perazim. 
+<sup>20&#160;</sup>David came to Baal Perazim, and David struck them there. Then he said, “Yahuah has broken my enemies before me, like the breach of waters.” Therefore he called the name of that place Baal Perazim. 
 <sup>21&#160;</sup>They left their images there, and David and his men took them away. 
 </p><p>
 <sup>22&#160;</sup>The Philistines came up yet again and spread themselves in the valley of Rephaim. 
-<sup>23&#160;</sup>When David inquired of Yahweh, he said, “You shall not go up. Circle around behind them, and attack them in front of the mulberry trees. 
-<sup>24&#160;</sup>When you hear the sound of marching in the tops of the mulberry trees, then stir yourself up; for then Yahweh has gone out before you to strike the army of the Philistines.” 
+<sup>23&#160;</sup>When David inquired of Yahuah, he said, “You shall not go up. Circle around behind them, and attack them in front of the mulberry trees. 
+<sup>24&#160;</sup>When you hear the sound of marching in the tops of the mulberry trees, then stir yourself up; for then Yahuah has gone out before you to strike the army of the Philistines.” 
 </p><p>
-<sup>25&#160;</sup>David did so, as Yahweh commanded him, and struck the Philistines all the way from Geba to Gezer. 
+<sup>25&#160;</sup>David did so, as Yahuah commanded him, and struck the Philistines all the way from Geba to Gezer. 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
 <sup>1&#160;</sup>David again gathered together all the chosen men of Israel, thirty thousand. 
-<sup>2&#160;</sup>David arose and went with all the people who were with him from Baale Judah, to bring up from there Elohim’s ark, which is called by the Name, even the name of Yahweh of Armies who sits above the cherubim. 
+<sup>2&#160;</sup>David arose and went with all the people who were with him from Baale Judah, to bring up from there Elohim’s ark, which is called by the Name, even the name of Yahuah of Armies who sits above the cherubim. 
 <sup>3&#160;</sup>They set Elohim’s ark on a new cart, and brought it out of Abinadab’s house that was on the hill; and Uzzah and Ahio, the sons of Abinadab, drove the new cart. 
 <sup>4&#160;</sup>They brought it out of Abinadab’s house which was in the hill, with Elohim’s ark; and Ahio went before the ark. 
-<sup>5&#160;</sup>David and all the house of Israel played before Yahweh with all kinds of instruments made of cypress wood, with harps, with stringed instruments, with tambourines, with castanets, and with cymbals. 
+<sup>5&#160;</sup>David and all the house of Israel played before Yahuah with all kinds of instruments made of cypress wood, with harps, with stringed instruments, with tambourines, with castanets, and with cymbals. 
 </p><p>
 <sup>6&#160;</sup>When they came to the threshing floor of Nacon, Uzzah reached for Elohim’s ark and took hold of it, for the cattle stumbled. 
-<sup>7&#160;</sup>Yahweh’s anger burned against Uzzah, and Elohim struck him there for his error; and he died there by Elohim’s ark. 
-<sup>8&#160;</sup>David was displeased because Yahweh had broken out against Uzzah; and he called that place Perez Uzzah to this day. 
-<sup>9&#160;</sup>David was afraid of Yahweh that day; and he said, “How could Yahweh’s ark come to me?” 
-<sup>10&#160;</sup>So David would not move Yahweh’s ark to be with him in David’s city; but David carried it aside into Obed-Edom the Gittite’s house. 
-<sup>11&#160;</sup>Yahweh’s ark remained in Obed-Edom the Gittite’s house three months; and Yahweh blessed Obed-Edom and all his house. 
-<sup>12&#160;</sup>King David was told, “Yahweh has blessed the house of Obed-Edom, and all that belongs to him, because of Elohim’s ark.” 
+<sup>7&#160;</sup>Yahuah’s anger burned against Uzzah, and Elohim struck him there for his error; and he died there by Elohim’s ark. 
+<sup>8&#160;</sup>David was displeased because Yahuah had broken out against Uzzah; and he called that place Perez Uzzah to this day. 
+<sup>9&#160;</sup>David was afraid of Yahuah that day; and he said, “How could Yahuah’s ark come to me?” 
+<sup>10&#160;</sup>So David would not move Yahuah’s ark to be with him in David’s city; but David carried it aside into Obed-Edom the Gittite’s house. 
+<sup>11&#160;</sup>Yahuah’s ark remained in Obed-Edom the Gittite’s house three months; and Yahuah blessed Obed-Edom and all his house. 
+<sup>12&#160;</sup>King David was told, “Yahuah has blessed the house of Obed-Edom, and all that belongs to him, because of Elohim’s ark.” 
 </p><p>So David went and brought up Elohim’s ark from the house of Obed-Edom into David’s city with joy. 
-<sup>13&#160;</sup>When those who bore Yahweh’s ark had gone six paces, he sacrificed an ox and a fattened calf. 
-<sup>14&#160;</sup>David danced before Yahweh with all his might; and David was clothed in a linen ephod. 
-<sup>15&#160;</sup>So David and all the house of Israel brought up Yahweh’s ark with shouting and with the sound of the trumpet. 
+<sup>13&#160;</sup>When those who bore Yahuah’s ark had gone six paces, he sacrificed an ox and a fattened calf. 
+<sup>14&#160;</sup>David danced before Yahuah with all his might; and David was clothed in a linen ephod. 
+<sup>15&#160;</sup>So David and all the house of Israel brought up Yahuah’s ark with shouting and with the sound of the trumpet. 
 </p><p>
-<sup>16&#160;</sup>As Yahweh’s ark came into David’s city, Michal the daughter of Saul looked out through the window and saw King David leaping and dancing before Yahweh; and she despised him in her heart. 
-<sup>17&#160;</sup>They brought in Yahweh’s ark, and set it in its place in the middle of the tent that David had pitched for it; and David offered burnt offerings and peace offerings before Yahweh. 
-<sup>18&#160;</sup>When David had finished offering the burnt offering and the peace offerings, he blessed the people in the name of Yahweh of Armies. 
+<sup>16&#160;</sup>As Yahuah’s ark came into David’s city, Michal the daughter of Saul looked out through the window and saw King David leaping and dancing before Yahuah; and she despised him in her heart. 
+<sup>17&#160;</sup>They brought in Yahuah’s ark, and set it in its place in the middle of the tent that David had pitched for it; and David offered burnt offerings and peace offerings before Yahuah. 
+<sup>18&#160;</sup>When David had finished offering the burnt offering and the peace offerings, he blessed the people in the name of Yahuah of Armies. 
 <sup>19&#160;</sup>He gave to all the people, even among the whole multitude of Israel, both to men and women, to everyone a portion of bread, dates, and raisins. So all the people departed, each to his own house. 
 </p><p>
 <sup>20&#160;</sup>Then David returned to bless his household. Michal the daughter of Saul came out to meet David, and said, “How glorious the king of Israel was today, who uncovered himself today in the eyes of his servants’ maids, as one of the vain fellows shamelessly uncovers himself!” 
 </p><p>
-<sup>21&#160;</sup>David said to Michal, “It was before Yahweh, who chose me above your father, and above all his house, to appoint me prince over the people of Yahweh, over Israel. Therefore I will celebrate before Yahweh. 
+<sup>21&#160;</sup>David said to Michal, “It was before Yahuah, who chose me above your father, and above all his house, to appoint me prince over the people of Yahuah, over Israel. Therefore I will celebrate before Yahuah. 
 <sup>22&#160;</sup>I will be yet more undignified than this, and will be worthless in my own sight. But the maids of whom you have spoken will honor me.” 
 </p><p>
 <sup>23&#160;</sup>Michal the daughter of Saul had no child to the day of her death. 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>When the king lived in his house, and Yahweh had given him rest from all his enemies all around, 
+<sup>1&#160;</sup>When the king lived in his house, and Yahuah had given him rest from all his enemies all around, 
 <sup>2&#160;</sup>the king said to Nathan the prophet, “See now, I dwell in a house of cedar, but Elohim’s ark dwells within curtains.” 
 </p><p>
-<sup>3&#160;</sup>Nathan said to the king, “Go, do all that is in your heart, for Yahweh is with you.” 
+<sup>3&#160;</sup>Nathan said to the king, “Go, do all that is in your heart, for Yahuah is with you.” 
 </p><p>
-<sup>4&#160;</sup>That same night, Yahweh’s word came to Nathan, saying, 
-<sup>5&#160;</sup>“Go and tell my servant David, ‘Yahweh says, “Should you build me a house for me to dwell in? 
+<sup>4&#160;</sup>That same night, Yahuah’s word came to Nathan, saying, 
+<sup>5&#160;</sup>“Go and tell my servant David, ‘Yahuah says, “Should you build me a house for me to dwell in? 
 <sup>6&#160;</sup>For I have not lived in a house since the day that I brought the children of Israel up out of Egypt, even to this day, but have moved around in a tent and in a tabernacle. 
 <sup>7&#160;</sup>In all places in which I have walked with all the children of Israel, did I say a word to anyone from the tribes of Israel whom I commanded to be shepherd of my people Israel, saying, ‘Why have you not built me a house of cedar?’&#160;”&#160;’ 
-<sup>8&#160;</sup>Now therefore tell my servant David this: ‘Yahweh of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people, over Israel. 
+<sup>8&#160;</sup>Now therefore tell my servant David this: ‘Yahuah of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people, over Israel. 
 <sup>9&#160;</sup>I have been with you wherever you went, and have cut off all your enemies from before you. I will make you a great name, like the name of the great ones who are in the earth. 
 <sup>10&#160;</sup>I will appoint a place for my people Israel, and will plant them, that they may dwell in their own place and be moved no more. The children of wickedness will not afflict them any more, as at the first, 
-<sup>11&#160;</sup>and as from the day that I commanded judges to be over my people Israel. I will cause you to rest from all your enemies. Moreover Yahweh tells you that Yahweh will make you a house. 
+<sup>11&#160;</sup>and as from the day that I commanded judges to be over my people Israel. I will cause you to rest from all your enemies. Moreover Yahuah tells you that Yahuah will make you a house. 
 <sup>12&#160;</sup>When your days are fulfilled and you sleep with your fathers, I will set up your offspring after you, who will proceed out of your body, and I will establish his kingdom. 
 <sup>13&#160;</sup>He will build a house for my name, and I will establish the throne of his kingdom forever. 
 <sup>14&#160;</sup>I will be his father, and he will be my son. If he commits iniquity, I will chasten him with the rod of men and with the stripes of the children of men; 
@@ -358,20 +358,20 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>Your house and your kingdom will be made sure forever before you. Your throne will be established forever.”&#160;’&#160;” 
 <sup>17&#160;</sup>Nathan spoke to David all these words, and according to all this vision. 
 </p><p>
-<sup>18&#160;</sup>Then David the king went in and sat before Yahweh; and he said, “Who am I, Lord Yahweh, and what is my house, that you have brought me this far? 
-<sup>19&#160;</sup>This was yet a small thing in your eyes, Lord Yahweh, but you have spoken also of your servant’s house for a great while to come; and this among men, Lord Yahweh! 
-<sup>20&#160;</sup>What more can David say to you? For you know your servant, Lord Yahweh. 
+<sup>18&#160;</sup>Then David the king went in and sat before Yahuah; and he said, “Who am I, Lord Yahuah, and what is my house, that you have brought me this far? 
+<sup>19&#160;</sup>This was yet a small thing in your eyes, Lord Yahuah, but you have spoken also of your servant’s house for a great while to come; and this among men, Lord Yahuah! 
+<sup>20&#160;</sup>What more can David say to you? For you know your servant, Lord Yahuah. 
 <sup>21&#160;</sup>For your word’s sake, and according to your own heart, you have worked all this greatness, to make your servant know it. 
-<sup>22&#160;</sup>Therefore you are great, Yahweh Elohim. For there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
+<sup>22&#160;</sup>Therefore you are great, Yahuah Elohim. For there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
 <sup>23&#160;</sup>What one nation in the earth is like your people, even like Israel, whom Elohim went to redeem to himself for a people, and to make himself a name, and to do great things for you, and awesome things for your land, before your people, whom you redeemed to yourself out of Egypt, from the nations and their elohims? 
-<sup>24&#160;</sup>You established for yourself your people Israel to be your people forever; and you, Yahweh, became their Elohim. 
+<sup>24&#160;</sup>You established for yourself your people Israel to be your people forever; and you, Yahuah, became their Elohim. 
 </p><p>
-<sup>25&#160;</sup>“Now, Yahweh Elohim, the word that you have spoken concerning your servant, and concerning his house, confirm it forever, and do as you have spoken. 
-<sup>26&#160;</sup>Let your name be magnified forever, saying, ‘Yahweh of Armies is Elohim over Israel; and the house of your servant David will be established before you.’ 
-<sup>27&#160;</sup>For you, Yahweh of Armies, the Elohim of Israel, have revealed to your servant, saying, ‘I will build you a house.’ Therefore your servant has found in his heart to pray this prayer to you. 
+<sup>25&#160;</sup>“Now, Yahuah Elohim, the word that you have spoken concerning your servant, and concerning his house, confirm it forever, and do as you have spoken. 
+<sup>26&#160;</sup>Let your name be magnified forever, saying, ‘Yahuah of Armies is Elohim over Israel; and the house of your servant David will be established before you.’ 
+<sup>27&#160;</sup>For you, Yahuah of Armies, the Elohim of Israel, have revealed to your servant, saying, ‘I will build you a house.’ Therefore your servant has found in his heart to pray this prayer to you. 
 </p><p>
-<sup>28&#160;</sup>“Now, O Lord Yahweh, you are Elohim, and your words are truth, and you have promised this good thing to your servant. 
-<sup>29&#160;</sup>Now therefore, let it please you to bless the house of your servant, that it may continue forever before you; for you, Lord Yahweh, have spoken it. Let the house of your servant be blessed forever with your blessing.” 
+<sup>28&#160;</sup>“Now, O Lord Yahuah, you are Elohim, and your words are truth, and you have promised this good thing to your servant. 
+<sup>29&#160;</sup>Now therefore, let it please you to bless the house of your servant, that it may continue forever before you; for you, Lord Yahuah, have spoken it. Let the house of your servant be blessed forever with your blessing.” 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
 <sup>1&#160;</sup>After this, David struck the Philistines and subdued them; and David took the bridle of the mother city out of the hand of the Philistines. 
@@ -380,16 +380,16 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>David also struck Hadadezer the son of Rehob, king of Zobah, as he went to recover his dominion at the River. 
 <sup>4&#160;</sup>David took from him one thousand seven hundred horsemen and twenty thousand footmen. David hamstrung the chariot horses, but reserved enough of them for one hundred chariots. 
 <sup>5&#160;</sup>When the Syrians of Damascus came to help Hadadezer king of Zobah, David struck twenty two thousand men of the Syrians. 
-<sup>6&#160;</sup>Then David put garrisons in Syria of Damascus; and the Syrians became servants to David, and brought tribute. Yahweh gave victory to David wherever he went. 
+<sup>6&#160;</sup>Then David put garrisons in Syria of Damascus; and the Syrians became servants to David, and brought tribute. Yahuah gave victory to David wherever he went. 
 <sup>7&#160;</sup>David took the shields of gold that were on the servants of Hadadezer, and brought them to Jerusalem. 
 <sup>8&#160;</sup>From Betah and from Berothai, cities of Hadadezer, King David took a great quantity of bronze. 
 </p><p>
 <sup>9&#160;</sup>When Toi king of Hamath heard that David had struck all the army of Hadadezer, 
 <sup>10&#160;</sup>then Toi sent Joram his son to King David to greet him and to bless him, because he had fought against Hadadezer and struck him; for Hadadezer had wars with Toi. Joram brought with him vessels of silver, vessels of gold, and vessels of bronze. 
-<sup>11&#160;</sup>King David also dedicated these to Yahweh, with the silver and gold that he dedicated of all the nations which he subdued—<sup>12&#160;</sup>of Syria, of Moab, of the children of Ammon, of the Philistines, of Amalek, and of the plunder of Hadadezer, son of Rehob, king of Zobah. 
+<sup>11&#160;</sup>King David also dedicated these to Yahuah, with the silver and gold that he dedicated of all the nations which he subdued—<sup>12&#160;</sup>of Syria, of Moab, of the children of Ammon, of the Philistines, of Amalek, and of the plunder of Hadadezer, son of Rehob, king of Zobah. 
 </p><p>
 <sup>13&#160;</sup>David earned a reputation when he returned from striking down eighteen thousand men of the Syrians in the Valley of Salt. 
-<sup>14&#160;</sup>He put garrisons in Edom. Throughout all Edom, he put garrisons, and all the Edomites became servants to David. Yahweh gave victory to David wherever he went. 
+<sup>14&#160;</sup>He put garrisons in Edom. Throughout all Edom, he put garrisons, and all the Edomites became servants to David. Yahuah gave victory to David wherever he went. 
 </p><p>
 <sup>15&#160;</sup>David reigned over all Israel; and David executed justice and righteousness for all his people. 
 <sup>16&#160;</sup>Joab the son of Zeruiah was over the army, Jehoshaphat the son of Ahilud was recorder, 
@@ -437,7 +437,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Now when Joab saw that the battle was set against him before and behind, he chose of all the choice men of Israel and put them in array against the Syrians. 
 <sup>10&#160;</sup>The rest of the people he committed into the hand of Abishai his brother; and he put them in array against the children of Ammon. 
 <sup>11&#160;</sup>He said, “If the Syrians are too strong for me, then you shall help me; but if the children of Ammon are too strong for you, then I will come and help you. 
-<sup>12&#160;</sup>Be courageous, and let’s be strong for our people and for the cities of our Elohim; and may Yahweh do what seems good to him.” 
+<sup>12&#160;</sup>Be courageous, and let’s be strong for our people and for the cities of our Elohim; and may Yahuah do what seems good to him.” 
 <sup>13&#160;</sup>So Joab and the people who were with him came near to the battle against the Syrians, and they fled before him. 
 <sup>14&#160;</sup>When the children of Ammon saw that the Syrians had fled, they likewise fled before Abishai, and entered into the city. Then Joab returned from the children of Ammon and came to Jerusalem. 
 </p><p>
@@ -482,30 +482,30 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>Then David said to the messenger, “Tell Joab, ‘Don’t let this thing displease you, for the sword devours one as well as another. Make your battle stronger against the city, and overthrow it.’ Encourage him.” 
 </p><p>
 <sup>26&#160;</sup>When Uriah’s woman heard that Uriah her man was dead, she mourned for her owner. 
-<sup>27&#160;</sup>When the mourning was past, David sent and took her home to his house, and she became his woman and bore him a son. But the thing that David had done displeased Yahweh. 
+<sup>27&#160;</sup>When the mourning was past, David sent and took her home to his house, and she became his woman and bore him a son. But the thing that David had done displeased Yahuah. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
-<sup>1&#160;</sup>Yahweh sent Nathan to David. He came to him, and said to him, “There were two men in one city: the one rich, and the other poor. 
+<sup>1&#160;</sup>Yahuah sent Nathan to David. He came to him, and said to him, “There were two men in one city: the one rich, and the other poor. 
 <sup>2&#160;</sup>The rich man had very many flocks and herds, 
 <sup>3&#160;</sup>but the poor man had nothing, except one little ewe lamb, which he had bought and raised. It grew up together with him and with his children. It ate of his own food, drank of his own cup, and lay in his bosom, and was like a daughter to him. 
 <sup>4&#160;</sup>A traveler came to the rich man, and he didn’t want to take of his own flock and of his own herd to prepare for the wayfaring man who had come to him, but took the poor man’s lamb and prepared it for the man who had come to him.” 
 </p><p>
-<sup>5&#160;</sup>David’s anger burned hot against the man, and he said to Nathan, “As Yahweh lives, the man who has done this deserves to die! 
+<sup>5&#160;</sup>David’s anger burned hot against the man, and he said to Nathan, “As Yahuah lives, the man who has done this deserves to die! 
 <sup>6&#160;</sup>He must restore the lamb fourfold, because he did this thing and because he had no pity!” 
 </p><p>
-<sup>7&#160;</sup>Nathan said to David, “You are the man! This is what Yahweh, the Elohim of Israel, says: ‘I anointed you king over Israel, and I delivered you out of the hand of Saul. 
+<sup>7&#160;</sup>Nathan said to David, “You are the man! This is what Yahuah, the Elohim of Israel, says: ‘I anointed you king over Israel, and I delivered you out of the hand of Saul. 
 <sup>8&#160;</sup>I gave you your master’s house and your master’s women into your bosom, and gave you the house of Israel and of Judah; and if that would have been too little, I would have added to you many more such things. 
-<sup>9&#160;</sup>Why have you despised Yahweh’s word, to do that which is evil in his sight? You have struck Uriah the Hittite with the sword, have taken his woman to be your woman, and have slain him with the sword of the children of Ammon. 
+<sup>9&#160;</sup>Why have you despised Yahuah’s word, to do that which is evil in his sight? You have struck Uriah the Hittite with the sword, have taken his woman to be your woman, and have slain him with the sword of the children of Ammon. 
 <sup>10&#160;</sup>Now therefore the sword will never depart from your house, because you have despised me and have taken Uriah the Hittite’s woman to be your woman.’ 
 </p><p>
-<sup>11&#160;</sup>“This is what Yahweh says: ‘Behold, I will raise up evil against you out of your own house; and I will take your women before your eyes and give them to your neighbor, and he will lie with your women in the sight of this sun. 
+<sup>11&#160;</sup>“This is what Yahuah says: ‘Behold, I will raise up evil against you out of your own house; and I will take your women before your eyes and give them to your neighbor, and he will lie with your women in the sight of this sun. 
 <sup>12&#160;</sup>For you did this secretly, but I will do this thing before all Israel, and before the sun.’&#160;” 
 </p><p>
-<sup>13&#160;</sup>David said to Nathan, “I have sinned against Yahweh.” 
-</p><p>Nathan said to David, “Yahweh also has put away your sin. You will not die. 
-<sup>14&#160;</sup>However, because by this deed you have given great occasion to Yahweh’s enemies to blaspheme, the child also who is born to you will surely die.” 
+<sup>13&#160;</sup>David said to Nathan, “I have sinned against Yahuah.” 
+</p><p>Nathan said to David, “Yahuah also has put away your sin. You will not die. 
+<sup>14&#160;</sup>However, because by this deed you have given great occasion to Yahuah’s enemies to blaspheme, the child also who is born to you will surely die.” 
 <sup>15&#160;</sup>Then Nathan departed to his house. 
-</p><p>Yahweh struck the child that Uriah’s woman bore to David, and he was very sick. 
+</p><p>Yahuah struck the child that Uriah’s woman bore to David, and he was very sick. 
 <sup>16&#160;</sup>David therefore begged Elohim for the child; and David fasted, and went in and lay all night on the ground. 
 <sup>17&#160;</sup>The elders of his house arose beside him, to raise him up from the earth; but he would not, and he didn’t eat bread with them. 
 <sup>18&#160;</sup>On the seventh day, the child died. David’s servants were afraid to tell him that the child was dead, for they said, “Behold, while the child was yet alive, we spoke to him and he didn’t listen to our voice. How will he then harm himself if we tell him that the child is dead?” 
@@ -513,14 +513,14 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>But when David saw that his servants were whispering together, David perceived that the child was dead; and David said to his servants, “Is the child dead?” 
 </p><p>They said, “He is dead.” 
 </p><p>
-<sup>20&#160;</sup>Then David arose from the earth, and washed and anointed himself, and changed his clothing; and he came into Yahweh’s house, and worshiped. Then he came to his own house; and when he requested, they set bread before him and he ate. 
+<sup>20&#160;</sup>Then David arose from the earth, and washed and anointed himself, and changed his clothing; and he came into Yahuah’s house, and worshiped. Then he came to his own house; and when he requested, they set bread before him and he ate. 
 <sup>21&#160;</sup>Then his servants said to him, “What is this that you have done? You fasted and wept for the child while he was alive, but when the child was dead, you rose up and ate bread.” 
 </p><p>
-<sup>22&#160;</sup>He said, “While the child was yet alive, I fasted and wept; for I said, ‘Who knows whether Yahweh will not be gracious to me, that the child may live?’ 
+<sup>22&#160;</sup>He said, “While the child was yet alive, I fasted and wept; for I said, ‘Who knows whether Yahuah will not be gracious to me, that the child may live?’ 
 <sup>23&#160;</sup>But now he is dead. Why should I fast? Can I bring him back again? I will go to him, but he will not return to me.” 
 </p><p>
-<sup>24&#160;</sup>David comforted Bathsheba his woman, and went in to her, and lay with her. She bore a son, and he called his name Solomon. Yahweh loved him; 
-<sup>25&#160;</sup>and he sent by the hand of Nathan the prophet, and he named him Jedidiah, for Yahweh’s sake. 
+<sup>24&#160;</sup>David comforted Bathsheba his woman, and went in to her, and lay with her. She bore a son, and he called his name Solomon. Yahuah loved him; 
+<sup>25&#160;</sup>and he sent by the hand of Nathan the prophet, and he named him Jedidiah, for Yahuah’s sake. 
 </p><p>
 <sup>26&#160;</sup>Now Joab fought against Rabbah of the children of Ammon, and took the royal city. 
 <sup>27&#160;</sup>Joab sent messengers to David, and said, “I have fought against Rabbah. Yes, I have taken the city of waters. 
@@ -608,8 +608,8 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>10&#160;</sup>The king said, “Whoever says anything to you, bring him to me, and he will not bother you any more.” 
 </p><p>
-<sup>11&#160;</sup>Then she said, “Please let the king remember Yahweh your Elohim, that the avenger of blood destroy not any more, lest they destroy my son.” 
-</p><p>He said, “As Yahweh lives, not one hair of your son shall fall to the earth.” 
+<sup>11&#160;</sup>Then she said, “Please let the king remember Yahuah your Elohim, that the avenger of blood destroy not any more, lest they destroy my son.” 
+</p><p>He said, “As Yahuah lives, not one hair of your son shall fall to the earth.” 
 </p><p>
 <sup>12&#160;</sup>Then the woman said, “Please let your servant speak a word to my lord the king.” 
 </p><p>He said, “Say on.” 
@@ -618,7 +618,7 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>For we must die, and are like water spilled on the ground, which can’t be gathered up again; neither does Elohim take away life, but devises means, that he who is banished not be an outcast from him. 
 <sup>15&#160;</sup>Now therefore, seeing that I have come to speak this word to my lord the king, it is because the people have made me afraid. Your servant said, ‘I will now speak to the king; it may be that the king will perform the request of his servant.’ 
 <sup>16&#160;</sup>For the king will hear, to deliver his servant out of the hand of the man who would destroy me and my son together out of the inheritance of Elohim. 
-<sup>17&#160;</sup>Then your servant said, ‘Please let the word of my lord the king bring rest; for as an angel of Elohim, so is my lord the king to discern good and bad. May Yahweh, your Elohim, be with you.’&#160;” 
+<sup>17&#160;</sup>Then your servant said, ‘Please let the word of my lord the king bring rest; for as an angel of Elohim, so is my lord the king to discern good and bad. May Yahuah, your Elohim, be with you.’&#160;” 
 </p><p>
 <sup>18&#160;</sup>Then the king answered the woman, “Please don’t hide anything from me that I ask you.” 
 </p><p>The woman said, “Let my lord the king now speak.” 
@@ -656,8 +656,8 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>It was so, that when any man came near to bow down to him, he stretched out his hand, took hold of him, and kissed him. 
 <sup>6&#160;</sup>Absalom did this sort of thing to all Israel who came to the king for judgment. So Absalom stole the hearts of the men of Israel. 
 </p><p>
-<sup>7&#160;</sup>At the end of forty years, Absalom said to the king, “Please let me go and pay my vow, which I have vowed to Yahweh, in Hebron. 
-<sup>8&#160;</sup>For your servant vowed a vow while I stayed at Geshur in Syria, saying, ‘If Yahweh shall indeed bring me again to Jerusalem, then I will serve Yahweh.’&#160;” 
+<sup>7&#160;</sup>At the end of forty years, Absalom said to the king, “Please let me go and pay my vow, which I have vowed to Yahuah, in Hebron. 
+<sup>8&#160;</sup>For your servant vowed a vow while I stayed at Geshur in Syria, saying, ‘If Yahuah shall indeed bring me again to Jerusalem, then I will serve Yahuah.’&#160;” 
 </p><p>
 <sup>9&#160;</sup>The king said to him, “Go in peace.” 
 </p><p>So he arose and went to Hebron. 
@@ -678,12 +678,12 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>Then the king said to Ittai the Gittite, “Why do you also go with us? Return, and stay with the king; for you are a foreigner and also an exile. Return to your own place. 
 <sup>20&#160;</sup>Whereas you came but yesterday, should I today make you go up and down with us, since I go where I may? Return, and take back your brothers. Mercy and truth be with you.” 
 </p><p>
-<sup>21&#160;</sup>Ittai answered the king and said, “As Yahweh lives, and as my lord the king lives, surely in what place my lord the king is, whether for death or for life, your servant will be there also.” 
+<sup>21&#160;</sup>Ittai answered the king and said, “As Yahuah lives, and as my lord the king lives, surely in what place my lord the king is, whether for death or for life, your servant will be there also.” 
 </p><p>
 <sup>22&#160;</sup>David said to Ittai, “Go and pass over.” Ittai the Gittite passed over, and all his men, and all the little ones who were with him. 
 <sup>23&#160;</sup>All the country wept with a loud voice, and all the people passed over. The king also himself passed over the brook Kidron, and all the people passed over toward the way of the wilderness. 
 <sup>24&#160;</sup>Behold, Zadok also came, and all the Levites with him, bearing the ark of the covenant of Elohim; and they set down Elohim’s ark; and Abiathar went up until all the people finished passing out of the city. 
-<sup>25&#160;</sup>The king said to Zadok, “Carry Elohim’s ark back into the city. If I find favor in Yahweh’s eyes, he will bring me again, and show me both it and his habitation; 
+<sup>25&#160;</sup>The king said to Zadok, “Carry Elohim’s ark back into the city. If I find favor in Yahuah’s eyes, he will bring me again, and show me both it and his habitation; 
 <sup>26&#160;</sup>but if he says, ‘I have no delight in you,’ behold, here I am. Let him do to me as seems good to him.” 
 <sup>27&#160;</sup>The king said also to Zadok the priest, “Aren’t you a seer? Return into the city in peace, and your two sons with you, Ahimaaz your son and Jonathan the son of Abiathar. 
 <sup>28&#160;</sup>Behold, I will stay at the fords of the wilderness until word comes from you to inform me.” 
@@ -691,7 +691,7 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>David went up by the ascent of the Mount of Olives, and wept as he went up; and he had his head covered and went barefoot. All the people who were with him each covered his head, and they went up, weeping as they went up. 
 </p><p>
 <sup>31&#160;</sup>Someone told David, saying, “Ahithophel is among the conspirators with Absalom.” 
-</p><p>David said, “Yahweh, please turn the counsel of Ahithophel into foolishness.” 
+</p><p>David said, “Yahuah, please turn the counsel of Ahithophel into foolishness.” 
 </p><p>
 <sup>32&#160;</sup>When David had come to the top, where Elohim was worshiped, behold, Hushai the Archite came to meet him with his tunic torn and earth on his head. 
 <sup>33&#160;</sup>David said to him, “If you pass on with me, then you will be a burden to me; 
@@ -715,13 +715,13 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>When King David came to Bahurim, behold, a man of the family of Saul’s house came out, whose name was Shimei, the son of Gera. He came out and cursed as he came. 
 <sup>6&#160;</sup>He cast stones at David and at all the servants of King David, and all the people and all the mighty men were on his right hand and on his left. 
 <sup>7&#160;</sup>Shimei said when he cursed, “Be gone, be gone, you man of blood, and wicked fellow! 
-<sup>8&#160;</sup>Yahweh has returned on you all the blood of Saul’s house, in whose place you have reigned! Yahweh has delivered the kingdom into the hand of Absalom your son! Behold, you are caught by your own mischief, because you are a man of blood!” 
+<sup>8&#160;</sup>Yahuah has returned on you all the blood of Saul’s house, in whose place you have reigned! Yahuah has delivered the kingdom into the hand of Absalom your son! Behold, you are caught by your own mischief, because you are a man of blood!” 
 </p><p>
 <sup>9&#160;</sup>Then Abishai the son of Zeruiah said to the king, “Why should this dead dog curse my lord the king? Please let me go over and take off his head.” 
-<sup>10&#160;</sup>The king said, “What have I to do with you, you sons of Zeruiah? Because he curses, and because Yahweh has said to him, ‘Curse David,’ who then shall say, ‘Why have you done so?’&#160;” 
+<sup>10&#160;</sup>The king said, “What have I to do with you, you sons of Zeruiah? Because he curses, and because Yahuah has said to him, ‘Curse David,’ who then shall say, ‘Why have you done so?’&#160;” 
 </p><p>
-<sup>11&#160;</sup>David said to Abishai and to all his servants, “Behold, my son, who came out of my bowels, seeks my life. How much more this Benjamite, now? Leave him alone, and let him curse; for Yahweh has invited him. 
-<sup>12&#160;</sup>It may be that Yahweh will look on the wrong done to me, and that Yahweh will repay me good for the cursing of me today.” 
+<sup>11&#160;</sup>David said to Abishai and to all his servants, “Behold, my son, who came out of my bowels, seeks my life. How much more this Benjamite, now? Leave him alone, and let him curse; for Yahuah has invited him. 
+<sup>12&#160;</sup>It may be that Yahuah will look on the wrong done to me, and that Yahuah will repay me good for the cursing of me today.” 
 <sup>13&#160;</sup>So David and his men went by the way; and Shimei went along on the hillside opposite him and cursed as he went, threw stones at him, and threw dust. 
 <sup>14&#160;</sup>The king and all the people who were with him arrived weary; and he refreshed himself there. 
 </p><p>
@@ -730,7 +730,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>17&#160;</sup>Absalom said to Hushai, “Is this your kindness to your friend? Why didn’t you go with your friend?” 
 </p><p>
-<sup>18&#160;</sup>Hushai said to Absalom, “No; but whomever Yahweh and this people and all the men of Israel have chosen, I will be his, and I will stay with him. 
+<sup>18&#160;</sup>Hushai said to Absalom, “No; but whomever Yahuah and this people and all the men of Israel have chosen, I will be his, and I will stay with him. 
 <sup>19&#160;</sup>Again, whom should I serve? Shouldn’t I serve in the presence of his son? As I have served in your father’s presence, so I will be in your presence.” 
 </p><p>
 <sup>20&#160;</sup>Then Absalom said to Ahithophel, “Give your counsel what we shall do.” 
@@ -759,7 +759,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>So we will come on him in some place where he will be found, and we will light on him as the dew falls on the ground, then we will not leave so much as one of him and of all the men who are with him. 
 <sup>13&#160;</sup>Moreover, if he has gone into a city, then all Israel will bring ropes to that city, and we will draw it into the river, until there isn’t one small stone found there.” 
 </p><p>
-<sup>14&#160;</sup>Absalom and all the men of Israel said, “The counsel of Hushai the Archite is better than the counsel of Ahithophel.” For Yahweh had ordained to defeat the good counsel of Ahithophel, to the intent that Yahweh might bring evil on Absalom. 
+<sup>14&#160;</sup>Absalom and all the men of Israel said, “The counsel of Hushai the Archite is better than the counsel of Ahithophel.” For Yahuah had ordained to defeat the good counsel of Ahithophel, to the intent that Yahuah might bring evil on Absalom. 
 </p><p>
 <sup>15&#160;</sup>Then Hushai said to Zadok and to Abiathar the priests, “Ahithophel counseled Absalom and the elders of Israel that way; and I have counseled this way. 
 <sup>16&#160;</sup>Now therefore send quickly, and tell David, saying, ‘Don’t lodge tonight at the fords of the wilderness, but by all means pass over, lest the king be swallowed up, and all the people who are with him.’&#160;” 
@@ -813,7 +813,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>18&#160;</sup>Now Absalom in his lifetime had taken and reared up for himself the pillar which is in the king’s valley, for he said, “I have no son to keep my name in memory.” He called the pillar after his own name. It is called Absalom’s monument, to this day. 
 </p><p>
-<sup>19&#160;</sup>Then Ahimaaz the son of Zadok said, “Let me now run and carry the king news, how Yahweh has avenged him of his enemies.” 
+<sup>19&#160;</sup>Then Ahimaaz the son of Zadok said, “Let me now run and carry the king news, how Yahuah has avenged him of his enemies.” 
 </p><p>
 <sup>20&#160;</sup>Joab said to him, “You must not be the bearer of news today, but you must carry news another day. But today you must carry no news, because the king’s son is dead.” 
 </p><p>
@@ -834,14 +834,14 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>The watchman said, “I think the running of the first one is like the running of Ahimaaz the son of Zadok.” 
 </p><p>The king said, “He is a good man, and comes with good news.” 
 </p><p>
-<sup>28&#160;</sup>Ahimaaz called, and said to the king, “All is well.” He bowed himself before the king with his face to the earth, and said, “Blessed is Yahweh your Elohim, who has delivered up the men who lifted up their hand against my lord the king!” 
+<sup>28&#160;</sup>Ahimaaz called, and said to the king, “All is well.” He bowed himself before the king with his face to the earth, and said, “Blessed is Yahuah your Elohim, who has delivered up the men who lifted up their hand against my lord the king!” 
 </p><p>
 <sup>29&#160;</sup>The king said, “Is it well with the young man Absalom?” 
 </p><p>Ahimaaz answered, “When Joab sent the king’s servant, even me your servant, I saw a great tumult, but I don’t know what it was.” 
 </p><p>
 <sup>30&#160;</sup>The king said, “Come and stand here.” He came and stood still. 
 </p><p>
-<sup>31&#160;</sup>Behold, the Cushite came. The Cushite said, “Good news for my lord the king, for Yahweh has avenged you today of all those who rose up against you.” 
+<sup>31&#160;</sup>Behold, the Cushite came. The Cushite said, “Good news for my lord the king, for Yahuah has avenged you today of all those who rose up against you.” 
 </p><p>
 <sup>32&#160;</sup>The king said to the Cushite, “Is it well with the young man Absalom?” 
 </p><p>The Cushite answered, “May the enemies of my lord the king, and all who rise up against you to do you harm, be as that young man is.” 
@@ -857,7 +857,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>5&#160;</sup>Joab came into the house to the king, and said, “Today you have shamed the faces of all your servants who today have saved your life, and the lives of your sons and of your daughters, and the lives of your women, and the lives of your concubines; 
 <sup>6&#160;</sup>in that you love those who hate you and hate those who love you. For you have declared today that princes and servants are nothing to you. For today I perceive that if Absalom had lived and we had all died today, then it would have pleased you well. 
-<sup>7&#160;</sup>Now therefore arise, go out and speak to comfort your servants; for I swear by Yahweh, if you don’t go out, not a man will stay with you this night. That would be worse to you than all the evil that has happened to you from your youth until now.” 
+<sup>7&#160;</sup>Now therefore arise, go out and speak to comfort your servants; for I swear by Yahuah, if you don’t go out, not a man will stay with you this night. That would be worse to you than all the evil that has happened to you from your youth until now.” 
 </p><p>
 <sup>8&#160;</sup>Then the king arose and sat in the gate. The people were all told, “Behold, the king is sitting in the gate.” All the people came before the king. Now Israel had fled every man to his tent. 
 <sup>9&#160;</sup>All the people were at strife throughout all the tribes of Israel, saying, “The king delivered us out of the hand of our enemies, and he saved us out of the hand of the Philistines; and now he has fled out of the land from Absalom. 
@@ -876,7 +876,7 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>He said to the king, “Don’t let my lord impute iniquity to me, or remember that which your servant did perversely the day that my lord the king went out of Jerusalem, that the king should take it to his heart. 
 <sup>20&#160;</sup>For your servant knows that I have sinned. Therefore behold, I have come today as the first of all the house of Joseph to go down to meet my lord the king.” 
 </p><p>
-<sup>21&#160;</sup>But Abishai the son of Zeruiah answered, “Shouldn’t Shimei be put to death for this, because he cursed Yahweh’s anointed?” 
+<sup>21&#160;</sup>But Abishai the son of Zeruiah answered, “Shouldn’t Shimei be put to death for this, because he cursed Yahuah’s anointed?” 
 </p><p>
 <sup>22&#160;</sup>David said, “What have I to do with you, you sons of Zeruiah, that you should be adversaries to me today? Shall any man be put to death today in Israel? For don’t I know that I am king over Israel today?” 
 <sup>23&#160;</sup>The king said to Shimei, “You will not die.” The king swore to him. 
@@ -941,7 +941,7 @@ html[dir=ltr] .q2 {
 </p><p>He answered, “I’m listening.” 
 </p><p>
 <sup>18&#160;</sup>Then she spoke, saying, “They used to say in old times, ‘They shall surely ask counsel at Abel,’ and so they settled a matter. 
-<sup>19&#160;</sup>I am among those who are peaceable and faithful in Israel. You seek to destroy a city and a mother in Israel. Why will you swallow up Yahweh’s inheritance?” 
+<sup>19&#160;</sup>I am among those who are peaceable and faithful in Israel. You seek to destroy a city and a mother in Israel. Why will you swallow up Yahuah’s inheritance?” 
 </p><p>
 <sup>20&#160;</sup>Joab answered, “Far be it, far be it from me, that I should swallow up or destroy. 
 <sup>21&#160;</sup>The matter is not so. But a man of the hill country of Ephraim, Sheba the son of Bichri by name, has lifted up his hand against the king, even against David. Just deliver him, and I will depart from the city.” 
@@ -955,21 +955,21 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>and Ira the Jairite was chief minister to David. 
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
-<sup>1&#160;</sup>There was a famine in the days of David for three years, year after year; and David sought the face of Yahweh. Yahweh said, “It is for Saul, and for his bloody house, because he put the Gibeonites to death.” 
+<sup>1&#160;</sup>There was a famine in the days of David for three years, year after year; and David sought the face of Yahuah. Yahuah said, “It is for Saul, and for his bloody house, because he put the Gibeonites to death.” 
 </p><p>
 <sup>2&#160;</sup>The king called the Gibeonites and said to them (now the Gibeonites were not of the children of Israel, but of the remnant of the Amorites, and the children of Israel had sworn to them; and Saul sought to kill them in his zeal for the children of Israel and Judah); 
-<sup>3&#160;</sup>and David said to the Gibeonites, “What should I do for you? And with what should I make atonement, that you may bless Yahweh’s inheritance?” 
+<sup>3&#160;</sup>and David said to the Gibeonites, “What should I do for you? And with what should I make atonement, that you may bless Yahuah’s inheritance?” 
 </p><p>
 <sup>4&#160;</sup>The Gibeonites said to him, “It is no matter of silver or gold between us and Saul or his house; neither is it for us to put any man to death in Israel.” 
 </p><p>He said, “I will do for you whatever you say.” 
 </p><p>
 <sup>5&#160;</sup>They said to the king, “The man who consumed us and who plotted against us, that we should be destroyed from remaining in any of the borders of Israel, 
-<sup>6&#160;</sup>let seven men of his sons be delivered to us, and we will hang them up to Yahweh in Gibeah of Saul, the chosen of Yahweh.” 
+<sup>6&#160;</sup>let seven men of his sons be delivered to us, and we will hang them up to Yahuah in Gibeah of Saul, the chosen of Yahuah.” 
 </p><p>The king said, “I will give them.” 
 </p><p>
-<sup>7&#160;</sup>But the king spared Mephibosheth the son of Jonathan the son of Saul, because of Yahweh’s oath that was between them, between David and Jonathan the son of Saul. 
+<sup>7&#160;</sup>But the king spared Mephibosheth the son of Jonathan the son of Saul, because of Yahuah’s oath that was between them, between David and Jonathan the son of Saul. 
 <sup>8&#160;</sup>But the king took the two sons of Rizpah the daughter of Aiah, whom she bore to Saul, Armoni and Mephibosheth; and the five sons of Merab the daughter of Saul, whom she bore to Adriel the son of Barzillai the Meholathite. 
-<sup>9&#160;</sup>He delivered them into the hands of the Gibeonites; and they hanged them on the mountain before Yahweh, and all seven of them fell together. They were put to death in the days of harvest, in the first days, at the beginning of barley harvest. 
+<sup>9&#160;</sup>He delivered them into the hands of the Gibeonites; and they hanged them on the mountain before Yahuah, and all seven of them fell together. They were put to death in the days of harvest, in the first days, at the beginning of barley harvest. 
 </p><p>
 <sup>10&#160;</sup>Rizpah the daughter of Aiah took sackcloth and spread it for herself on the rock, from the beginning of harvest until water poured on them from the sky. She allowed neither the birds of the sky to rest on them by day, nor the animals of the field by night. 
 <sup>11&#160;</sup>David was told what Rizpah the daughter of Aiah, the concubine of Saul, had done. 
@@ -988,9 +988,9 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>These four were born to the giant in Gath; and they fell by the hand of David and by the hand of his servants. 
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
-<sup>1&#160;</sup>David spoke to Yahweh the words of this song in the day that Yahweh delivered him out of the hand of all his enemies, and out of the hand of Saul, 
+<sup>1&#160;</sup>David spoke to Yahuah the words of this song in the day that Yahuah delivered him out of the hand of all his enemies, and out of the hand of Saul, 
 <sup>2&#160;</sup>and he said: 
-</p><p class="q1">“Yahweh is my rock, 
+</p><p class="q1">“Yahuah is my rock, 
 </p><p class="q2">my fortress, 
 </p><p class="q2">and my deliverer, even mine; 
 </p><p class="q1">
@@ -999,7 +999,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">my high tower, and my refuge. 
 </p><p class="q2">My savior, you save me from violence. 
 </p><p class="q1">
-<sup>4&#160;</sup>I call on Yahweh, who is worthy to be praised; 
+<sup>4&#160;</sup>I call on Yahuah, who is worthy to be praised; 
 </p><p class="q2">So shall I be saved from my enemies. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -1009,7 +1009,7 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>The cords of Sheol were around me. 
 </p><p class="q2">The snares of death caught me. 
 </p><p class="q1">
-<sup>7&#160;</sup>In my distress, I called on Yahweh. 
+<sup>7&#160;</sup>In my distress, I called on Yahuah. 
 </p><p class="q2">Yes, I called to my Elohim. 
 </p><p class="q1">He heard my voice out of his temple. 
 </p><p class="q2">My cry came into his ears. 
@@ -1034,14 +1034,14 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>At the brightness before him, 
 </p><p class="q2">coals of fire were kindled. 
 </p><p class="q1">
-<sup>14&#160;</sup>Yahweh thundered from heaven. 
+<sup>14&#160;</sup>Yahuah thundered from heaven. 
 </p><p class="q2">The Most High uttered his voice. 
 </p><p class="q1">
 <sup>15&#160;</sup>He sent out arrows and scattered them, 
 </p><p class="q2">lightning and confused them. 
 </p><p class="q1">
 <sup>16&#160;</sup>Then the channels of the sea appeared. 
-</p><p class="q2">The foundations of the world were laid bare by Yahweh’s rebuke, 
+</p><p class="q2">The foundations of the world were laid bare by Yahuah’s rebuke, 
 </p><p class="q2">at the blast of the breath of his nostrils. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -1052,16 +1052,16 @@ html[dir=ltr] .q2 {
 </p><p class="q2">from those who hated me, for they were too mighty for me. 
 </p><p class="q1">
 <sup>19&#160;</sup>They came on me in the day of my calamity, 
-</p><p class="q2">but Yahweh was my support. 
+</p><p class="q2">but Yahuah was my support. 
 </p><p class="q1">
 <sup>20&#160;</sup>He also brought me out into a large place. 
 </p><p class="q2">He delivered me, because he delighted in me. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>21&#160;</sup>Yahweh rewarded me according to my righteousness. 
+<sup>21&#160;</sup>Yahuah rewarded me according to my righteousness. 
 </p><p class="q2">He rewarded me according to the cleanness of my hands. 
 </p><p class="q1">
-<sup>22&#160;</sup>For I have kept Yahweh’s ways, 
+<sup>22&#160;</sup>For I have kept Yahuah’s ways, 
 </p><p class="q2">and have not wickedly departed from my Elohim. 
 </p><p class="q1">
 <sup>23&#160;</sup>For all his ordinances were before me. 
@@ -1070,7 +1070,7 @@ html[dir=ltr] .q2 {
 <sup>24&#160;</sup>I was also perfect toward him. 
 </p><p class="q2">I kept myself from my iniquity. 
 </p><p class="q1">
-<sup>25&#160;</sup>Therefore Yahweh has rewarded me according to my righteousness, 
+<sup>25&#160;</sup>Therefore Yahuah has rewarded me according to my righteousness, 
 </p><p class="q2">According to my cleanness in his eyesight. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -1083,18 +1083,18 @@ html[dir=ltr] .q2 {
 <sup>28&#160;</sup>You will save the afflicted people, 
 </p><p class="q2">but your eyes are on the arrogant, that you may bring them down. 
 </p><p class="q1">
-<sup>29&#160;</sup>For you are my lamp, Yahweh. 
-</p><p class="q2">Yahweh will light up my darkness. 
+<sup>29&#160;</sup>For you are my lamp, Yahuah. 
+</p><p class="q2">Yahuah will light up my darkness. 
 </p><p class="q1">
 <sup>30&#160;</sup>For by you, I run against a troop. 
 </p><p class="q2">By my Elohim, I leap over a wall. 
 </p><p class="q1">
 <sup>31&#160;</sup>As for Elohim, his way is perfect. 
-</p><p class="q2">Yahweh’s word is tested. 
+</p><p class="q2">Yahuah’s word is tested. 
 </p><p class="q2">He is a shield to all those who take refuge in him. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>32&#160;</sup>For who is Elohim, besides Yahweh? 
+<sup>32&#160;</sup>For who is Elohim, besides Yahuah? 
 </p><p class="q2">Who is a rock, besides our Elohim? 
 </p><p class="q1">
 <sup>33&#160;</sup>Elohim is my strong fortress. 
@@ -1127,7 +1127,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">that I might cut off those who hate me. 
 </p><p class="q1">
 <sup>42&#160;</sup>They looked, but there was no one to save; 
-</p><p class="q2">even to Yahweh, but he didn’t answer them. 
+</p><p class="q2">even to Yahuah, but he didn’t answer them. 
 </p><p class="q1">
 <sup>43&#160;</sup>Then I beat them as small as the dust of the earth. 
 </p><p class="q2">I crushed them as the mire of the streets, and spread them abroad. 
@@ -1144,7 +1144,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will come trembling out of their close places. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>47&#160;</sup>Yahweh lives! 
+<sup>47&#160;</sup>Yahuah lives! 
 </p><p class="q2">Blessed be my rock! 
 </p><p class="q1">Exalted be Elohim, the rock of my salvation, 
 </p><p class="q2">
@@ -1155,7 +1155,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Yes, you lift me up above those who rise up against me. 
 </p><p class="q2">You deliver me from the violent man. 
 </p><p class="q1">
-<sup>50&#160;</sup>Therefore I will give thanks to you, Yahweh, among the nations, 
+<sup>50&#160;</sup>Therefore I will give thanks to you, Yahuah, among the nations, 
 </p><p class="q2">and will sing praises to your name. 
 </p><p class="q1">
 <sup>51&#160;</sup>He gives great deliverance to his king, 
@@ -1169,7 +1169,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the anointed of the Elohim of Jacob, 
 </p><p class="q2">the sweet psalmist of Israel: 
 </p><p class="q1">
-<sup>2&#160;</sup>“Yahweh’s Spirit spoke by me. 
+<sup>2&#160;</sup>“Yahuah’s Spirit spoke by me. 
 </p><p class="q2">His word was on my tongue. 
 </p><p class="q1">
 <sup>3&#160;</sup>The Elohim of Israel said, 
@@ -1197,16 +1197,16 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>8&#160;</sup>These are the names of the mighty men whom David had: Josheb Basshebeth a Tahchemonite, chief of the captains; he was called Adino the Eznite, who killed eight hundred at one time. 
 <sup>9&#160;</sup>After him was Eleazar the son of Dodai the son of an Ahohite, one of the three mighty men with David when they defied the Philistines who were there gathered together to battle, and the men of Israel had gone away. 
-<sup>10&#160;</sup>He arose and struck the Philistines until his hand was weary, and his hand froze to the sword; and Yahweh worked a great victory that day; and the people returned after him only to take plunder. 
+<sup>10&#160;</sup>He arose and struck the Philistines until his hand was weary, and his hand froze to the sword; and Yahuah worked a great victory that day; and the people returned after him only to take plunder. 
 <sup>11&#160;</sup>After him was Shammah the son of Agee a Hararite. The Philistines had gathered together into a troop where there was a plot of ground full of lentils; and the people fled from the Philistines. 
-<sup>12&#160;</sup>But he stood in the middle of the plot and defended it, and killed the Philistines; and Yahweh worked a great victory. 
+<sup>12&#160;</sup>But he stood in the middle of the plot and defended it, and killed the Philistines; and Yahuah worked a great victory. 
 </p><p>
 <sup>13&#160;</sup>Three of the thirty chief men went down, and came to David in the harvest time to the cave of Adullam; and the troop of the Philistines was encamped in the valley of Rephaim. 
 <sup>14&#160;</sup>David was then in the stronghold; and the garrison of the Philistines was then in Bethlehem. 
 <sup>15&#160;</sup>David said longingly, “Oh that someone would give me water to drink from the well of Bethlehem, which is by the gate!” 
 </p><p>
-<sup>16&#160;</sup>The three mighty men broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate and took it and brought it to David; but he would not drink of it, but poured it out to Yahweh. 
-<sup>17&#160;</sup>He said, “Be it far from me, Yahweh, that I should do this! Isn’t this the blood of the men who risked their lives to go?” Therefore he would not drink it. The three mighty men did these things. 
+<sup>16&#160;</sup>The three mighty men broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate and took it and brought it to David; but he would not drink of it, but poured it out to Yahuah. 
+<sup>17&#160;</sup>He said, “Be it far from me, Yahuah, that I should do this! Isn’t this the blood of the men who risked their lives to go?” Therefore he would not drink it. The three mighty men did these things. 
 </p><p>
 <sup>18&#160;</sup>Abishai, the brother of Joab, the son of Zeruiah, was chief of the three. He lifted up his spear against three hundred and killed them, and had a name among the three. 
 <sup>19&#160;</sup>Wasn’t he most honorable of the three? Therefore he was made their captain. However he wasn’t included as one of the three. 
@@ -1234,10 +1234,10 @@ html[dir=ltr] .q2 {
 <sup>39&#160;</sup>and Uriah the Hittite: thirty-seven in all. 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
-<sup>1&#160;</sup>Again Yahweh’s anger burned against Israel, and he moved David against them, saying, “Go, count Israel and Judah.” 
+<sup>1&#160;</sup>Again Yahuah’s anger burned against Israel, and he moved David against them, saying, “Go, count Israel and Judah.” 
 <sup>2&#160;</sup>The king said to Joab the captain of the army, who was with him, “Now go back and forth through all the tribes of Israel, from Dan even to Beersheba, and count the people, that I may know the sum of the people.” 
 </p><p>
-<sup>3&#160;</sup>Joab said to the king, “Now may Yahweh your Elohim add to the people, however many they may be, one hundred times; and may the eyes of my lord the king see it. But why does my lord the king delight in this thing?” 
+<sup>3&#160;</sup>Joab said to the king, “Now may Yahuah your Elohim add to the people, however many they may be, one hundred times; and may the eyes of my lord the king see it. But why does my lord the king delight in this thing?” 
 </p><p>
 <sup>4&#160;</sup>Notwithstanding, the king’s word prevailed against Joab and against the captains of the army. Joab and the captains of the army went out from the presence of the king to count the people of Israel. 
 <sup>5&#160;</sup>They passed over the Jordan and encamped in Aroer, on the right side of the city that is in the middle of the valley of Gad, and to Jazer; 
@@ -1246,29 +1246,29 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>So when they had gone back and forth through all the land, they came to Jerusalem at the end of nine months and twenty days. 
 <sup>9&#160;</sup>Joab gave up the sum of the counting of the people to the king; and there were in Israel eight hundred thousand valiant men who drew the sword, and the men of Judah were five hundred thousand men. 
 </p><p>
-<sup>10&#160;</sup>David’s heart struck him after he had counted the people. David said to Yahweh, “I have sinned greatly in that which I have done. But now, Yahweh, put away, I beg you, the iniquity of your servant; for I have done very foolishly.” 
+<sup>10&#160;</sup>David’s heart struck him after he had counted the people. David said to Yahuah, “I have sinned greatly in that which I have done. But now, Yahuah, put away, I beg you, the iniquity of your servant; for I have done very foolishly.” 
 </p><p>
-<sup>11&#160;</sup>When David rose up in the morning, Yahweh’s word came to the prophet Gad, David’s seer, saying, 
-<sup>12&#160;</sup>“Go and speak to David, ‘Yahweh says, “I offer you three things. Choose one of them, that I may do it to you.”&#160;’&#160;” 
+<sup>11&#160;</sup>When David rose up in the morning, Yahuah’s word came to the prophet Gad, David’s seer, saying, 
+<sup>12&#160;</sup>“Go and speak to David, ‘Yahuah says, “I offer you three things. Choose one of them, that I may do it to you.”&#160;’&#160;” 
 </p><p>
 <sup>13&#160;</sup>So Gad came to David, and told him, saying, “Shall seven years of famine come to you in your land? Or will you flee three months before your foes while they pursue you? Or shall there be three days’ pestilence in your land? Now answer, and consider what answer I shall return to him who sent me.” 
 </p><p>
-<sup>14&#160;</sup>David said to Gad, “I am in distress. Let us fall now into Yahweh’s hand, for his mercies are great. Let me not fall into man’s hand.” 
+<sup>14&#160;</sup>David said to Gad, “I am in distress. Let us fall now into Yahuah’s hand, for his mercies are great. Let me not fall into man’s hand.” 
 </p><p>
-<sup>15&#160;</sup>So Yahweh sent a pestilence on Israel from the morning even to the appointed time; and seventy thousand men died of the people from Dan even to Beersheba. 
-<sup>16&#160;</sup>When the angel stretched out his hand toward Jerusalem to destroy it, Yahweh relented of the disaster, and said to the angel who destroyed the people, “It is enough. Now withdraw your hand.” Yahweh’s angel was by the threshing floor of Araunah the Jebusite. 
+<sup>15&#160;</sup>So Yahuah sent a pestilence on Israel from the morning even to the appointed time; and seventy thousand men died of the people from Dan even to Beersheba. 
+<sup>16&#160;</sup>When the angel stretched out his hand toward Jerusalem to destroy it, Yahuah relented of the disaster, and said to the angel who destroyed the people, “It is enough. Now withdraw your hand.” Yahuah’s angel was by the threshing floor of Araunah the Jebusite. 
 </p><p>
-<sup>17&#160;</sup>David spoke to Yahweh when he saw the angel who struck the people, and said, “Behold, I have sinned, and I have done perversely; but these sheep, what have they done? Please let your hand be against me, and against my father’s house.” 
+<sup>17&#160;</sup>David spoke to Yahuah when he saw the angel who struck the people, and said, “Behold, I have sinned, and I have done perversely; but these sheep, what have they done? Please let your hand be against me, and against my father’s house.” 
 </p><p>
-<sup>18&#160;</sup>Gad came that day to David and said to him, “Go up, build an altar to Yahweh on the threshing floor of Araunah the Jebusite.” 
+<sup>18&#160;</sup>Gad came that day to David and said to him, “Go up, build an altar to Yahuah on the threshing floor of Araunah the Jebusite.” 
 </p><p>
-<sup>19&#160;</sup>David went up according to the saying of Gad, as Yahweh commanded. 
+<sup>19&#160;</sup>David went up according to the saying of Gad, as Yahuah commanded. 
 <sup>20&#160;</sup>Araunah looked out, and saw the king and his servants coming on toward him. Then Araunah went out and bowed himself before the king with his face to the ground. 
 <sup>21&#160;</sup>Araunah said, “Why has my lord the king come to his servant?” 
-</p><p>David said, “To buy your threshing floor, to build an altar to Yahweh, that the plague may be stopped from afflicting the people.” 
+</p><p>David said, “To buy your threshing floor, to build an altar to Yahuah, that the plague may be stopped from afflicting the people.” 
 </p><p>
 <sup>22&#160;</sup>Araunah said to David, “Let my lord the king take and offer up what seems good to him. Behold, the cattle for the burnt offering, and the threshing sledges and the yokes of the oxen for the wood. 
-<sup>23&#160;</sup>All this, O king, does Araunah give to the king.” Araunah said to the king, “May Yahweh your Elohim accept you.” 
+<sup>23&#160;</sup>All this, O king, does Araunah give to the king.” Araunah said to the king, “May Yahuah your Elohim accept you.” 
 </p><p>
-<sup>24&#160;</sup>The king said to Araunah, “No, but I will most certainly buy it from you for a price. I will not offer burnt offerings to Yahweh my Elohim which cost me nothing.” So David bought the threshing floor and the oxen for fifty shekels of silver. 
-<sup>25&#160;</sup>David built an altar to Yahweh there, and offered burnt offerings and peace offerings. So Yahweh was entreated for the land, and the plague was removed from Israel. </p></div><script src="../main.js"></script></body></html>
+<sup>24&#160;</sup>The king said to Araunah, “No, but I will most certainly buy it from you for a price. I will not offer burnt offerings to Yahuah my Elohim which cost me nothing.” So David bought the threshing floor and the oxen for fifty shekels of silver. 
+<sup>25&#160;</sup>David built an altar to Yahuah there, and offered burnt offerings and peace offerings. So Yahuah was entreated for the land, and the plague was removed from Israel. </p></div><script src="../main.js"></script></body></html>

--- a/book/amos.html
+++ b/book/amos.html
@@ -70,12 +70,12 @@ html[dir=ltr] .q2 {
 <p class="p1">
 <sup>1&#160;</sup>The words of Amos, who was among the herdsmen of Tekoa, which he saw concerning Israel in the days of Uzziah king of Judah and in the days of Jeroboam the son of Joash, king of Israel, two years before the earthquake. 
 <sup>2&#160;</sup>He said: 
-</p><p class="q1">“Yahweh will roar from Zion, 
+</p><p class="q1">“Yahuah will roar from Zion, 
 </p><p class="q2">and utter his voice from Jerusalem; 
 </p><p class="q1">and the pastures of the shepherds will mourn, 
 </p><p class="q2">and the top of Carmel will wither.” 
 </p><p>
-<sup>3&#160;</sup>Yahweh says: 
+<sup>3&#160;</sup>Yahuah says: 
 </p><p class="q1">“For three transgressions of Damascus, yes, for four, 
 </p><p class="q2">I will not turn away its punishment, 
 </p><p class="q2">because they have threshed Gilead with threshing instruments of iron; 
@@ -87,9 +87,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and cut off the inhabitant from the valley of Aven, 
 </p><p class="q2">and him who holds the scepter from the house of Eden; 
 </p><p class="q2">and the people of Syria shall go into captivity to Kir,” 
-</p><p>says Yahweh. 
+</p><p>says Yahuah. 
 </p><p>
-<sup>6&#160;</sup>Yahweh says: 
+<sup>6&#160;</sup>Yahuah says: 
 </p><p class="q1">“For three transgressions of Gaza, yes, for four, 
 </p><p class="q2">I will not turn away its punishment, 
 </p><p class="q2">because they carried away captive the whole community, 
@@ -102,9 +102,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and him who holds the scepter from Ashkelon; 
 </p><p class="q1">and I will turn my hand against Ekron; 
 </p><p class="q2">and the remnant of the Philistines will perish,” 
-</p><p>says the Lord Yahweh. 
+</p><p>says the Lord Yahuah. 
 </p><p>
-<sup>9&#160;</sup>Yahweh says: 
+<sup>9&#160;</sup>Yahuah says: 
 </p><p class="q1">“For three transgressions of Tyre, yes, for four, 
 </p><p class="q2">I will not turn away its punishment; 
 </p><p class="q2">because they delivered up the whole community to Edom, 
@@ -113,7 +113,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>but I will send a fire on the wall of Tyre, 
 </p><p class="q2">and it will devour its palaces.” 
 </p><p>
-<sup>11&#160;</sup>Yahweh says: 
+<sup>11&#160;</sup>Yahuah says: 
 </p><p class="q1">“For three transgressions of Edom, yes, for four, 
 </p><p class="q2">I will not turn away its punishment, 
 </p><p class="q2">because he pursued his brother with the sword 
@@ -124,7 +124,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>but I will send a fire on Teman, 
 </p><p class="q2">and it will devour the palaces of Bozrah.” 
 </p><p>
-<sup>13&#160;</sup>Yahweh says: 
+<sup>13&#160;</sup>Yahuah says: 
 </p><p class="q1">“For three transgressions of the children of Ammon, yes, for four, 
 </p><p class="q2">I will not turn away its punishment, 
 </p><p class="q2">because they have ripped open the pregnant women of Gilead, 
@@ -137,10 +137,10 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>15&#160;</sup>and their king will go into captivity, 
 </p><p class="q2">he and his princes together,” 
-</p><p>says Yahweh. 
+</p><p>says Yahuah. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>Yahweh says: 
+<sup>1&#160;</sup>Yahuah says: 
 </p><p class="q1">“For three transgressions of Moab, yes, for four, 
 </p><p class="q2">I will not turn away its punishment, 
 </p><p class="q2">because he burned the bones of the king of Edom into lime; 
@@ -151,12 +151,12 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>3&#160;</sup>and I will cut off the judge from among them, 
 </p><p class="q2">and will kill all its princes with him,” 
-</p><p>says Yahweh. 
+</p><p>says Yahuah. 
 </p><p>
-<sup>4&#160;</sup>Yahweh says: 
+<sup>4&#160;</sup>Yahuah says: 
 </p><p class="q1">“For three transgressions of Judah, yes, for four, 
 </p><p class="q2">I will not turn away its punishment, 
-</p><p class="q2">because they have rejected Yahweh’s law, 
+</p><p class="q2">because they have rejected Yahuah’s law, 
 </p><p class="q2">and have not kept his statutes, 
 </p><p class="q2">and their lies have led them astray, 
 </p><p class="q2">after which their fathers walked; 
@@ -164,7 +164,7 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>but I will send a fire on Judah, 
 </p><p class="q2">and it will devour the palaces of Jerusalem.” 
 </p><p>
-<sup>6&#160;</sup>Yahweh says: 
+<sup>6&#160;</sup>Yahuah says: 
 </p><p class="q1">“For three transgressions of Israel, yes, for four, 
 </p><p class="q2">I will not turn away its punishment, 
 </p><p class="q2">because they have sold the righteous for silver, 
@@ -190,7 +190,7 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>I raised up some of your sons for prophets, 
 </p><p class="q2">and some of your young men for Nazirites. 
 </p><p class="q1">Isn’t this true, 
-</p><p class="q2">you children of Israel?” says Yahweh. 
+</p><p class="q2">you children of Israel?” says Yahuah. 
 </p><p class="q1">
 <sup>12&#160;</sup>“But you gave the Nazirites wine to drink, 
 </p><p class="q2">and commanded the prophets, saying, ‘Don’t prophesy!’ 
@@ -208,10 +208,10 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>16&#160;</sup>He who is courageous among the mighty 
 </p><p class="q2">will flee away naked on that day,” 
-</p><p>says Yahweh. 
+</p><p>says Yahuah. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>Hear this word that Yahweh has spoken against you, children of Israel, against the whole family which I brought up out of the land of Egypt, saying: 
+<sup>1&#160;</sup>Hear this word that Yahuah has spoken against you, children of Israel, against the whole family which I brought up out of the land of Egypt, saying: 
 </p><p class="q1">
 <sup>2&#160;</sup>“I have only chosen you of all the families of the earth. 
 </p><p class="q2">Therefore I will punish you for all of your sins.” 
@@ -232,14 +232,14 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>Does the trumpet alarm sound in a city, 
 </p><p class="q2">without the people being afraid? 
 </p><p class="q1">Does evil happen to a city, 
-</p><p class="q2">and Yahweh hasn’t done it? 
+</p><p class="q2">and Yahuah hasn’t done it? 
 </p><p class="q1">
-<sup>7&#160;</sup>Surely the Lord Yahweh will do nothing, 
+<sup>7&#160;</sup>Surely the Lord Yahuah will do nothing, 
 </p><p class="q2">unless he reveals his secret to his servants the prophets. 
 </p><p class="q1">
 <sup>8&#160;</sup>The lion has roared. 
 </p><p class="q2">Who will not fear? 
-</p><p class="q1">The Lord Yahweh has spoken. 
+</p><p class="q1">The Lord Yahuah has spoken. 
 </p><p class="q2">Who can but prophesy? 
 </p><p class="q1">
 <sup>9&#160;</sup>Proclaim in the palaces at Ashdod, 
@@ -248,21 +248,21 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and see what unrest is in her, 
 </p><p class="q2">and what oppression is among them.” 
 </p><p class="q1">
-<sup>10&#160;</sup>“Indeed they don’t know to do right,” says Yahweh, 
+<sup>10&#160;</sup>“Indeed they don’t know to do right,” says Yahuah, 
 </p><p class="q2">“Who hoard plunder and loot in their palaces.” 
 </p><p>
-<sup>11&#160;</sup>Therefore the Lord Yahweh says: 
+<sup>11&#160;</sup>Therefore the Lord Yahuah says: 
 </p><p class="q1">“An adversary will overrun the land; 
 </p><p class="q2">and he will pull down your strongholds, 
 </p><p class="q2">and your fortresses will be plundered.” 
 </p><p>
-<sup>12&#160;</sup>Yahweh says: 
+<sup>12&#160;</sup>Yahuah says: 
 </p><p class="q1">“As the shepherd rescues out of the mouth of the lion two legs, 
 </p><p class="q2">or a piece of an ear, 
 </p><p class="q2">so shall the children of Israel be rescued who sit in Samaria on the corner of a couch, 
 </p><p class="q2">and on the silken cushions of a bed.” 
 </p><p>
-<sup>13&#160;</sup>“Listen, and testify against the house of Jacob,” says the Lord Yahweh, the Elohim of Armies. 
+<sup>13&#160;</sup>“Listen, and testify against the house of Jacob,” says the Lord Yahuah, the Elohim of Armies. 
 </p><p class="q1">
 <sup>14&#160;</sup>“For in the day that I visit the transgressions of Israel on him, 
 </p><p class="q2">I will also visit the altars of Bethel; 
@@ -272,18 +272,18 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>I will strike the winter house with the summer house; 
 </p><p class="q2">and the houses of ivory will perish, 
 </p><p class="q2">and the great houses will have an end,” 
-</p><p>says Yahweh. 
+</p><p>says Yahuah. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
 <sup>1&#160;</sup>Listen to this word, you cows of Bashan, who are on the mountain of Samaria, who oppress the poor, who crush the needy, who tell their lords, “Bring us drinks!” 
 </p><p class="q1">
-<sup>2&#160;</sup>The Lord Yahweh has sworn by his set-apartness, 
+<sup>2&#160;</sup>The Lord Yahuah has sworn by his set-apartness, 
 </p><p class="q2">“Behold, the days shall come on you that they will take you away with hooks, 
 </p><p class="q2">and the last of you with fish hooks. 
 </p><p class="q1">
 <sup>3&#160;</sup>You will go out at the breaks in the wall, 
 </p><p class="q2">everyone straight before her; 
-</p><p class="q2">and you will cast yourselves into Harmon,” says Yahweh. 
+</p><p class="q2">and you will cast yourselves into Harmon,” says Yahuah. 
 </p><p class="q1">
 <sup>4&#160;</sup>“Go to Bethel, and sin; 
 </p><p class="q2">to Gilgal, and sin more. 
@@ -292,11 +292,11 @@ html[dir=ltr] .q2 {
 </p><p class="q2">
 <sup>5&#160;</sup>offer a sacrifice of thanksgiving of that which is leavened, 
 </p><p class="q2">and proclaim free will offerings and brag about them; 
-</p><p class="q2">for this pleases you, you children of Israel,” says the Lord Yahweh. 
+</p><p class="q2">for this pleases you, you children of Israel,” says the Lord Yahuah. 
 </p><p class="q1">
 <sup>6&#160;</sup>“I also have given you cleanness of teeth in all your cities, 
 </p><p class="q2">and lack of bread in every town; 
-</p><p class="q2">yet you haven’t returned to me,” says Yahweh. 
+</p><p class="q2">yet you haven’t returned to me,” says Yahuah. 
 </p><p class="q1">
 <sup>7&#160;</sup>“I also have withheld the rain from you, 
 </p><p class="q2">when there were yet three months to the harvest; 
@@ -307,22 +307,22 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>8&#160;</sup>So two or three cities staggered to one city to drink water, 
 </p><p class="q2">and were not satisfied; 
-</p><p class="q2">yet you haven’t returned to me,” says Yahweh. 
+</p><p class="q2">yet you haven’t returned to me,” says Yahuah. 
 </p><p class="q1">
 <sup>9&#160;</sup>“I struck you with blight and mildew many times in your gardens and your vineyards, 
 </p><p class="q2">and the swarming locusts have devoured your fig trees and your olive trees; 
-</p><p class="q2">yet you haven’t returned to me,” says Yahweh. 
+</p><p class="q2">yet you haven’t returned to me,” says Yahuah. 
 </p><p class="q1">
 <sup>10&#160;</sup>“I sent plagues among you like I did Egypt. 
 </p><p class="q2">I have slain your young men with the sword, 
 </p><p class="q2">and have carried away your horses. 
 </p><p class="q1">I filled your nostrils with the stench of your camp, 
-</p><p class="q2">yet you haven’t returned to me,” says Yahweh. 
+</p><p class="q2">yet you haven’t returned to me,” says Yahuah. 
 </p><p class="q1">
 <sup>11&#160;</sup>“I have overthrown some of you, 
 </p><p class="q2">as when Elohim overthrew Sodom and Gomorrah, 
 </p><p class="q2">and you were like a burning stick plucked out of the fire; 
-</p><p class="q2">yet you haven’t returned to me,” says Yahweh. 
+</p><p class="q2">yet you haven’t returned to me,” says Yahuah. 
 </p><p class="q1">
 <sup>12&#160;</sup>“Therefore I will do this to you, Israel; 
 </p><p class="q2">because I will do this to you, 
@@ -330,7 +330,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>13&#160;</sup>For, behold, he who forms the mountains, creates the wind, declares to man what is his thought, 
 </p><p class="q2">who makes the morning darkness, and treads on the high places of the earth: 
-</p><p class="q2">Yahweh, the Elohim of Armies, is his name.” 
+</p><p class="q2">Yahuah, the Elohim of Armies, is his name.” 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
 <sup>1&#160;</sup>Listen to this word which I take up for a lamentation over you, O house of Israel: 
@@ -340,11 +340,11 @@ html[dir=ltr] .q2 {
 </p><p class="q1">She is cast down on her land; 
 </p><p class="q2">there is no one to raise her up.” 
 </p><p>
-<sup>3&#160;</sup>For the Lord Yahweh says: 
+<sup>3&#160;</sup>For the Lord Yahuah says: 
 </p><p class="q1">“The city that went out a thousand shall have a hundred left, 
 </p><p class="q2">and that which went out one hundred shall have ten left to the house of Israel.” 
 </p><p>
-<sup>4&#160;</sup>For Yahweh says to the house of Israel: 
+<sup>4&#160;</sup>For Yahuah says to the house of Israel: 
 </p><p class="q1">“Seek me, and you will live; 
 </p><p class="q1">
 <sup>5&#160;</sup>but don’t seek Bethel, 
@@ -353,7 +353,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">for Gilgal shall surely go into captivity, 
 </p><p class="q2">and Bethel shall come to nothing. 
 </p><p class="q1">
-<sup>6&#160;</sup>Seek Yahweh, and you will live, 
+<sup>6&#160;</sup>Seek Yahuah, and you will live, 
 </p><p class="q2">lest he break out like fire in the house of Joseph, 
 </p><p class="q2">and it devour, and there be no one to quench it in Bethel. 
 </p><p class="q1">
@@ -364,7 +364,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and turns the shadow of death into the morning, 
 </p><p class="q2">and makes the day dark with night; 
 </p><p class="q2">who calls for the waters of the sea, 
-</p><p class="q2">and pours them out on the surface of the earth, Yahweh is his name, 
+</p><p class="q2">and pours them out on the surface of the earth, Yahuah is his name, 
 </p><p class="q1">
 <sup>9&#160;</sup>who brings sudden destruction on the strong, 
 </p><p class="q2">so that destruction comes on the fortress. 
@@ -387,24 +387,24 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>14&#160;</sup>Seek good, and not evil, 
 </p><p class="q2">that you may live; 
-</p><p class="q2">and so Yahweh, the Elohim of Armies, will be with you, 
+</p><p class="q2">and so Yahuah, the Elohim of Armies, will be with you, 
 </p><p class="q2">as you say. 
 </p><p class="q1">
 <sup>15&#160;</sup>Hate evil, love good, 
 </p><p class="q2">and establish justice in the courts. 
-</p><p class="q2">It may be that Yahweh, the Elohim of Armies, will be gracious to the remnant of Joseph.” 
+</p><p class="q2">It may be that Yahuah, the Elohim of Armies, will be gracious to the remnant of Joseph.” 
 </p><p>
-<sup>16&#160;</sup>Therefore Yahweh, the Elohim of Armies, the Lord, says: 
+<sup>16&#160;</sup>Therefore Yahuah, the Elohim of Armies, the Lord, says: 
 </p><p class="q1">“Wailing will be in all the wide ways. 
 </p><p class="q2">They will say in all the streets, ‘Alas! Alas!’ 
 </p><p class="q2">They will call the farmer to mourning, 
 </p><p class="q2">and those who are skillful in lamentation to wailing. 
 </p><p class="q1">
 <sup>17&#160;</sup>In all vineyards there will be wailing, 
-</p><p class="q2">for I will pass through the middle of you,” says Yahweh. 
+</p><p class="q2">for I will pass through the middle of you,” says Yahuah. 
 </p><p class="q1">
-<sup>18&#160;</sup>“Woe to you who desire the day of Yahweh! 
-</p><p class="q2">Why do you long for the day of Yahweh? 
+<sup>18&#160;</sup>“Woe to you who desire the day of Yahuah! 
+</p><p class="q2">Why do you long for the day of Yahuah? 
 </p><p class="q1">It is darkness, 
 </p><p class="q2">and not light. 
 </p><p class="q1">
@@ -413,7 +413,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">or he went into the house and leaned his hand on the wall, 
 </p><p class="q2">and a snake bit him. 
 </p><p class="q1">
-<sup>20&#160;</sup>Won’t the day of Yahweh be darkness, and not light? 
+<sup>20&#160;</sup>Won’t the day of Yahuah be darkness, and not light? 
 </p><p class="q2">Even very dark, and no brightness in it? 
 </p><p class="q1">
 <sup>21&#160;</sup>I hate, I despise your feasts, 
@@ -431,7 +431,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>25&#160;</sup>“Did you bring to me sacrifices and offerings in the wilderness forty years, house of Israel? 
 <sup>26&#160;</sup>You also carried the tent of your king and the shrine of your images, the star of your elohim, which you made for yourselves. 
-<sup>27&#160;</sup>Therefore I will cause you to go into captivity beyond Damascus,” says Yahweh, whose name is the Elohim of Armies. 
+<sup>27&#160;</sup>Therefore I will cause you to go into captivity beyond Damascus,” says Yahuah, whose name is the Elohim of Armies. 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
 <sup>1&#160;</sup>Woe to those who are at ease in Zion, 
@@ -463,7 +463,7 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>Therefore they will now go captive with the first who go captive. 
 </p><p class="q2">The feasting and lounging will end. 
 </p><p class="q1">
-<sup>8&#160;</sup>“The Lord Yahweh has sworn by himself,” says Yahweh, the Elohim of Armies: 
+<sup>8&#160;</sup>“The Lord Yahuah has sworn by himself,” says Yahuah, the Elohim of Armies: 
 </p><p class="q2">“I abhor the pride of Jacob, 
 </p><p class="q2">and detest his fortresses. 
 </p><p class="q2">Therefore I will deliver up the city with all that is in it. 
@@ -471,10 +471,10 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>It will happen that if ten men remain in one house, 
 </p><p class="q2">they will die. 
 </p><p>
-<sup>10&#160;</sup>“When a man’s relative carries him, even he who burns him, to bring bodies out of the house, and asks him who is in the innermost parts of the house, ‘Is there yet any with you?’ And he says, ‘No;’ then he will say, ‘Hush! Indeed we must not mention Yahweh’s name.’ 
+<sup>10&#160;</sup>“When a man’s relative carries him, even he who burns him, to bring bodies out of the house, and asks him who is in the innermost parts of the house, ‘Is there yet any with you?’ And he says, ‘No;’ then he will say, ‘Hush! Indeed we must not mention Yahuah’s name.’ 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>11&#160;</sup>“For, behold, Yahweh commands, and the great house will be smashed to pieces, 
+<sup>11&#160;</sup>“For, behold, Yahuah commands, and the great house will be smashed to pieces, 
 </p><p class="q2">and the little house into bits. 
 </p><p class="q1">
 <sup>12&#160;</sup>Do horses run on the rocky crags? 
@@ -486,22 +486,22 @@ html[dir=ltr] .q2 {
 </p><p class="q2">‘Haven’t we taken for ourselves horns by our own strength?’ 
 </p><p class="q1">
 <sup>14&#160;</sup>For, behold, I will raise up against you a nation, house of Israel,” 
-</p><p class="q2">says Yahweh, the Elohim of Armies; 
+</p><p class="q2">says Yahuah, the Elohim of Armies; 
 </p><p class="q2">“and they will afflict you from the entrance of Hamath to the brook of the Arabah.” 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>Thus the Lord Yahweh showed me: behold, he formed locusts in the beginning of the shooting up of the latter growth; and behold, it was the latter growth after the king’s harvest. 
-<sup>2&#160;</sup>When they finished eating the grass of the land, then I said, “Lord Yahweh, forgive, I beg you! How could Jacob stand? For he is small.” 
+<sup>1&#160;</sup>Thus the Lord Yahuah showed me: behold, he formed locusts in the beginning of the shooting up of the latter growth; and behold, it was the latter growth after the king’s harvest. 
+<sup>2&#160;</sup>When they finished eating the grass of the land, then I said, “Lord Yahuah, forgive, I beg you! How could Jacob stand? For he is small.” 
 </p><p>
-<sup>3&#160;</sup>Yahweh relented concerning this. “It shall not be,” says Yahweh. 
+<sup>3&#160;</sup>Yahuah relented concerning this. “It shall not be,” says Yahuah. 
 </p><p>
-<sup>4&#160;</sup>Thus the Lord Yahweh showed me: behold, the Lord Yahweh called for judgment by fire; and it dried up the great deep, and would have devoured the land. 
-<sup>5&#160;</sup>Then I said, “Lord Yahweh, stop, I beg you! How could Jacob stand? For he is small.” 
+<sup>4&#160;</sup>Thus the Lord Yahuah showed me: behold, the Lord Yahuah called for judgment by fire; and it dried up the great deep, and would have devoured the land. 
+<sup>5&#160;</sup>Then I said, “Lord Yahuah, stop, I beg you! How could Jacob stand? For he is small.” 
 </p><p>
-<sup>6&#160;</sup>Yahweh relented concerning this. “This also shall not be,” says the Lord Yahweh. 
+<sup>6&#160;</sup>Yahuah relented concerning this. “This also shall not be,” says the Lord Yahuah. 
 </p><p>
 <sup>7&#160;</sup>Thus he showed me: behold, the Lord stood beside a wall made by a plumb line, with a plumb line in his hand. 
-<sup>8&#160;</sup>Yahweh said to me, “Amos, what do you see?” 
+<sup>8&#160;</sup>Yahuah said to me, “Amos, what do you see?” 
 </p><p>I said, “A plumb line.” 
 </p><p>Then the Lord said, “Behold, I will set a plumb line in the middle of my people Israel. I will not again pass by them any more. 
 <sup>9&#160;</sup>The high places of Isaac will be desolate, the sanctuaries of Israel will be laid waste; and I will rise against the house of Jeroboam with the sword.” 
@@ -513,20 +513,20 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>but don’t prophesy again any more at Bethel; for it is the king’s sanctuary, and it is a royal house!” 
 </p><p>
 <sup>14&#160;</sup>Then Amos answered Amaziah, “I was no prophet, neither was I a prophet’s son, but I was a herdsman, and a farmer of sycamore figs; 
-<sup>15&#160;</sup>and Yahweh took me from following the flock, and Yahweh said to me, ‘Go, prophesy to my people Israel.’ 
-<sup>16&#160;</sup>Now therefore listen to Yahweh’s word: ‘You say, Don’t prophesy against Israel, and don’t preach against the house of Isaac.’ 
-<sup>17&#160;</sup>Therefore Yahweh says: ‘Your woman shall be a prostitute in the city, and your sons and your daughters shall fall by the sword, and your land shall be divided by line; and you yourself shall die in a land that is unclean, and Israel shall surely be led away captive out of his land.’&#160;” 
+<sup>15&#160;</sup>and Yahuah took me from following the flock, and Yahuah said to me, ‘Go, prophesy to my people Israel.’ 
+<sup>16&#160;</sup>Now therefore listen to Yahuah’s word: ‘You say, Don’t prophesy against Israel, and don’t preach against the house of Isaac.’ 
+<sup>17&#160;</sup>Therefore Yahuah says: ‘Your woman shall be a prostitute in the city, and your sons and your daughters shall fall by the sword, and your land shall be divided by line; and you yourself shall die in a land that is unclean, and Israel shall surely be led away captive out of his land.’&#160;” 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>Thus the Lord Yahweh showed me: behold, a basket of summer fruit. 
+<sup>1&#160;</sup>Thus the Lord Yahuah showed me: behold, a basket of summer fruit. 
 </p><p>
 <sup>2&#160;</sup>He said, “Amos, what do you see?” 
 </p><p>I said, “A basket of summer fruit.” 
-</p><p>Then Yahweh said to me, 
+</p><p>Then Yahuah said to me, 
 </p><p class="q1">“The end has come on my people Israel. 
 </p><p class="q2">I will not again pass by them any more. 
 </p><p class="q1">
-<sup>3&#160;</sup>The songs of the temple will be wailing in that day,” says the Lord Yahweh. 
+<sup>3&#160;</sup>The songs of the temple will be wailing in that day,” says the Lord Yahuah. 
 </p><p class="q2">“The dead bodies will be many. In every place they will throw them out with silence. 
 </p><p class="q1">
 <sup>4&#160;</sup>Hear this, you who desire to swallow up the needy, 
@@ -541,7 +541,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and the needy for a pair of sandals, 
 </p><p class="q2">and sell the sweepings with the wheat?’&#160;” 
 </p><p class="q1">
-<sup>7&#160;</sup>Yahweh has sworn by the pride of Jacob, 
+<sup>7&#160;</sup>Yahuah has sworn by the pride of Jacob, 
 </p><p class="q2">“Surely I will never forget any of their works. 
 </p><p class="q1">
 <sup>8&#160;</sup>Won’t the land tremble for this, 
@@ -549,7 +549,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Yes, it will rise up wholly like the River; 
 </p><p class="q2">and it will be stirred up and sink again, like the River of Egypt. 
 </p><p class="q1">
-<sup>9&#160;</sup>It will happen in that day,” says the Lord Yahweh, 
+<sup>9&#160;</sup>It will happen in that day,” says the Lord Yahuah, 
 </p><p class="q2">“that I will cause the sun to go down at noon, 
 </p><p class="q2">and I will darken the earth in the clear day. 
 </p><p class="q1">
@@ -560,15 +560,15 @@ html[dir=ltr] .q2 {
 </p><p class="q1">I will make it like the mourning for an only son, 
 </p><p class="q2">and its end like a bitter day. 
 </p><p class="q1">
-<sup>11&#160;</sup>Behold, the days come,” says the Lord Yahweh, 
+<sup>11&#160;</sup>Behold, the days come,” says the Lord Yahuah, 
 </p><p class="q2">“that I will send a famine in the land, 
 </p><p class="q2">not a famine of bread, 
 </p><p class="q2">nor a thirst for water, 
-</p><p class="q2">but of hearing Yahweh’s words. 
+</p><p class="q2">but of hearing Yahuah’s words. 
 </p><p class="q1">
 <sup>12&#160;</sup>They will wander from sea to sea, 
 </p><p class="q2">and from the north even to the east; 
-</p><p class="q2">they will run back and forth to seek Yahweh’s word, 
+</p><p class="q2">they will run back and forth to seek Yahuah’s word, 
 </p><p class="q2">and will not find it. 
 </p><p class="q1">
 <sup>13&#160;</sup>In that day the beautiful virgins 
@@ -584,16 +584,16 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>Though they dig into Sheol, there my hand will take them; and though they climb up to heaven, there I will bring them down. 
 <sup>3&#160;</sup>Though they hide themselves in the top of Carmel, I will search and take them out from there; and though they be hidden from my sight in the bottom of the sea, there I will command the serpent, and it will bite them. 
 <sup>4&#160;</sup>Though they go into captivity before their enemies, there I will command the sword, and it will kill them. I will set my eyes on them for evil, and not for good. 
-<sup>5&#160;</sup>For the Lord, Yahweh of Armies, is he who touches the land and it melts, and all who dwell in it will mourn; and it will rise up wholly like the River, and will sink again, like the River of Egypt. 
-<sup>6&#160;</sup>It is he who builds his rooms in the heavens, and has founded his vault on the earth; he who calls for the waters of the sea, and pours them out on the surface of the earth—Yahweh is his name. 
-<sup>7&#160;</sup>Are you not like the children of the Ethiopians to me, children of Israel?” says Yahweh. “Haven’t I brought up Israel out of the land of Egypt, and the Philistines from Caphtor, and the Syrians from Kir? 
-<sup>8&#160;</sup>Behold, the eyes of the Lord Yahweh are on the sinful kingdom, and I will destroy it from off the surface of the earth, except that I will not utterly destroy the house of Jacob,” says Yahweh. 
+<sup>5&#160;</sup>For the Lord, Yahuah of Armies, is he who touches the land and it melts, and all who dwell in it will mourn; and it will rise up wholly like the River, and will sink again, like the River of Egypt. 
+<sup>6&#160;</sup>It is he who builds his rooms in the heavens, and has founded his vault on the earth; he who calls for the waters of the sea, and pours them out on the surface of the earth—Yahuah is his name. 
+<sup>7&#160;</sup>Are you not like the children of the Ethiopians to me, children of Israel?” says Yahuah. “Haven’t I brought up Israel out of the land of Egypt, and the Philistines from Caphtor, and the Syrians from Kir? 
+<sup>8&#160;</sup>Behold, the eyes of the Lord Yahuah are on the sinful kingdom, and I will destroy it from off the surface of the earth, except that I will not utterly destroy the house of Jacob,” says Yahuah. 
 <sup>9&#160;</sup>“For behold, I will command, and I will sift the house of Israel among all the nations as grain is sifted in a sieve, yet not the least kernel will fall on the earth. 
 <sup>10&#160;</sup>All the sinners of my people will die by the sword, who say, ‘Evil won’t overtake nor meet us.’ 
 <sup>11&#160;</sup>In that day I will raise up the tent of David who is fallen and close up its breaches, and I will raise up its ruins, and I will build it as in the days of old, 
-<sup>12&#160;</sup>that they may possess the remnant of Edom and all the nations who are called by my name,” says Yahweh who does this. 
+<sup>12&#160;</sup>that they may possess the remnant of Edom and all the nations who are called by my name,” says Yahuah who does this. 
 </p><p class="q1">
-<sup>13&#160;</sup>“Behold, the days come,” says Yahweh, 
+<sup>13&#160;</sup>“Behold, the days come,” says Yahuah, 
 </p><p class="q2">“that the plowman shall overtake the reaper, 
 </p><p class="q2">and the one treading grapes him who sows seed; 
 </p><p class="q2">and sweet wine will drip from the mountains, 
@@ -607,4 +607,4 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>15&#160;</sup>I will plant them on their land, 
 </p><p class="q2">and they will no more be plucked up out of their land which I have given them,” 
-</p><p class="q2">says Yahweh your Elohim. </p></div><script src="../main.js"></script></body></html>
+</p><p class="q2">says Yahuah your Elohim. </p></div><script src="../main.js"></script></body></html>

--- a/book/daniel.html
+++ b/book/daniel.html
@@ -493,10 +493,10 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>I, Daniel, fainted, and was sick for some days. Then I rose up and did the king’s business. I wondered at the vision, but no one understood it. 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
-<sup>1&#160;</sup>In the first year of Darius the son of Ahasuerus, of the offspring of the Medes, who was made king over the realm of the Chaldeans—<sup>2&#160;</sup>in the first year of his reign I, Daniel, understood by the books the number of the years about which Yahweh’s word came to Jeremiah the prophet for the accomplishing of the desolations of Jerusalem, even seventy years. 
+<sup>1&#160;</sup>In the first year of Darius the son of Ahasuerus, of the offspring of the Medes, who was made king over the realm of the Chaldeans—<sup>2&#160;</sup>in the first year of his reign I, Daniel, understood by the books the number of the years about which Yahuah’s word came to Jeremiah the prophet for the accomplishing of the desolations of Jerusalem, even seventy years. 
 <sup>3&#160;</sup>I set my face to the Lord Elohim, to seek by prayer and petitions, with fasting and sackcloth and ashes. 
 </p><p>
-<sup>4&#160;</sup>I prayed to Yahweh my Elohim, and made confession, and said, 
+<sup>4&#160;</sup>I prayed to Yahuah my Elohim, and made confession, and said, 
 </p><p class="pi1">“Oh, Lord, the great and dreadful Elohim, who keeps covenant and loving kindness with those who love him and keep his commandments, 
 <sup>5&#160;</sup>we have sinned, and have dealt perversely, and have done wickedly, and have rebelled, even turning aside from your precepts and from your ordinances. 
 <sup>6&#160;</sup>We haven’t listened to your servants the prophets, who spoke in your name to our kings, our princes, and our fathers, and to all the people of the land. 
@@ -504,12 +504,12 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>“Lord, righteousness belongs to you, but to us confusion of face, as it is today; to the men of Judah, and to the inhabitants of Jerusalem, and to all Israel, who are near and who are far off, through all the countries where you have driven them, because of their trespass that they have trespassed against you. 
 <sup>8&#160;</sup>Lord, to us belongs confusion of face, to our kings, to our princes, and to our fathers, because we have sinned against you. 
 <sup>9&#160;</sup>To the Lord our Elohim belong mercies and forgiveness, for we have rebelled against him. 
-<sup>10&#160;</sup>We haven’t obeyed Yahweh our Elohim’s voice, to walk in his laws, which he set before us by his servants the prophets. 
+<sup>10&#160;</sup>We haven’t obeyed Yahuah our Elohim’s voice, to walk in his laws, which he set before us by his servants the prophets. 
 <sup>11&#160;</sup>Yes, all Israel have transgressed your law, turning aside, that they should not obey your voice. 
 </p><p class="pi1">“Therefore the curse and the oath written in the law of Moses the servant of Elohim has been poured out on us, for we have sinned against him. 
 <sup>12&#160;</sup>He has confirmed his words, which he spoke against us and against our judges who judged us, by bringing on us a great evil; for under the whole sky, such has not been done as has been done to Jerusalem. 
-<sup>13&#160;</sup>As it is written in the law of Moses, all this evil has come on us. Yet we have not entreated the favor of Yahweh our Elohim, that we should turn from our iniquities and have discernment in your truth. 
-<sup>14&#160;</sup>Therefore Yahweh has watched over the evil, and brought it on us; for Yahweh our Elohim is righteous in all his works which he does, and we have not obeyed his voice. 
+<sup>13&#160;</sup>As it is written in the law of Moses, all this evil has come on us. Yet we have not entreated the favor of Yahuah our Elohim, that we should turn from our iniquities and have discernment in your truth. 
+<sup>14&#160;</sup>Therefore Yahuah has watched over the evil, and brought it on us; for Yahuah our Elohim is righteous in all his works which he does, and we have not obeyed his voice. 
 </p><p class="pi1">
 <sup>15&#160;</sup>“Now, Lord our Elohim, who has brought your people out of the land of Egypt with a mighty hand, and have gotten yourself renown, as it is today, we have sinned. We have done wickedly. 
 <sup>16&#160;</sup>Lord, according to all your righteousness, please let your anger and your wrath be turned away from your city Jerusalem, your set-apart mountain; because for our sins and for the iniquities of our fathers, Jerusalem and your people have become a reproach to all who are around us. 
@@ -519,7 +519,7 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>Lord, hear. Lord, forgive. Lord, listen and do. Don’t defer, for your own sake, my Elohim, because your city and your people are called by your name.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>20&#160;</sup>While I was speaking, praying, and confessing my sin and the sin of my people Israel, and presenting my supplication before Yahweh my Elohim for the set-apart mountain of my Elohim—<sup>21&#160;</sup>yes, while I was speaking in prayer—the man Gabriel, whom I had seen in the vision at the beginning, being caused to fly swiftly, touched me about the time of the evening offering. 
+<sup>20&#160;</sup>While I was speaking, praying, and confessing my sin and the sin of my people Israel, and presenting my supplication before Yahuah my Elohim for the set-apart mountain of my Elohim—<sup>21&#160;</sup>yes, while I was speaking in prayer—the man Gabriel, whom I had seen in the vision at the beginning, being caused to fly swiftly, touched me about the time of the evening offering. 
 <sup>22&#160;</sup>He instructed me and talked with me, and said, “Daniel, I have now come to give you wisdom and understanding. 
 <sup>23&#160;</sup>At the beginning of your petitions the commandment went out, and I have come to tell you, for you are greatly beloved. Therefore consider the matter and understand the vision. 
 </p><p>

--- a/book/deuteronomy.html
+++ b/book/deuteronomy.html
@@ -95,16 +95,16 @@ html[dir=ltr] .q2 {
 <p class="p1">
 <sup>1&#160;</sup>These are the words which Moses spoke to all Israel beyond the Jordan in the wilderness, in the Arabah opposite Suf, between Paran, Tophel, Laban, Hazeroth, and Dizahab. 
 <sup>2&#160;</sup>It is eleven days’ journey from Horeb by the way of Mount Seir to Kadesh Barnea. 
-<sup>3&#160;</sup>In the fortieth year, in the eleventh month, on the first day of the month, Moses spoke to the children of Israel according to all that Yahweh had given him in commandment to them, 
+<sup>3&#160;</sup>In the fortieth year, in the eleventh month, on the first day of the month, Moses spoke to the children of Israel according to all that Yahuah had given him in commandment to them, 
 <sup>4&#160;</sup>after he had struck Sihon the king of the Amorites who lived in Heshbon, and Og the king of Bashan who lived in Ashtaroth, at Edrei. 
 <sup>5&#160;</sup>Beyond the Jordan, in the land of Moab, Moses began to declare this law, saying, 
-<sup>6&#160;</sup>“Yahweh our Elohim spoke to us in Horeb, saying, ‘You have lived long enough at this mountain. 
+<sup>6&#160;</sup>“Yahuah our Elohim spoke to us in Horeb, saying, ‘You have lived long enough at this mountain. 
 <sup>7&#160;</sup>Turn, and take your journey, and go to the hill country of the Amorites and to all the places near there: in the Arabah, in the hill country, in the lowland, in the South, by the seashore, in the land of the Canaanites, and in Lebanon as far as the great river, the river Euphrates. 
-<sup>8&#160;</sup>Behold, I have set the land before you. Go in and possess the land which Yahweh swore to your fathers—to Abraham, to Isaac, and to Jacob—to give to them and to their offspring after them.’&#160;” 
+<sup>8&#160;</sup>Behold, I have set the land before you. Go in and possess the land which Yahuah swore to your fathers—to Abraham, to Isaac, and to Jacob—to give to them and to their offspring after them.’&#160;” 
 </p><p>
 <sup>9&#160;</sup>I spoke to you at that time, saying, “I am not able to bear you myself alone. 
-<sup>10&#160;</sup>Yahweh your Elohim has multiplied you, and behold, you are today as the stars of the sky for multitude. 
-<sup>11&#160;</sup>May Yahweh, the Elohim of your fathers, make you a thousand times as many as you are and bless you, as he has promised you! 
+<sup>10&#160;</sup>Yahuah your Elohim has multiplied you, and behold, you are today as the stars of the sky for multitude. 
+<sup>11&#160;</sup>May Yahuah, the Elohim of your fathers, make you a thousand times as many as you are and bless you, as he has promised you! 
 <sup>12&#160;</sup>How can I myself alone bear your problems, your burdens, and your strife? 
 <sup>13&#160;</sup>Take wise men of understanding who are respected among your tribes, and I will make them heads over you.” 
 </p><p>
@@ -113,74 +113,74 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>I commanded your judges at that time, saying, “Hear cases between your brothers and judge righteously between a man and his brother, and the foreigner who is living with him. 
 <sup>17&#160;</sup>You shall not show partiality in judgment; you shall hear the small and the great alike. You shall not be afraid of the face of man, for the judgment is Elohim’s. The case that is too hard for you, you shall bring to me, and I will hear it.” 
 <sup>18&#160;</sup>I commanded you at that time all the things which you should do. 
-<sup>19&#160;</sup>We traveled from Horeb and went through all that great and terrible wilderness which you saw, by the way to the hill country of the Amorites, as Yahweh our Elohim commanded us; and we came to Kadesh Barnea. 
-<sup>20&#160;</sup>I said to you, “You have come to the hill country of the Amorites, which Yahweh our Elohim gives to us. 
-<sup>21&#160;</sup>Behold, Yahweh your Elohim has set the land before you. Go up, take possession, as Yahweh the Elohim of your fathers has spoken to you. Don’t be afraid, neither be dismayed.” 
+<sup>19&#160;</sup>We traveled from Horeb and went through all that great and terrible wilderness which you saw, by the way to the hill country of the Amorites, as Yahuah our Elohim commanded us; and we came to Kadesh Barnea. 
+<sup>20&#160;</sup>I said to you, “You have come to the hill country of the Amorites, which Yahuah our Elohim gives to us. 
+<sup>21&#160;</sup>Behold, Yahuah your Elohim has set the land before you. Go up, take possession, as Yahuah the Elohim of your fathers has spoken to you. Don’t be afraid, neither be dismayed.” 
 </p><p>
 <sup>22&#160;</sup>You came near to me, everyone of you, and said, “Let’s send men before us, that they may search the land for us, and bring back to us word of the way by which we must go up, and the cities to which we shall come.” 
 </p><p>
 <sup>23&#160;</sup>The thing pleased me well. I took twelve of your men, one man for every tribe. 
 <sup>24&#160;</sup>They turned and went up into the hill country, and came to the valley of Eshcol, and spied it out. 
-<sup>25&#160;</sup>They took some of the fruit of the land in their hands and brought it down to us, and brought us word again, and said, “It is a good land which Yahweh our Elohim gives to us.” 
+<sup>25&#160;</sup>They took some of the fruit of the land in their hands and brought it down to us, and brought us word again, and said, “It is a good land which Yahuah our Elohim gives to us.” 
 </p><p>
-<sup>26&#160;</sup>Yet you wouldn’t go up, but rebelled against the commandment of Yahweh your Elohim. 
-<sup>27&#160;</sup>You murmured in your tents, and said, “Because Yahweh hated us, he has brought us out of the land of Egypt, to deliver us into the hand of the Amorites to destroy us. 
+<sup>26&#160;</sup>Yet you wouldn’t go up, but rebelled against the commandment of Yahuah your Elohim. 
+<sup>27&#160;</sup>You murmured in your tents, and said, “Because Yahuah hated us, he has brought us out of the land of Egypt, to deliver us into the hand of the Amorites to destroy us. 
 <sup>28&#160;</sup>Where are we going up? Our brothers have made our heart melt, saying, ‘The people are greater and taller than we. The cities are great and fortified up to the sky. Moreover we have seen the sons of the Anakim there!’&#160;” 
 </p><p>
 <sup>29&#160;</sup>Then I said to you, “Don’t be terrified. Don’t be afraid of them. 
-<sup>30&#160;</sup>Yahweh your Elohim, who goes before you, he will fight for you, according to all that he did for you in Egypt before your eyes, 
-<sup>31&#160;</sup>and in the wilderness where you have seen how that Yahweh your Elohim carried you, as a man carries his son, in all the way that you went, until you came to this place.” 
+<sup>30&#160;</sup>Yahuah your Elohim, who goes before you, he will fight for you, according to all that he did for you in Egypt before your eyes, 
+<sup>31&#160;</sup>and in the wilderness where you have seen how that Yahuah your Elohim carried you, as a man carries his son, in all the way that you went, until you came to this place.” 
 </p><p>
-<sup>32&#160;</sup>Yet in this thing you didn’t believe Yahweh your Elohim, 
+<sup>32&#160;</sup>Yet in this thing you didn’t believe Yahuah your Elohim, 
 <sup>33&#160;</sup>who went before you on the way, to seek out a place for you to pitch your tents in: in fire by night, to show you by what way you should go, and in the cloud by day. 
-<sup>34&#160;</sup>Yahweh heard the voice of your words and was angry, and swore, saying, 
+<sup>34&#160;</sup>Yahuah heard the voice of your words and was angry, and swore, saying, 
 <sup>35&#160;</sup>“Surely not one of these men of this evil generation shall see the good land which I swore to give to your fathers, 
-<sup>36&#160;</sup>except Caleb the son of Jephunneh. He shall see it. I will give the land that he has trodden on to him and to his children, because he has wholly followed Yahweh.” 
+<sup>36&#160;</sup>except Caleb the son of Jephunneh. He shall see it. I will give the land that he has trodden on to him and to his children, because he has wholly followed Yahuah.” 
 </p><p>
-<sup>37&#160;</sup>Also Yahweh was angry with me for your sakes, saying, “You also shall not go in there. 
+<sup>37&#160;</sup>Also Yahuah was angry with me for your sakes, saying, “You also shall not go in there. 
 <sup>38&#160;</sup>Joshua the son of Nun, who stands before you, shall go in there. Encourage him, for he shall cause Israel to inherit it. 
 <sup>39&#160;</sup>Moreover your little ones, whom you said would be captured or killed, your children, who today have no knowledge of good or evil, shall go in there. I will give it to them, and they shall possess it. 
 <sup>40&#160;</sup>But as for you, turn, and take your journey into the wilderness by the way to the Red Sea.” 
 </p><p>
-<sup>41&#160;</sup>Then you answered and said to me, “We have sinned against Yahweh. We will go up and fight, according to all that Yahweh our Elohim commanded us.” Every man of you put on his weapons of war, and presumed to go up into the hill country. 
+<sup>41&#160;</sup>Then you answered and said to me, “We have sinned against Yahuah. We will go up and fight, according to all that Yahuah our Elohim commanded us.” Every man of you put on his weapons of war, and presumed to go up into the hill country. 
 </p><p>
-<sup>42&#160;</sup>Yahweh said to me, “Tell them, ‘Don’t go up and don’t fight; for I am not among you, lest you be struck before your enemies.’&#160;” 
+<sup>42&#160;</sup>Yahuah said to me, “Tell them, ‘Don’t go up and don’t fight; for I am not among you, lest you be struck before your enemies.’&#160;” 
 </p><p>
-<sup>43&#160;</sup>So I spoke to you, and you didn’t listen; but you rebelled against the commandment of Yahweh, and were presumptuous, and went up into the hill country. 
+<sup>43&#160;</sup>So I spoke to you, and you didn’t listen; but you rebelled against the commandment of Yahuah, and were presumptuous, and went up into the hill country. 
 <sup>44&#160;</sup>The Amorites, who lived in that hill country, came out against you and chased you as bees do, and beat you down in Seir, even to Hormah. 
-<sup>45&#160;</sup>You returned and wept before Yahweh, but Yahweh didn’t listen to your voice, nor turn his ear to you. 
+<sup>45&#160;</sup>You returned and wept before Yahuah, but Yahuah didn’t listen to your voice, nor turn his ear to you. 
 <sup>46&#160;</sup>So you stayed in Kadesh many days, according to the days that you remained. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>Then we turned, and took our journey into the wilderness by the way to the Red Sea, as Yahweh spoke to me; and we encircled Mount Seir many days. 
+<sup>1&#160;</sup>Then we turned, and took our journey into the wilderness by the way to the Red Sea, as Yahuah spoke to me; and we encircled Mount Seir many days. 
 </p><p>
-<sup>2&#160;</sup>Yahweh spoke to me, saying, 
+<sup>2&#160;</sup>Yahuah spoke to me, saying, 
 <sup>3&#160;</sup>“You have encircled this mountain long enough. Turn northward. 
 <sup>4&#160;</sup>Command the people, saying, ‘You are to pass through the border of your brothers, the children of Esau, who dwell in Seir; and they will be afraid of you. Therefore be careful. 
 <sup>5&#160;</sup>Don’t contend with them; for I will not give you any of their land, no, not so much as for the sole of the foot to tread on, because I have given Mount Seir to Esau for a possession. 
 <sup>6&#160;</sup>You shall purchase food from them for money, that you may eat. You shall also buy water from them for money, that you may drink.’&#160;” 
 </p><p>
-<sup>7&#160;</sup>For Yahweh your Elohim has blessed you in all the work of your hands. He has known your walking through this great wilderness. These forty years, Yahweh your Elohim has been with you. You have lacked nothing. 
+<sup>7&#160;</sup>For Yahuah your Elohim has blessed you in all the work of your hands. He has known your walking through this great wilderness. These forty years, Yahuah your Elohim has been with you. You have lacked nothing. 
 </p><p>
 <sup>8&#160;</sup>So we passed by from our brothers, the children of Esau, who dwell in Seir, from the way of the Arabah from Elath and from Ezion Geber. We turned and passed by the way of the wilderness of Moab. 
 </p><p>
-<sup>9&#160;</sup>Yahweh said to me, “Don’t bother Moab, neither contend with them in battle; for I will not give you any of his land for a possession, because I have given Ar to the children of Lot for a possession.” 
+<sup>9&#160;</sup>Yahuah said to me, “Don’t bother Moab, neither contend with them in battle; for I will not give you any of his land for a possession, because I have given Ar to the children of Lot for a possession.” 
 </p><p>
 <sup>10&#160;</sup>(The Emim lived there before, a great and numerous people, and tall as the Anakim. 
 <sup>11&#160;</sup>These also are considered to be Rephaim, as the Anakim; but the Moabites call them Emim. 
-<sup>12&#160;</sup>The Horites also lived in Seir in the past, but the children of Esau succeeded them. They destroyed them from before them, and lived in their place, as Israel did to the land of his possession, which Yahweh gave to them.) 
+<sup>12&#160;</sup>The Horites also lived in Seir in the past, but the children of Esau succeeded them. They destroyed them from before them, and lived in their place, as Israel did to the land of his possession, which Yahuah gave to them.) 
 </p><p>
 <sup>13&#160;</sup>“Now rise up and cross over the brook Zered.” We went over the brook Zered. 
 </p><p>
-<sup>14&#160;</sup>The days in which we came from Kadesh Barnea until we had come over the brook Zered were thirty-eight years, until all the generation of the men of war were consumed from the middle of the camp, as Yahweh swore to them. 
-<sup>15&#160;</sup>Moreover Yahweh’s hand was against them, to destroy them from the middle of the camp, until they were consumed. 
+<sup>14&#160;</sup>The days in which we came from Kadesh Barnea until we had come over the brook Zered were thirty-eight years, until all the generation of the men of war were consumed from the middle of the camp, as Yahuah swore to them. 
+<sup>15&#160;</sup>Moreover Yahuah’s hand was against them, to destroy them from the middle of the camp, until they were consumed. 
 <sup>16&#160;</sup>So, when all the men of war were consumed and dead from among the people, 
-<sup>17&#160;</sup>Yahweh spoke to me, saying, 
+<sup>17&#160;</sup>Yahuah spoke to me, saying, 
 <sup>18&#160;</sup>“You are to pass over Ar, the border of Moab, today. 
 <sup>19&#160;</sup>When you come near the border of the children of Ammon, don’t bother them, nor contend with them; for I will not give you any of the land of the children of Ammon for a possession, because I have given it to the children of Lot for a possession.” 
 </p><p>
 <sup>20&#160;</sup>(That also is considered a land of Rephaim. Rephaim lived there in the past, but the Ammonites call them Zamzummim, 
-<sup>21&#160;</sup>a great people, many, and tall, as the Anakim; but Yahweh destroyed them from before Israel, and they succeeded them, and lived in their place, 
+<sup>21&#160;</sup>a great people, many, and tall, as the Anakim; but Yahuah destroyed them from before Israel, and they succeeded them, and lived in their place, 
 <sup>22&#160;</sup>as he did for the children of Esau who dwell in Seir, when he destroyed the Horites from before them; and they succeeded them, and lived in their place even to this day. 
 <sup>23&#160;</sup>Then the Avvim, who lived in villages as far as Gaza: the Caphtorim, who came out of Caphtor, destroyed them and lived in their place.) 
 </p><p>
@@ -190,22 +190,22 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>I sent messengers out of the wilderness of Kedemoth to Sihon king of Heshbon with words of peace, saying, 
 <sup>27&#160;</sup>“Let me pass through your land. I will go along by the highway. I will turn neither to the right hand nor to the left. 
 <sup>28&#160;</sup>You shall sell me food for money, that I may eat; and give me water for money, that I may drink. Just let me pass through on my feet, 
-<sup>29&#160;</sup>as the children of Esau who dwell in Seir, and the Moabites who dwell in Ar, did to me, until I pass over the Jordan into the land which Yahweh our Elohim gives us.” 
-<sup>30&#160;</sup>But Sihon king of Heshbon would not let us pass by him, for Yahweh your Elohim hardened his spirit and made his heart obstinate, that he might deliver him into your hand, as it is today. 
+<sup>29&#160;</sup>as the children of Esau who dwell in Seir, and the Moabites who dwell in Ar, did to me, until I pass over the Jordan into the land which Yahuah our Elohim gives us.” 
+<sup>30&#160;</sup>But Sihon king of Heshbon would not let us pass by him, for Yahuah your Elohim hardened his spirit and made his heart obstinate, that he might deliver him into your hand, as it is today. 
 </p><p>
-<sup>31&#160;</sup>Yahweh said to me, “Behold, I have begun to deliver up Sihon and his land before you. Begin to possess, that you may inherit his land.” 
+<sup>31&#160;</sup>Yahuah said to me, “Behold, I have begun to deliver up Sihon and his land before you. Begin to possess, that you may inherit his land.” 
 <sup>32&#160;</sup>Then Sihon came out against us, he and all his people, to battle at Jahaz. 
-<sup>33&#160;</sup>Yahweh our Elohim delivered him up before us; and we struck him, his sons, and all his people. 
+<sup>33&#160;</sup>Yahuah our Elohim delivered him up before us; and we struck him, his sons, and all his people. 
 <sup>34&#160;</sup>We took all his cities at that time, and utterly destroyed every inhabited city, with the women and the little ones. We left no one remaining. 
 <sup>35&#160;</sup>Only the livestock we took for plunder for ourselves, with the plunder of the cities which we had taken. 
-<sup>36&#160;</sup>From Aroer, which is on the edge of the valley of the Arnon, and the city that is in the valley, even to Gilead, there was not a city too high for us. Yahweh our Elohim delivered up all before us. 
-<sup>37&#160;</sup>Only to the land of the children of Ammon you didn’t come near: all the banks of the river Jabbok, and the cities of the hill country, and wherever Yahweh our Elohim forbade us. 
+<sup>36&#160;</sup>From Aroer, which is on the edge of the valley of the Arnon, and the city that is in the valley, even to Gilead, there was not a city too high for us. Yahuah our Elohim delivered up all before us. 
+<sup>37&#160;</sup>Only to the land of the children of Ammon you didn’t come near: all the banks of the river Jabbok, and the cities of the hill country, and wherever Yahuah our Elohim forbade us. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
 <sup>1&#160;</sup>Then we turned, and went up the way to Bashan. Og the king of Bashan came out against us, he and all his people, to battle at Edrei. 
-<sup>2&#160;</sup>Yahweh said to me, “Don’t fear him; for I have delivered him, with all his people and his land, into your hand. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
+<sup>2&#160;</sup>Yahuah said to me, “Don’t fear him; for I have delivered him, with all his people and his land, into your hand. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
 </p><p>
-<sup>3&#160;</sup>So Yahweh our Elohim also delivered into our hand Og, the king of Bashan, and all his people. We struck him until no one was left to him remaining. 
+<sup>3&#160;</sup>So Yahuah our Elohim also delivered into our hand Og, the king of Bashan, and all his people. We struck him until no one was left to him remaining. 
 <sup>4&#160;</sup>We took all his cities at that time. There was not a city which we didn’t take from them: sixty cities, all the region of Argob, the kingdom of Og in Bashan. 
 <sup>5&#160;</sup>All these were cities fortified with high walls, gates, and bars, in addition to a great many villages without walls. 
 <sup>6&#160;</sup>We utterly destroyed them, as we did to Sihon king of Heshbon, utterly destroying every inhabited city, with the women and the little ones. 
@@ -221,63 +221,63 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>To the Reubenites and to the Gadites I gave from Gilead even to the valley of the Arnon, the middle of the valley, and its border, even to the river Jabbok, which is the border of the children of Ammon; 
 <sup>17&#160;</sup>the Arabah also, and the Jordan and its border, from Chinnereth even to the sea of the Arabah, the Salt Sea, under the slopes of Pisgah eastward. 
 </p><p>
-<sup>18&#160;</sup>I commanded you at that time, saying, “Yahweh your Elohim has given you this land to possess it. All of you men of valor shall pass over armed before your brothers, the children of Israel. 
+<sup>18&#160;</sup>I commanded you at that time, saying, “Yahuah your Elohim has given you this land to possess it. All of you men of valor shall pass over armed before your brothers, the children of Israel. 
 <sup>19&#160;</sup>But your women, and your little ones, and your livestock, (I know that you have much livestock), shall live in your cities which I have given you, 
-<sup>20&#160;</sup>until Yahweh gives rest to your brothers, as to you, and they also possess the land which Yahweh your Elohim gives them beyond the Jordan. Then you shall each return to his own possession, which I have given you.” 
+<sup>20&#160;</sup>until Yahuah gives rest to your brothers, as to you, and they also possess the land which Yahuah your Elohim gives them beyond the Jordan. Then you shall each return to his own possession, which I have given you.” 
 </p><p>
-<sup>21&#160;</sup>I commanded Joshua at that time, saying, “Your eyes have seen all that Yahweh your Elohim has done to these two kings. So shall Yahweh do to all the kingdoms where you go over. 
-<sup>22&#160;</sup>You shall not fear them; for Yahweh your Elohim himself fights for you.” 
+<sup>21&#160;</sup>I commanded Joshua at that time, saying, “Your eyes have seen all that Yahuah your Elohim has done to these two kings. So shall Yahuah do to all the kingdoms where you go over. 
+<sup>22&#160;</sup>You shall not fear them; for Yahuah your Elohim himself fights for you.” 
 </p><p>
-<sup>23&#160;</sup>I begged Yahweh at that time, saying, 
-<sup>24&#160;</sup>“Lord Yahweh, you have begun to show your servant your greatness, and your strong hand. For what elohim is there in heaven or in earth that can do works like yours, and mighty acts like yours? 
+<sup>23&#160;</sup>I begged Yahuah at that time, saying, 
+<sup>24&#160;</sup>“Lord Yahuah, you have begun to show your servant your greatness, and your strong hand. For what elohim is there in heaven or in earth that can do works like yours, and mighty acts like yours? 
 <sup>25&#160;</sup>Please let me go over and see the good land that is beyond the Jordan, that fine mountain, and Lebanon.” 
 </p><p>
-<sup>26&#160;</sup>But Yahweh was angry with me because of you, and didn’t listen to me. Yahweh said to me, “That is enough! Speak no more to me of this matter. 
+<sup>26&#160;</sup>But Yahuah was angry with me because of you, and didn’t listen to me. Yahuah said to me, “That is enough! Speak no more to me of this matter. 
 <sup>27&#160;</sup>Go up to the top of Pisgah, and lift up your eyes westward, and northward, and southward, and eastward, and see with your eyes; for you shall not go over this Jordan. 
 <sup>28&#160;</sup>But commission Joshua, and encourage him, and strengthen him; for he shall go over before this people, and he shall cause them to inherit the land which you shall see.” 
 <sup>29&#160;</sup>So we stayed in the valley near Beth Peor. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>Now, Israel, listen to the statutes and to the ordinances which I teach you, to do them, that you may live and go in and possess the land which Yahweh, the Elohim of your fathers, gives you. 
-<sup>2&#160;</sup>You shall not add to the word which I command you, neither shall you take away from it, that you may keep the commandments of Yahweh your Elohim which I command you. 
-<sup>3&#160;</sup>Your eyes have seen what Yahweh did because of Baal Peor; for Yahweh your Elohim has destroyed all the men who followed Baal Peor from among you. 
-<sup>4&#160;</sup>But you who were faithful to Yahweh your Elohim are all alive today. 
-<sup>5&#160;</sup>Behold, I have taught you statutes and ordinances, even as Yahweh my Elohim commanded me, that you should do so in the middle of the land where you go in to possess it. 
+<sup>1&#160;</sup>Now, Israel, listen to the statutes and to the ordinances which I teach you, to do them, that you may live and go in and possess the land which Yahuah, the Elohim of your fathers, gives you. 
+<sup>2&#160;</sup>You shall not add to the word which I command you, neither shall you take away from it, that you may keep the commandments of Yahuah your Elohim which I command you. 
+<sup>3&#160;</sup>Your eyes have seen what Yahuah did because of Baal Peor; for Yahuah your Elohim has destroyed all the men who followed Baal Peor from among you. 
+<sup>4&#160;</sup>But you who were faithful to Yahuah your Elohim are all alive today. 
+<sup>5&#160;</sup>Behold, I have taught you statutes and ordinances, even as Yahuah my Elohim commanded me, that you should do so in the middle of the land where you go in to possess it. 
 <sup>6&#160;</sup>Keep therefore and do them; for this is your wisdom and your understanding in the sight of the peoples who shall hear all these statutes and say, “Surely this great nation is a wise and understanding people.” 
-<sup>7&#160;</sup>For what great nation is there that has an elohim so near to them as Yahweh our Elohim is whenever we call on him? 
+<sup>7&#160;</sup>For what great nation is there that has an elohim so near to them as Yahuah our Elohim is whenever we call on him? 
 <sup>8&#160;</sup>What great nation is there that has statutes and ordinances so righteous as all this law which I set before you today? 
 </p><p>
-<sup>9&#160;</sup>Only be careful, and keep your soul diligently, lest you forget the things which your eyes saw, and lest they depart from your heart all the days of your life; but make them known to your children and your children’s children—<sup>10&#160;</sup>the day that you stood before Yahweh your Elohim in Horeb, when Yahweh said to me, “Assemble the people to me, and I will make them hear my words, that they may learn to fear me all the days that they live on the earth, and that they may teach their children.” 
+<sup>9&#160;</sup>Only be careful, and keep your soul diligently, lest you forget the things which your eyes saw, and lest they depart from your heart all the days of your life; but make them known to your children and your children’s children—<sup>10&#160;</sup>the day that you stood before Yahuah your Elohim in Horeb, when Yahuah said to me, “Assemble the people to me, and I will make them hear my words, that they may learn to fear me all the days that they live on the earth, and that they may teach their children.” 
 <sup>11&#160;</sup>You came near and stood under the mountain. The mountain burned with fire to the heart of the sky, with darkness, cloud, and thick darkness. 
-<sup>12&#160;</sup>Yahweh spoke to you out of the middle of the fire: you heard the voice of words, but you saw no form; you only heard a voice. 
+<sup>12&#160;</sup>Yahuah spoke to you out of the middle of the fire: you heard the voice of words, but you saw no form; you only heard a voice. 
 <sup>13&#160;</sup>He declared to you his covenant, which he commanded you to perform, even the ten commandments. He wrote them on two stone tablets. 
-<sup>14&#160;</sup>Yahweh commanded me at that time to teach you statutes and ordinances, that you might do them in the land where you go over to possess it. 
-<sup>15&#160;</sup>Be very careful, for you saw no kind of form on the day that Yahweh spoke to you in Horeb out of the middle of the fire, 
+<sup>14&#160;</sup>Yahuah commanded me at that time to teach you statutes and ordinances, that you might do them in the land where you go over to possess it. 
+<sup>15&#160;</sup>Be very careful, for you saw no kind of form on the day that Yahuah spoke to you in Horeb out of the middle of the fire, 
 <sup>16&#160;</sup>lest you corrupt yourselves, and make yourself a carved image in the form of any figure, the likeness of male or female, 
 <sup>17&#160;</sup>the likeness of any animal that is on the earth, the likeness of any winged bird that flies in the sky, 
 <sup>18&#160;</sup>the likeness of anything that creeps on the ground, the likeness of any fish that is in the water under the earth; 
-<sup>19&#160;</sup>and lest you lift up your eyes to the sky, and when you see the sun and the moon and the stars, even all the army of the sky, you are drawn away and worship them, and serve them, which Yahweh your Elohim has allotted to all the peoples under the whole sky. 
-<sup>20&#160;</sup>But Yahweh has taken you, and brought you out of the iron furnace, out of Egypt, to be to him a people of inheritance, as it is today. 
-<sup>21&#160;</sup>Furthermore Yahweh was angry with me for your sakes, and swore that I should not go over the Jordan, and that I should not go in to that good land which Yahweh your Elohim gives you for an inheritance; 
+<sup>19&#160;</sup>and lest you lift up your eyes to the sky, and when you see the sun and the moon and the stars, even all the army of the sky, you are drawn away and worship them, and serve them, which Yahuah your Elohim has allotted to all the peoples under the whole sky. 
+<sup>20&#160;</sup>But Yahuah has taken you, and brought you out of the iron furnace, out of Egypt, to be to him a people of inheritance, as it is today. 
+<sup>21&#160;</sup>Furthermore Yahuah was angry with me for your sakes, and swore that I should not go over the Jordan, and that I should not go in to that good land which Yahuah your Elohim gives you for an inheritance; 
 <sup>22&#160;</sup>but I must die in this land. I must not go over the Jordan, but you shall go over and possess that good land. 
-<sup>23&#160;</sup>Be careful, lest you forget the covenant of Yahweh your Elohim, which he made with you, and make yourselves a carved image in the form of anything which Yahweh your Elohim has forbidden you. 
-<sup>24&#160;</sup>For Yahweh your Elohim is a devouring fire, a jealous Elohim. 
-<sup>25&#160;</sup>When you father children and children’s children, and you have been long in the land, and then corrupt yourselves, and make a carved image in the form of anything, and do that which is evil in Yahweh your Elohim’s sight to provoke him to anger, 
+<sup>23&#160;</sup>Be careful, lest you forget the covenant of Yahuah your Elohim, which he made with you, and make yourselves a carved image in the form of anything which Yahuah your Elohim has forbidden you. 
+<sup>24&#160;</sup>For Yahuah your Elohim is a devouring fire, a jealous Elohim. 
+<sup>25&#160;</sup>When you father children and children’s children, and you have been long in the land, and then corrupt yourselves, and make a carved image in the form of anything, and do that which is evil in Yahuah your Elohim’s sight to provoke him to anger, 
 <sup>26&#160;</sup>I call heaven and earth to witness against you today, that you will soon utterly perish from off the land which you go over the Jordan to possess it. You will not prolong your days on it, but will utterly be destroyed. 
-<sup>27&#160;</sup>Yahweh will scatter you among the peoples, and you will be left few in number among the nations where Yahweh will lead you away. 
+<sup>27&#160;</sup>Yahuah will scatter you among the peoples, and you will be left few in number among the nations where Yahuah will lead you away. 
 <sup>28&#160;</sup>There you will serve elohims, the work of men’s hands, wood and stone, which neither see, nor hear, nor eat, nor smell. 
-<sup>29&#160;</sup>But from there you shall seek Yahweh your Elohim, and you will find him when you search after him with all your heart and with all your soul. 
-<sup>30&#160;</sup>When you are in oppression, and all these things have come on you, in the latter days you shall return to Yahweh your Elohim and listen to his voice. 
-<sup>31&#160;</sup>For Yahweh your Elohim is a merciful Elohim. He will not fail you nor destroy you, nor forget the covenant of your fathers which he swore to them. 
+<sup>29&#160;</sup>But from there you shall seek Yahuah your Elohim, and you will find him when you search after him with all your heart and with all your soul. 
+<sup>30&#160;</sup>When you are in oppression, and all these things have come on you, in the latter days you shall return to Yahuah your Elohim and listen to his voice. 
+<sup>31&#160;</sup>For Yahuah your Elohim is a merciful Elohim. He will not fail you nor destroy you, nor forget the covenant of your fathers which he swore to them. 
 <sup>32&#160;</sup>For ask now of the days that are past, which were before you, since the day that Elohim created man on the earth, and from the one end of the sky to the other, whether there has been anything as great as this thing is, or has been heard like it? 
 <sup>33&#160;</sup>Did a people ever hear the voice of Elohim speaking out of the middle of the fire, as you have heard, and live? 
-<sup>34&#160;</sup>Or has Elohim tried to go and take a nation for himself from among another nation, by trials, by signs, by wonders, by war, by a mighty hand, by an outstretched arm, and by great terrors, according to all that Yahweh your Elohim did for you in Egypt before your eyes? 
-<sup>35&#160;</sup>It was shown to you so that you might know that Yahweh is Elohim. There is no one else besides him. 
+<sup>34&#160;</sup>Or has Elohim tried to go and take a nation for himself from among another nation, by trials, by signs, by wonders, by war, by a mighty hand, by an outstretched arm, and by great terrors, according to all that Yahuah your Elohim did for you in Egypt before your eyes? 
+<sup>35&#160;</sup>It was shown to you so that you might know that Yahuah is Elohim. There is no one else besides him. 
 <sup>36&#160;</sup>Out of heaven he made you to hear his voice, that he might instruct you. On earth he made you to see his great fire; and you heard his words out of the middle of the fire. 
 <sup>37&#160;</sup>Because he loved your fathers, therefore he chose their offspring after them, and brought you out with his presence, with his great power, out of Egypt; 
 <sup>38&#160;</sup>to drive out nations from before you greater and mightier than you, to bring you in, to give you their land for an inheritance, as it is today. 
-<sup>39&#160;</sup>Know therefore today, and take it to heart, that Yahweh himself is Elohim in heaven above and on the earth beneath. There is no one else. 
-<sup>40&#160;</sup>You shall keep his statutes and his commandments which I command you today, that it may go well with you and with your children after you, and that you may prolong your days in the land which Yahweh your Elohim gives you for all time. 
+<sup>39&#160;</sup>Know therefore today, and take it to heart, that Yahuah himself is Elohim in heaven above and on the earth beneath. There is no one else. 
+<sup>40&#160;</sup>You shall keep his statutes and his commandments which I command you today, that it may go well with you and with your children after you, and that you may prolong your days in the land which Yahuah your Elohim gives you for all time. 
 </p><p>
 <sup>41&#160;</sup>Then Moses set apart three cities beyond the Jordan toward the sunrise, 
 <sup>42&#160;</sup>that the man slayer might flee there, who kills his neighbor unintentionally and didn’t hate him in time past, and that fleeing to one of these cities he might live: 
@@ -292,27 +292,27 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
 <sup>1&#160;</sup>Moses called to all Israel, and said to them, “Hear, Israel, the statutes and the ordinances which I speak in your ears today, that you may learn them, and observe to do them.” 
-<sup>2&#160;</sup>Yahweh our Elohim made a covenant with us in Horeb. 
-<sup>3&#160;</sup>Yahweh didn’t make this covenant with our fathers, but with us, even us, who are all of us here alive today. 
-<sup>4&#160;</sup>Yahweh spoke with you face to face on the mountain out of the middle of the fire, 
-<sup>5&#160;</sup>(I stood between Yahweh and you at that time, to show you Yahweh’s word; for you were afraid because of the fire, and didn’t go up onto the mountain) saying, 
+<sup>2&#160;</sup>Yahuah our Elohim made a covenant with us in Horeb. 
+<sup>3&#160;</sup>Yahuah didn’t make this covenant with our fathers, but with us, even us, who are all of us here alive today. 
+<sup>4&#160;</sup>Yahuah spoke with you face to face on the mountain out of the middle of the fire, 
+<sup>5&#160;</sup>(I stood between Yahuah and you at that time, to show you Yahuah’s word; for you were afraid because of the fire, and didn’t go up onto the mountain) saying, 
 </p><p class="m">
-<sup>6&#160;</sup>“I am Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
+<sup>6&#160;</sup>“I am Yahuah your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
 </p><p>
 <sup>7&#160;</sup>“You shall have no other elohims before me. 
 </p><p>
 <sup>8&#160;</sup>“You shall not make a carved image for yourself—any likeness of what is in heaven above, or what is in the earth beneath, or that is in the water under the earth. 
-<sup>9&#160;</sup>You shall not bow yourself down to them, nor serve them, for I, Yahweh your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children and on the third and on the fourth generation of those who hate me 
+<sup>9&#160;</sup>You shall not bow yourself down to them, nor serve them, for I, Yahuah your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children and on the third and on the fourth generation of those who hate me 
 <sup>10&#160;</sup>and showing loving kindness to thousands of those who love me and keep my commandments. 
 </p><p>
-<sup>11&#160;</sup>“You shall not misuse the name of Yahweh your Elohim; for Yahweh will not hold him guiltless who misuses his name. 
+<sup>11&#160;</sup>“You shall not misuse the name of Yahuah your Elohim; for Yahuah will not hold him guiltless who misuses his name. 
 </p><p>
-<sup>12&#160;</sup>“Observe the Sabbath day, to keep it set-apart, as Yahweh your Elohim commanded you. 
+<sup>12&#160;</sup>“Observe the Sabbath day, to keep it set-apart, as Yahuah your Elohim commanded you. 
 <sup>13&#160;</sup>You shall labor six days, and do all your work; 
-<sup>14&#160;</sup>but the seventh day is a Sabbath to Yahweh your Elohim, in which you shall not do any work—neither you, nor your son, nor your daughter, nor your male servant, nor your female servant, nor your ox, nor your donkey, nor any of your livestock, nor your stranger who is within your gates; that your male servant and your female servant may rest as well as you. 
-<sup>15&#160;</sup>You shall remember that you were a servant in the land of Egypt, and Yahweh your Elohim brought you out of there by a mighty hand and by an outstretched arm. Therefore Yahweh your Elohim commanded you to keep the Sabbath day. 
+<sup>14&#160;</sup>but the seventh day is a Sabbath to Yahuah your Elohim, in which you shall not do any work—neither you, nor your son, nor your daughter, nor your male servant, nor your female servant, nor your ox, nor your donkey, nor any of your livestock, nor your stranger who is within your gates; that your male servant and your female servant may rest as well as you. 
+<sup>15&#160;</sup>You shall remember that you were a servant in the land of Egypt, and Yahuah your Elohim brought you out of there by a mighty hand and by an outstretched arm. Therefore Yahuah your Elohim commanded you to keep the Sabbath day. 
 </p><p>
-<sup>16&#160;</sup>“Honor your father and your mother, as Yahweh your Elohim commanded you, that your days may be long and that it may go well with you in the land which Yahweh your Elohim gives you. 
+<sup>16&#160;</sup>“Honor your father and your mother, as Yahuah your Elohim commanded you, that your days may be long and that it may go well with you in the land which Yahuah your Elohim gives you. 
 </p><p>
 <sup>17&#160;</sup>“You shall not murder. 
 </p><p>
@@ -324,261 +324,261 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>21&#160;</sup>“You shall not desire your neighbor’s woman. Neither shall you desire your neighbor’s house, his field, or his male servant, or his female servant, his ox, or his donkey, or anything that is your neighbor’s.” 
 </p><p>
-<sup>22&#160;</sup>Yahweh spoke these words to all your assembly on the mountain out of the middle of the fire, of the cloud, and of the thick darkness, with a great voice. He added no more. He wrote them on two stone tablets, and gave them to me. 
+<sup>22&#160;</sup>Yahuah spoke these words to all your assembly on the mountain out of the middle of the fire, of the cloud, and of the thick darkness, with a great voice. He added no more. He wrote them on two stone tablets, and gave them to me. 
 <sup>23&#160;</sup>When you heard the voice out of the middle of the darkness, while the mountain was burning with fire, you came near to me, even all the heads of your tribes, and your elders; 
-<sup>24&#160;</sup>and you said, “Behold, Yahweh our Elohim has shown us his glory and his greatness, and we have heard his voice out of the middle of the fire. We have seen today that Elohim does speak with man, and he lives. 
-<sup>25&#160;</sup>Now therefore, why should we die? For this great fire will consume us. If we hear Yahweh our Elohim’s voice any more, then we shall die. 
+<sup>24&#160;</sup>and you said, “Behold, Yahuah our Elohim has shown us his glory and his greatness, and we have heard his voice out of the middle of the fire. We have seen today that Elohim does speak with man, and he lives. 
+<sup>25&#160;</sup>Now therefore, why should we die? For this great fire will consume us. If we hear Yahuah our Elohim’s voice any more, then we shall die. 
 <sup>26&#160;</sup>For who is there of all flesh who has heard the voice of the living Elohim speaking out of the middle of the fire, as we have, and lived? 
-<sup>27&#160;</sup>Go near, and hear all that Yahweh our Elohim shall say, and tell us all that Yahweh our Elohim tells you; and we will hear it, and do it.” 
+<sup>27&#160;</sup>Go near, and hear all that Yahuah our Elohim shall say, and tell us all that Yahuah our Elohim tells you; and we will hear it, and do it.” 
 </p><p>
-<sup>28&#160;</sup>Yahweh heard the voice of your words when you spoke to me; and Yahweh said to me, “I have heard the voice of the words of this people which they have spoken to you. They have well said all that they have spoken. 
+<sup>28&#160;</sup>Yahuah heard the voice of your words when you spoke to me; and Yahuah said to me, “I have heard the voice of the words of this people which they have spoken to you. They have well said all that they have spoken. 
 <sup>29&#160;</sup>Oh that there were such a heart in them that they would fear me and keep all my commandments always, that it might be well with them and with their children forever! 
 </p><p>
 <sup>30&#160;</sup>“Go tell them, ‘Return to your tents.’ 
 <sup>31&#160;</sup>But as for you, stand here by me, and I will tell you all the commandments, and the statutes, and the ordinances, which you shall teach them, that they may do them in the land which I give them to possess.” 
 </p><p>
-<sup>32&#160;</sup>You shall observe to do therefore as Yahweh your Elohim has commanded you. You shall not turn away to the right hand or to the left. 
-<sup>33&#160;</sup>You shall walk in all the way which Yahweh your Elohim has commanded you, that you may live and that it may be well with you, and that you may prolong your days in the land which you shall possess. 
+<sup>32&#160;</sup>You shall observe to do therefore as Yahuah your Elohim has commanded you. You shall not turn away to the right hand or to the left. 
+<sup>33&#160;</sup>You shall walk in all the way which Yahuah your Elohim has commanded you, that you may live and that it may be well with you, and that you may prolong your days in the land which you shall possess. 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>Now these are the commandments, the statutes, and the ordinances, which Yahweh your Elohim commanded to teach you, that you might do them in the land that you go over to possess; 
-<sup>2&#160;</sup>that you might fear Yahweh your Elohim, to keep all his statutes and his commandments, which I command you—you, your son, and your son’s son, all the days of your life; and that your days may be prolonged. 
-<sup>3&#160;</sup>Hear therefore, Israel, and observe to do it, that it may be well with you, and that you may increase mightily, as Yahweh, the Elohim of your fathers, has promised to you, in a land flowing with milk and honey. 
+<sup>1&#160;</sup>Now these are the commandments, the statutes, and the ordinances, which Yahuah your Elohim commanded to teach you, that you might do them in the land that you go over to possess; 
+<sup>2&#160;</sup>that you might fear Yahuah your Elohim, to keep all his statutes and his commandments, which I command you—you, your son, and your son’s son, all the days of your life; and that your days may be prolonged. 
+<sup>3&#160;</sup>Hear therefore, Israel, and observe to do it, that it may be well with you, and that you may increase mightily, as Yahuah, the Elohim of your fathers, has promised to you, in a land flowing with milk and honey. 
 </p><p>
-<sup>4&#160;</sup>Hear, Israel: Yahweh is our Elohim. Yahweh is one. 
-<sup>5&#160;</sup>You shall love Yahweh your Elohim with all your heart, with all your soul, and with all your might. 
+<sup>4&#160;</sup>Hear, Israel: Yahuah is our Elohim. Yahuah is one. 
+<sup>5&#160;</sup>You shall love Yahuah your Elohim with all your heart, with all your soul, and with all your might. 
 <sup>6&#160;</sup>These words, which I command you today, shall be on your heart; 
 <sup>7&#160;</sup>and you shall teach them diligently to your children, and shall talk of them when you sit in your house, and when you walk by the way, and when you lie down, and when you rise up. 
 <sup>8&#160;</sup>You shall bind them for a sign on your hand, and they shall be for frontlets between your eyes. 
 <sup>9&#160;</sup>You shall write them on the door posts of your house and on your gates. 
 </p><p>
-<sup>10&#160;</sup>It shall be, when Yahweh your Elohim brings you into the land which he swore to your fathers, to Abraham, to Isaac, and to Jacob, to give you, great and goodly cities which you didn’t build, 
+<sup>10&#160;</sup>It shall be, when Yahuah your Elohim brings you into the land which he swore to your fathers, to Abraham, to Isaac, and to Jacob, to give you, great and goodly cities which you didn’t build, 
 <sup>11&#160;</sup>and houses full of all good things which you didn’t fill, and cisterns dug out which you didn’t dig, vineyards and olive trees which you didn’t plant, and you shall eat and be full; 
-<sup>12&#160;</sup>then beware lest you forget Yahweh, who brought you out of the land of Egypt, out of the house of bondage. 
-<sup>13&#160;</sup>You shall fear Yahweh your Elohim; and you shall serve him, and shall swear by his name. 
+<sup>12&#160;</sup>then beware lest you forget Yahuah, who brought you out of the land of Egypt, out of the house of bondage. 
+<sup>13&#160;</sup>You shall fear Yahuah your Elohim; and you shall serve him, and shall swear by his name. 
 <sup>14&#160;</sup>You shall not go after other elohims, of the elohims of the peoples who are around you, 
-<sup>15&#160;</sup>for Yahweh your Elohim among you is a jealous Elohim, lest the anger of Yahweh your Elohim be kindled against you, and he destroy you from off the face of the earth. 
-<sup>16&#160;</sup>You shall not tempt Yahweh your Elohim, as you tempted him in Massah. 
-<sup>17&#160;</sup>You shall diligently keep the commandments of Yahweh your Elohim, and his testimonies, and his statutes, which he has commanded you. 
-<sup>18&#160;</sup>You shall do that which is right and good in Yahweh’s sight, that it may be well with you and that you may go in and possess the good land which Yahweh swore to your fathers, 
-<sup>19&#160;</sup>to thrust out all your enemies from before you, as Yahweh has spoken. 
+<sup>15&#160;</sup>for Yahuah your Elohim among you is a jealous Elohim, lest the anger of Yahuah your Elohim be kindled against you, and he destroy you from off the face of the earth. 
+<sup>16&#160;</sup>You shall not tempt Yahuah your Elohim, as you tempted him in Massah. 
+<sup>17&#160;</sup>You shall diligently keep the commandments of Yahuah your Elohim, and his testimonies, and his statutes, which he has commanded you. 
+<sup>18&#160;</sup>You shall do that which is right and good in Yahuah’s sight, that it may be well with you and that you may go in and possess the good land which Yahuah swore to your fathers, 
+<sup>19&#160;</sup>to thrust out all your enemies from before you, as Yahuah has spoken. 
 </p><p>
-<sup>20&#160;</sup>When your son asks you in time to come, saying, “What do the testimonies, the statutes, and the ordinances, which Yahweh our Elohim has commanded you mean?” 
-<sup>21&#160;</sup>then you shall tell your son, “We were Pharaoh’s slaves in Egypt. Yahweh brought us out of Egypt with a mighty hand; 
-<sup>22&#160;</sup>and Yahweh showed great and awesome signs and wonders on Egypt, on Pharaoh, and on all his house, before our eyes; 
+<sup>20&#160;</sup>When your son asks you in time to come, saying, “What do the testimonies, the statutes, and the ordinances, which Yahuah our Elohim has commanded you mean?” 
+<sup>21&#160;</sup>then you shall tell your son, “We were Pharaoh’s slaves in Egypt. Yahuah brought us out of Egypt with a mighty hand; 
+<sup>22&#160;</sup>and Yahuah showed great and awesome signs and wonders on Egypt, on Pharaoh, and on all his house, before our eyes; 
 <sup>23&#160;</sup>and he brought us out from there, that he might bring us in, to give us the land which he swore to our fathers. 
-<sup>24&#160;</sup>Yahweh commanded us to do all these statutes, to fear Yahweh our Elohim, for our good always, that he might preserve us alive, as we are today. 
-<sup>25&#160;</sup>It shall be righteousness to us, if we observe to do all these commandments before Yahweh our Elohim, as he has commanded us.” 
+<sup>24&#160;</sup>Yahuah commanded us to do all these statutes, to fear Yahuah our Elohim, for our good always, that he might preserve us alive, as we are today. 
+<sup>25&#160;</sup>It shall be righteousness to us, if we observe to do all these commandments before Yahuah our Elohim, as he has commanded us.” 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>When Yahweh your Elohim brings you into the land where you go to possess it, and casts out many nations before you—the Hittite, the Girgashite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite—seven nations greater and mightier than you; 
-<sup>2&#160;</sup>and when Yahweh your Elohim delivers them up before you, and you strike them, then you shall utterly destroy them. You shall make no covenant with them, nor show mercy to them. 
+<sup>1&#160;</sup>When Yahuah your Elohim brings you into the land where you go to possess it, and casts out many nations before you—the Hittite, the Girgashite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite—seven nations greater and mightier than you; 
+<sup>2&#160;</sup>and when Yahuah your Elohim delivers them up before you, and you strike them, then you shall utterly destroy them. You shall make no covenant with them, nor show mercy to them. 
 <sup>3&#160;</sup>You shall not make yourself a relative of them. You shall not give your daughter to his son, nor shall you take his daughter for your son. 
-<sup>4&#160;</sup>For that would turn away your sons from following me, that they may serve other elohims. So Yahweh’s anger would be kindled against you, and he would destroy you quickly. 
+<sup>4&#160;</sup>For that would turn away your sons from following me, that they may serve other elohims. So Yahuah’s anger would be kindled against you, and he would destroy you quickly. 
 <sup>5&#160;</sup>But you shall deal with them like this: you shall break down their altars, dash their pillars in pieces, cut down their Asherah poles, and burn their engraved images with fire. 
-<sup>6&#160;</sup>For you are a set-apart people to Yahweh your Elohim. Yahweh your Elohim has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
-<sup>7&#160;</sup>Yahweh didn’t set his love on you nor choose you, because you were more in number than any people; for you were the fewest of all peoples; 
-<sup>8&#160;</sup>but because Yahweh loves you, and because he desires to keep the oath which he swore to your fathers, Yahweh has brought you out with a mighty hand and redeemed you out of the house of bondage, from the hand of Pharaoh king of Egypt. 
-<sup>9&#160;</sup>Know therefore that Yahweh your Elohim himself is Elohim, the faithful Elohim, who keeps covenant and loving kindness to a thousand generations with those who love him and keep his commandments, 
+<sup>6&#160;</sup>For you are a set-apart people to Yahuah your Elohim. Yahuah your Elohim has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
+<sup>7&#160;</sup>Yahuah didn’t set his love on you nor choose you, because you were more in number than any people; for you were the fewest of all peoples; 
+<sup>8&#160;</sup>but because Yahuah loves you, and because he desires to keep the oath which he swore to your fathers, Yahuah has brought you out with a mighty hand and redeemed you out of the house of bondage, from the hand of Pharaoh king of Egypt. 
+<sup>9&#160;</sup>Know therefore that Yahuah your Elohim himself is Elohim, the faithful Elohim, who keeps covenant and loving kindness to a thousand generations with those who love him and keep his commandments, 
 <sup>10&#160;</sup>and repays those who hate him to their face, to destroy them. He will not be slack to him who hates him. He will repay him to his face. 
 <sup>11&#160;</sup>You shall therefore keep the commandments, the statutes, and the ordinances which I command you today, to do them. 
-<sup>12&#160;</sup>It shall happen, because you listen to these ordinances and keep and do them, that Yahweh your Elohim will keep with you the covenant and the loving kindness which he swore to your fathers. 
+<sup>12&#160;</sup>It shall happen, because you listen to these ordinances and keep and do them, that Yahuah your Elohim will keep with you the covenant and the loving kindness which he swore to your fathers. 
 <sup>13&#160;</sup>He will love you, bless you, and multiply you. He will also bless the fruit of your body and the fruit of your ground, your grain and your new wine and your oil, the increase of your livestock and the young of your flock, in the land which he swore to your fathers to give you. 
 <sup>14&#160;</sup>You will be blessed above all peoples. There won’t be male or female barren among you, or among your livestock. 
-<sup>15&#160;</sup>Yahweh will take away from you all sickness; and he will put none of the evil diseases of Egypt, which you know, on you, but will lay them on all those who hate you. 
-<sup>16&#160;</sup>You shall consume all the peoples whom Yahweh your Elohim shall deliver to you. Your eye shall not pity them. You shall not serve their elohims; for that would be a snare to you. 
+<sup>15&#160;</sup>Yahuah will take away from you all sickness; and he will put none of the evil diseases of Egypt, which you know, on you, but will lay them on all those who hate you. 
+<sup>16&#160;</sup>You shall consume all the peoples whom Yahuah your Elohim shall deliver to you. Your eye shall not pity them. You shall not serve their elohims; for that would be a snare to you. 
 <sup>17&#160;</sup>If you shall say in your heart, “These nations are more than I; how can I dispossess them?” 
-<sup>18&#160;</sup>you shall not be afraid of them. You shall remember well what Yahweh your Elohim did to Pharaoh and to all Egypt: 
-<sup>19&#160;</sup>the great trials which your eyes saw, the signs, the wonders, the mighty hand, and the outstretched arm, by which Yahweh your Elohim brought you out. So shall Yahweh your Elohim do to all the peoples of whom you are afraid. 
-<sup>20&#160;</sup>Moreover Yahweh your Elohim will send the hornet among them, until those who are left, and hide themselves, perish from before you. 
-<sup>21&#160;</sup>You shall not be scared of them; for Yahweh your Elohim is among you, a great and awesome Elohim. 
-<sup>22&#160;</sup>Yahweh your Elohim will cast out those nations before you little by little. You may not consume them at once, lest the animals of the field increase on you. 
-<sup>23&#160;</sup>But Yahweh your Elohim will deliver them up before you, and will confuse them with a great confusion, until they are destroyed. 
+<sup>18&#160;</sup>you shall not be afraid of them. You shall remember well what Yahuah your Elohim did to Pharaoh and to all Egypt: 
+<sup>19&#160;</sup>the great trials which your eyes saw, the signs, the wonders, the mighty hand, and the outstretched arm, by which Yahuah your Elohim brought you out. So shall Yahuah your Elohim do to all the peoples of whom you are afraid. 
+<sup>20&#160;</sup>Moreover Yahuah your Elohim will send the hornet among them, until those who are left, and hide themselves, perish from before you. 
+<sup>21&#160;</sup>You shall not be scared of them; for Yahuah your Elohim is among you, a great and awesome Elohim. 
+<sup>22&#160;</sup>Yahuah your Elohim will cast out those nations before you little by little. You may not consume them at once, lest the animals of the field increase on you. 
+<sup>23&#160;</sup>But Yahuah your Elohim will deliver them up before you, and will confuse them with a great confusion, until they are destroyed. 
 <sup>24&#160;</sup>He will deliver their kings into your hand, and you shall make their name perish from under the sky. No one will be able to stand before you until you have destroyed them. 
-<sup>25&#160;</sup>You shall burn the engraved images of their elohims with fire. You shall not desire the silver or the gold that is on them, nor take it for yourself, lest you be snared in it; for it is an abomination to Yahweh your Elohim. 
+<sup>25&#160;</sup>You shall burn the engraved images of their elohims with fire. You shall not desire the silver or the gold that is on them, nor take it for yourself, lest you be snared in it; for it is an abomination to Yahuah your Elohim. 
 <sup>26&#160;</sup>You shall not bring an abomination into your house and become a devoted thing like it. You shall utterly detest it. You shall utterly abhor it; for it is a devoted thing. 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>You shall observe to do all the commandments which I command you today, that you may live, and multiply, and go in and possess the land which Yahweh swore to your fathers. 
-<sup>2&#160;</sup>You shall remember all the way which Yahweh your Elohim has led you these forty years in the wilderness, that he might humble you, to test you, to know what was in your heart, whether you would keep his commandments or not. 
-<sup>3&#160;</sup>He humbled you, allowed you to be hungry, and fed you with manna, which you didn’t know, neither did your fathers know, that he might teach you that man does not live by bread only, but man lives by every word that proceeds out of Yahweh’s mouth. 
+<sup>1&#160;</sup>You shall observe to do all the commandments which I command you today, that you may live, and multiply, and go in and possess the land which Yahuah swore to your fathers. 
+<sup>2&#160;</sup>You shall remember all the way which Yahuah your Elohim has led you these forty years in the wilderness, that he might humble you, to test you, to know what was in your heart, whether you would keep his commandments or not. 
+<sup>3&#160;</sup>He humbled you, allowed you to be hungry, and fed you with manna, which you didn’t know, neither did your fathers know, that he might teach you that man does not live by bread only, but man lives by every word that proceeds out of Yahuah’s mouth. 
 <sup>4&#160;</sup>Your clothing didn’t grow old on you, neither did your foot swell, these forty years. 
-<sup>5&#160;</sup>You shall consider in your heart that as a man disciplines his son, so Yahweh your Elohim disciplines you. 
-<sup>6&#160;</sup>You shall keep the commandments of Yahweh your Elohim, to walk in his ways, and to fear him. 
-<sup>7&#160;</sup>For Yahweh your Elohim brings you into a good land, a land of brooks of water, of springs, and underground water flowing into valleys and hills; 
+<sup>5&#160;</sup>You shall consider in your heart that as a man disciplines his son, so Yahuah your Elohim disciplines you. 
+<sup>6&#160;</sup>You shall keep the commandments of Yahuah your Elohim, to walk in his ways, and to fear him. 
+<sup>7&#160;</sup>For Yahuah your Elohim brings you into a good land, a land of brooks of water, of springs, and underground water flowing into valleys and hills; 
 <sup>8&#160;</sup>a land of wheat, barley, vines, fig trees, and pomegranates; a land of olive trees and honey; 
 <sup>9&#160;</sup>a land in which you shall eat bread without scarcity, you shall not lack anything in it; a land whose stones are iron, and out of whose hills you may dig copper. 
-<sup>10&#160;</sup>You shall eat and be full, and you shall bless Yahweh your Elohim for the good land which he has given you. 
+<sup>10&#160;</sup>You shall eat and be full, and you shall bless Yahuah your Elohim for the good land which he has given you. 
 </p><p>
-<sup>11&#160;</sup>Beware lest you forget Yahweh your Elohim, in not keeping his commandments, his ordinances, and his statutes, which I command you today; 
+<sup>11&#160;</sup>Beware lest you forget Yahuah your Elohim, in not keeping his commandments, his ordinances, and his statutes, which I command you today; 
 <sup>12&#160;</sup>lest, when you have eaten and are full, and have built fine houses and lived in them; 
 <sup>13&#160;</sup>and when your herds and your flocks multiply, and your silver and your gold is multiplied, and all that you have is multiplied; 
-<sup>14&#160;</sup>then your heart might be lifted up, and you forget Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage; 
+<sup>14&#160;</sup>then your heart might be lifted up, and you forget Yahuah your Elohim, who brought you out of the land of Egypt, out of the house of bondage; 
 <sup>15&#160;</sup>who led you through the great and terrible wilderness, with venomous snakes and scorpions, and thirsty ground where there was no water; who poured water for you out of the rock of flint; 
 <sup>16&#160;</sup>who fed you in the wilderness with manna, which your fathers didn’t know, that he might humble you, and that he might prove you, to do you good at your latter end; 
 <sup>17&#160;</sup>and lest you say in your heart, “My power and the might of my hand has gotten me this wealth.” 
-<sup>18&#160;</sup>But you shall remember Yahweh your Elohim, for it is he who gives you power to get wealth, that he may establish his covenant which he swore to your fathers, as it is today. 
+<sup>18&#160;</sup>But you shall remember Yahuah your Elohim, for it is he who gives you power to get wealth, that he may establish his covenant which he swore to your fathers, as it is today. 
 </p><p>
-<sup>19&#160;</sup>It shall be, if you shall forget Yahweh your Elohim, and walk after other elohims, and serve them and worship them, I testify against you today that you shall surely perish. 
-<sup>20&#160;</sup>As the nations that Yahweh makes to perish before you, so you shall perish, because you wouldn’t listen to Yahweh your Elohim’s voice. 
+<sup>19&#160;</sup>It shall be, if you shall forget Yahuah your Elohim, and walk after other elohims, and serve them and worship them, I testify against you today that you shall surely perish. 
+<sup>20&#160;</sup>As the nations that Yahuah makes to perish before you, so you shall perish, because you wouldn’t listen to Yahuah your Elohim’s voice. 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
 <sup>1&#160;</sup>Hear, Israel! You are to pass over the Jordan today, to go in to dispossess nations greater and mightier than yourself, cities great and fortified up to the sky, 
 <sup>2&#160;</sup>a people great and tall, the sons of the Anakim, whom you know, and of whom you have heard say, “Who can stand before the sons of Anak?” 
-<sup>3&#160;</sup>Know therefore today that Yahweh your Elohim is he who goes over before you as a devouring fire. He will destroy them and he will bring them down before you. So you shall drive them out and make them perish quickly, as Yahweh has spoken to you. 
+<sup>3&#160;</sup>Know therefore today that Yahuah your Elohim is he who goes over before you as a devouring fire. He will destroy them and he will bring them down before you. So you shall drive them out and make them perish quickly, as Yahuah has spoken to you. 
 </p><p>
-<sup>4&#160;</sup>Don’t say in your heart, after Yahweh your Elohim has thrust them out from before you, “For my righteousness Yahweh has brought me in to possess this land;” because Yahweh drives them out before you because of the wickedness of these nations. 
-<sup>5&#160;</sup>Not for your righteousness or for the uprightness of your heart do you go in to possess their land; but for the wickedness of these nations Yahweh your Elohim does drive them out from before you, and that he may establish the word which Yahweh swore to your fathers, to Abraham, to Isaac, and to Jacob. 
-<sup>6&#160;</sup>Know therefore that Yahweh your Elohim doesn’t give you this good land to possess for your righteousness, for you are a stiff-necked people. 
-<sup>7&#160;</sup>Remember, and don’t forget, how you provoked Yahweh your Elohim to wrath in the wilderness. From the day that you left the land of Egypt until you came to this place, you have been rebellious against Yahweh. 
-<sup>8&#160;</sup>Also in Horeb you provoked Yahweh to wrath, and Yahweh was angry with you to destroy you. 
-<sup>9&#160;</sup>When I had gone up onto the mountain to receive the stone tablets, even the tablets of the covenant which Yahweh made with you, then I stayed on the mountain forty days and forty nights. I neither ate bread nor drank water. 
-<sup>10&#160;</sup>Yahweh delivered to me the two stone tablets written with Elohim’s finger. On them were all the words which Yahweh spoke with you on the mountain out of the middle of the fire in the day of the assembly. 
+<sup>4&#160;</sup>Don’t say in your heart, after Yahuah your Elohim has thrust them out from before you, “For my righteousness Yahuah has brought me in to possess this land;” because Yahuah drives them out before you because of the wickedness of these nations. 
+<sup>5&#160;</sup>Not for your righteousness or for the uprightness of your heart do you go in to possess their land; but for the wickedness of these nations Yahuah your Elohim does drive them out from before you, and that he may establish the word which Yahuah swore to your fathers, to Abraham, to Isaac, and to Jacob. 
+<sup>6&#160;</sup>Know therefore that Yahuah your Elohim doesn’t give you this good land to possess for your righteousness, for you are a stiff-necked people. 
+<sup>7&#160;</sup>Remember, and don’t forget, how you provoked Yahuah your Elohim to wrath in the wilderness. From the day that you left the land of Egypt until you came to this place, you have been rebellious against Yahuah. 
+<sup>8&#160;</sup>Also in Horeb you provoked Yahuah to wrath, and Yahuah was angry with you to destroy you. 
+<sup>9&#160;</sup>When I had gone up onto the mountain to receive the stone tablets, even the tablets of the covenant which Yahuah made with you, then I stayed on the mountain forty days and forty nights. I neither ate bread nor drank water. 
+<sup>10&#160;</sup>Yahuah delivered to me the two stone tablets written with Elohim’s finger. On them were all the words which Yahuah spoke with you on the mountain out of the middle of the fire in the day of the assembly. 
 </p><p>
-<sup>11&#160;</sup>It came to pass at the end of forty days and forty nights that Yahweh gave me the two stone tablets, even the tablets of the covenant. 
-<sup>12&#160;</sup>Yahweh said to me, “Arise, get down quickly from here; for your people whom you have brought out of Egypt have corrupted themselves. They have quickly turned away from the way which I commanded them. They have made a molten image for themselves!” 
+<sup>11&#160;</sup>It came to pass at the end of forty days and forty nights that Yahuah gave me the two stone tablets, even the tablets of the covenant. 
+<sup>12&#160;</sup>Yahuah said to me, “Arise, get down quickly from here; for your people whom you have brought out of Egypt have corrupted themselves. They have quickly turned away from the way which I commanded them. They have made a molten image for themselves!” 
 </p><p>
-<sup>13&#160;</sup>Furthermore Yahweh spoke to me, saying, “I have seen these people, and behold, they are a stiff-necked people. 
+<sup>13&#160;</sup>Furthermore Yahuah spoke to me, saying, “I have seen these people, and behold, they are a stiff-necked people. 
 <sup>14&#160;</sup>Leave me alone, that I may destroy them, and blot out their name from under the sky; and I will make of you a nation mightier and greater than they.” 
 </p><p>
 <sup>15&#160;</sup>So I turned and came down from the mountain, and the mountain was burning with fire. The two tablets of the covenant were in my two hands. 
-<sup>16&#160;</sup>I looked, and behold, you had sinned against Yahweh your Elohim. You had made yourselves a molded calf. You had quickly turned away from the way which Yahweh had commanded you. 
+<sup>16&#160;</sup>I looked, and behold, you had sinned against Yahuah your Elohim. You had made yourselves a molded calf. You had quickly turned away from the way which Yahuah had commanded you. 
 <sup>17&#160;</sup>I took hold of the two tablets, and threw them out of my two hands, and broke them before your eyes. 
-<sup>18&#160;</sup>I fell down before Yahweh, as at the first, forty days and forty nights. I neither ate bread nor drank water, because of all your sin which you sinned, in doing that which was evil in Yahweh’s sight, to provoke him to anger. 
-<sup>19&#160;</sup>For I was afraid of the anger and hot displeasure with which Yahweh was angry against you to destroy you. But Yahweh listened to me that time also. 
-<sup>20&#160;</sup>Yahweh was angry enough with Aaron to destroy him. I prayed for Aaron also at the same time. 
+<sup>18&#160;</sup>I fell down before Yahuah, as at the first, forty days and forty nights. I neither ate bread nor drank water, because of all your sin which you sinned, in doing that which was evil in Yahuah’s sight, to provoke him to anger. 
+<sup>19&#160;</sup>For I was afraid of the anger and hot displeasure with which Yahuah was angry against you to destroy you. But Yahuah listened to me that time also. 
+<sup>20&#160;</sup>Yahuah was angry enough with Aaron to destroy him. I prayed for Aaron also at the same time. 
 <sup>21&#160;</sup>I took your sin, the calf which you had made, and burned it with fire, and crushed it, grinding it very small, until it was as fine as dust. I threw its dust into the brook that descended out of the mountain. 
-<sup>22&#160;</sup>At Taberah, at Massah, and at Kibroth Hattaavah you provoked Yahweh to wrath. 
-<sup>23&#160;</sup>When Yahweh sent you from Kadesh Barnea, saying, “Go up and possess the land which I have given you,” you rebelled against the commandment of Yahweh your Elohim, and you didn’t believe him or listen to his voice. 
-<sup>24&#160;</sup>You have been rebellious against Yahweh from the day that I knew you. 
-<sup>25&#160;</sup>So I fell down before Yahweh the forty days and forty nights that I fell down, because Yahweh had said he would destroy you. 
-<sup>26&#160;</sup>I prayed to Yahweh, and said, “Lord Yahweh, don’t destroy your people and your inheritance that you have redeemed through your greatness, that you have brought out of Egypt with a mighty hand. 
+<sup>22&#160;</sup>At Taberah, at Massah, and at Kibroth Hattaavah you provoked Yahuah to wrath. 
+<sup>23&#160;</sup>When Yahuah sent you from Kadesh Barnea, saying, “Go up and possess the land which I have given you,” you rebelled against the commandment of Yahuah your Elohim, and you didn’t believe him or listen to his voice. 
+<sup>24&#160;</sup>You have been rebellious against Yahuah from the day that I knew you. 
+<sup>25&#160;</sup>So I fell down before Yahuah the forty days and forty nights that I fell down, because Yahuah had said he would destroy you. 
+<sup>26&#160;</sup>I prayed to Yahuah, and said, “Lord Yahuah, don’t destroy your people and your inheritance that you have redeemed through your greatness, that you have brought out of Egypt with a mighty hand. 
 <sup>27&#160;</sup>Remember your servants, Abraham, Isaac, and Jacob. Don’t look at the stubbornness of this people, nor at their wickedness, nor at their sin, 
-<sup>28&#160;</sup>lest the land you brought us out from say, ‘Because Yahweh was not able to bring them into the land which he promised to them, and because he hated them, he has brought them out to kill them in the wilderness.’ 
+<sup>28&#160;</sup>lest the land you brought us out from say, ‘Because Yahuah was not able to bring them into the land which he promised to them, and because he hated them, he has brought them out to kill them in the wilderness.’ 
 <sup>29&#160;</sup>Yet they are your people and your inheritance, which you brought out by your great power and by your outstretched arm.” 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p>
-<sup>1&#160;</sup>At that time Yahweh said to me, “Cut two stone tablets like the first, and come up to me onto the mountain, and make an ark of wood. 
+<sup>1&#160;</sup>At that time Yahuah said to me, “Cut two stone tablets like the first, and come up to me onto the mountain, and make an ark of wood. 
 <sup>2&#160;</sup>I will write on the tablets the words that were on the first tablets which you broke, and you shall put them in the ark.” 
 <sup>3&#160;</sup>So I made an ark of acacia wood, and cut two stone tablets like the first, and went up onto the mountain, having the two tablets in my hand. 
-<sup>4&#160;</sup>He wrote on the tablets, according to the first writing, the ten commandments, which Yahweh spoke to you on the mountain out of the middle of the fire in the day of the assembly; and Yahweh gave them to me. 
-<sup>5&#160;</sup>I turned and came down from the mountain, and put the tablets in the ark which I had made; and there they are as Yahweh commanded me. 
+<sup>4&#160;</sup>He wrote on the tablets, according to the first writing, the ten commandments, which Yahuah spoke to you on the mountain out of the middle of the fire in the day of the assembly; and Yahuah gave them to me. 
+<sup>5&#160;</sup>I turned and came down from the mountain, and put the tablets in the ark which I had made; and there they are as Yahuah commanded me. 
 </p><p>
 <sup>6&#160;</sup>(The children of Israel traveled from Beeroth Bene Jaakan to Moserah. There Aaron died, and there he was buried; and Eleazar his son ministered in the priest’s office in his place. 
 <sup>7&#160;</sup>From there they traveled to Gudgodah; and from Gudgodah to Jotbathah, a land of brooks of water. 
-<sup>8&#160;</sup>At that time Yahweh set apart the tribe of Levi to bear the ark of Yahweh’s covenant, to stand before Yahweh to minister to him, and to bless in his name, to this day. 
-<sup>9&#160;</sup>Therefore Levi has no portion nor inheritance with his brothers; Yahweh is his inheritance, according as Yahweh your Elohim spoke to him.) 
+<sup>8&#160;</sup>At that time Yahuah set apart the tribe of Levi to bear the ark of Yahuah’s covenant, to stand before Yahuah to minister to him, and to bless in his name, to this day. 
+<sup>9&#160;</sup>Therefore Levi has no portion nor inheritance with his brothers; Yahuah is his inheritance, according as Yahuah your Elohim spoke to him.) 
 </p><p>
-<sup>10&#160;</sup>I stayed on the mountain, as at the first time, forty days and forty nights; and Yahweh listened to me that time also. Yahweh would not destroy you. 
-<sup>11&#160;</sup>Yahweh said to me, “Arise, take your journey before the people; and they shall go in and possess the land which I swore to their fathers to give to them.” 
+<sup>10&#160;</sup>I stayed on the mountain, as at the first time, forty days and forty nights; and Yahuah listened to me that time also. Yahuah would not destroy you. 
+<sup>11&#160;</sup>Yahuah said to me, “Arise, take your journey before the people; and they shall go in and possess the land which I swore to their fathers to give to them.” 
 </p><p>
-<sup>12&#160;</sup>Now, Israel, what does Yahweh your Elohim require of you, but to fear Yahweh your Elohim, to walk in all his ways, to love him, and to serve Yahweh your Elohim with all your heart and with all your soul, 
-<sup>13&#160;</sup>to keep Yahweh’s commandments and statutes, which I command you today for your good? 
-<sup>14&#160;</sup>Behold, to Yahweh your Elohim belongs heaven, the heaven of heavens, and the earth, with all that is therein. 
-<sup>15&#160;</sup>Only Yahweh had a delight in your fathers to love them, and he chose their offspring after them, even you above all peoples, as it is today. 
+<sup>12&#160;</sup>Now, Israel, what does Yahuah your Elohim require of you, but to fear Yahuah your Elohim, to walk in all his ways, to love him, and to serve Yahuah your Elohim with all your heart and with all your soul, 
+<sup>13&#160;</sup>to keep Yahuah’s commandments and statutes, which I command you today for your good? 
+<sup>14&#160;</sup>Behold, to Yahuah your Elohim belongs heaven, the heaven of heavens, and the earth, with all that is therein. 
+<sup>15&#160;</sup>Only Yahuah had a delight in your fathers to love them, and he chose their offspring after them, even you above all peoples, as it is today. 
 <sup>16&#160;</sup>Circumcise therefore the foreskin of your heart, and be no more stiff-necked. 
-<sup>17&#160;</sup>For Yahweh your Elohim, he is Elohim of elohims and Lord of lords, the great Elohim, the mighty, and the awesome, who doesn’t respect persons or take bribes. 
+<sup>17&#160;</sup>For Yahuah your Elohim, he is Elohim of elohims and Lord of lords, the great Elohim, the mighty, and the awesome, who doesn’t respect persons or take bribes. 
 <sup>18&#160;</sup>He executes justice for the fatherless and widow and loves the foreigner in giving him food and clothing. 
 <sup>19&#160;</sup>Therefore love the foreigner, for you were foreigners in the land of Egypt. 
-<sup>20&#160;</sup>You shall fear Yahweh your Elohim. You shall serve him. You shall cling to him, and you shall swear by his name. 
+<sup>20&#160;</sup>You shall fear Yahuah your Elohim. You shall serve him. You shall cling to him, and you shall swear by his name. 
 <sup>21&#160;</sup>He is your praise, and he is your Elohim, who has done for you these great and awesome things which your eyes have seen. 
-<sup>22&#160;</sup>Your fathers went down into Egypt with seventy persons; and now Yahweh your Elohim has made you as the stars of the sky for multitude. 
+<sup>22&#160;</sup>Your fathers went down into Egypt with seventy persons; and now Yahuah your Elohim has made you as the stars of the sky for multitude. 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p>
-<sup>1&#160;</sup>Therefore you shall love Yahweh your Elohim, and keep his instructions, his statutes, his ordinances, and his commandments, always. 
-<sup>2&#160;</sup>Know this day—for I don’t speak with your children who have not known, and who have not seen the chastisement of Yahweh your Elohim, his greatness, his mighty hand, his outstretched arm, 
+<sup>1&#160;</sup>Therefore you shall love Yahuah your Elohim, and keep his instructions, his statutes, his ordinances, and his commandments, always. 
+<sup>2&#160;</sup>Know this day—for I don’t speak with your children who have not known, and who have not seen the chastisement of Yahuah your Elohim, his greatness, his mighty hand, his outstretched arm, 
 <sup>3&#160;</sup>his signs, and his works, which he did in the middle of Egypt to Pharaoh the king of Egypt, and to all his land; 
-<sup>4&#160;</sup>and what he did to the army of Egypt, to their horses, and to their chariots; how he made the water of the Red Sea to overflow them as they pursued you, and how Yahweh has destroyed them to this day; 
+<sup>4&#160;</sup>and what he did to the army of Egypt, to their horses, and to their chariots; how he made the water of the Red Sea to overflow them as they pursued you, and how Yahuah has destroyed them to this day; 
 <sup>5&#160;</sup>and what he did to you in the wilderness until you came to this place; 
 <sup>6&#160;</sup>and what he did to Dathan and Abiram, the sons of Eliab, the son of Reuben—how the earth opened its mouth and swallowed them up, with their households, their tents, and every living thing that followed them, in the middle of all Israel; 
-<sup>7&#160;</sup>but your eyes have seen all of Yahweh’s great work which he did. 
+<sup>7&#160;</sup>but your eyes have seen all of Yahuah’s great work which he did. 
 </p><p>
 <sup>8&#160;</sup>Therefore you shall keep the entire commandment which I command you today, that you may be strong, and go in and possess the land that you go over to possess; 
-<sup>9&#160;</sup>and that you may prolong your days in the land which Yahweh swore to your fathers to give to them and to their offspring, a land flowing with milk and honey. 
+<sup>9&#160;</sup>and that you may prolong your days in the land which Yahuah swore to your fathers to give to them and to their offspring, a land flowing with milk and honey. 
 <sup>10&#160;</sup>For the land, where you go in to possess isn’t like the land of Egypt that you came out of, where you sowed your seed and watered it with your foot, as a garden of herbs; 
 <sup>11&#160;</sup>but the land that you go over to possess is a land of hills and valleys which drinks water from the rain of the sky, 
-<sup>12&#160;</sup>a land which Yahweh your Elohim cares for. Yahweh your Elohim’s eyes are always on it, from the beginning of the year even to the end of the year. 
-<sup>13&#160;</sup>It shall happen, if you shall listen diligently to my commandments which I command you today, to love Yahweh your Elohim, and to serve him with all your heart and with all your soul, 
+<sup>12&#160;</sup>a land which Yahuah your Elohim cares for. Yahuah your Elohim’s eyes are always on it, from the beginning of the year even to the end of the year. 
+<sup>13&#160;</sup>It shall happen, if you shall listen diligently to my commandments which I command you today, to love Yahuah your Elohim, and to serve him with all your heart and with all your soul, 
 <sup>14&#160;</sup>that I will give the rain for your land in its season, the early rain and the latter rain, that you may gather in your grain, your new wine, and your oil. 
 <sup>15&#160;</sup>I will give grass in your fields for your livestock, and you shall eat and be full. 
 <sup>16&#160;</sup>Be careful, lest your heart be deceived, and you turn away to serve other elohims and worship them; 
-<sup>17&#160;</sup>and Yahweh’s anger be kindled against you, and he shut up the sky so that there is no rain, and the land doesn’t yield its fruit; and you perish quickly from off the good land which Yahweh gives you. 
+<sup>17&#160;</sup>and Yahuah’s anger be kindled against you, and he shut up the sky so that there is no rain, and the land doesn’t yield its fruit; and you perish quickly from off the good land which Yahuah gives you. 
 <sup>18&#160;</sup>Therefore you shall lay up these words of mine in your heart and in your soul. You shall bind them for a sign on your hand, and they shall be for frontlets between your eyes. 
 <sup>19&#160;</sup>You shall teach them to your children, talking of them when you sit in your house, when you walk by the way, when you lie down, and when you rise up. 
 <sup>20&#160;</sup>You shall write them on the door posts of your house and on your gates; 
-<sup>21&#160;</sup>that your days and your children’s days may be multiplied in the land which Yahweh swore to your fathers to give them, as the days of the heavens above the earth. 
-<sup>22&#160;</sup>For if you shall diligently keep all these commandments which I command you—to do them, to love Yahweh your Elohim, to walk in all his ways, and to cling to him—<sup>23&#160;</sup>then Yahweh will drive out all these nations from before you, and you shall dispossess nations greater and mightier than yourselves. 
+<sup>21&#160;</sup>that your days and your children’s days may be multiplied in the land which Yahuah swore to your fathers to give them, as the days of the heavens above the earth. 
+<sup>22&#160;</sup>For if you shall diligently keep all these commandments which I command you—to do them, to love Yahuah your Elohim, to walk in all his ways, and to cling to him—<sup>23&#160;</sup>then Yahuah will drive out all these nations from before you, and you shall dispossess nations greater and mightier than yourselves. 
 <sup>24&#160;</sup>Every place on which the sole of your foot treads shall be yours: from the wilderness and Lebanon, from the river, the river Euphrates, even to the western sea shall be your border. 
-<sup>25&#160;</sup>No man will be able to stand before you. Yahweh your Elohim will lay the fear of you and the dread of you on all the land that you tread on, as he has spoken to you. 
+<sup>25&#160;</sup>No man will be able to stand before you. Yahuah your Elohim will lay the fear of you and the dread of you on all the land that you tread on, as he has spoken to you. 
 <sup>26&#160;</sup>Behold, I set before you today a blessing and a curse: 
-<sup>27&#160;</sup>the blessing, if you listen to the commandments of Yahweh your Elohim, which I command you today; 
-<sup>28&#160;</sup>and the curse, if you do not listen to the commandments of Yahweh your Elohim, but turn away out of the way which I command you today, to go after other elohims which you have not known. 
-<sup>29&#160;</sup>It shall happen, when Yahweh your Elohim brings you into the land that you go to possess, that you shall set the blessing on Mount Gerizim, and the curse on Mount Ebal. 
+<sup>27&#160;</sup>the blessing, if you listen to the commandments of Yahuah your Elohim, which I command you today; 
+<sup>28&#160;</sup>and the curse, if you do not listen to the commandments of Yahuah your Elohim, but turn away out of the way which I command you today, to go after other elohims which you have not known. 
+<sup>29&#160;</sup>It shall happen, when Yahuah your Elohim brings you into the land that you go to possess, that you shall set the blessing on Mount Gerizim, and the curse on Mount Ebal. 
 <sup>30&#160;</sup>Aren’t they beyond the Jordan, behind the way of the going down of the sun, in the land of the Canaanites who dwell in the Arabah near Gilgal, beside the oaks of Moreh? 
-<sup>31&#160;</sup>For you are to pass over the Jordan to go in to possess the land which Yahweh your Elohim gives you, and you shall possess it and dwell in it. 
+<sup>31&#160;</sup>For you are to pass over the Jordan to go in to possess the land which Yahuah your Elohim gives you, and you shall possess it and dwell in it. 
 <sup>32&#160;</sup>You shall observe to do all the statutes and the ordinances which I set before you today. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
-<sup>1&#160;</sup>These are the statutes and the ordinances which you shall observe to do in the land which Yahweh, the Elohim of your fathers, has given you to possess all the days that you live on the earth. 
+<sup>1&#160;</sup>These are the statutes and the ordinances which you shall observe to do in the land which Yahuah, the Elohim of your fathers, has given you to possess all the days that you live on the earth. 
 <sup>2&#160;</sup>You shall surely destroy all the places in which the nations that you shall dispossess served their elohims: on the high mountains, and on the hills, and under every green tree. 
 <sup>3&#160;</sup>You shall break down their altars, dash their pillars in pieces, and burn their Asherah poles with fire. You shall cut down the engraved images of their elohims. You shall destroy their name out of that place. 
-<sup>4&#160;</sup>You shall not do so to Yahweh your Elohim. 
-<sup>5&#160;</sup>But to the place which Yahweh your Elohim shall choose out of all your tribes, to put his name there, you shall seek his habitation, and you shall come there. 
+<sup>4&#160;</sup>You shall not do so to Yahuah your Elohim. 
+<sup>5&#160;</sup>But to the place which Yahuah your Elohim shall choose out of all your tribes, to put his name there, you shall seek his habitation, and you shall come there. 
 <sup>6&#160;</sup>You shall bring your burnt offerings, your sacrifices, your tithes, the wave offering of your hand, your vows, your free will offerings, and the firstborn of your herd and of your flock there. 
-<sup>7&#160;</sup>There you shall eat before Yahweh your Elohim, and you shall rejoice in all that you put your hand to, you and your households, in which Yahweh your Elohim has blessed you. 
+<sup>7&#160;</sup>There you shall eat before Yahuah your Elohim, and you shall rejoice in all that you put your hand to, you and your households, in which Yahuah your Elohim has blessed you. 
 <sup>8&#160;</sup>You shall not do all the things that we do here today, every man whatever is right in his own eyes; 
-<sup>9&#160;</sup>for you haven’t yet come to the rest and to the inheritance which Yahweh your Elohim gives you. 
-<sup>10&#160;</sup>But when you go over the Jordan and dwell in the land which Yahweh your Elohim causes you to inherit, and he gives you rest from all your enemies around you, so that you dwell in safety, 
-<sup>11&#160;</sup>then it shall happen that to the place which Yahweh your Elohim shall choose, to cause his name to dwell there, there you shall bring all that I command you: your burnt offerings, your sacrifices, your tithes, the wave offering of your hand, and all your choice vows which you vow to Yahweh. 
-<sup>12&#160;</sup>You shall rejoice before Yahweh your Elohim—you, and your sons, your daughters, your male servants, your female servants, and the Levite who is within your gates, because he has no portion nor inheritance with you. 
+<sup>9&#160;</sup>for you haven’t yet come to the rest and to the inheritance which Yahuah your Elohim gives you. 
+<sup>10&#160;</sup>But when you go over the Jordan and dwell in the land which Yahuah your Elohim causes you to inherit, and he gives you rest from all your enemies around you, so that you dwell in safety, 
+<sup>11&#160;</sup>then it shall happen that to the place which Yahuah your Elohim shall choose, to cause his name to dwell there, there you shall bring all that I command you: your burnt offerings, your sacrifices, your tithes, the wave offering of your hand, and all your choice vows which you vow to Yahuah. 
+<sup>12&#160;</sup>You shall rejoice before Yahuah your Elohim—you, and your sons, your daughters, your male servants, your female servants, and the Levite who is within your gates, because he has no portion nor inheritance with you. 
 <sup>13&#160;</sup>Be careful that you don’t offer your burnt offerings in every place that you see; 
-<sup>14&#160;</sup>but in the place which Yahweh chooses in one of your tribes, there you shall offer your burnt offerings, and there you shall do all that I command you. 
+<sup>14&#160;</sup>but in the place which Yahuah chooses in one of your tribes, there you shall offer your burnt offerings, and there you shall do all that I command you. 
 </p><p>
-<sup>15&#160;</sup>Yet you may kill and eat meat within all your gates, after all the desire of your soul, according to Yahweh your Elohim’s blessing which he has given you. The unclean and the clean may eat of it, as of the gazelle and the deer. 
+<sup>15&#160;</sup>Yet you may kill and eat meat within all your gates, after all the desire of your soul, according to Yahuah your Elohim’s blessing which he has given you. The unclean and the clean may eat of it, as of the gazelle and the deer. 
 <sup>16&#160;</sup>Only you shall not eat the blood. You shall pour it out on the earth like water. 
 <sup>17&#160;</sup>You may not eat within your gates the tithe of your grain, or of your new wine, or of your oil, or the firstborn of your herd or of your flock, nor any of your vows which you vow, nor your free will offerings, nor the wave offering of your hand; 
-<sup>18&#160;</sup>but you shall eat them before Yahweh your Elohim in the place which Yahweh your Elohim shall choose: you, your son, your daughter, your male servant, your female servant, and the Levite who is within your gates. You shall rejoice before Yahweh your Elohim in all that you put your hand to. 
+<sup>18&#160;</sup>but you shall eat them before Yahuah your Elohim in the place which Yahuah your Elohim shall choose: you, your son, your daughter, your male servant, your female servant, and the Levite who is within your gates. You shall rejoice before Yahuah your Elohim in all that you put your hand to. 
 <sup>19&#160;</sup>Be careful that you don’t forsake the Levite as long as you live in your land. 
 </p><p>
-<sup>20&#160;</sup>When Yahweh your Elohim enlarges your border, as he has promised you, and you say, “I want to eat meat,” because your soul desires to eat meat, you may eat meat, after all the desire of your soul. 
-<sup>21&#160;</sup>If the place which Yahweh your Elohim shall choose to put his name is too far from you, then you shall kill of your herd and of your flock, which Yahweh has given you, as I have commanded you; and you may eat within your gates, after all the desire of your soul. 
+<sup>20&#160;</sup>When Yahuah your Elohim enlarges your border, as he has promised you, and you say, “I want to eat meat,” because your soul desires to eat meat, you may eat meat, after all the desire of your soul. 
+<sup>21&#160;</sup>If the place which Yahuah your Elohim shall choose to put his name is too far from you, then you shall kill of your herd and of your flock, which Yahuah has given you, as I have commanded you; and you may eat within your gates, after all the desire of your soul. 
 <sup>22&#160;</sup>Even as the gazelle and as the deer is eaten, so you shall eat of it. The unclean and the clean may eat of it alike. 
 <sup>23&#160;</sup>Only be sure that you don’t eat the blood; for the blood is the life. You shall not eat the life with the meat. 
 <sup>24&#160;</sup>You shall not eat it. You shall pour it out on the earth like water. 
-<sup>25&#160;</sup>You shall not eat it, that it may go well with you and with your children after you, when you do that which is right in Yahweh’s eyes. 
-<sup>26&#160;</sup>Only your set-apart things which you have, and your vows, you shall take and go to the place which Yahweh shall choose. 
-<sup>27&#160;</sup>You shall offer your burnt offerings, the meat and the blood, on Yahweh your Elohim’s altar. The blood of your sacrifices shall be poured out on Yahweh your Elohim’s altar, and you shall eat the meat. 
-<sup>28&#160;</sup>Observe and hear all these words which I command you, that it may go well with you and with your children after you forever, when you do that which is good and right in Yahweh your Elohim’s eyes. 
+<sup>25&#160;</sup>You shall not eat it, that it may go well with you and with your children after you, when you do that which is right in Yahuah’s eyes. 
+<sup>26&#160;</sup>Only your set-apart things which you have, and your vows, you shall take and go to the place which Yahuah shall choose. 
+<sup>27&#160;</sup>You shall offer your burnt offerings, the meat and the blood, on Yahuah your Elohim’s altar. The blood of your sacrifices shall be poured out on Yahuah your Elohim’s altar, and you shall eat the meat. 
+<sup>28&#160;</sup>Observe and hear all these words which I command you, that it may go well with you and with your children after you forever, when you do that which is good and right in Yahuah your Elohim’s eyes. 
 </p><p>
-<sup>29&#160;</sup>When Yahweh your Elohim cuts off the nations from before you where you go in to dispossess them, and you dispossess them and dwell in their land, 
+<sup>29&#160;</sup>When Yahuah your Elohim cuts off the nations from before you where you go in to dispossess them, and you dispossess them and dwell in their land, 
 <sup>30&#160;</sup>be careful that you are not ensnared to follow them after they are destroyed from before you, and that you not inquire after their elohims, saying, “How do these nations serve their elohims? I will do likewise.” 
-<sup>31&#160;</sup>You shall not do so to Yahweh your Elohim; for every abomination to Yahweh, which he hates, they have done to their elohims; for they even burn their sons and their daughters in the fire to their elohims. 
+<sup>31&#160;</sup>You shall not do so to Yahuah your Elohim; for every abomination to Yahuah, which he hates, they have done to their elohims; for they even burn their sons and their daughters in the fire to their elohims. 
 <sup>32&#160;</sup>Whatever thing I command you, that you shall observe to do. You shall not add to it, nor take away from it. 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
 <sup>1&#160;</sup>If a prophet or a dreamer of dreams arises among you, and he gives you a sign or a wonder, 
 <sup>2&#160;</sup>and the sign or the wonder comes to pass, of which he spoke to you, saying, “Let’s go after other elohims” (which you have not known) “and let’s serve them,” 
-<sup>3&#160;</sup>you shall not listen to the words of that prophet, or to that dreamer of dreams; for Yahweh your Elohim is testing you, to know whether you love Yahweh your Elohim with all your heart and with all your soul. 
-<sup>4&#160;</sup>You shall walk after Yahweh your Elohim, fear him, keep his commandments, and obey his voice. You shall serve him, and cling to him. 
-<sup>5&#160;</sup>That prophet, or that dreamer of dreams, shall be put to death, because he has spoken rebellion against Yahweh your Elohim, who brought you out of the land of Egypt and redeemed you out of the house of bondage, to draw you aside out of the way which Yahweh your Elohim commanded you to walk in. So you shall remove the evil from among you. 
+<sup>3&#160;</sup>you shall not listen to the words of that prophet, or to that dreamer of dreams; for Yahuah your Elohim is testing you, to know whether you love Yahuah your Elohim with all your heart and with all your soul. 
+<sup>4&#160;</sup>You shall walk after Yahuah your Elohim, fear him, keep his commandments, and obey his voice. You shall serve him, and cling to him. 
+<sup>5&#160;</sup>That prophet, or that dreamer of dreams, shall be put to death, because he has spoken rebellion against Yahuah your Elohim, who brought you out of the land of Egypt and redeemed you out of the house of bondage, to draw you aside out of the way which Yahuah your Elohim commanded you to walk in. So you shall remove the evil from among you. 
 </p><p>
 <sup>6&#160;</sup>If your brother, the son of your mother, or your son, or your daughter, or the woman of your bosom, or your friend who is as your own soul, entices you secretly, saying, “Let’s go and serve other elohims”—which you have not known, you, nor your fathers; 
 <sup>7&#160;</sup>of the elohims of the peoples who are around you, near to you, or far off from you, from the one end of the earth even to the other end of the earth—<sup>8&#160;</sup>you shall not consent to him nor listen to him; neither shall your eye pity him, neither shall you spare, neither shall you conceal him; 
 <sup>9&#160;</sup>but you shall surely kill him. Your hand shall be first on him to put him to death, and afterwards the hands of all the people. 
-<sup>10&#160;</sup>You shall stone him to death with stones, because he has sought to draw you away from Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
+<sup>10&#160;</sup>You shall stone him to death with stones, because he has sought to draw you away from Yahuah your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
 <sup>11&#160;</sup>All Israel shall hear, and fear, and shall not do any more wickedness like this among you. 
 </p><p>
-<sup>12&#160;</sup>If you hear about one of your cities, which Yahweh your Elohim gives you to dwell there, that 
+<sup>12&#160;</sup>If you hear about one of your cities, which Yahuah your Elohim gives you to dwell there, that 
 <sup>13&#160;</sup>certain wicked fellows have gone out from among you and have drawn away the inhabitants of their city, saying, “Let’s go and serve other elohims,” which you have not known, 
 <sup>14&#160;</sup>then you shall inquire, investigate, and ask diligently. Behold, if it is true, and the thing certain, that such abomination was done among you, 
 <sup>15&#160;</sup>you shall surely strike the inhabitants of that city with the edge of the sword, destroying it utterly, with all that is therein and its livestock, with the edge of the sword. 
-<sup>16&#160;</sup>You shall gather all its plunder into the middle of its street, and shall burn with fire the city, with all of its plunder, to Yahweh your Elohim. It shall be a heap forever. It shall not be built again. 
-<sup>17&#160;</sup>Nothing of the devoted thing shall cling to your hand, that Yahweh may turn from the fierceness of his anger and show you mercy, and have compassion on you and multiply you, as he has sworn to your fathers, 
-<sup>18&#160;</sup>when you listen to Yahweh your Elohim’s voice, to keep all his commandments which I command you today, to do that which is right in Yahweh your Elohim’s eyes. 
+<sup>16&#160;</sup>You shall gather all its plunder into the middle of its street, and shall burn with fire the city, with all of its plunder, to Yahuah your Elohim. It shall be a heap forever. It shall not be built again. 
+<sup>17&#160;</sup>Nothing of the devoted thing shall cling to your hand, that Yahuah may turn from the fierceness of his anger and show you mercy, and have compassion on you and multiply you, as he has sworn to your fathers, 
+<sup>18&#160;</sup>when you listen to Yahuah your Elohim’s voice, to keep all his commandments which I command you today, to do that which is right in Yahuah your Elohim’s eyes. 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
-<sup>1&#160;</sup>You are the children of Yahweh your Elohim. You shall not cut yourselves, nor make any baldness between your eyes for the dead. 
-<sup>2&#160;</sup>For you are a set-apart people to Yahweh your Elohim, and Yahweh has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
+<sup>1&#160;</sup>You are the children of Yahuah your Elohim. You shall not cut yourselves, nor make any baldness between your eyes for the dead. 
+<sup>2&#160;</sup>For you are a set-apart people to Yahuah your Elohim, and Yahuah has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
 </p><p>
 <sup>3&#160;</sup>You shall not eat any abominable thing. 
 <sup>4&#160;</sup>These are the animals which you may eat: the ox, the sheep, the goat, 
@@ -599,152 +599,152 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>All winged creeping things are unclean to you. They shall not be eaten. 
 <sup>20&#160;</sup>Of all clean birds you may eat. 
 </p><p>
-<sup>21&#160;</sup>You shall not eat of anything that dies of itself. You may give it to the foreigner living among you who is within your gates, that he may eat it; or you may sell it to a foreigner; for you are a set-apart people to Yahweh your Elohim. 
+<sup>21&#160;</sup>You shall not eat of anything that dies of itself. You may give it to the foreigner living among you who is within your gates, that he may eat it; or you may sell it to a foreigner; for you are a set-apart people to Yahuah your Elohim. 
 </p><p>You shall not boil a young goat in its mother’s milk. 
 </p><p>
 <sup>22&#160;</sup>You shall surely tithe all the increase of your seed, that which comes out of the field year by year. 
-<sup>23&#160;</sup>You shall eat before Yahweh your Elohim, in the place which he chooses to cause his name to dwell, the tithe of your grain, of your new wine, and of your oil, and the firstborn of your herd and of your flock; that you may learn to fear Yahweh your Elohim always. 
-<sup>24&#160;</sup>If the way is too long for you, so that you are not able to carry it because the place which Yahweh your Elohim shall choose to set his name there is too far from you, when Yahweh your Elohim blesses you, 
-<sup>25&#160;</sup>then you shall turn it into money, bind up the money in your hand, and shall go to the place which Yahweh your Elohim shall choose. 
-<sup>26&#160;</sup>You shall trade the money for whatever your soul desires: for cattle, or for sheep, or for wine, or for strong drink, or for whatever your soul asks of you. You shall eat there before Yahweh your Elohim, and you shall rejoice, you and your household. 
+<sup>23&#160;</sup>You shall eat before Yahuah your Elohim, in the place which he chooses to cause his name to dwell, the tithe of your grain, of your new wine, and of your oil, and the firstborn of your herd and of your flock; that you may learn to fear Yahuah your Elohim always. 
+<sup>24&#160;</sup>If the way is too long for you, so that you are not able to carry it because the place which Yahuah your Elohim shall choose to set his name there is too far from you, when Yahuah your Elohim blesses you, 
+<sup>25&#160;</sup>then you shall turn it into money, bind up the money in your hand, and shall go to the place which Yahuah your Elohim shall choose. 
+<sup>26&#160;</sup>You shall trade the money for whatever your soul desires: for cattle, or for sheep, or for wine, or for strong drink, or for whatever your soul asks of you. You shall eat there before Yahuah your Elohim, and you shall rejoice, you and your household. 
 <sup>27&#160;</sup>You shall not forsake the Levite who is within your gates, for he has no portion nor inheritance with you. 
 <sup>28&#160;</sup>At the end of every three years you shall bring all the tithe of your increase in the same year, and shall store it within your gates. 
-<sup>29&#160;</sup>The Levite, because he has no portion nor inheritance with you, as well as the foreigner living among you, the fatherless, and the widow who are within your gates shall come, and shall eat and be satisfied; that Yahweh your Elohim may bless you in all the work of your hand which you do. 
+<sup>29&#160;</sup>The Levite, because he has no portion nor inheritance with you, as well as the foreigner living among you, the fatherless, and the widow who are within your gates shall come, and shall eat and be satisfied; that Yahuah your Elohim may bless you in all the work of your hand which you do. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
 <sup>1&#160;</sup>At the end of every seven years, you shall cancel debts. 
-<sup>2&#160;</sup>This is the way it shall be done: every owner of a loan shall release that which he has lent to his neighbor. He shall not require payment from his neighbor and his brother, because Yahweh’s release has been proclaimed. 
+<sup>2&#160;</sup>This is the way it shall be done: every owner of a loan shall release that which he has lent to his neighbor. He shall not require payment from his neighbor and his brother, because Yahuah’s release has been proclaimed. 
 <sup>3&#160;</sup>Of a foreigner you may require it; but whatever of yours is with your brother, your hand shall release. 
-<sup>4&#160;</sup>However there will be no poor with you (for Yahweh will surely bless you in the land which Yahweh your Elohim gives you for an inheritance to possess) 
-<sup>5&#160;</sup>if only you diligently listen to Yahweh your Elohim’s voice, to observe to do all this commandment which I command you today. 
-<sup>6&#160;</sup>For Yahweh your Elohim will bless you, as he promised you. You will lend to many nations, but you will not borrow. You will rule over many nations, but they will not rule over you. 
-<sup>7&#160;</sup>If a poor man, one of your brothers, is with you within any of your gates in your land which Yahweh your Elohim gives you, you shall not harden your heart, nor shut your hand from your poor brother; 
+<sup>4&#160;</sup>However there will be no poor with you (for Yahuah will surely bless you in the land which Yahuah your Elohim gives you for an inheritance to possess) 
+<sup>5&#160;</sup>if only you diligently listen to Yahuah your Elohim’s voice, to observe to do all this commandment which I command you today. 
+<sup>6&#160;</sup>For Yahuah your Elohim will bless you, as he promised you. You will lend to many nations, but you will not borrow. You will rule over many nations, but they will not rule over you. 
+<sup>7&#160;</sup>If a poor man, one of your brothers, is with you within any of your gates in your land which Yahuah your Elohim gives you, you shall not harden your heart, nor shut your hand from your poor brother; 
 <sup>8&#160;</sup>but you shall surely open your hand to him, and shall surely lend him sufficient for his need, which he lacks. 
-<sup>9&#160;</sup>Beware that there not be a wicked thought in your heart, saying, “The seventh year, the year of release, is at hand,” and your eye be evil against your poor brother and you give him nothing; and he cry to Yahweh against you, and it be sin to you. 
-<sup>10&#160;</sup>You shall surely give, and your heart shall not be grieved when you give to him, because it is for this thing Yahweh your Elohim will bless you in all your work and in all that you put your hand to. 
+<sup>9&#160;</sup>Beware that there not be a wicked thought in your heart, saying, “The seventh year, the year of release, is at hand,” and your eye be evil against your poor brother and you give him nothing; and he cry to Yahuah against you, and it be sin to you. 
+<sup>10&#160;</sup>You shall surely give, and your heart shall not be grieved when you give to him, because it is for this thing Yahuah your Elohim will bless you in all your work and in all that you put your hand to. 
 <sup>11&#160;</sup>For the poor will never cease out of the land. Therefore I command you to surely open your hand to your brother, to your needy, and to your poor, in your land. 
 <sup>12&#160;</sup>If your brother, a Hebrew man, or a Hebrew woman, is sold to you and serves you six years, then in the seventh year you shall let him go free from you. 
 <sup>13&#160;</sup>When you let him go free from you, you shall not let him go empty. 
-<sup>14&#160;</sup>You shall furnish him liberally out of your flock, out of your threshing floor, and out of your wine press. As Yahweh your Elohim has blessed you, you shall give to him. 
-<sup>15&#160;</sup>You shall remember that you were a slave in the land of Egypt, and Yahweh your Elohim redeemed you. Therefore I command you this thing today. 
+<sup>14&#160;</sup>You shall furnish him liberally out of your flock, out of your threshing floor, and out of your wine press. As Yahuah your Elohim has blessed you, you shall give to him. 
+<sup>15&#160;</sup>You shall remember that you were a slave in the land of Egypt, and Yahuah your Elohim redeemed you. Therefore I command you this thing today. 
 <sup>16&#160;</sup>It shall be, if he tells you, “I will not go out from you,” because he loves you and your house, because he is well with you, 
 <sup>17&#160;</sup>then you shall take an awl, and thrust it through his ear to the door, and he shall be your servant forever. Also to your female servant you shall do likewise. 
-<sup>18&#160;</sup>It shall not seem hard to you when you let him go free from you, for he has been double the value of a hired hand as he served you six years. Yahweh your Elohim will bless you in all that you do. 
-<sup>19&#160;</sup>You shall dedicate all the firstborn males that are born of your herd and of your flock to Yahweh your Elohim. You shall do no work with the firstborn of your herd, nor shear the firstborn of your flock. 
-<sup>20&#160;</sup>You shall eat it before Yahweh your Elohim year by year in the place which Yahweh shall choose, you and your household. 
-<sup>21&#160;</sup>If it has any defect—is lame or blind, or has any defect whatever, you shall not sacrifice it to Yahweh your Elohim. 
+<sup>18&#160;</sup>It shall not seem hard to you when you let him go free from you, for he has been double the value of a hired hand as he served you six years. Yahuah your Elohim will bless you in all that you do. 
+<sup>19&#160;</sup>You shall dedicate all the firstborn males that are born of your herd and of your flock to Yahuah your Elohim. You shall do no work with the firstborn of your herd, nor shear the firstborn of your flock. 
+<sup>20&#160;</sup>You shall eat it before Yahuah your Elohim year by year in the place which Yahuah shall choose, you and your household. 
+<sup>21&#160;</sup>If it has any defect—is lame or blind, or has any defect whatever, you shall not sacrifice it to Yahuah your Elohim. 
 <sup>22&#160;</sup>You shall eat it within your gates. The unclean and the clean shall eat it alike, as the gazelle and as the deer. 
 <sup>23&#160;</sup>Only you shall not eat its blood. You shall pour it out on the ground like water. 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
-<sup>1&#160;</sup>Observe the month of Abib, and keep the Passover to Yahweh your Elohim; for in the month of Abib Yahweh your Elohim brought you out of Egypt by night. 
-<sup>2&#160;</sup>You shall sacrifice the Passover to Yahweh your Elohim, of the flock and the herd, in the place which Yahweh shall choose to cause his name to dwell there. 
+<sup>1&#160;</sup>Observe the month of Abib, and keep the Passover to Yahuah your Elohim; for in the month of Abib Yahuah your Elohim brought you out of Egypt by night. 
+<sup>2&#160;</sup>You shall sacrifice the Passover to Yahuah your Elohim, of the flock and the herd, in the place which Yahuah shall choose to cause his name to dwell there. 
 <sup>3&#160;</sup>You shall eat no leavened bread with it. You shall eat unleavened bread with it seven days, even the bread of affliction (for you came out of the land of Egypt in haste) that you may remember the day when you came out of the land of Egypt all the days of your life. 
 <sup>4&#160;</sup>No yeast shall be seen with you in all your borders seven days; neither shall any of the meat, which you sacrifice the first day at evening, remain all night until the morning. 
-<sup>5&#160;</sup>You may not sacrifice the Passover within any of your gates which Yahweh your Elohim gives you; 
-<sup>6&#160;</sup>but at the place which Yahweh your Elohim shall choose to cause his name to dwell in, there you shall sacrifice the Passover at evening, at the going down of the sun, at the season that you came out of Egypt. 
-<sup>7&#160;</sup>You shall roast and eat it in the place which Yahweh your Elohim chooses. In the morning you shall return to your tents. 
-<sup>8&#160;</sup>Six days you shall eat unleavened bread. On the seventh day shall be a solemn assembly to Yahweh your Elohim. You shall do no work. 
+<sup>5&#160;</sup>You may not sacrifice the Passover within any of your gates which Yahuah your Elohim gives you; 
+<sup>6&#160;</sup>but at the place which Yahuah your Elohim shall choose to cause his name to dwell in, there you shall sacrifice the Passover at evening, at the going down of the sun, at the season that you came out of Egypt. 
+<sup>7&#160;</sup>You shall roast and eat it in the place which Yahuah your Elohim chooses. In the morning you shall return to your tents. 
+<sup>8&#160;</sup>Six days you shall eat unleavened bread. On the seventh day shall be a solemn assembly to Yahuah your Elohim. You shall do no work. 
 </p><p>
 <sup>9&#160;</sup>You shall count for yourselves seven weeks. From the time you begin to put the sickle to the standing grain you shall begin to count seven weeks. 
-<sup>10&#160;</sup>You shall keep the feast of weeks to Yahweh your Elohim with a tribute of a free will offering of your hand, which you shall give according to how Yahweh your Elohim blesses you. 
-<sup>11&#160;</sup>You shall rejoice before Yahweh your Elohim: you, your son, your daughter, your male servant, your female servant, the Levite who is within your gates, the foreigner, the fatherless, and the widow who are among you, in the place which Yahweh your Elohim shall choose to cause his name to dwell there. 
+<sup>10&#160;</sup>You shall keep the feast of weeks to Yahuah your Elohim with a tribute of a free will offering of your hand, which you shall give according to how Yahuah your Elohim blesses you. 
+<sup>11&#160;</sup>You shall rejoice before Yahuah your Elohim: you, your son, your daughter, your male servant, your female servant, the Levite who is within your gates, the foreigner, the fatherless, and the widow who are among you, in the place which Yahuah your Elohim shall choose to cause his name to dwell there. 
 <sup>12&#160;</sup>You shall remember that you were a slave in Egypt. You shall observe and do these statutes. 
 </p><p>
 <sup>13&#160;</sup>You shall keep the feast of booths seven days, after you have gathered in from your threshing floor and from your wine press. 
 <sup>14&#160;</sup>You shall rejoice in your feast, you, your son, your daughter, your male servant, your female servant, the Levite, the foreigner, the fatherless, and the widow who are within your gates. 
-<sup>15&#160;</sup>You shall keep a feast to Yahweh your Elohim seven days in the place which Yahweh chooses, because Yahweh your Elohim will bless you in all your increase and in all the work of your hands, and you shall be altogether joyful. 
-<sup>16&#160;</sup>Three times in a year all of your males shall appear before Yahweh your Elohim in the place which he chooses: in the feast of unleavened bread, in the feast of weeks, and in the feast of booths. They shall not appear before Yahweh empty. 
-<sup>17&#160;</sup>Every man shall give as he is able, according to Yahweh your Elohim’s blessing which he has given you. 
-<sup>18&#160;</sup>You shall make judges and officers in all your gates, which Yahweh your Elohim gives you, according to your tribes; and they shall judge the people with righteous judgment. 
+<sup>15&#160;</sup>You shall keep a feast to Yahuah your Elohim seven days in the place which Yahuah chooses, because Yahuah your Elohim will bless you in all your increase and in all the work of your hands, and you shall be altogether joyful. 
+<sup>16&#160;</sup>Three times in a year all of your males shall appear before Yahuah your Elohim in the place which he chooses: in the feast of unleavened bread, in the feast of weeks, and in the feast of booths. They shall not appear before Yahuah empty. 
+<sup>17&#160;</sup>Every man shall give as he is able, according to Yahuah your Elohim’s blessing which he has given you. 
+<sup>18&#160;</sup>You shall make judges and officers in all your gates, which Yahuah your Elohim gives you, according to your tribes; and they shall judge the people with righteous judgment. 
 <sup>19&#160;</sup>You shall not pervert justice. You shall not show partiality. You shall not take a bribe, for a bribe blinds the eyes of the wise and perverts the words of the righteous. 
-<sup>20&#160;</sup>You shall follow that which is altogether just, that you may live and inherit the land which Yahweh your Elohim gives you. 
-<sup>21&#160;</sup>You shall not plant for yourselves an Asherah of any kind of tree beside Yahweh your Elohim’s altar, which you shall make for yourselves. 
-<sup>22&#160;</sup>Neither shall you set yourself up a sacred stone which Yahweh your Elohim hates. 
+<sup>20&#160;</sup>You shall follow that which is altogether just, that you may live and inherit the land which Yahuah your Elohim gives you. 
+<sup>21&#160;</sup>You shall not plant for yourselves an Asherah of any kind of tree beside Yahuah your Elohim’s altar, which you shall make for yourselves. 
+<sup>22&#160;</sup>Neither shall you set yourself up a sacred stone which Yahuah your Elohim hates. 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
-<sup>1&#160;</sup>You shall not sacrifice to Yahweh your Elohim an ox or a sheep in which is a defect or anything evil; for that is an abomination to Yahweh your Elohim. 
+<sup>1&#160;</sup>You shall not sacrifice to Yahuah your Elohim an ox or a sheep in which is a defect or anything evil; for that is an abomination to Yahuah your Elohim. 
 </p><p>
-<sup>2&#160;</sup>If there is found among you, within any of your gates which Yahweh your Elohim gives you, a man or woman who does that which is evil in Yahweh your Elohim’s sight in transgressing his covenant, 
+<sup>2&#160;</sup>If there is found among you, within any of your gates which Yahuah your Elohim gives you, a man or woman who does that which is evil in Yahuah your Elohim’s sight in transgressing his covenant, 
 <sup>3&#160;</sup>and has gone and served other elohims and worshiped them, or the sun, or the moon, or any of the stars of the sky, which I have not commanded, 
 <sup>4&#160;</sup>and you are told, and you have heard of it, then you shall inquire diligently. Behold, if it is true, and the thing certain, that such abomination is done in Israel, 
 <sup>5&#160;</sup>then you shall bring out that man or that woman who has done this evil thing to your gates, even that same man or woman; and you shall stone them to death with stones. 
 <sup>6&#160;</sup>At the mouth of two witnesses, or three witnesses, he who is to die shall be put to death. At the mouth of one witness he shall not be put to death. 
 <sup>7&#160;</sup>The hands of the witnesses shall be first on him to put him to death, and afterward the hands of all the people. So you shall remove the evil from among you. 
 </p><p>
-<sup>8&#160;</sup>If there arises a matter too hard for you in judgment, between blood and blood, between plea and plea, and between stroke and stroke, being matters of controversy within your gates, then you shall arise, and go up to the place which Yahweh your Elohim chooses. 
+<sup>8&#160;</sup>If there arises a matter too hard for you in judgment, between blood and blood, between plea and plea, and between stroke and stroke, being matters of controversy within your gates, then you shall arise, and go up to the place which Yahuah your Elohim chooses. 
 <sup>9&#160;</sup>You shall come to the priests who are Levites and to the judge who shall be in those days. You shall inquire, and they shall give you the verdict. 
-<sup>10&#160;</sup>You shall do according to the decisions of the verdict which they shall give you from that place which Yahweh chooses. You shall observe to do according to all that they shall teach you. 
+<sup>10&#160;</sup>You shall do according to the decisions of the verdict which they shall give you from that place which Yahuah chooses. You shall observe to do according to all that they shall teach you. 
 <sup>11&#160;</sup>According to the decisions of the law which they shall teach you, and according to the judgment which they shall tell you, you shall do. You shall not turn away from the sentence which they announce to you, to the right hand, nor to the left. 
-<sup>12&#160;</sup>The man who does presumptuously in not listening to the priest who stands to minister there before Yahweh your Elohim, or to the judge, even that man shall die. You shall put away the evil from Israel. 
+<sup>12&#160;</sup>The man who does presumptuously in not listening to the priest who stands to minister there before Yahuah your Elohim, or to the judge, even that man shall die. You shall put away the evil from Israel. 
 <sup>13&#160;</sup>All the people shall hear and fear, and do no more presumptuously. 
 </p><p>
-<sup>14&#160;</sup>When you have come to the land which Yahweh your Elohim gives you, and possess it and dwell in it, and say, “I will set a king over me, like all the nations that are around me,” 
-<sup>15&#160;</sup>you shall surely set him whom Yahweh your Elohim chooses as king over yourselves. You shall set as king over you one from among your brothers. You may not put a foreigner over you, who is not your brother. 
-<sup>16&#160;</sup>Only he shall not multiply horses to himself, nor cause the people to return to Egypt, to the end that he may multiply horses; because Yahweh has said to you, “You shall not go back that way again.” 
+<sup>14&#160;</sup>When you have come to the land which Yahuah your Elohim gives you, and possess it and dwell in it, and say, “I will set a king over me, like all the nations that are around me,” 
+<sup>15&#160;</sup>you shall surely set him whom Yahuah your Elohim chooses as king over yourselves. You shall set as king over you one from among your brothers. You may not put a foreigner over you, who is not your brother. 
+<sup>16&#160;</sup>Only he shall not multiply horses to himself, nor cause the people to return to Egypt, to the end that he may multiply horses; because Yahuah has said to you, “You shall not go back that way again.” 
 <sup>17&#160;</sup>He shall not multiply women to himself, that his heart not turn away. He shall not greatly multiply to himself silver and gold. 
 </p><p>
 <sup>18&#160;</sup>It shall be, when he sits on the throne of his kingdom, that he shall write himself a copy of this law in a book, out of that which is before the Levitical priests. 
-<sup>19&#160;</sup>It shall be with him, and he shall read from it all the days of his life, that he may learn to fear Yahweh his Elohim, to keep all the words of this law and these statutes, to do them; 
+<sup>19&#160;</sup>It shall be with him, and he shall read from it all the days of his life, that he may learn to fear Yahuah his Elohim, to keep all the words of this law and these statutes, to do them; 
 <sup>20&#160;</sup>that his heart not be lifted up above his brothers, and that he not turn away from the commandment to the right hand, or to the left, to the end that he may prolong his days in his kingdom, he and his children, in the middle of Israel. 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
-<sup>1&#160;</sup>The priests and the Levites—all the tribe of Levi—shall have no portion nor inheritance with Israel. They shall eat the offerings of Yahweh made by fire and his portion. 
-<sup>2&#160;</sup>They shall have no inheritance among their brothers. Yahweh is their inheritance, as he has spoken to them. 
+<sup>1&#160;</sup>The priests and the Levites—all the tribe of Levi—shall have no portion nor inheritance with Israel. They shall eat the offerings of Yahuah made by fire and his portion. 
+<sup>2&#160;</sup>They shall have no inheritance among their brothers. Yahuah is their inheritance, as he has spoken to them. 
 <sup>3&#160;</sup>This shall be the priests’ due from the people, from those who offer a sacrifice, whether it be ox or sheep, that they shall give to the priest: the shoulder, the two cheeks, and the inner parts. 
 <sup>4&#160;</sup>You shall give him the first fruits of your grain, of your new wine, and of your oil, and the first of the fleece of your sheep. 
-<sup>5&#160;</sup>For Yahweh your Elohim has chosen him out of all your tribes to stand to minister in Yahweh’s name, him and his sons forever. 
+<sup>5&#160;</sup>For Yahuah your Elohim has chosen him out of all your tribes to stand to minister in Yahuah’s name, him and his sons forever. 
 </p><p>
-<sup>6&#160;</sup>If a Levite comes from any of your gates out of all Israel where he lives, and comes with all the desire of his soul to the place which Yahweh shall choose, 
-<sup>7&#160;</sup>then he shall minister in the name of Yahweh his Elohim, as all his brothers the Levites do, who stand there before Yahweh. 
+<sup>6&#160;</sup>If a Levite comes from any of your gates out of all Israel where he lives, and comes with all the desire of his soul to the place which Yahuah shall choose, 
+<sup>7&#160;</sup>then he shall minister in the name of Yahuah his Elohim, as all his brothers the Levites do, who stand there before Yahuah. 
 <sup>8&#160;</sup>They shall have like portions to eat, in addition to that which comes from the sale of his family possessions. 
 </p><p>
-<sup>9&#160;</sup>When you have come into the land which Yahweh your Elohim gives you, you shall not learn to imitate the abominations of those nations. 
+<sup>9&#160;</sup>When you have come into the land which Yahuah your Elohim gives you, you shall not learn to imitate the abominations of those nations. 
 <sup>10&#160;</sup>There shall not be found with you anyone who makes his son or his daughter to pass through the fire, one who uses divination, one who tells fortunes, or an enchanter, or a sorcerer, 
 <sup>11&#160;</sup>or a charmer, or someone who consults with a familiar spirit, or a wizard, or a necromancer. 
-<sup>12&#160;</sup>For whoever does these things is an abomination to Yahweh. Because of these abominations, Yahweh your Elohim drives them out from before you. 
-<sup>13&#160;</sup>You shall be blameless with Yahweh your Elohim. 
-<sup>14&#160;</sup>For these nations that you shall dispossess listen to those who practice sorcery and to diviners; but as for you, Yahweh your Elohim has not allowed you so to do. 
-<sup>15&#160;</sup>Yahweh your Elohim will raise up to you a prophet from among you, of your brothers, like me. You shall listen to him. 
-<sup>16&#160;</sup>This is according to all that you desired of Yahweh your Elohim in Horeb in the day of the assembly, saying, “Let me not hear again Yahweh my Elohim’s voice, neither let me see this great fire any more, that I not die.” 
+<sup>12&#160;</sup>For whoever does these things is an abomination to Yahuah. Because of these abominations, Yahuah your Elohim drives them out from before you. 
+<sup>13&#160;</sup>You shall be blameless with Yahuah your Elohim. 
+<sup>14&#160;</sup>For these nations that you shall dispossess listen to those who practice sorcery and to diviners; but as for you, Yahuah your Elohim has not allowed you so to do. 
+<sup>15&#160;</sup>Yahuah your Elohim will raise up to you a prophet from among you, of your brothers, like me. You shall listen to him. 
+<sup>16&#160;</sup>This is according to all that you desired of Yahuah your Elohim in Horeb in the day of the assembly, saying, “Let me not hear again Yahuah my Elohim’s voice, neither let me see this great fire any more, that I not die.” 
 </p><p>
-<sup>17&#160;</sup>Yahweh said to me, “They have well said that which they have spoken. 
+<sup>17&#160;</sup>Yahuah said to me, “They have well said that which they have spoken. 
 <sup>18&#160;</sup>I will raise them up a prophet from among their brothers, like you. I will put my words in his mouth, and he shall speak to them all that I shall command him. 
 <sup>19&#160;</sup>It shall happen, that whoever will not listen to my words which he shall speak in my name, I will require it of him. 
 <sup>20&#160;</sup>But the prophet who speaks a word presumptuously in my name, which I have not commanded him to speak, or who speaks in the name of other elohims, that same prophet shall die.” 
 </p><p>
-<sup>21&#160;</sup>You may say in your heart, “How shall we know the word which Yahweh has not spoken?” 
-<sup>22&#160;</sup>When a prophet speaks in Yahweh’s name, if the thing doesn’t follow, nor happen, that is the thing which Yahweh has not spoken. The prophet has spoken it presumptuously. You shall not be afraid of him. 
+<sup>21&#160;</sup>You may say in your heart, “How shall we know the word which Yahuah has not spoken?” 
+<sup>22&#160;</sup>When a prophet speaks in Yahuah’s name, if the thing doesn’t follow, nor happen, that is the thing which Yahuah has not spoken. The prophet has spoken it presumptuously. You shall not be afraid of him. 
 </p><h2 class="chapterlabel" id="19">19</h2>
 <p>
-<sup>1&#160;</sup>When Yahweh your Elohim cuts off the nations whose land Yahweh your Elohim gives you, and you succeed them and dwell in their cities and in their houses, 
-<sup>2&#160;</sup>you shall set apart three cities for yourselves in the middle of your land, which Yahweh your Elohim gives you to possess. 
-<sup>3&#160;</sup>You shall prepare the way, and divide the borders of your land which Yahweh your Elohim causes you to inherit into three parts, that every man slayer may flee there. 
+<sup>1&#160;</sup>When Yahuah your Elohim cuts off the nations whose land Yahuah your Elohim gives you, and you succeed them and dwell in their cities and in their houses, 
+<sup>2&#160;</sup>you shall set apart three cities for yourselves in the middle of your land, which Yahuah your Elohim gives you to possess. 
+<sup>3&#160;</sup>You shall prepare the way, and divide the borders of your land which Yahuah your Elohim causes you to inherit into three parts, that every man slayer may flee there. 
 <sup>4&#160;</sup>This is the case of the man slayer who shall flee there and live: Whoever kills his neighbor unintentionally, and didn’t hate him in time past—<sup>5&#160;</sup>as when a man goes into the forest with his neighbor to chop wood and his hand swings the ax to cut down the tree, and the head slips from the handle and hits his neighbor so that he dies—he shall flee to one of these cities and live. 
 <sup>6&#160;</sup>Otherwise, the avenger of blood might pursue the man slayer while hot anger is in his heart and overtake him, because the way is long, and strike him mortally, even though he was not worthy of death, because he didn’t hate him in time past. 
 <sup>7&#160;</sup>Therefore I command you to set apart three cities for yourselves. 
-<sup>8&#160;</sup>If Yahweh your Elohim enlarges your border, as he has sworn to your fathers, and gives you all the land which he promised to give to your fathers; 
-<sup>9&#160;</sup>and if you keep all this commandment to do it, which I command you today, to love Yahweh your Elohim, and to walk ever in his ways, then you shall add three cities more for yourselves, in addition to these three. 
-<sup>10&#160;</sup>This is so that innocent blood will not be shed in the middle of your land which Yahweh your Elohim gives you for an inheritance, leaving blood guilt on you. 
+<sup>8&#160;</sup>If Yahuah your Elohim enlarges your border, as he has sworn to your fathers, and gives you all the land which he promised to give to your fathers; 
+<sup>9&#160;</sup>and if you keep all this commandment to do it, which I command you today, to love Yahuah your Elohim, and to walk ever in his ways, then you shall add three cities more for yourselves, in addition to these three. 
+<sup>10&#160;</sup>This is so that innocent blood will not be shed in the middle of your land which Yahuah your Elohim gives you for an inheritance, leaving blood guilt on you. 
 <sup>11&#160;</sup>But if any man hates his neighbor, lies in wait for him, rises up against him, strikes him mortally so that he dies, and he flees into one of these cities; 
 <sup>12&#160;</sup>then the elders of his city shall send and bring him there, and deliver him into the hand of the avenger of blood, that he may die. 
 <sup>13&#160;</sup>Your eye shall not pity him, but you shall purge the innocent blood from Israel that it may go well with you. 
 </p><p>
-<sup>14&#160;</sup>You shall not remove your neighbor’s landmark, which they of old time have set, in your inheritance which you shall inherit, in the land that Yahweh your Elohim gives you to possess. 
+<sup>14&#160;</sup>You shall not remove your neighbor’s landmark, which they of old time have set, in your inheritance which you shall inherit, in the land that Yahuah your Elohim gives you to possess. 
 </p><p>
 <sup>15&#160;</sup>One witness shall not rise up against a man for any iniquity, or for any sin that he sins. At the mouth of two witnesses, or at the mouth of three witnesses, shall a matter be established. 
 <sup>16&#160;</sup>If an unrighteous witness rises up against any man to testify against him of wrongdoing, 
-<sup>17&#160;</sup>then both the men, between whom the controversy is, shall stand before Yahweh, before the priests and the judges who shall be in those days; 
+<sup>17&#160;</sup>then both the men, between whom the controversy is, shall stand before Yahuah, before the priests and the judges who shall be in those days; 
 <sup>18&#160;</sup>and the judges shall make diligent inquisition; and behold, if the witness is a false witness, and has testified falsely against his brother, 
 <sup>19&#160;</sup>then you shall do to him as he had thought to do to his brother. So you shall remove the evil from among you. 
 <sup>20&#160;</sup>Those who remain shall hear, and fear, and will never again commit any such evil among you. 
 <sup>21&#160;</sup>Your eyes shall not pity: life for life, eye for eye, tooth for tooth, hand for hand, foot for foot. 
 </p><h2 class="chapterlabel" id="20">20</h2>
 <p>
-<sup>1&#160;</sup>When you go out to battle against your enemies, and see horses, chariots, and a people more numerous than you, you shall not be afraid of them; for Yahweh your Elohim, who brought you up out of the land of Egypt, is with you. 
+<sup>1&#160;</sup>When you go out to battle against your enemies, and see horses, chariots, and a people more numerous than you, you shall not be afraid of them; for Yahuah your Elohim, who brought you up out of the land of Egypt, is with you. 
 <sup>2&#160;</sup>It shall be, when you draw near to the battle, that the priest shall approach and speak to the people, 
 <sup>3&#160;</sup>and shall tell them, “Hear, Israel, you draw near today to battle against your enemies. Don’t let your heart faint! Don’t be afraid, nor tremble, neither be scared of them; 
-<sup>4&#160;</sup>for Yahweh your Elohim is he who goes with you, to fight for you against your enemies, to save you.” 
+<sup>4&#160;</sup>for Yahuah your Elohim is he who goes with you, to fight for you against your enemies, to save you.” 
 </p><p>
 <sup>5&#160;</sup>The officers shall speak to the people, saying, “What man is there who has built a new house, and has not dedicated it? Let him go and return to his house, lest he die in the battle, and another man dedicate it. 
 <sup>6&#160;</sup>What man is there who has planted a vineyard, and has not used its fruit? Let him go and return to his house, lest he die in the battle, and another man use its fruit. 
@@ -755,27 +755,27 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>When you draw near to a city to fight against it, then proclaim peace to it. 
 <sup>11&#160;</sup>It shall be, if it gives you answer of peace and opens to you, then it shall be that all the people who are found therein shall become forced laborers to you, and shall serve you. 
 <sup>12&#160;</sup>If it will make no peace with you, but will make war against you, then you shall besiege it. 
-<sup>13&#160;</sup>When Yahweh your Elohim delivers it into your hand, you shall strike every male of it with the edge of the sword; 
-<sup>14&#160;</sup>but the women, the little ones, the livestock, and all that is in the city, even all its plunder, you shall take for plunder for yourself. You may use the plunder of your enemies, which Yahweh your Elohim has given you. 
+<sup>13&#160;</sup>When Yahuah your Elohim delivers it into your hand, you shall strike every male of it with the edge of the sword; 
+<sup>14&#160;</sup>but the women, the little ones, the livestock, and all that is in the city, even all its plunder, you shall take for plunder for yourself. You may use the plunder of your enemies, which Yahuah your Elohim has given you. 
 <sup>15&#160;</sup>Thus you shall do to all the cities which are very far off from you, which are not of the cities of these nations. 
-<sup>16&#160;</sup>But of the cities of these peoples that Yahweh your Elohim gives you for an inheritance, you shall save alive nothing that breathes; 
-<sup>17&#160;</sup>but you shall utterly destroy them: the Hittite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite, as Yahweh your Elohim has commanded you; 
-<sup>18&#160;</sup>that they not teach you to follow all their abominations, which they have done for their elohims; so would you sin against Yahweh your Elohim. 
+<sup>16&#160;</sup>But of the cities of these peoples that Yahuah your Elohim gives you for an inheritance, you shall save alive nothing that breathes; 
+<sup>17&#160;</sup>but you shall utterly destroy them: the Hittite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite, as Yahuah your Elohim has commanded you; 
+<sup>18&#160;</sup>that they not teach you to follow all their abominations, which they have done for their elohims; so would you sin against Yahuah your Elohim. 
 <sup>19&#160;</sup>When you shall besiege a city a long time, in making war against it to take it, you shall not destroy its trees by wielding an ax against them; for you may eat of them. You shall not cut them down, for is the tree of the field man, that it should be besieged by you? 
 <sup>20&#160;</sup>Only the trees that you know are not trees for food, you shall destroy and cut them down. You shall build bulwarks against the city that makes war with you, until it falls. 
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
-<sup>1&#160;</sup>If someone is found slain in the land which Yahweh your Elohim gives you to possess, lying in the field, and it isn’t known who has struck him, 
+<sup>1&#160;</sup>If someone is found slain in the land which Yahuah your Elohim gives you to possess, lying in the field, and it isn’t known who has struck him, 
 <sup>2&#160;</sup>then your elders and your judges shall come out, and they shall measure to the cities which are around him who is slain. 
 <sup>3&#160;</sup>It shall be that the elders of the city which is nearest to the slain man shall take a heifer of the herd, which hasn’t been worked with and which has not drawn in the yoke. 
 <sup>4&#160;</sup>The elders of that city shall bring the heifer down to a valley with running water, which is neither plowed nor sown, and shall break the heifer’s neck there in the valley. 
-<sup>5&#160;</sup>The priests the sons of Levi shall come near, for them Yahweh your Elohim has chosen to minister to him, and to bless in Yahweh’s name; and according to their word shall every controversy and every assault be decided. 
+<sup>5&#160;</sup>The priests the sons of Levi shall come near, for them Yahuah your Elohim has chosen to minister to him, and to bless in Yahuah’s name; and according to their word shall every controversy and every assault be decided. 
 <sup>6&#160;</sup>All the elders of that city which is nearest to the slain man shall wash their hands over the heifer whose neck was broken in the valley. 
 <sup>7&#160;</sup>They shall answer and say, “Our hands have not shed this blood, neither have our eyes seen it. 
-<sup>8&#160;</sup>Forgive, Yahweh, your people Israel, whom you have redeemed, and don’t allow innocent blood among your people Israel.” The blood shall be forgiven them. 
-<sup>9&#160;</sup>So you shall put away the innocent blood from among you, when you shall do that which is right in Yahweh’s eyes. 
+<sup>8&#160;</sup>Forgive, Yahuah, your people Israel, whom you have redeemed, and don’t allow innocent blood among your people Israel.” The blood shall be forgiven them. 
+<sup>9&#160;</sup>So you shall put away the innocent blood from among you, when you shall do that which is right in Yahuah’s eyes. 
 </p><p>
-<sup>10&#160;</sup>When you go out to battle against your enemies, and Yahweh your Elohim delivers them into your hands and you carry them away captive, 
+<sup>10&#160;</sup>When you go out to battle against your enemies, and Yahuah your Elohim delivers them into your hands and you carry them away captive, 
 <sup>11&#160;</sup>and see among the captives a beautiful woman, and you are attracted to her, and desire to take her as your woman, 
 <sup>12&#160;</sup>then you shall bring her home to your house. She shall shave her head and trim her nails. 
 <sup>13&#160;</sup>She shall take off the clothing of her captivity, and shall remain in your house, and bewail her father and her mother a full month. After that you shall go in to her and be her owner, and she shall be your woman. 
@@ -791,7 +791,7 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>All the men of his city shall stone him to death with stones. So you shall remove the evil from among you. All Israel shall hear, and fear. 
 </p><p>
 <sup>22&#160;</sup>If a man has committed a sin worthy of death, and he is put to death, and you hang him on a tree, 
-<sup>23&#160;</sup>his body shall not remain all night on the tree, but you shall surely bury him the same day; for he who is hanged is accursed of Elohim. Don’t defile your land which Yahweh your Elohim gives you for an inheritance. 
+<sup>23&#160;</sup>his body shall not remain all night on the tree, but you shall surely bury him the same day; for he who is hanged is accursed of Elohim. Don’t defile your land which Yahuah your Elohim gives you for an inheritance. 
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
 <sup>1&#160;</sup>You shall not see your brother’s ox or his sheep go astray and hide yourself from them. You shall surely bring them again to your brother. 
@@ -799,7 +799,7 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>So you shall do with his donkey. So you shall do with his garment. So you shall do with every lost thing of your brother’s, which he has lost and you have found. You may not hide yourself. 
 <sup>4&#160;</sup>You shall not see your brother’s donkey or his ox fallen down by the way, and hide yourself from them. You shall surely help him to lift them up again. 
 </p><p>
-<sup>5&#160;</sup>A woman shall not wear men’s clothing, neither shall a man put on women’s clothing; for whoever does these things is an abomination to Yahweh your Elohim. 
+<sup>5&#160;</sup>A woman shall not wear men’s clothing, neither shall a man put on women’s clothing; for whoever does these things is an abomination to Yahuah your Elohim. 
 </p><p>
 <sup>6&#160;</sup>If you come across a bird’s nest on the way, in any tree or on the ground, with young ones or eggs, and the hen sitting on the young, or on the eggs, you shall not take the hen with the young. 
 <sup>7&#160;</sup>You shall surely let the hen go, but the young you may take for yourself, that it may be well with you, and that you may prolong your days. 
@@ -834,34 +834,34 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>A man shall not take his father’s woman, and shall not uncover his father’s skirt. 
 </p><h2 class="chapterlabel" id="23">23</h2>
 <p>
-<sup>1&#160;</sup>He who is emasculated by crushing or cutting shall not enter into Yahweh’s assembly. 
-<sup>2&#160;</sup>A person born of a forbidden union shall not enter into Yahweh’s assembly; even to the tenth generation shall no one of his enter into Yahweh’s assembly. 
-<sup>3&#160;</sup>An Ammonite or a Moabite shall not enter into Yahweh’s assembly; even to the tenth generation shall no one belonging to them enter into Yahweh’s assembly forever, 
+<sup>1&#160;</sup>He who is emasculated by crushing or cutting shall not enter into Yahuah’s assembly. 
+<sup>2&#160;</sup>A person born of a forbidden union shall not enter into Yahuah’s assembly; even to the tenth generation shall no one of his enter into Yahuah’s assembly. 
+<sup>3&#160;</sup>An Ammonite or a Moabite shall not enter into Yahuah’s assembly; even to the tenth generation shall no one belonging to them enter into Yahuah’s assembly forever, 
 <sup>4&#160;</sup>because they didn’t meet you with bread and with water on the way when you came out of Egypt, and because they hired against you Balaam the son of Beor from Pethor of Mesopotamia, to curse you. 
-<sup>5&#160;</sup>Nevertheless Yahweh your Elohim wouldn’t listen to Balaam, but Yahweh your Elohim turned the curse into a blessing to you, because Yahweh your Elohim loved you. 
+<sup>5&#160;</sup>Nevertheless Yahuah your Elohim wouldn’t listen to Balaam, but Yahuah your Elohim turned the curse into a blessing to you, because Yahuah your Elohim loved you. 
 <sup>6&#160;</sup>You shall not seek their peace nor their prosperity all your days forever. 
 <sup>7&#160;</sup>You shall not abhor an Edomite, for he is your brother. You shall not abhor an Egyptian, because you lived as a foreigner in his land. 
-<sup>8&#160;</sup>The children of the third generation who are born to them may enter into Yahweh’s assembly. 
+<sup>8&#160;</sup>The children of the third generation who are born to them may enter into Yahuah’s assembly. 
 </p><p>
 <sup>9&#160;</sup>When you go out and camp against your enemies, then you shall keep yourselves from every evil thing. 
 <sup>10&#160;</sup>If there is among you any man who is not clean by reason of that which happens to him by night, then shall he go outside of the camp. He shall not come within the camp; 
 <sup>11&#160;</sup>but it shall be, when evening comes, he shall bathe himself in water. When the sun is down, he shall come within the camp. 
 <sup>12&#160;</sup>You shall have a place also outside of the camp where you go relieve yourself. 
 <sup>13&#160;</sup>You shall have a trowel among your weapons. It shall be, when you relieve yourself, you shall dig with it, and shall turn back and cover your excrement; 
-<sup>14&#160;</sup>for Yahweh your Elohim walks in the middle of your camp, to deliver you, and to give up your enemies before you. Therefore your camp shall be set-apart, that he may not see an unclean thing in you, and turn away from you. 
+<sup>14&#160;</sup>for Yahuah your Elohim walks in the middle of your camp, to deliver you, and to give up your enemies before you. Therefore your camp shall be set-apart, that he may not see an unclean thing in you, and turn away from you. 
 </p><p>
 <sup>15&#160;</sup>You shall not deliver to his master a servant who has escaped from his master to you. 
 <sup>16&#160;</sup>He shall dwell with you, among you, in the place which he shall choose within one of your gates, where it pleases him best. You shall not oppress him. 
 </p><p>
 <sup>17&#160;</sup>There shall be no prostitute of the daughters of Israel, neither shall there be a sodomite of the sons of Israel. 
-<sup>18&#160;</sup>You shall not bring the hire of a prostitute, or the wages of a male prostitute, into the house of Yahweh your Elohim for any vow; for both of these are an abomination to Yahweh your Elohim. 
+<sup>18&#160;</sup>You shall not bring the hire of a prostitute, or the wages of a male prostitute, into the house of Yahuah your Elohim for any vow; for both of these are an abomination to Yahuah your Elohim. 
 </p><p>
 <sup>19&#160;</sup>You shall not lend on interest to your brother: interest of money, interest of food, interest of anything that is lent on interest. 
-<sup>20&#160;</sup>You may charge a foreigner interest; but you shall not charge your brother interest, that Yahweh your Elohim may bless you in all that you put your hand to, in the land where you go in to possess it. 
+<sup>20&#160;</sup>You may charge a foreigner interest; but you shall not charge your brother interest, that Yahuah your Elohim may bless you in all that you put your hand to, in the land where you go in to possess it. 
 </p><p>
-<sup>21&#160;</sup>When you vow a vow to Yahweh your Elohim, you shall not be slack to pay it, for Yahweh your Elohim will surely require it of you; and it would be sin in you. 
+<sup>21&#160;</sup>When you vow a vow to Yahuah your Elohim, you shall not be slack to pay it, for Yahuah your Elohim will surely require it of you; and it would be sin in you. 
 <sup>22&#160;</sup>But if you refrain from making a vow, it shall be no sin in you. 
-<sup>23&#160;</sup>You shall observe and do that which has gone out of your lips. Whatever you have vowed to Yahweh your Elohim as a free will offering, which you have promised with your mouth, you must do. 
+<sup>23&#160;</sup>You shall observe and do that which has gone out of your lips. Whatever you have vowed to Yahuah your Elohim as a free will offering, which you have promised with your mouth, you must do. 
 <sup>24&#160;</sup>When you come into your neighbor’s vineyard, then you may eat your fill of grapes at your own pleasure; but you shall not put any in your container. 
 <sup>25&#160;</sup>When you come into your neighbor’s standing grain, then you may pluck the ears with your hand; but you shall not use a sickle on your neighbor’s standing grain. 
 </p><h2 class="chapterlabel" id="24">24</h2>
@@ -869,7 +869,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>When a man takes a woman and owns her, then it shall be, if she finds no favor in his eyes because he has found some unseemly thing in her, that he shall write her a certificate of divorce, put it in her hand, and send her out of his house. 
 <sup>2&#160;</sup>When she has departed out of his house, she may go and be another man’s woman. 
 <sup>3&#160;</sup>If the latter man hates her, and writes her a certificate of divorce, puts it in her hand, and sends her out of his house; or if the latter man dies, who took her to be his woman; 
-<sup>4&#160;</sup>her former owner, who sent her away, may not take her again to be his woman after she is defiled; for that would be an abomination to Yahweh. You shall not cause the land to sin, which Yahweh your Elohim gives you for an inheritance. 
+<sup>4&#160;</sup>her former owner, who sent her away, may not take her again to be his woman after she is defiled; for that would be an abomination to Yahuah. You shall not cause the land to sin, which Yahuah your Elohim gives you for an inheritance. 
 <sup>5&#160;</sup>When a man takes a new woman, he shall not go out in the army, neither shall he be assigned any business. He shall be free at home one year, and shall cheer his woman whom he has taken. 
 </p><p>
 <sup>6&#160;</sup>No man shall take the mill or the upper millstone as a pledge, for he takes a life in pledge. 
@@ -877,22 +877,22 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>If a man is found stealing any of his brothers of the children of Israel, and he deals with him as a slave, or sells him, then that thief shall die. So you shall remove the evil from among you. 
 </p><p>
 <sup>8&#160;</sup>Be careful in the plague of leprosy, that you observe diligently and do according to all that the Levitical priests teach you. As I commanded them, so you shall observe to do. 
-<sup>9&#160;</sup>Remember what Yahweh your Elohim did to Miriam, by the way as you came out of Egypt. 
+<sup>9&#160;</sup>Remember what Yahuah your Elohim did to Miriam, by the way as you came out of Egypt. 
 </p><p>
 <sup>10&#160;</sup>When you lend your neighbor any kind of loan, you shall not go into his house to get his pledge. 
 <sup>11&#160;</sup>You shall stand outside, and the man to whom you lend shall bring the pledge outside to you. 
 <sup>12&#160;</sup>If he is a poor man, you shall not sleep with his pledge. 
-<sup>13&#160;</sup>You shall surely restore to him the pledge when the sun goes down, that he may sleep in his garment and bless you. It shall be righteousness to you before Yahweh your Elohim. 
+<sup>13&#160;</sup>You shall surely restore to him the pledge when the sun goes down, that he may sleep in his garment and bless you. It shall be righteousness to you before Yahuah your Elohim. 
 </p><p>
 <sup>14&#160;</sup>You shall not oppress a hired servant who is poor and needy, whether he is one of your brothers or one of the foreigners who are in your land within your gates. 
-<sup>15&#160;</sup>In his day you shall give him his wages, neither shall the sun go down on it, for he is poor and sets his heart on it, lest he cry against you to Yahweh, and it be sin to you. 
+<sup>15&#160;</sup>In his day you shall give him his wages, neither shall the sun go down on it, for he is poor and sets his heart on it, lest he cry against you to Yahuah, and it be sin to you. 
 </p><p>
 <sup>16&#160;</sup>The fathers shall not be put to death for the children, neither shall the children be put to death for the fathers. Every man shall be put to death for his own sin. 
 </p><p>
 <sup>17&#160;</sup>You shall not deprive the foreigner or the fatherless of justice, nor take a widow’s clothing in pledge; 
-<sup>18&#160;</sup>but you shall remember that you were a slave in Egypt, and Yahweh your Elohim redeemed you there. Therefore I command you to do this thing. 
+<sup>18&#160;</sup>but you shall remember that you were a slave in Egypt, and Yahuah your Elohim redeemed you there. Therefore I command you to do this thing. 
 </p><p>
-<sup>19&#160;</sup>When you reap your harvest in your field, and have forgotten a sheaf in the field, you shall not go again to get it. It shall be for the foreigner, for the fatherless, and for the widow, that Yahweh your Elohim may bless you in all the work of your hands. 
+<sup>19&#160;</sup>When you reap your harvest in your field, and have forgotten a sheaf in the field, you shall not go again to get it. It shall be for the foreigner, for the fatherless, and for the widow, that Yahuah your Elohim may bless you in all the work of your hands. 
 <sup>20&#160;</sup>When you beat your olive tree, you shall not go over the boughs again. It shall be for the foreigner, for the fatherless, and for the widow. 
 </p><p>
 <sup>21&#160;</sup>When you harvest your vineyard, you shall not glean it after yourselves. It shall be for the foreigner, for the fatherless, and for the widow. 
@@ -918,54 +918,54 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>13&#160;</sup>You shall not have in your bag diverse weights, one heavy and one light. 
 <sup>14&#160;</sup>You shall not have in your house diverse measures, one large and one small. 
-<sup>15&#160;</sup>You shall have a perfect and just weight. You shall have a perfect and just measure, that your days may be long in the land which Yahweh your Elohim gives you. 
-<sup>16&#160;</sup>For all who do such things, all who do unrighteously, are an abomination to Yahweh your Elohim. 
+<sup>15&#160;</sup>You shall have a perfect and just weight. You shall have a perfect and just measure, that your days may be long in the land which Yahuah your Elohim gives you. 
+<sup>16&#160;</sup>For all who do such things, all who do unrighteously, are an abomination to Yahuah your Elohim. 
 </p><p>
 <sup>17&#160;</sup>Remember what Amalek did to you by the way as you came out of Egypt, 
 <sup>18&#160;</sup>how he met you by the way, and struck the rearmost of you, all who were feeble behind you, when you were faint and weary; and he didn’t fear Elohim. 
-<sup>19&#160;</sup>Therefore it shall be, when Yahweh your Elohim has given you rest from all your enemies all around, in the land which Yahweh your Elohim gives you for an inheritance to possess it, that you shall blot out the memory of Amalek from under the sky. You shall not forget. 
+<sup>19&#160;</sup>Therefore it shall be, when Yahuah your Elohim has given you rest from all your enemies all around, in the land which Yahuah your Elohim gives you for an inheritance to possess it, that you shall blot out the memory of Amalek from under the sky. You shall not forget. 
 </p><h2 class="chapterlabel" id="26">26</h2>
 <p>
-<sup>1&#160;</sup>It shall be, when you have come in to the land which Yahweh your Elohim gives you for an inheritance, possess it, and dwell in it, 
-<sup>2&#160;</sup>that you shall take some of the first of all the fruit of the ground, which you shall bring in from your land that Yahweh your Elohim gives you. You shall put it in a basket, and shall go to the place which Yahweh your Elohim shall choose to cause his name to dwell there. 
-<sup>3&#160;</sup>You shall come to the priest who shall be in those days, and tell him, “I profess today to Yahweh your Elohim, that I have come to the land which Yahweh swore to our fathers to give us.” 
-<sup>4&#160;</sup>The priest shall take the basket out of your hand, and set it down before Yahweh your Elohim’s altar. 
-<sup>5&#160;</sup>You shall answer and say before Yahweh your Elohim, “My father was a Syrian ready to perish. He went down into Egypt, and lived there, few in number. There he became a great, mighty, and populous nation. 
+<sup>1&#160;</sup>It shall be, when you have come in to the land which Yahuah your Elohim gives you for an inheritance, possess it, and dwell in it, 
+<sup>2&#160;</sup>that you shall take some of the first of all the fruit of the ground, which you shall bring in from your land that Yahuah your Elohim gives you. You shall put it in a basket, and shall go to the place which Yahuah your Elohim shall choose to cause his name to dwell there. 
+<sup>3&#160;</sup>You shall come to the priest who shall be in those days, and tell him, “I profess today to Yahuah your Elohim, that I have come to the land which Yahuah swore to our fathers to give us.” 
+<sup>4&#160;</sup>The priest shall take the basket out of your hand, and set it down before Yahuah your Elohim’s altar. 
+<sup>5&#160;</sup>You shall answer and say before Yahuah your Elohim, “My father was a Syrian ready to perish. He went down into Egypt, and lived there, few in number. There he became a great, mighty, and populous nation. 
 <sup>6&#160;</sup>The Egyptians mistreated us, afflicted us, and imposed hard labor on us. 
-<sup>7&#160;</sup>Then we cried to Yahweh, the Elohim of our fathers. Yahweh heard our voice, and saw our affliction, our toil, and our oppression. 
-<sup>8&#160;</sup>Yahweh brought us out of Egypt with a mighty hand, with an outstretched arm, with great terror, with signs, and with wonders; 
+<sup>7&#160;</sup>Then we cried to Yahuah, the Elohim of our fathers. Yahuah heard our voice, and saw our affliction, our toil, and our oppression. 
+<sup>8&#160;</sup>Yahuah brought us out of Egypt with a mighty hand, with an outstretched arm, with great terror, with signs, and with wonders; 
 <sup>9&#160;</sup>and he has brought us into this place, and has given us this land, a land flowing with milk and honey. 
-<sup>10&#160;</sup>Now, behold, I have brought the first of the fruit of the ground, which you, Yahweh, have given me.” You shall set it down before Yahweh your Elohim, and worship before Yahweh your Elohim. 
-<sup>11&#160;</sup>You shall rejoice in all the good which Yahweh your Elohim has given to you, and to your house, you, and the Levite, and the foreigner who is among you. 
+<sup>10&#160;</sup>Now, behold, I have brought the first of the fruit of the ground, which you, Yahuah, have given me.” You shall set it down before Yahuah your Elohim, and worship before Yahuah your Elohim. 
+<sup>11&#160;</sup>You shall rejoice in all the good which Yahuah your Elohim has given to you, and to your house, you, and the Levite, and the foreigner who is among you. 
 </p><p>
 <sup>12&#160;</sup>When you have finished tithing all the tithe of your increase in the third year, which is the year of tithing, then you shall give it to the Levite, to the foreigner, to the fatherless, and to the widow, that they may eat within your gates and be filled. 
-<sup>13&#160;</sup>You shall say before Yahweh your Elohim, “I have put away the set-apart things out of my house, and also have given them to the Levite, to the foreigner, to the fatherless, and to the widow, according to all your commandment which you have commanded me. I have not transgressed any of your commandments, neither have I forgotten them. 
-<sup>14&#160;</sup>I have not eaten of it in my mourning, neither have I removed any of it while I was unclean, nor given of it for the dead. I have listened to Yahweh my Elohim’s voice. I have done according to all that you have commanded me. 
+<sup>13&#160;</sup>You shall say before Yahuah your Elohim, “I have put away the set-apart things out of my house, and also have given them to the Levite, to the foreigner, to the fatherless, and to the widow, according to all your commandment which you have commanded me. I have not transgressed any of your commandments, neither have I forgotten them. 
+<sup>14&#160;</sup>I have not eaten of it in my mourning, neither have I removed any of it while I was unclean, nor given of it for the dead. I have listened to Yahuah my Elohim’s voice. I have done according to all that you have commanded me. 
 <sup>15&#160;</sup>Look down from your set-apart habitation, from heaven, and bless your people Israel, and the ground which you have given us, as you swore to our fathers, a land flowing with milk and honey.” 
 </p><p>
-<sup>16&#160;</sup>Today Yahweh your Elohim commands you to do these statutes and ordinances. You shall therefore keep and do them with all your heart and with all your soul. 
-<sup>17&#160;</sup>You have declared today that Yahweh is your Elohim, and that you would walk in his ways, keep his statutes, his commandments, and his ordinances, and listen to his voice. 
-<sup>18&#160;</sup>Yahweh has declared today that you are a people for his own possession, as he has promised you, and that you should keep all his commandments. 
-<sup>19&#160;</sup>He will make you high above all nations that he has made, in praise, in name, and in honor, and that you may be a set-apart people to Yahweh your Elohim, as he has spoken. 
+<sup>16&#160;</sup>Today Yahuah your Elohim commands you to do these statutes and ordinances. You shall therefore keep and do them with all your heart and with all your soul. 
+<sup>17&#160;</sup>You have declared today that Yahuah is your Elohim, and that you would walk in his ways, keep his statutes, his commandments, and his ordinances, and listen to his voice. 
+<sup>18&#160;</sup>Yahuah has declared today that you are a people for his own possession, as he has promised you, and that you should keep all his commandments. 
+<sup>19&#160;</sup>He will make you high above all nations that he has made, in praise, in name, and in honor, and that you may be a set-apart people to Yahuah your Elohim, as he has spoken. 
 </p><h2 class="chapterlabel" id="27">27</h2>
 <p>
 <sup>1&#160;</sup>Moses and the elders of Israel commanded the people, saying, “Keep all the commandment which I command you today. 
-<sup>2&#160;</sup>It shall be on the day when you shall pass over the Jordan to the land which Yahweh your Elohim gives you, that you shall set yourself up great stones, and coat them with plaster. 
-<sup>3&#160;</sup>You shall write on them all the words of this law, when you have passed over, that you may go in to the land which Yahweh your Elohim gives you, a land flowing with milk and honey, as Yahweh, the Elohim of your fathers, has promised you. 
+<sup>2&#160;</sup>It shall be on the day when you shall pass over the Jordan to the land which Yahuah your Elohim gives you, that you shall set yourself up great stones, and coat them with plaster. 
+<sup>3&#160;</sup>You shall write on them all the words of this law, when you have passed over, that you may go in to the land which Yahuah your Elohim gives you, a land flowing with milk and honey, as Yahuah, the Elohim of your fathers, has promised you. 
 <sup>4&#160;</sup>It shall be, when you have crossed over the Jordan, that you shall set up these stones, which I command you today, on Mount Ebal, and you shall coat them with plaster. 
-<sup>5&#160;</sup>There you shall build an altar to Yahweh your Elohim, an altar of stones. You shall not use any iron tool on them. 
-<sup>6&#160;</sup>You shall build Yahweh your Elohim’s altar of uncut stones. You shall offer burnt offerings on it to Yahweh your Elohim. 
-<sup>7&#160;</sup>You shall sacrifice peace offerings, and shall eat there. You shall rejoice before Yahweh your Elohim. 
+<sup>5&#160;</sup>There you shall build an altar to Yahuah your Elohim, an altar of stones. You shall not use any iron tool on them. 
+<sup>6&#160;</sup>You shall build Yahuah your Elohim’s altar of uncut stones. You shall offer burnt offerings on it to Yahuah your Elohim. 
+<sup>7&#160;</sup>You shall sacrifice peace offerings, and shall eat there. You shall rejoice before Yahuah your Elohim. 
 <sup>8&#160;</sup>You shall write on the stones all the words of this law very plainly.” 
 </p><p>
-<sup>9&#160;</sup>Moses and the Levitical priests spoke to all Israel, saying, “Be silent and listen, Israel! Today you have become the people of Yahweh your Elohim. 
-<sup>10&#160;</sup>You shall therefore obey Yahweh your Elohim’s voice, and do his commandments and his statutes, which I command you today.” 
+<sup>9&#160;</sup>Moses and the Levitical priests spoke to all Israel, saying, “Be silent and listen, Israel! Today you have become the people of Yahuah your Elohim. 
+<sup>10&#160;</sup>You shall therefore obey Yahuah your Elohim’s voice, and do his commandments and his statutes, which I command you today.” 
 </p><p>
 <sup>11&#160;</sup>Moses commanded the people the same day, saying, 
 <sup>12&#160;</sup>“These shall stand on Mount Gerizim to bless the people, when you have crossed over the Jordan: Simeon, Levi, Judah, Issachar, Joseph, and Benjamin. 
 <sup>13&#160;</sup>These shall stand on Mount Ebal for the curse: Reuben, Gad, Asher, Zebulun, Dan, and Naphtali. 
 <sup>14&#160;</sup>With a loud voice, the Levites shall say to all the men of Israel, 
-<sup>15&#160;</sup>‘Cursed is the man who makes an engraved or molten image, an abomination to Yahweh, the work of the hands of the craftsman, and sets it up in secret.’ 
+<sup>15&#160;</sup>‘Cursed is the man who makes an engraved or molten image, an abomination to Yahuah, the work of the hands of the craftsman, and sets it up in secret.’ 
 </p><p>All the people shall answer and say, ‘Amen.’ 
 </p><p>
 <sup>16&#160;</sup>‘Cursed is he who dishonors his father or his mother.’ 
@@ -1002,44 +1002,44 @@ html[dir=ltr] .q2 {
 </p><p>All the people shall say, ‘Amen.’&#160;” 
 </p><h2 class="chapterlabel" id="28">28</h2>
 <p>
-<sup>1&#160;</sup>It shall happen, if you shall listen diligently to Yahweh your Elohim’s voice, to observe to do all his commandments which I command you today, that Yahweh your Elohim will set you high above all the nations of the earth. 
-<sup>2&#160;</sup>All these blessings will come upon you, and overtake you, if you listen to Yahweh your Elohim’s voice. 
+<sup>1&#160;</sup>It shall happen, if you shall listen diligently to Yahuah your Elohim’s voice, to observe to do all his commandments which I command you today, that Yahuah your Elohim will set you high above all the nations of the earth. 
+<sup>2&#160;</sup>All these blessings will come upon you, and overtake you, if you listen to Yahuah your Elohim’s voice. 
 <sup>3&#160;</sup>You shall be blessed in the city, and you shall be blessed in the field. 
 <sup>4&#160;</sup>You shall be blessed in the fruit of your body, the fruit of your ground, the fruit of your animals, the increase of your livestock, and the young of your flock. 
 <sup>5&#160;</sup>Your basket and your kneading trough shall be blessed. 
 <sup>6&#160;</sup>You shall be blessed when you come in, and you shall be blessed when you go out. 
-<sup>7&#160;</sup>Yahweh will cause your enemies who rise up against you to be struck before you. They will come out against you one way, and will flee before you seven ways. 
-<sup>8&#160;</sup>Yahweh will command the blessing on you in your barns, and in all that you put your hand to. He will bless you in the land which Yahweh your Elohim gives you. 
-<sup>9&#160;</sup>Yahweh will establish you for a set-apart people to himself, as he has sworn to you, if you shall keep the commandments of Yahweh your Elohim, and walk in his ways. 
-<sup>10&#160;</sup>All the peoples of the earth shall see that you are called by Yahweh’s name, and they will be afraid of you. 
-<sup>11&#160;</sup>Yahweh will grant you abundant prosperity in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, in the land which Yahweh swore to your fathers to give you. 
-<sup>12&#160;</sup>Yahweh will open to you his good treasure in the sky, to give the rain of your land in its season, and to bless all the work of your hand. You will lend to many nations, and you will not borrow. 
-<sup>13&#160;</sup>Yahweh will make you the head, and not the tail. You will be above only, and you will not be beneath, if you listen to the commandments of Yahweh your Elohim which I command you today, to observe and to do, 
+<sup>7&#160;</sup>Yahuah will cause your enemies who rise up against you to be struck before you. They will come out against you one way, and will flee before you seven ways. 
+<sup>8&#160;</sup>Yahuah will command the blessing on you in your barns, and in all that you put your hand to. He will bless you in the land which Yahuah your Elohim gives you. 
+<sup>9&#160;</sup>Yahuah will establish you for a set-apart people to himself, as he has sworn to you, if you shall keep the commandments of Yahuah your Elohim, and walk in his ways. 
+<sup>10&#160;</sup>All the peoples of the earth shall see that you are called by Yahuah’s name, and they will be afraid of you. 
+<sup>11&#160;</sup>Yahuah will grant you abundant prosperity in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, in the land which Yahuah swore to your fathers to give you. 
+<sup>12&#160;</sup>Yahuah will open to you his good treasure in the sky, to give the rain of your land in its season, and to bless all the work of your hand. You will lend to many nations, and you will not borrow. 
+<sup>13&#160;</sup>Yahuah will make you the head, and not the tail. You will be above only, and you will not be beneath, if you listen to the commandments of Yahuah your Elohim which I command you today, to observe and to do, 
 <sup>14&#160;</sup>and shall not turn away from any of the words which I command you today, to the right hand or to the left, to go after other elohims to serve them. 
 </p><p>
-<sup>15&#160;</sup>But it shall come to pass, if you will not listen to Yahweh your Elohim’s voice, to observe to do all his commandments and his statutes which I command you today, that all these curses will come on you and overtake you. 
+<sup>15&#160;</sup>But it shall come to pass, if you will not listen to Yahuah your Elohim’s voice, to observe to do all his commandments and his statutes which I command you today, that all these curses will come on you and overtake you. 
 <sup>16&#160;</sup>You will be cursed in the city, and you will be cursed in the field. 
 <sup>17&#160;</sup>Your basket and your kneading trough will be cursed. 
 <sup>18&#160;</sup>The fruit of your body, the fruit of your ground, the increase of your livestock, and the young of your flock will be cursed. 
 <sup>19&#160;</sup>You will be cursed when you come in, and you will be cursed when you go out. 
-<sup>20&#160;</sup>Yahweh will send on you cursing, confusion, and rebuke in all that you put your hand to do, until you are destroyed and until you perish quickly, because of the evil of your doings, by which you have forsaken me. 
-<sup>21&#160;</sup>Yahweh will make the pestilence cling to you, until he has consumed you from off the land where you go in to possess it. 
-<sup>22&#160;</sup>Yahweh will strike you with consumption, with fever, with inflammation, with fiery heat, with the sword, with blight, and with mildew. They will pursue you until you perish. 
+<sup>20&#160;</sup>Yahuah will send on you cursing, confusion, and rebuke in all that you put your hand to do, until you are destroyed and until you perish quickly, because of the evil of your doings, by which you have forsaken me. 
+<sup>21&#160;</sup>Yahuah will make the pestilence cling to you, until he has consumed you from off the land where you go in to possess it. 
+<sup>22&#160;</sup>Yahuah will strike you with consumption, with fever, with inflammation, with fiery heat, with the sword, with blight, and with mildew. They will pursue you until you perish. 
 <sup>23&#160;</sup>Your sky that is over your head will be bronze, and the earth that is under you will be iron. 
-<sup>24&#160;</sup>Yahweh will make the rain of your land powder and dust. It will come down on you from the sky, until you are destroyed. 
-<sup>25&#160;</sup>Yahweh will cause you to be struck before your enemies. You will go out one way against them, and will flee seven ways before them. You will be tossed back and forth among all the kingdoms of the earth. 
+<sup>24&#160;</sup>Yahuah will make the rain of your land powder and dust. It will come down on you from the sky, until you are destroyed. 
+<sup>25&#160;</sup>Yahuah will cause you to be struck before your enemies. You will go out one way against them, and will flee seven ways before them. You will be tossed back and forth among all the kingdoms of the earth. 
 <sup>26&#160;</sup>Your dead bodies will be food to all birds of the sky, and to the animals of the earth; and there will be no one to frighten them away. 
-<sup>27&#160;</sup>Yahweh will strike you with the boils of Egypt, with the tumors, with the scurvy, and with the itch, of which you can not be healed. 
-<sup>28&#160;</sup>Yahweh will strike you with madness, with blindness, and with astonishment of heart. 
+<sup>27&#160;</sup>Yahuah will strike you with the boils of Egypt, with the tumors, with the scurvy, and with the itch, of which you can not be healed. 
+<sup>28&#160;</sup>Yahuah will strike you with madness, with blindness, and with astonishment of heart. 
 <sup>29&#160;</sup>You will grope at noonday, as the blind gropes in darkness, and you shall not prosper in your ways. You will only be oppressed and robbed always, and there will be no one to save you. 
 <sup>30&#160;</sup>You will betroth a woman, and another man shall lie with her. You will build a house, and you won’t dwell in it. You will plant a vineyard, and not use its fruit. 
 <sup>31&#160;</sup>Your ox will be slain before your eyes, and you will not eat any of it. Your donkey will be violently taken away from before your face, and will not be restored to you. Your sheep will be given to your enemies, and you will have no one to save you. 
 <sup>32&#160;</sup>Your sons and your daughters will be given to another people. Your eyes will look and fail with longing for them all day long. There will be no power in your hand. 
 <sup>33&#160;</sup>A nation which you don’t know will eat the fruit of your ground and all of your work. You will only be oppressed and crushed always, 
 <sup>34&#160;</sup>so that the sights that you see with your eyes will drive you mad. 
-<sup>35&#160;</sup>Yahweh will strike you in the knees and in the legs with a sore boil, of which you cannot be healed, from the sole of your foot to the crown of your head. 
-<sup>36&#160;</sup>Yahweh will bring you, and your king whom you will set over yourselves, to a nation that you have not known, you nor your fathers. There you will serve other elohims of wood and stone. 
-<sup>37&#160;</sup>You will become an astonishment, a proverb, and a byword among all the peoples where Yahweh will lead you away. 
+<sup>35&#160;</sup>Yahuah will strike you in the knees and in the legs with a sore boil, of which you cannot be healed, from the sole of your foot to the crown of your head. 
+<sup>36&#160;</sup>Yahuah will bring you, and your king whom you will set over yourselves, to a nation that you have not known, you nor your fathers. There you will serve other elohims of wood and stone. 
+<sup>37&#160;</sup>You will become an astonishment, a proverb, and a byword among all the peoples where Yahuah will lead you away. 
 <sup>38&#160;</sup>You will carry much seed out into the field, and will gather little in, for the locust will consume it. 
 <sup>39&#160;</sup>You will plant vineyards and dress them, but you will neither drink of the wine, nor harvest, because worms will eat them. 
 <sup>40&#160;</sup>You will have olive trees throughout all your borders, but you won’t anoint yourself with the oil, for your olives will drop off. 
@@ -1048,111 +1048,111 @@ html[dir=ltr] .q2 {
 <sup>43&#160;</sup>The foreigner who is among you will mount up above you higher and higher, and you will come down lower and lower. 
 <sup>44&#160;</sup>He will lend to you, and you won’t lend to him. He will be the head, and you will be the tail. 
 </p><p>
-<sup>45&#160;</sup>All these curses will come on you, and will pursue you and overtake you, until you are destroyed, because you didn’t listen to Yahweh your Elohim’s voice, to keep his commandments and his statutes which he commanded you. 
+<sup>45&#160;</sup>All these curses will come on you, and will pursue you and overtake you, until you are destroyed, because you didn’t listen to Yahuah your Elohim’s voice, to keep his commandments and his statutes which he commanded you. 
 <sup>46&#160;</sup>They will be for a sign and for a wonder to you and to your offspring forever. 
-<sup>47&#160;</sup>Because you didn’t serve Yahweh your Elohim with joyfulness and with gladness of heart, by reason of the abundance of all things; 
-<sup>48&#160;</sup>therefore you will serve your enemies whom Yahweh sends against you, in hunger, in thirst, in nakedness, and in lack of all things. He will put an iron yoke on your neck until he has destroyed you. 
-<sup>49&#160;</sup>Yahweh will bring a nation against you from far away, from the end of the earth, as the eagle flies: a nation whose language you will not understand, 
+<sup>47&#160;</sup>Because you didn’t serve Yahuah your Elohim with joyfulness and with gladness of heart, by reason of the abundance of all things; 
+<sup>48&#160;</sup>therefore you will serve your enemies whom Yahuah sends against you, in hunger, in thirst, in nakedness, and in lack of all things. He will put an iron yoke on your neck until he has destroyed you. 
+<sup>49&#160;</sup>Yahuah will bring a nation against you from far away, from the end of the earth, as the eagle flies: a nation whose language you will not understand, 
 <sup>50&#160;</sup>a nation of fierce facial expressions, that doesn’t respect the elderly, nor show favor to the young. 
 <sup>51&#160;</sup>They will eat the fruit of your livestock and the fruit of your ground, until you are destroyed. They also won’t leave you grain, new wine, oil, the increase of your livestock, or the young of your flock, until they have caused you to perish. 
-<sup>52&#160;</sup>They will besiege you in all your gates until your high and fortified walls in which you trusted come down throughout all your land. They will besiege you in all your gates throughout all your land which Yahweh your Elohim has given you. 
-<sup>53&#160;</sup>You will eat the fruit of your own body, the flesh of your sons and of your daughters, whom Yahweh your Elohim has given you, in the siege and in the distress with which your enemies will distress you. 
+<sup>52&#160;</sup>They will besiege you in all your gates until your high and fortified walls in which you trusted come down throughout all your land. They will besiege you in all your gates throughout all your land which Yahuah your Elohim has given you. 
+<sup>53&#160;</sup>You will eat the fruit of your own body, the flesh of your sons and of your daughters, whom Yahuah your Elohim has given you, in the siege and in the distress with which your enemies will distress you. 
 <sup>54&#160;</sup>The man who is tender among you, and very delicate, his eye will be evil toward his brother, toward the woman whom he loves, and toward the remnant of his children whom he has remaining, 
 <sup>55&#160;</sup>so that he will not give to any of them of the flesh of his children whom he will eat, because he has nothing left to him, in the siege and in the distress with which your enemy will distress you in all your gates. 
 <sup>56&#160;</sup>The tender and delicate woman among you, who would not venture to set the sole of her foot on the ground for delicateness and tenderness, her eye will be evil toward the man that she loves, toward her son, toward her daughter, 
 <sup>57&#160;</sup>toward her young one who comes out from between her feet, and toward her children whom she bears; for she will eat them secretly for lack of all things in the siege and in the distress with which your enemy will distress you in your gates. 
-<sup>58&#160;</sup>If you will not observe to do all the words of this law that are written in this book, that you may fear this glorious and fearful name, YAHWEH your Elohim, 
-<sup>59&#160;</sup>then Yahweh will make your plagues and the plagues of your offspring fearful, even great plagues, and of long duration, and severe sicknesses, and of long duration. 
+<sup>58&#160;</sup>If you will not observe to do all the words of this law that are written in this book, that you may fear this glorious and fearful name, YAHUAH your Elohim, 
+<sup>59&#160;</sup>then Yahuah will make your plagues and the plagues of your offspring fearful, even great plagues, and of long duration, and severe sicknesses, and of long duration. 
 <sup>60&#160;</sup>He will bring on you again all the diseases of Egypt, which you were afraid of; and they will cling to you. 
-<sup>61&#160;</sup>Also every sickness and every plague which is not written in the book of this law, Yahweh will bring them on you until you are destroyed. 
-<sup>62&#160;</sup>You will be left few in number, even though you were as the stars of the sky for multitude, because you didn’t listen to Yahweh your Elohim’s voice. 
-<sup>63&#160;</sup>It will happen that as Yahweh rejoiced over you to do you good, and to multiply you, so Yahweh will rejoice over you to cause you to perish and to destroy you. You will be plucked from the land that you are going in to possess. 
-<sup>64&#160;</sup>Yahweh will scatter you among all peoples, from one end of the earth to the other end of the earth. There you will serve other elohims which you have not known, you nor your fathers, even wood and stone. 
-<sup>65&#160;</sup>Among these nations you will find no ease, and there will be no rest for the sole of your foot; but Yahweh will give you there a trembling heart, failing of eyes, and pining of soul. 
+<sup>61&#160;</sup>Also every sickness and every plague which is not written in the book of this law, Yahuah will bring them on you until you are destroyed. 
+<sup>62&#160;</sup>You will be left few in number, even though you were as the stars of the sky for multitude, because you didn’t listen to Yahuah your Elohim’s voice. 
+<sup>63&#160;</sup>It will happen that as Yahuah rejoiced over you to do you good, and to multiply you, so Yahuah will rejoice over you to cause you to perish and to destroy you. You will be plucked from the land that you are going in to possess. 
+<sup>64&#160;</sup>Yahuah will scatter you among all peoples, from one end of the earth to the other end of the earth. There you will serve other elohims which you have not known, you nor your fathers, even wood and stone. 
+<sup>65&#160;</sup>Among these nations you will find no ease, and there will be no rest for the sole of your foot; but Yahuah will give you there a trembling heart, failing of eyes, and pining of soul. 
 <sup>66&#160;</sup>Your life will hang in doubt before you. You will be afraid night and day, and will have no assurance of your life. 
 <sup>67&#160;</sup>In the morning you will say, “I wish it were evening!” and at evening you will say, “I wish it were morning!” for the fear of your heart which you will fear, and for the sights which your eyes will see. 
-<sup>68&#160;</sup>Yahweh will bring you into Egypt again with ships, by the way of which I told to you that you would never see it again. There you will offer yourselves to your enemies for male and female slaves, and nobody will buy you. 
+<sup>68&#160;</sup>Yahuah will bring you into Egypt again with ships, by the way of which I told to you that you would never see it again. There you will offer yourselves to your enemies for male and female slaves, and nobody will buy you. 
 </p><h2 class="chapterlabel" id="29">29</h2>
 <p>
-<sup>1&#160;</sup>These are the words of the covenant which Yahweh commanded Moses to make with the children of Israel in the land of Moab, in addition to the covenant which he made with them in Horeb. 
+<sup>1&#160;</sup>These are the words of the covenant which Yahuah commanded Moses to make with the children of Israel in the land of Moab, in addition to the covenant which he made with them in Horeb. 
 <sup>2&#160;</sup>Moses called to all Israel, and said to them: 
-</p><p>Your eyes have seen all that Yahweh did in the land of Egypt to Pharaoh, and to all his servants, and to all his land; 
+</p><p>Your eyes have seen all that Yahuah did in the land of Egypt to Pharaoh, and to all his servants, and to all his land; 
 <sup>3&#160;</sup>the great trials which your eyes saw, the signs, and those great wonders. 
-<sup>4&#160;</sup>But Yahweh has not given you a heart to know, eyes to see, and ears to hear, to this day. 
+<sup>4&#160;</sup>But Yahuah has not given you a heart to know, eyes to see, and ears to hear, to this day. 
 <sup>5&#160;</sup>I have led you forty years in the wilderness. Your clothes have not grown old on you, and your sandals have not grown old on your feet. 
-<sup>6&#160;</sup>You have not eaten bread, neither have you drunk wine or strong drink, that you may know that I am Yahweh your Elohim. 
+<sup>6&#160;</sup>You have not eaten bread, neither have you drunk wine or strong drink, that you may know that I am Yahuah your Elohim. 
 <sup>7&#160;</sup>When you came to this place, Sihon the king of Heshbon and Og the king of Bashan came out against us to battle, and we struck them. 
 <sup>8&#160;</sup>We took their land, and gave it for an inheritance to the Reubenites, and to the Gadites, and to the half-tribe of the Manassites. 
 <sup>9&#160;</sup>Therefore keep the words of this covenant and do them, that you may prosper in all that you do. 
-<sup>10&#160;</sup>All of you stand today in the presence of Yahweh your Elohim: your heads, your tribes, your elders, and your officers, even all the men of Israel, 
+<sup>10&#160;</sup>All of you stand today in the presence of Yahuah your Elohim: your heads, your tribes, your elders, and your officers, even all the men of Israel, 
 <sup>11&#160;</sup>your little ones, your women, and the foreigners who are in the middle of your camps, from the one who cuts your wood to the one who draws your water, 
-<sup>12&#160;</sup>that you may enter into the covenant of Yahweh your Elohim, and into his oath, which Yahweh your Elohim makes with you today, 
+<sup>12&#160;</sup>that you may enter into the covenant of Yahuah your Elohim, and into his oath, which Yahuah your Elohim makes with you today, 
 <sup>13&#160;</sup>that he may establish you today as his people, and that he may be your Elohim, as he spoke to you and as he swore to your fathers, to Abraham, to Isaac, and to Jacob. 
 <sup>14&#160;</sup>Neither do I make this covenant and this oath with you only, 
-<sup>15&#160;</sup>but with those who stand here with us today before Yahweh our Elohim, and also with those who are not here with us today 
+<sup>15&#160;</sup>but with those who stand here with us today before Yahuah our Elohim, and also with those who are not here with us today 
 <sup>16&#160;</sup>(for you know how we lived in the land of Egypt, and how we came through the middle of the nations through which you passed; 
 <sup>17&#160;</sup>and you have seen their abominations and their idols of wood, stone, silver, and gold, which were among them); 
-<sup>18&#160;</sup>lest there should be among you man, woman, family, or tribe whose heart turns away today from Yahweh our Elohim, to go to serve the elohims of those nations; lest there should be among you a root that produces bitter poison; 
+<sup>18&#160;</sup>lest there should be among you man, woman, family, or tribe whose heart turns away today from Yahuah our Elohim, to go to serve the elohims of those nations; lest there should be among you a root that produces bitter poison; 
 <sup>19&#160;</sup>and it happen, when he hears the words of this curse, that he bless himself in his heart, saying, “I shall have peace, though I walk in the stubbornness of my heart,” to destroy the moist with the dry. 
-<sup>20&#160;</sup>Yahweh will not pardon him, but then Yahweh’s anger and his jealousy will smoke against that man, and all the curse that is written in this book will fall on him, and Yahweh will blot out his name from under the sky. 
-<sup>21&#160;</sup>Yahweh will set him apart for evil out of all the tribes of Israel, according to all the curses of the covenant written in this book of the law. 
+<sup>20&#160;</sup>Yahuah will not pardon him, but then Yahuah’s anger and his jealousy will smoke against that man, and all the curse that is written in this book will fall on him, and Yahuah will blot out his name from under the sky. 
+<sup>21&#160;</sup>Yahuah will set him apart for evil out of all the tribes of Israel, according to all the curses of the covenant written in this book of the law. 
 </p><p>
-<sup>22&#160;</sup>The generation to come—your children who will rise up after you, and the foreigner who will come from a far land—will say, when they see the plagues of that land, and the sicknesses with which Yahweh has made it sick, 
-<sup>23&#160;</sup>that all of its land is sulfur, salt, and burning, that it is not sown, doesn’t produce, nor does any grass grow in it, like the overthrow of Sodom, Gomorrah, Admah, and Zeboiim, which Yahweh overthrew in his anger, and in his wrath. 
-<sup>24&#160;</sup>Even all the nations will say, “Why has Yahweh done this to this land? What does the heat of this great anger mean?” 
+<sup>22&#160;</sup>The generation to come—your children who will rise up after you, and the foreigner who will come from a far land—will say, when they see the plagues of that land, and the sicknesses with which Yahuah has made it sick, 
+<sup>23&#160;</sup>that all of its land is sulfur, salt, and burning, that it is not sown, doesn’t produce, nor does any grass grow in it, like the overthrow of Sodom, Gomorrah, Admah, and Zeboiim, which Yahuah overthrew in his anger, and in his wrath. 
+<sup>24&#160;</sup>Even all the nations will say, “Why has Yahuah done this to this land? What does the heat of this great anger mean?” 
 </p><p>
-<sup>25&#160;</sup>Then men will say, “Because they abandoned the covenant of Yahweh, the Elohim of their fathers, which he made with them when he brought them out of the land of Egypt, 
+<sup>25&#160;</sup>Then men will say, “Because they abandoned the covenant of Yahuah, the Elohim of their fathers, which he made with them when he brought them out of the land of Egypt, 
 <sup>26&#160;</sup>and went and served other elohims and worshiped them, elohims that they didn’t know and that he had not given to them. 
-<sup>27&#160;</sup>Therefore Yahweh’s anger burned against this land, to bring on it all the curses that are written in this book. 
-<sup>28&#160;</sup>Yahweh rooted them out of their land in anger, in wrath, and in great indignation, and thrust them into another land, as it is today.” 
+<sup>27&#160;</sup>Therefore Yahuah’s anger burned against this land, to bring on it all the curses that are written in this book. 
+<sup>28&#160;</sup>Yahuah rooted them out of their land in anger, in wrath, and in great indignation, and thrust them into another land, as it is today.” 
 </p><p>
-<sup>29&#160;</sup>The secret things belong to Yahweh our Elohim; but the things that are revealed belong to us and to our children forever, that we may do all the words of this law. 
+<sup>29&#160;</sup>The secret things belong to Yahuah our Elohim; but the things that are revealed belong to us and to our children forever, that we may do all the words of this law. 
 </p><h2 class="chapterlabel" id="30">30</h2>
 <p>
-<sup>1&#160;</sup>It shall happen, when all these things have come on you, the blessing and the curse, which I have set before you, and you shall call them to mind among all the nations where Yahweh your Elohim has driven you, 
-<sup>2&#160;</sup>and return to Yahweh your Elohim and obey his voice according to all that I command you today, you and your children, with all your heart and with all your soul, 
-<sup>3&#160;</sup>that then Yahweh your Elohim will release you from captivity, have compassion on you, and will return and gather you from all the peoples where Yahweh your Elohim has scattered you. 
-<sup>4&#160;</sup>If your outcasts are in the uttermost parts of the heavens, from there Yahweh your Elohim will gather you, and from there he will bring you back. 
-<sup>5&#160;</sup>Yahweh your Elohim will bring you into the land which your fathers possessed, and you will possess it. He will do you good, and increase your numbers more than your fathers. 
-<sup>6&#160;</sup>Yahweh your Elohim will circumcise your heart, and the heart of your offspring, to love Yahweh your Elohim with all your heart and with all your soul, that you may live. 
-<sup>7&#160;</sup>Yahweh your Elohim will put all these curses on your enemies and on those who hate you, who persecuted you. 
-<sup>8&#160;</sup>You shall return and obey Yahweh’s voice, and do all his commandments which I command you today. 
-<sup>9&#160;</sup>Yahweh your Elohim will make you prosperous in all the work of your hand, in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, for good; for Yahweh will again rejoice over you for good, as he rejoiced over your fathers, 
-<sup>10&#160;</sup>if you will obey Yahweh your Elohim’s voice, to keep his commandments and his statutes which are written in this book of the law, if you turn to Yahweh your Elohim with all your heart and with all your soul. 
+<sup>1&#160;</sup>It shall happen, when all these things have come on you, the blessing and the curse, which I have set before you, and you shall call them to mind among all the nations where Yahuah your Elohim has driven you, 
+<sup>2&#160;</sup>and return to Yahuah your Elohim and obey his voice according to all that I command you today, you and your children, with all your heart and with all your soul, 
+<sup>3&#160;</sup>that then Yahuah your Elohim will release you from captivity, have compassion on you, and will return and gather you from all the peoples where Yahuah your Elohim has scattered you. 
+<sup>4&#160;</sup>If your outcasts are in the uttermost parts of the heavens, from there Yahuah your Elohim will gather you, and from there he will bring you back. 
+<sup>5&#160;</sup>Yahuah your Elohim will bring you into the land which your fathers possessed, and you will possess it. He will do you good, and increase your numbers more than your fathers. 
+<sup>6&#160;</sup>Yahuah your Elohim will circumcise your heart, and the heart of your offspring, to love Yahuah your Elohim with all your heart and with all your soul, that you may live. 
+<sup>7&#160;</sup>Yahuah your Elohim will put all these curses on your enemies and on those who hate you, who persecuted you. 
+<sup>8&#160;</sup>You shall return and obey Yahuah’s voice, and do all his commandments which I command you today. 
+<sup>9&#160;</sup>Yahuah your Elohim will make you prosperous in all the work of your hand, in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, for good; for Yahuah will again rejoice over you for good, as he rejoiced over your fathers, 
+<sup>10&#160;</sup>if you will obey Yahuah your Elohim’s voice, to keep his commandments and his statutes which are written in this book of the law, if you turn to Yahuah your Elohim with all your heart and with all your soul. 
 </p><p>
 <sup>11&#160;</sup>For this commandment which I command you today is not too hard for you or too distant. 
 <sup>12&#160;</sup>It is not in heaven, that you should say, “Who will go up for us to heaven, bring it to us, and proclaim it to us, that we may do it?” 
 <sup>13&#160;</sup>Neither is it beyond the sea, that you should say, “Who will go over the sea for us, bring it to us, and proclaim it to us, that we may do it?” 
 <sup>14&#160;</sup>But the word is very near to you, in your mouth and in your heart, that you may do it. 
 <sup>15&#160;</sup>Behold, I have set before you today life and prosperity, and death and evil. 
-<sup>16&#160;</sup>For I command you today to love Yahweh your Elohim, to walk in his ways and to keep his commandments, his statutes, and his ordinances, that you may live and multiply, and that Yahweh your Elohim may bless you in the land where you go in to possess it. 
+<sup>16&#160;</sup>For I command you today to love Yahuah your Elohim, to walk in his ways and to keep his commandments, his statutes, and his ordinances, that you may live and multiply, and that Yahuah your Elohim may bless you in the land where you go in to possess it. 
 <sup>17&#160;</sup>But if your heart turns away, and you will not hear, but are drawn away and worship other elohims, and serve them, 
 <sup>18&#160;</sup>I declare to you today that you will surely perish. You will not prolong your days in the land where you pass over the Jordan to go in to possess it. 
 <sup>19&#160;</sup>I call heaven and earth to witness against you today that I have set before you life and death, the blessing and the curse. Therefore choose life, that you may live, you and your descendants, 
-<sup>20&#160;</sup>to love Yahweh your Elohim, to obey his voice, and to cling to him; for he is your life, and the length of your days, that you may dwell in the land which Yahweh swore to your fathers, to Abraham, to Isaac, and to Jacob, to give them. 
+<sup>20&#160;</sup>to love Yahuah your Elohim, to obey his voice, and to cling to him; for he is your life, and the length of your days, that you may dwell in the land which Yahuah swore to your fathers, to Abraham, to Isaac, and to Jacob, to give them. 
 </p><h2 class="chapterlabel" id="31">31</h2>
 <p>
 <sup>1&#160;</sup>Moses went and spoke these words to all Israel. 
-<sup>2&#160;</sup>He said to them, “I am one hundred twenty years old today. I can no more go out and come in. Yahweh has said to me, ‘You shall not go over this Jordan.’ 
-<sup>3&#160;</sup>Yahweh your Elohim himself will go over before you. He will destroy these nations from before you, and you shall dispossess them. Joshua will go over before you, as Yahweh has spoken. 
-<sup>4&#160;</sup>Yahweh will do to them as he did to Sihon and to Og, the kings of the Amorites, and to their land, when he destroyed them. 
-<sup>5&#160;</sup>Yahweh will deliver them up before you, and you shall do to them according to all the commandment which I have commanded you. 
-<sup>6&#160;</sup>Be strong and courageous. Don’t be afraid or scared of them, for Yahweh your Elohim himself is who goes with you. He will not fail you nor forsake you.” 
+<sup>2&#160;</sup>He said to them, “I am one hundred twenty years old today. I can no more go out and come in. Yahuah has said to me, ‘You shall not go over this Jordan.’ 
+<sup>3&#160;</sup>Yahuah your Elohim himself will go over before you. He will destroy these nations from before you, and you shall dispossess them. Joshua will go over before you, as Yahuah has spoken. 
+<sup>4&#160;</sup>Yahuah will do to them as he did to Sihon and to Og, the kings of the Amorites, and to their land, when he destroyed them. 
+<sup>5&#160;</sup>Yahuah will deliver them up before you, and you shall do to them according to all the commandment which I have commanded you. 
+<sup>6&#160;</sup>Be strong and courageous. Don’t be afraid or scared of them, for Yahuah your Elohim himself is who goes with you. He will not fail you nor forsake you.” 
 </p><p>
-<sup>7&#160;</sup>Moses called to Joshua, and said to him in the sight of all Israel, “Be strong and courageous, for you shall go with this people into the land which Yahweh has sworn to their fathers to give them; and you shall cause them to inherit it. 
-<sup>8&#160;</sup>Yahweh himself is who goes before you. He will be with you. He will not fail you nor forsake you. Don’t be afraid. Don’t be discouraged.” 
+<sup>7&#160;</sup>Moses called to Joshua, and said to him in the sight of all Israel, “Be strong and courageous, for you shall go with this people into the land which Yahuah has sworn to their fathers to give them; and you shall cause them to inherit it. 
+<sup>8&#160;</sup>Yahuah himself is who goes before you. He will be with you. He will not fail you nor forsake you. Don’t be afraid. Don’t be discouraged.” 
 </p><p>
-<sup>9&#160;</sup>Moses wrote this law and delivered it to the priests the sons of Levi, who bore the ark of Yahweh’s covenant, and to all the elders of Israel. 
+<sup>9&#160;</sup>Moses wrote this law and delivered it to the priests the sons of Levi, who bore the ark of Yahuah’s covenant, and to all the elders of Israel. 
 <sup>10&#160;</sup>Moses commanded them, saying, “At the end of every seven years, in the set time of the year of release, in the feast of booths, 
-<sup>11&#160;</sup>when all Israel has come to appear before Yahweh your Elohim in the place which he will choose, you shall read this law before all Israel in their hearing. 
-<sup>12&#160;</sup>Assemble the people, the men and the women and the little ones, and the foreigners who are within your gates, that they may hear, learn, fear Yahweh your Elohim, and observe to do all the words of this law, 
-<sup>13&#160;</sup>and that their children, who have not known, may hear and learn to fear Yahweh your Elohim, as long as you live in the land where you go over the Jordan to possess it.” 
+<sup>11&#160;</sup>when all Israel has come to appear before Yahuah your Elohim in the place which he will choose, you shall read this law before all Israel in their hearing. 
+<sup>12&#160;</sup>Assemble the people, the men and the women and the little ones, and the foreigners who are within your gates, that they may hear, learn, fear Yahuah your Elohim, and observe to do all the words of this law, 
+<sup>13&#160;</sup>and that their children, who have not known, may hear and learn to fear Yahuah your Elohim, as long as you live in the land where you go over the Jordan to possess it.” 
 </p><p>
-<sup>14&#160;</sup>Yahweh said to Moses, “Behold, your days approach that you must die. Call Joshua, and present yourselves in the Tent of Meeting, that I may commission him.” 
+<sup>14&#160;</sup>Yahuah said to Moses, “Behold, your days approach that you must die. Call Joshua, and present yourselves in the Tent of Meeting, that I may commission him.” 
 </p><p>Moses and Joshua went, and presented themselves in the Tent of Meeting. 
 </p><p>
-<sup>15&#160;</sup>Yahweh appeared in the Tent in a pillar of cloud, and the pillar of cloud stood over the Tent’s door. 
-<sup>16&#160;</sup>Yahweh said to Moses, “Behold, you shall sleep with your fathers. This people will rise up and play the prostitute after the strange elohims of the land where they go to be among them, and will forsake me and break my covenant which I have made with them. 
+<sup>15&#160;</sup>Yahuah appeared in the Tent in a pillar of cloud, and the pillar of cloud stood over the Tent’s door. 
+<sup>16&#160;</sup>Yahuah said to Moses, “Behold, you shall sleep with your fathers. This people will rise up and play the prostitute after the strange elohims of the land where they go to be among them, and will forsake me and break my covenant which I have made with them. 
 <sup>17&#160;</sup>Then my anger shall be kindled against them in that day, and I will forsake them, and I will hide my face from them, and they shall be devoured, and many evils and troubles shall come on them; so that they will say in that day, ‘Haven’t these evils come on us because our Elohim is not among us?’ 
 <sup>18&#160;</sup>I will surely hide my face in that day for all the evil which they have done, in that they have turned to other elohims. 
 </p><p>
@@ -1165,11 +1165,11 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>He commissioned Joshua the son of Nun, and said, “Be strong and courageous; for you shall bring the children of Israel into the land which I swore to them. I will be with you.” 
 </p><p>
 <sup>24&#160;</sup>When Moses had finished writing the words of this law in a book, until they were finished, 
-<sup>25&#160;</sup>Moses commanded the Levites, who bore the ark of Yahweh’s covenant, saying, 
-<sup>26&#160;</sup>“Take this book of the law, and put it by the side of the ark of Yahweh your Elohim’s covenant, that it may be there for a witness against you. 
-<sup>27&#160;</sup>For I know your rebellion and your stiff neck. Behold, while I am yet alive with you today, you have been rebellious against Yahweh. How much more after my death? 
+<sup>25&#160;</sup>Moses commanded the Levites, who bore the ark of Yahuah’s covenant, saying, 
+<sup>26&#160;</sup>“Take this book of the law, and put it by the side of the ark of Yahuah your Elohim’s covenant, that it may be there for a witness against you. 
+<sup>27&#160;</sup>For I know your rebellion and your stiff neck. Behold, while I am yet alive with you today, you have been rebellious against Yahuah. How much more after my death? 
 <sup>28&#160;</sup>Assemble to me all the elders of your tribes and your officers, that I may speak these words in their ears, and call heaven and earth to witness against them. 
-<sup>29&#160;</sup>For I know that after my death you will utterly corrupt yourselves, and turn away from the way which I have commanded you; and evil will happen to you in the latter days, because you will do that which is evil in Yahweh’s sight, to provoke him to anger through the work of your hands.” 
+<sup>29&#160;</sup>For I know that after my death you will utterly corrupt yourselves, and turn away from the way which I have commanded you; and evil will happen to you in the latter days, because you will do that which is evil in Yahuah’s sight, to provoke him to anger through the work of your hands.” 
 </p><p>
 <sup>30&#160;</sup>Moses spoke in the ears of all the assembly of Israel the words of this song, until they were finished. 
 </p><h2 class="chapterlabel" id="32">32</h2>
@@ -1182,7 +1182,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">as the misty rain on the tender grass, 
 </p><p class="q2">as the showers on the herb. 
 </p><p class="q1">
-<sup>3&#160;</sup>For I will proclaim Yahweh’s name. 
+<sup>3&#160;</sup>For I will proclaim Yahuah’s name. 
 </p><p class="q2">Ascribe greatness to our Elohim! 
 </p><p class="q1">
 <sup>4&#160;</sup>The Rock: his work is perfect, 
@@ -1194,7 +1194,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They are not his children, because of their defect. 
 </p><p class="q2">They are a perverse and crooked generation. 
 </p><p class="q1">
-<sup>6&#160;</sup>Is this the way you repay Yahweh, 
+<sup>6&#160;</sup>Is this the way you repay Yahuah, 
 </p><p class="q2">foolish and unwise people? 
 </p><p class="q1">Isn’t he your father who has bought you? 
 </p><p class="q2">He has made you and established you. 
@@ -1209,7 +1209,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">he set the bounds of the peoples 
 </p><p class="q2">according to the number of the children of Israel. 
 </p><p class="q1">
-<sup>9&#160;</sup>For Yahweh’s portion is his people. 
+<sup>9&#160;</sup>For Yahuah’s portion is his people. 
 </p><p class="q2">Jacob is the lot of his inheritance. 
 </p><p class="q1">
 <sup>10&#160;</sup>He found him in a desert land, 
@@ -1224,7 +1224,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">he took them, 
 </p><p class="q2">he bore them on his feathers. 
 </p><p class="q1">
-<sup>12&#160;</sup>Yahweh alone led him. 
+<sup>12&#160;</sup>Yahuah alone led him. 
 </p><p class="q2">There was no foreign elohim with him. 
 </p><p class="q1">
 <sup>13&#160;</sup>He made him ride on the high places of the earth. 
@@ -1256,7 +1256,7 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>Of the Rock who became your father, you are unmindful, 
 </p><p class="q2">and have forgotten Elohim who gave you birth. 
 </p><p class="q1">
-<sup>19&#160;</sup>Yahweh saw and abhorred, 
+<sup>19&#160;</sup>Yahuah saw and abhorred, 
 </p><p class="q2">because of the provocation of his sons and his daughters. 
 </p><p class="q1">
 <sup>20&#160;</sup>He said, “I will hide my face from them. 
@@ -1295,7 +1295,7 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>were it not that I feared the provocation of the enemy, 
 </p><p class="q2">lest their adversaries should judge wrongly, 
 </p><p class="q2">lest they should say, ‘Our hand is exalted; 
-</p><p class="q2">Yahweh has not done all this.’&#160;” 
+</p><p class="q2">Yahuah has not done all this.’&#160;” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>28&#160;</sup>For they are a nation void of counsel. 
@@ -1307,7 +1307,7 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>How could one chase a thousand, 
 </p><p class="q2">and two put ten thousand to flight, 
 </p><p class="q1">unless their Rock had sold them, 
-</p><p class="q2">and Yahweh had delivered them up? 
+</p><p class="q2">and Yahuah had delivered them up? 
 </p><p class="q1">
 <sup>31&#160;</sup>For their rock is not as our Rock, 
 </p><p class="q2">even our enemies themselves concede. 
@@ -1330,7 +1330,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Their doom rushes at them.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>36&#160;</sup>For Yahweh will judge his people, 
+<sup>36&#160;</sup>For Yahuah will judge his people, 
 </p><p class="q2">and have compassion on his servants, 
 </p><p class="q1">when he sees that their power is gone, 
 </p><p class="q2">that there is no one remaining, shut up or left at large. 
@@ -1373,7 +1373,7 @@ html[dir=ltr] .q2 {
 <sup>46&#160;</sup>He said to them, “Set your heart to all the words which I testify to you today, which you shall command your children to observe to do, all the words of this law. 
 <sup>47&#160;</sup>For it is no vain thing for you, because it is your life, and through this thing you shall prolong your days in the land, where you go over the Jordan to possess it.” 
 </p><p>
-<sup>48&#160;</sup>Yahweh spoke to Moses that same day, saying, 
+<sup>48&#160;</sup>Yahuah spoke to Moses that same day, saying, 
 <sup>49&#160;</sup>“Go up into this mountain of Abarim, to Mount Nebo, which is in the land of Moab, that is across from Jericho; and see the land of Canaan, which I give to the children of Israel for a possession. 
 <sup>50&#160;</sup>Die on the mountain where you go up, and be gathered to your people, as Aaron your brother died on Mount Hor, and was gathered to his people; 
 <sup>51&#160;</sup>because you trespassed against me among the children of Israel at the waters of Meribah of Kadesh, in the wilderness of Zin; because you didn’t uphold my set-apartness among the children of Israel. 
@@ -1382,7 +1382,7 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>This is the blessing with which Moses the man of Elohim blessed the children of Israel before his death. 
 <sup>2&#160;</sup>He said, 
-</p><p class="q1">“Yahweh came from Sinai, 
+</p><p class="q1">“Yahuah came from Sinai, 
 </p><p class="q2">and rose from Seir to them. 
 </p><p class="q1">He shone from Mount Paran. 
 </p><p class="q2">He came from the ten thousands of set-apart ones. 
@@ -1405,7 +1405,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Nor let his men be few.” 
 </p><p>
 <sup>7&#160;</sup>This is for Judah. He said, 
-</p><p class="q1">“Hear, Yahweh, the voice of Judah. 
+</p><p class="q1">“Hear, Yahuah, the voice of Judah. 
 </p><p class="q2">Bring him in to his people. 
 </p><p class="q1">With his hands he contended for himself. 
 </p><p class="q2">You shall be a help against his adversaries.” 
@@ -1426,18 +1426,18 @@ html[dir=ltr] .q2 {
 </p><p class="q1">They shall put incense before you, 
 </p><p class="q2">and whole burnt offering on your altar. 
 </p><p class="q1">
-<sup>11&#160;</sup>Yahweh, bless his skills. 
+<sup>11&#160;</sup>Yahuah, bless his skills. 
 </p><p class="q2">Accept the work of his hands. 
 </p><p class="q1">Strike through the hips of those who rise up against him, 
 </p><p class="q2">of those who hate him, that they not rise again.” 
 </p><p>
 <sup>12&#160;</sup>About Benjamin he said, 
-</p><p class="q1">“The beloved of Yahweh will dwell in safety by him. 
+</p><p class="q1">“The beloved of Yahuah will dwell in safety by him. 
 </p><p class="q2">He covers him all day long. 
 </p><p class="q2">He dwells between his shoulders.” 
 </p><p>
 <sup>13&#160;</sup>About Joseph he said, 
-</p><p class="q1">“His land is blessed by Yahweh, 
+</p><p class="q1">“His land is blessed by Yahuah, 
 </p><p class="q2">for the precious things of the heavens, for the dew, 
 </p><p class="q2">for the deep that couches beneath, 
 </p><p class="q1">
@@ -1475,7 +1475,7 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>He provided the first part for himself, 
 </p><p class="q2">for the lawgiver’s portion was reserved for him. 
 </p><p class="q1">He came with the heads of the people. 
-</p><p class="q2">He executed the righteousness of Yahweh, 
+</p><p class="q2">He executed the righteousness of Yahuah, 
 </p><p class="q2">His ordinances with Israel.” 
 </p><p>
 <sup>22&#160;</sup>About Dan he said, 
@@ -1484,7 +1484,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>23&#160;</sup>About Naphtali he said, 
 </p><p class="q1">“Naphtali, satisfied with favor, 
-</p><p class="q2">full of Yahweh’s blessing, 
+</p><p class="q2">full of Yahuah’s blessing, 
 </p><p class="q2">Possess the west and the south.” 
 </p><p>
 <sup>24&#160;</sup>About Asher he said, 
@@ -1511,23 +1511,23 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Yes, his heavens drop down dew. 
 </p><p class="q1">
 <sup>29&#160;</sup>You are happy, Israel! 
-</p><p class="q2">Who is like you, a people saved by Yahweh, 
+</p><p class="q2">Who is like you, a people saved by Yahuah, 
 </p><p class="q2">the shield of your help, 
 </p><p class="q2">the sword of your excellency? 
 </p><p class="q1">Your enemies will submit themselves to you. 
 </p><p class="q2">You will tread on their high places.” 
 </p><h2 class="chapterlabel" id="34">34</h2>
 <p>
-<sup>1&#160;</sup>Moses went up from the plains of Moab to Mount Nebo, to the top of Pisgah, that is opposite Jericho. Yahweh showed him all the land of Gilead to Dan, 
+<sup>1&#160;</sup>Moses went up from the plains of Moab to Mount Nebo, to the top of Pisgah, that is opposite Jericho. Yahuah showed him all the land of Gilead to Dan, 
 <sup>2&#160;</sup>and all Naphtali, and the land of Ephraim and Manasseh, and all the land of Judah, to the Western Sea, 
 <sup>3&#160;</sup>and the south, and the Plain of the valley of Jericho the city of palm trees, to Zoar. 
-<sup>4&#160;</sup>Yahweh said to him, “This is the land which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ I have caused you to see it with your eyes, but you shall not go over there.” 
+<sup>4&#160;</sup>Yahuah said to him, “This is the land which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ I have caused you to see it with your eyes, but you shall not go over there.” 
 </p><p>
-<sup>5&#160;</sup>So Moses the servant of Yahweh died there in the land of Moab, according to Yahweh’s word. 
+<sup>5&#160;</sup>So Moses the servant of Yahuah died there in the land of Moab, according to Yahuah’s word. 
 <sup>6&#160;</sup>He buried him in the valley in the land of Moab opposite Beth Peor, but no man knows where his tomb is to this day. 
 <sup>7&#160;</sup>Moses was one hundred twenty years old when he died. His eye was not dim, nor his strength gone. 
 <sup>8&#160;</sup>The children of Israel wept for Moses in the plains of Moab thirty days, until the days of weeping in the mourning for Moses were ended. 
-<sup>9&#160;</sup>Joshua the son of Nun was full of the spirit of wisdom, for Moses had laid his hands on him. The children of Israel listened to him, and did as Yahweh commanded Moses. 
-<sup>10&#160;</sup>Since then, there has not arisen a prophet in Israel like Moses, whom Yahweh knew face to face, 
-<sup>11&#160;</sup>in all the signs and the wonders which Yahweh sent him to do in the land of Egypt, to Pharaoh, and to all his servants, and to all his land, 
+<sup>9&#160;</sup>Joshua the son of Nun was full of the spirit of wisdom, for Moses had laid his hands on him. The children of Israel listened to him, and did as Yahuah commanded Moses. 
+<sup>10&#160;</sup>Since then, there has not arisen a prophet in Israel like Moses, whom Yahuah knew face to face, 
+<sup>11&#160;</sup>in all the signs and the wonders which Yahuah sent him to do in the land of Egypt, to Pharaoh, and to all his servants, and to all his land, 
 <sup>12&#160;</sup>and in all the mighty hand, and in all the awesome deeds, which Moses did in the sight of all Israel. </p></div><script src="../main.js"></script></body></html>

--- a/book/exodus.html
+++ b/book/exodus.html
@@ -168,17 +168,17 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
 <sup>1&#160;</sup>Now Moses was keeping the flock of Jethro, his father-in-law, the priest of Midian, and he led the flock to the back of the wilderness, and came to Elohim’s mountain, to Horeb. 
-<sup>2&#160;</sup>Yahweh’s angel appeared to him in a flame of fire out of the middle of a bush. He looked, and behold, the bush burned with fire, and the bush was not consumed. 
+<sup>2&#160;</sup>Yahuah’s angel appeared to him in a flame of fire out of the middle of a bush. He looked, and behold, the bush burned with fire, and the bush was not consumed. 
 <sup>3&#160;</sup>Moses said, “I will go now, and see this great sight, why the bush is not burned.” 
 </p><p>
-<sup>4&#160;</sup>When Yahweh saw that he came over to see, Elohim called to him out of the middle of the bush, and said, “Moses! Moses!” 
+<sup>4&#160;</sup>When Yahuah saw that he came over to see, Elohim called to him out of the middle of the bush, and said, “Moses! Moses!” 
 </p><p>He said, “Here I am.” 
 </p><p>
 <sup>5&#160;</sup>He said, “Don’t come close. Take off your sandals, for the place you are standing on is set-apart ground.” 
 <sup>6&#160;</sup>Moreover he said, “I am the Elohim of your father, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob.” 
 </p><p>Moses hid his face because he was afraid to look at Elohim. 
 </p><p>
-<sup>7&#160;</sup>Yahweh said, “I have surely seen the affliction of my people who are in Egypt, and have heard their cry because of their taskmasters, for I know their sorrows. 
+<sup>7&#160;</sup>Yahuah said, “I have surely seen the affliction of my people who are in Egypt, and have heard their cry because of their taskmasters, for I know their sorrows. 
 <sup>8&#160;</sup>I have come down to deliver them out of the hand of the Egyptians, and to bring them up out of that land to a good and large land, to a land flowing with milk and honey; to the place of the Canaanite, the Hittite, the Amorite, the Perizzite, the Hivite, and the Jebusite. 
 <sup>9&#160;</sup>Now, behold, the cry of the children of Israel has come to me. Moreover I have seen the oppression with which the Egyptians oppress them. 
 <sup>10&#160;</sup>Come now therefore, and I will send you to Pharaoh, that you may bring my people, the children of Israel, out of Egypt.” 
@@ -190,29 +190,29 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>Moses said to Elohim, “Behold, when I come to the children of Israel, and tell them, ‘The Elohim of your fathers has sent me to you,’ and they ask me, ‘What is his name?’ what should I tell them?” 
 </p><p>
 <sup>14&#160;</sup>Elohim said to Moses, “I will be who I will be,” and he said, “You shall tell the children of Israel this: ‘I will be has sent me to you.’&#160;” 
-<sup>15&#160;</sup>Elohim said moreover to Moses, “You shall tell the children of Israel this, ‘Yahweh, the Elohim of your fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has sent me to you.’ This is my name forever, and this is my memorial to all generations. 
-<sup>16&#160;</sup>Go and gather the elders of Israel together, and tell them, ‘Yahweh, the Elohim of your fathers, the Elohim of Abraham, of Isaac, and of Jacob, has appeared to me, saying, “I have surely visited you, and seen that which is done to you in Egypt. 
+<sup>15&#160;</sup>Elohim said moreover to Moses, “You shall tell the children of Israel this, ‘Yahuah, the Elohim of your fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has sent me to you.’ This is my name forever, and this is my memorial to all generations. 
+<sup>16&#160;</sup>Go and gather the elders of Israel together, and tell them, ‘Yahuah, the Elohim of your fathers, the Elohim of Abraham, of Isaac, and of Jacob, has appeared to me, saying, “I have surely visited you, and seen that which is done to you in Egypt. 
 <sup>17&#160;</sup>I have said, I will bring you up out of the affliction of Egypt to the land of the Canaanite, the Hittite, the Amorite, the Perizzite, the Hivite, and the Jebusite, to a land flowing with milk and honey.”&#160;’ 
-<sup>18&#160;</sup>They will listen to your voice. You shall come, you and the elders of Israel, to the king of Egypt, and you shall tell him, ‘Yahweh, the Elohim of the Hebrews, has met with us. Now please let us go three days’ journey into the wilderness, that we may sacrifice to Yahweh, our Elohim.’ 
+<sup>18&#160;</sup>They will listen to your voice. You shall come, you and the elders of Israel, to the king of Egypt, and you shall tell him, ‘Yahuah, the Elohim of the Hebrews, has met with us. Now please let us go three days’ journey into the wilderness, that we may sacrifice to Yahuah, our Elohim.’ 
 <sup>19&#160;</sup>I know that the king of Egypt won’t give you permission to go, no, not by a mighty hand. 
 <sup>20&#160;</sup>I will reach out my hand and strike Egypt with all my wonders which I will do among them, and after that he will let you go. 
 <sup>21&#160;</sup>I will give this people favor in the sight of the Egyptians, and it will happen that when you go, you shall not go empty-handed. 
 <sup>22&#160;</sup>But every woman shall ask of her neighbor, and of her who visits her house, jewels of silver, jewels of gold, and clothing. You shall put them on your sons, and on your daughters. You shall plunder the Egyptians.” 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>Moses answered, “But, behold, they will not believe me, nor listen to my voice; for they will say, ‘Yahweh has not appeared to you.’&#160;” 
+<sup>1&#160;</sup>Moses answered, “But, behold, they will not believe me, nor listen to my voice; for they will say, ‘Yahuah has not appeared to you.’&#160;” 
 </p><p>
-<sup>2&#160;</sup>Yahweh said to him, “What is that in your hand?” 
+<sup>2&#160;</sup>Yahuah said to him, “What is that in your hand?” 
 </p><p>He said, “A rod.” 
 </p><p>
 <sup>3&#160;</sup>He said, “Throw it on the ground.” 
 </p><p>He threw it on the ground, and it became a snake; and Moses ran away from it. 
 </p><p>
-<sup>4&#160;</sup>Yahweh said to Moses, “Stretch out your hand, and take it by the tail.” 
+<sup>4&#160;</sup>Yahuah said to Moses, “Stretch out your hand, and take it by the tail.” 
 </p><p>He stretched out his hand, and took hold of it, and it became a rod in his hand. 
 </p><p>
-<sup>5&#160;</sup>“This is so that they may believe that Yahweh, the Elohim of their fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has appeared to you.” 
-<sup>6&#160;</sup>Yahweh said furthermore to him, “Now put your hand inside your cloak.” 
+<sup>5&#160;</sup>“This is so that they may believe that Yahuah, the Elohim of their fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has appeared to you.” 
+<sup>6&#160;</sup>Yahuah said furthermore to him, “Now put your hand inside your cloak.” 
 </p><p>He put his hand inside his cloak, and when he took it out, behold, his hand was leprous, as white as snow. 
 </p><p>
 <sup>7&#160;</sup>He said, “Put your hand inside your cloak again.” 
@@ -221,14 +221,14 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>“It will happen, if they will not believe you or listen to the voice of the first sign, that they will believe the voice of the latter sign. 
 <sup>9&#160;</sup>It will happen, if they will not believe even these two signs or listen to your voice, that you shall take of the water of the river, and pour it on the dry land. The water which you take out of the river will become blood on the dry land.” 
 </p><p>
-<sup>10&#160;</sup>Moses said to Yahweh, “O Lord, I am not eloquent, neither before now, nor since you have spoken to your servant; for I am slow of speech, and of a slow tongue.” 
+<sup>10&#160;</sup>Moses said to Yahuah, “O Lord, I am not eloquent, neither before now, nor since you have spoken to your servant; for I am slow of speech, and of a slow tongue.” 
 </p><p>
-<sup>11&#160;</sup>Yahweh said to him, “Who made man’s mouth? Or who makes one mute, or deaf, or seeing, or blind? Isn’t it I, Yahweh? 
+<sup>11&#160;</sup>Yahuah said to him, “Who made man’s mouth? Or who makes one mute, or deaf, or seeing, or blind? Isn’t it I, Yahuah? 
 <sup>12&#160;</sup>Now therefore go, and I will be with your mouth, and teach you what you shall speak.” 
 </p><p>
 <sup>13&#160;</sup>Moses said, “Oh, Lord, please send someone else.” 
 </p><p>
-<sup>14&#160;</sup>Yahweh’s anger burned against Moses, and he said, “What about Aaron, your brother, the Levite? I know that he can speak well. Also, behold, he is coming out to meet you. When he sees you, he will be glad in his heart. 
+<sup>14&#160;</sup>Yahuah’s anger burned against Moses, and he said, “What about Aaron, your brother, the Levite? I know that he can speak well. Also, behold, he is coming out to meet you. When he sees you, he will be glad in his heart. 
 <sup>15&#160;</sup>You shall speak to him, and put the words in his mouth. I will be with your mouth, and with his mouth, and will teach you what you shall do. 
 <sup>16&#160;</sup>He will be your spokesman to the people. It will happen that he will be to you a mouth, and you will be to him as Elohim. 
 <sup>17&#160;</sup>You shall take this rod in your hand, with which you shall do the signs.” 
@@ -236,31 +236,31 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>Moses went and returned to Jethro his father-in-law, and said to him, “Please let me go and return to my brothers who are in Egypt, and see whether they are still alive.” 
 </p><p>Jethro said to Moses, “Go in peace.” 
 </p><p>
-<sup>19&#160;</sup>Yahweh said to Moses in Midian, “Go, return into Egypt; for all the men who sought your life are dead.” 
+<sup>19&#160;</sup>Yahuah said to Moses in Midian, “Go, return into Egypt; for all the men who sought your life are dead.” 
 </p><p>
 <sup>20&#160;</sup>Moses took his woman and his sons, and set them on a donkey, and he returned to the land of Egypt. Moses took Elohim’s rod in his hand. 
-<sup>21&#160;</sup>Yahweh said to Moses, “When you go back into Egypt, see that you do before Pharaoh all the wonders which I have put in your hand, but I will harden his heart and he will not let the people go. 
-<sup>22&#160;</sup>You shall tell Pharaoh, ‘Yahweh says, Israel is my son, my firstborn, 
+<sup>21&#160;</sup>Yahuah said to Moses, “When you go back into Egypt, see that you do before Pharaoh all the wonders which I have put in your hand, but I will harden his heart and he will not let the people go. 
+<sup>22&#160;</sup>You shall tell Pharaoh, ‘Yahuah says, Israel is my son, my firstborn, 
 <sup>23&#160;</sup>and I have said to you, “Let my son go, that he may serve me;” and you have refused to let him go. Behold, I will kill your firstborn son.’&#160;” 
 </p><p>
-<sup>24&#160;</sup>On the way at a lodging place, Yahweh met Moses and wanted to kill him. 
+<sup>24&#160;</sup>On the way at a lodging place, Yahuah met Moses and wanted to kill him. 
 <sup>25&#160;</sup>Then Zipporah took a flint, and cut off the foreskin of her son, and cast it at his feet; and she said, “Surely you are a bridegroom of blood to me.” 
 </p><p>
 <sup>26&#160;</sup>So he let him alone. Then she said, “You are a bridegroom of blood,” because of the circumcision. 
 </p><p>
-<sup>27&#160;</sup>Yahweh said to Aaron, “Go into the wilderness to meet Moses.” 
+<sup>27&#160;</sup>Yahuah said to Aaron, “Go into the wilderness to meet Moses.” 
 </p><p>He went, and met him on Elohim’s mountain, and kissed him. 
-<sup>28&#160;</sup>Moses told Aaron all Yahweh’s words with which he had sent him, and all the signs with which he had instructed him. 
+<sup>28&#160;</sup>Moses told Aaron all Yahuah’s words with which he had sent him, and all the signs with which he had instructed him. 
 <sup>29&#160;</sup>Moses and Aaron went and gathered together all the elders of the children of Israel. 
-<sup>30&#160;</sup>Aaron spoke all the words which Yahweh had spoken to Moses, and did the signs in the sight of the people. 
-<sup>31&#160;</sup>The people believed, and when they heard that Yahweh had visited the children of Israel, and that he had seen their affliction, then they bowed their heads and worshiped. 
+<sup>30&#160;</sup>Aaron spoke all the words which Yahuah had spoken to Moses, and did the signs in the sight of the people. 
+<sup>31&#160;</sup>The people believed, and when they heard that Yahuah had visited the children of Israel, and that he had seen their affliction, then they bowed their heads and worshiped. 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
-<sup>1&#160;</sup>Afterward Moses and Aaron came, and said to Pharaoh, “This is what Yahweh, the Elohim of Israel, says, ‘Let my people go, that they may hold a feast to me in the wilderness.’&#160;” 
+<sup>1&#160;</sup>Afterward Moses and Aaron came, and said to Pharaoh, “This is what Yahuah, the Elohim of Israel, says, ‘Let my people go, that they may hold a feast to me in the wilderness.’&#160;” 
 </p><p>
-<sup>2&#160;</sup>Pharaoh said, “Who is Yahweh, that I should listen to his voice to let Israel go? I don’t know Yahweh, and moreover I will not let Israel go.” 
+<sup>2&#160;</sup>Pharaoh said, “Who is Yahuah, that I should listen to his voice to let Israel go? I don’t know Yahuah, and moreover I will not let Israel go.” 
 </p><p>
-<sup>3&#160;</sup>They said, “The Elohim of the Hebrews has met with us. Please let us go three days’ journey into the wilderness, and sacrifice to Yahweh, our Elohim, lest he fall on us with pestilence, or with the sword.” 
+<sup>3&#160;</sup>They said, “The Elohim of the Hebrews has met with us. Please let us go three days’ journey into the wilderness, and sacrifice to Yahuah, our Elohim, lest he fall on us with pestilence, or with the sword.” 
 </p><p>
 <sup>4&#160;</sup>The king of Egypt said to them, “Why do you, Moses and Aaron, take the people from their work? Get back to your burdens!” 
 <sup>5&#160;</sup>Pharaoh said, “Behold, the people of the land are now many, and you make them rest from their burdens.” 
@@ -278,35 +278,35 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Then the officers of the children of Israel came and cried to Pharaoh, saying, “Why do you deal this way with your servants? 
 <sup>16&#160;</sup>No straw is given to your servants, and they tell us, ‘Make brick!’ and behold, your servants are beaten; but the fault is in your own people.” 
 </p><p>
-<sup>17&#160;</sup>But Pharaoh said, “You are idle! You are idle! Therefore you say, ‘Let’s go and sacrifice to Yahweh.’ 
+<sup>17&#160;</sup>But Pharaoh said, “You are idle! You are idle! Therefore you say, ‘Let’s go and sacrifice to Yahuah.’ 
 <sup>18&#160;</sup>Go therefore now, and work; for no straw shall be given to you; yet you shall deliver the same number of bricks!” 
 </p><p>
 <sup>19&#160;</sup>The officers of the children of Israel saw that they were in trouble when it was said, “You shall not diminish anything from your daily quota of bricks!” 
 </p><p>
 <sup>20&#160;</sup>They met Moses and Aaron, who stood along the way, as they came out from Pharaoh. 
-<sup>21&#160;</sup>They said to them, “May Yahweh look at you and judge, because you have made us a stench to be abhorred in the eyes of Pharaoh, and in the eyes of his servants, to put a sword in their hand to kill us!” 
+<sup>21&#160;</sup>They said to them, “May Yahuah look at you and judge, because you have made us a stench to be abhorred in the eyes of Pharaoh, and in the eyes of his servants, to put a sword in their hand to kill us!” 
 </p><p>
-<sup>22&#160;</sup>Moses returned to Yahweh, and said, “Lord, why have you brought trouble on this people? Why is it that you have sent me? 
+<sup>22&#160;</sup>Moses returned to Yahuah, and said, “Lord, why have you brought trouble on this people? Why is it that you have sent me? 
 <sup>23&#160;</sup>For since I came to Pharaoh to speak in your name, he has brought trouble on this people. You have not rescued your people at all!” 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Moses, “Now you shall see what I will do to Pharaoh, for by a strong hand he shall let them go, and by a strong hand he shall drive them out of his land.” 
+<sup>1&#160;</sup>Yahuah said to Moses, “Now you shall see what I will do to Pharaoh, for by a strong hand he shall let them go, and by a strong hand he shall drive them out of his land.” 
 </p><p>
-<sup>2&#160;</sup>Elohim spoke to Moses, and said to him, “I am Yahweh. 
-<sup>3&#160;</sup>I appeared to Abraham, to Isaac, and to Jacob, as Elohim Almighty; but by my name Yahweh I was not known to them. 
+<sup>2&#160;</sup>Elohim spoke to Moses, and said to him, “I am Yahuah. 
+<sup>3&#160;</sup>I appeared to Abraham, to Isaac, and to Jacob, as Elohim Almighty; but by my name Yahuah I was not known to them. 
 <sup>4&#160;</sup>I have also established my covenant with them, to give them the land of Canaan, the land of their travels, in which they lived as aliens. 
 <sup>5&#160;</sup>Moreover I have heard the groaning of the children of Israel, whom the Egyptians keep in bondage, and I have remembered my covenant. 
-<sup>6&#160;</sup>Therefore tell the children of Israel, ‘I am Yahweh, and I will bring you out from under the burdens of the Egyptians, and I will rid you out of their bondage, and I will redeem you with an outstretched arm, and with great judgments. 
-<sup>7&#160;</sup>I will take you to myself for a people. I will be your Elohim; and you shall know that I am Yahweh your Elohim, who brings you out from under the burdens of the Egyptians. 
-<sup>8&#160;</sup>I will bring you into the land which I swore to give to Abraham, to Isaac, and to Jacob; and I will give it to you for a heritage: I am Yahweh.’&#160;” 
+<sup>6&#160;</sup>Therefore tell the children of Israel, ‘I am Yahuah, and I will bring you out from under the burdens of the Egyptians, and I will rid you out of their bondage, and I will redeem you with an outstretched arm, and with great judgments. 
+<sup>7&#160;</sup>I will take you to myself for a people. I will be your Elohim; and you shall know that I am Yahuah your Elohim, who brings you out from under the burdens of the Egyptians. 
+<sup>8&#160;</sup>I will bring you into the land which I swore to give to Abraham, to Isaac, and to Jacob; and I will give it to you for a heritage: I am Yahuah.’&#160;” 
 </p><p>
 <sup>9&#160;</sup>Moses spoke so to the children of Israel, but they didn’t listen to Moses for anguish of spirit, and for cruel bondage. 
 </p><p>
-<sup>10&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>10&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>11&#160;</sup>“Go in, speak to Pharaoh king of Egypt, that he let the children of Israel go out of his land.” 
 </p><p>
-<sup>12&#160;</sup>Moses spoke before Yahweh, saying, “Behold, the children of Israel haven’t listened to me. How then shall Pharaoh listen to me, when I have uncircumcised lips?” 
-<sup>13&#160;</sup>Yahweh spoke to Moses and to Aaron, and gave them a command to the children of Israel, and to Pharaoh king of Egypt, to bring the children of Israel out of the land of Egypt. 
+<sup>12&#160;</sup>Moses spoke before Yahuah, saying, “Behold, the children of Israel haven’t listened to me. How then shall Pharaoh listen to me, when I have uncircumcised lips?” 
+<sup>13&#160;</sup>Yahuah spoke to Moses and to Aaron, and gave them a command to the children of Israel, and to Pharaoh king of Egypt, to bring the children of Israel out of the land of Egypt. 
 </p><p>
 <sup>14&#160;</sup>These are the heads of their fathers’ houses. The sons of Reuben the firstborn of Israel: Hanoch, and Pallu, Hezron, and Carmi; these are the families of Reuben. 
 <sup>15&#160;</sup>The sons of Simeon: Jemuel, and Jamin, and Ohad, and Jachin, and Zohar, and Shaul the son of a Canaanite woman; these are the families of Simeon. 
@@ -320,108 +320,108 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>Aaron took Elisheba, the daughter of Amminadab, the sister of Nahshon, as his woman; and she bore him Nadab and Abihu, Eleazar and Ithamar. 
 <sup>24&#160;</sup>The sons of Korah: Assir, Elkanah, and Abiasaph; these are the families of the Korahites. 
 <sup>25&#160;</sup>Eleazar Aaron’s son took one of the daughters of Putiel as his woman; and she bore him Phinehas. These are the heads of the fathers’ houses of the Levites according to their families. 
-<sup>26&#160;</sup>These are that Aaron and Moses to whom Yahweh said, “Bring out the children of Israel from the land of Egypt according to their armies.” 
+<sup>26&#160;</sup>These are that Aaron and Moses to whom Yahuah said, “Bring out the children of Israel from the land of Egypt according to their armies.” 
 <sup>27&#160;</sup>These are those who spoke to Pharaoh king of Egypt, to bring out the children of Israel from Egypt. These are that Moses and Aaron. 
 </p><p>
-<sup>28&#160;</sup>On the day when Yahweh spoke to Moses in the land of Egypt, 
-<sup>29&#160;</sup>Yahweh said to Moses, “I am Yahweh. Tell Pharaoh king of Egypt all that I tell you.” 
+<sup>28&#160;</sup>On the day when Yahuah spoke to Moses in the land of Egypt, 
+<sup>29&#160;</sup>Yahuah said to Moses, “I am Yahuah. Tell Pharaoh king of Egypt all that I tell you.” 
 </p><p>
-<sup>30&#160;</sup>Moses said before Yahweh, “Behold, I am of uncircumcised lips, and how shall Pharaoh listen to me?” 
+<sup>30&#160;</sup>Moses said before Yahuah, “Behold, I am of uncircumcised lips, and how shall Pharaoh listen to me?” 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Moses, “Behold, I have made you as Elohim to Pharaoh; and Aaron your brother shall be your prophet. 
+<sup>1&#160;</sup>Yahuah said to Moses, “Behold, I have made you as Elohim to Pharaoh; and Aaron your brother shall be your prophet. 
 <sup>2&#160;</sup>You shall speak all that I command you; and Aaron your brother shall speak to Pharaoh, that he let the children of Israel go out of his land. 
 <sup>3&#160;</sup>I will harden Pharaoh’s heart, and multiply my signs and my wonders in the land of Egypt. 
 <sup>4&#160;</sup>But Pharaoh will not listen to you, so I will lay my hand on Egypt, and bring out my armies, my people the children of Israel, out of the land of Egypt by great judgments. 
-<sup>5&#160;</sup>The Egyptians shall know that I am Yahweh when I stretch out my hand on Egypt, and bring the children of Israel out from among them.” 
+<sup>5&#160;</sup>The Egyptians shall know that I am Yahuah when I stretch out my hand on Egypt, and bring the children of Israel out from among them.” 
 </p><p>
-<sup>6&#160;</sup>Moses and Aaron did so. As Yahweh commanded them, so they did. 
+<sup>6&#160;</sup>Moses and Aaron did so. As Yahuah commanded them, so they did. 
 <sup>7&#160;</sup>Moses was eighty years old, and Aaron eighty-three years old, when they spoke to Pharaoh. 
 </p><p>
-<sup>8&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>8&#160;</sup>Yahuah spoke to Moses and to Aaron, saying, 
 <sup>9&#160;</sup>“When Pharaoh speaks to you, saying, ‘Perform a miracle!’ then you shall tell Aaron, ‘Take your rod, and cast it down before Pharaoh, and it will become a serpent.’&#160;” 
 </p><p>
-<sup>10&#160;</sup>Moses and Aaron went in to Pharaoh, and they did so, as Yahweh had commanded. Aaron cast down his rod before Pharaoh and before his servants, and it became a serpent. 
+<sup>10&#160;</sup>Moses and Aaron went in to Pharaoh, and they did so, as Yahuah had commanded. Aaron cast down his rod before Pharaoh and before his servants, and it became a serpent. 
 <sup>11&#160;</sup>Then Pharaoh also called for the wise men and the sorcerers. They also, the magicians of Egypt, did the same thing with their enchantments. 
 <sup>12&#160;</sup>For they each cast down their rods, and they became serpents; but Aaron’s rod swallowed up their rods. 
-<sup>13&#160;</sup>Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
+<sup>13&#160;</sup>Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahuah had spoken. 
 </p><p>
-<sup>14&#160;</sup>Yahweh said to Moses, “Pharaoh’s heart is stubborn. He refuses to let the people go. 
+<sup>14&#160;</sup>Yahuah said to Moses, “Pharaoh’s heart is stubborn. He refuses to let the people go. 
 <sup>15&#160;</sup>Go to Pharaoh in the morning. Behold, he is going out to the water. You shall stand by the river’s bank to meet him. You shall take the rod which was turned to a serpent in your hand. 
-<sup>16&#160;</sup>You shall tell him, ‘Yahweh, the Elohim of the Hebrews, has sent me to you, saying, “Let my people go, that they may serve me in the wilderness. Behold, until now you haven’t listened.” 
-<sup>17&#160;</sup>Yahweh says, “In this you shall know that I am Yahweh. Behold: I will strike with the rod that is in my hand on the waters which are in the river, and they shall be turned to blood. 
+<sup>16&#160;</sup>You shall tell him, ‘Yahuah, the Elohim of the Hebrews, has sent me to you, saying, “Let my people go, that they may serve me in the wilderness. Behold, until now you haven’t listened.” 
+<sup>17&#160;</sup>Yahuah says, “In this you shall know that I am Yahuah. Behold: I will strike with the rod that is in my hand on the waters which are in the river, and they shall be turned to blood. 
 <sup>18&#160;</sup>The fish that are in the river will die and the river will become foul. The Egyptians will loathe to drink water from the river.”&#160;’&#160;” 
-<sup>19&#160;</sup>Yahweh said to Moses, “Tell Aaron, ‘Take your rod, and stretch out your hand over the waters of Egypt, over their rivers, over their streams, and over their pools, and over all their ponds of water, that they may become blood. There will be blood throughout all the land of Egypt, both in vessels of wood and in vessels of stone.’&#160;” 
+<sup>19&#160;</sup>Yahuah said to Moses, “Tell Aaron, ‘Take your rod, and stretch out your hand over the waters of Egypt, over their rivers, over their streams, and over their pools, and over all their ponds of water, that they may become blood. There will be blood throughout all the land of Egypt, both in vessels of wood and in vessels of stone.’&#160;” 
 </p><p>
-<sup>20&#160;</sup>Moses and Aaron did so, as Yahweh commanded; and he lifted up the rod, and struck the waters that were in the river, in the sight of Pharaoh, and in the sight of his servants; and all the waters that were in the river were turned to blood. 
+<sup>20&#160;</sup>Moses and Aaron did so, as Yahuah commanded; and he lifted up the rod, and struck the waters that were in the river, in the sight of Pharaoh, and in the sight of his servants; and all the waters that were in the river were turned to blood. 
 <sup>21&#160;</sup>The fish that were in the river died. The river became foul. The Egyptians couldn’t drink water from the river. The blood was throughout all the land of Egypt. 
-<sup>22&#160;</sup>The magicians of Egypt did the same thing with their enchantments. So Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
+<sup>22&#160;</sup>The magicians of Egypt did the same thing with their enchantments. So Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahuah had spoken. 
 <sup>23&#160;</sup>Pharaoh turned and went into his house, and he didn’t even take this to heart. 
 <sup>24&#160;</sup>All the Egyptians dug around the river for water to drink; for they couldn’t drink the river water. 
-<sup>25&#160;</sup>Seven days were fulfilled, after Yahweh had struck the river. 
+<sup>25&#160;</sup>Seven days were fulfilled, after Yahuah had struck the river. 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahweh says, “Let my people go, that they may serve me. 
+<sup>1&#160;</sup>Yahuah spoke to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahuah says, “Let my people go, that they may serve me. 
 <sup>2&#160;</sup>If you refuse to let them go, behold, I will plague all your borders with frogs. 
 <sup>3&#160;</sup>The river will swarm with frogs, which will go up and come into your house, and into your bedroom, and on your bed, and into the house of your servants, and on your people, and into your ovens, and into your kneading troughs. 
 <sup>4&#160;</sup>The frogs shall come up both on you, and on your people, and on all your servants.”&#160;’&#160;” 
-<sup>5&#160;</sup>Yahweh said to Moses, “Tell Aaron, ‘Stretch out your hand with your rod over the rivers, over the streams, and over the pools, and cause frogs to come up on the land of Egypt.’&#160;” 
+<sup>5&#160;</sup>Yahuah said to Moses, “Tell Aaron, ‘Stretch out your hand with your rod over the rivers, over the streams, and over the pools, and cause frogs to come up on the land of Egypt.’&#160;” 
 <sup>6&#160;</sup>Aaron stretched out his hand over the waters of Egypt; and the frogs came up, and covered the land of Egypt. 
 <sup>7&#160;</sup>The magicians did the same thing with their enchantments, and brought up frogs on the land of Egypt. 
 </p><p>
-<sup>8&#160;</sup>Then Pharaoh called for Moses and Aaron, and said, “Entreat Yahweh, that he take away the frogs from me and from my people; and I will let the people go, that they may sacrifice to Yahweh.” 
+<sup>8&#160;</sup>Then Pharaoh called for Moses and Aaron, and said, “Entreat Yahuah, that he take away the frogs from me and from my people; and I will let the people go, that they may sacrifice to Yahuah.” 
 </p><p>
 <sup>9&#160;</sup>Moses said to Pharaoh, “I give you the honor of setting the time that I should pray for you, and for your servants, and for your people, that the frogs be destroyed from you and your houses, and remain in the river only.” 
 </p><p>
 <sup>10&#160;</sup>Pharaoh said, “Tomorrow.” 
-</p><p>Moses said, “Let it be according to your word, that you may know that there is no one like Yahweh our Elohim. 
+</p><p>Moses said, “Let it be according to your word, that you may know that there is no one like Yahuah our Elohim. 
 <sup>11&#160;</sup>The frogs shall depart from you, and from your houses, and from your servants, and from your people. They shall remain in the river only.” 
 </p><p>
-<sup>12&#160;</sup>Moses and Aaron went out from Pharaoh, and Moses cried to Yahweh concerning the frogs which he had brought on Pharaoh. 
-<sup>13&#160;</sup>Yahweh did according to the word of Moses, and the frogs died out of the houses, out of the courts, and out of the fields. 
+<sup>12&#160;</sup>Moses and Aaron went out from Pharaoh, and Moses cried to Yahuah concerning the frogs which he had brought on Pharaoh. 
+<sup>13&#160;</sup>Yahuah did according to the word of Moses, and the frogs died out of the houses, out of the courts, and out of the fields. 
 <sup>14&#160;</sup>They gathered them together in heaps, and the land stank. 
-<sup>15&#160;</sup>But when Pharaoh saw that there was a respite, he hardened his heart, and didn’t listen to them, as Yahweh had spoken. 
+<sup>15&#160;</sup>But when Pharaoh saw that there was a respite, he hardened his heart, and didn’t listen to them, as Yahuah had spoken. 
 </p><p>
-<sup>16&#160;</sup>Yahweh said to Moses, “Tell Aaron, ‘Stretch out your rod, and strike the dust of the earth, that it may become lice throughout all the land of Egypt.’&#160;” 
+<sup>16&#160;</sup>Yahuah said to Moses, “Tell Aaron, ‘Stretch out your rod, and strike the dust of the earth, that it may become lice throughout all the land of Egypt.’&#160;” 
 <sup>17&#160;</sup>They did so; and Aaron stretched out his hand with his rod, and struck the dust of the earth, and there were lice on man, and on animal; all the dust of the earth became lice throughout all the land of Egypt. 
 <sup>18&#160;</sup>The magicians tried with their enchantments to produce lice, but they couldn’t. There were lice on man, and on animal. 
-<sup>19&#160;</sup>Then the magicians said to Pharaoh, “This is Elohim’s finger;” but Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
+<sup>19&#160;</sup>Then the magicians said to Pharaoh, “This is Elohim’s finger;” but Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahuah had spoken. 
 </p><p>
-<sup>20&#160;</sup>Yahweh said to Moses, “Rise up early in the morning, and stand before Pharaoh; behold, he comes out to the water; and tell him, ‘This is what Yahweh says, “Let my people go, that they may serve me. 
+<sup>20&#160;</sup>Yahuah said to Moses, “Rise up early in the morning, and stand before Pharaoh; behold, he comes out to the water; and tell him, ‘This is what Yahuah says, “Let my people go, that they may serve me. 
 <sup>21&#160;</sup>Else, if you will not let my people go, behold, I will send swarms of flies on you, and on your servants, and on your people, and into your houses. The houses of the Egyptians shall be full of swarms of flies, and also the ground they are on. 
-<sup>22&#160;</sup>I will set apart in that day the land of Goshen, in which my people dwell, that no swarms of flies shall be there, to the end you may know that I am Yahweh on the earth. 
+<sup>22&#160;</sup>I will set apart in that day the land of Goshen, in which my people dwell, that no swarms of flies shall be there, to the end you may know that I am Yahuah on the earth. 
 <sup>23&#160;</sup>I will put a division between my people and your people. This sign shall happen by tomorrow.”&#160;’&#160;” 
-<sup>24&#160;</sup>Yahweh did so; and there came grievous swarms of flies into the house of Pharaoh, and into his servants’ houses. In all the land of Egypt the land was corrupted by reason of the swarms of flies. 
+<sup>24&#160;</sup>Yahuah did so; and there came grievous swarms of flies into the house of Pharaoh, and into his servants’ houses. In all the land of Egypt the land was corrupted by reason of the swarms of flies. 
 </p><p>
 <sup>25&#160;</sup>Pharaoh called for Moses and for Aaron, and said, “Go, sacrifice to your Elohim in the land!” 
 </p><p>
-<sup>26&#160;</sup>Moses said, “It isn’t appropriate to do so; for we shall sacrifice the abomination of the Egyptians to Yahweh our Elohim. Behold, if we sacrifice the abomination of the Egyptians before their eyes, won’t they stone us? 
-<sup>27&#160;</sup>We will go three days’ journey into the wilderness, and sacrifice to Yahweh our Elohim, as he shall command us.” 
+<sup>26&#160;</sup>Moses said, “It isn’t appropriate to do so; for we shall sacrifice the abomination of the Egyptians to Yahuah our Elohim. Behold, if we sacrifice the abomination of the Egyptians before their eyes, won’t they stone us? 
+<sup>27&#160;</sup>We will go three days’ journey into the wilderness, and sacrifice to Yahuah our Elohim, as he shall command us.” 
 </p><p>
-<sup>28&#160;</sup>Pharaoh said, “I will let you go, that you may sacrifice to Yahweh your Elohim in the wilderness, only you shall not go very far away. Pray for me.” 
+<sup>28&#160;</sup>Pharaoh said, “I will let you go, that you may sacrifice to Yahuah your Elohim in the wilderness, only you shall not go very far away. Pray for me.” 
 </p><p>
-<sup>29&#160;</sup>Moses said, “Behold, I am going out from you. I will pray to Yahweh that the swarms of flies may depart from Pharaoh, from his servants, and from his people, tomorrow; only don’t let Pharaoh deal deceitfully any more in not letting the people go to sacrifice to Yahweh.” 
-<sup>30&#160;</sup>Moses went out from Pharaoh, and prayed to Yahweh. 
-<sup>31&#160;</sup>Yahweh did according to the word of Moses, and he removed the swarms of flies from Pharaoh, from his servants, and from his people. There remained not one. 
+<sup>29&#160;</sup>Moses said, “Behold, I am going out from you. I will pray to Yahuah that the swarms of flies may depart from Pharaoh, from his servants, and from his people, tomorrow; only don’t let Pharaoh deal deceitfully any more in not letting the people go to sacrifice to Yahuah.” 
+<sup>30&#160;</sup>Moses went out from Pharaoh, and prayed to Yahuah. 
+<sup>31&#160;</sup>Yahuah did according to the word of Moses, and he removed the swarms of flies from Pharaoh, from his servants, and from his people. There remained not one. 
 <sup>32&#160;</sup>Pharaoh hardened his heart this time also, and he didn’t let the people go. 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
-<sup>1&#160;</sup>Then Yahweh said to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahweh, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
+<sup>1&#160;</sup>Then Yahuah said to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahuah, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
 <sup>2&#160;</sup>For if you refuse to let them go, and hold them still, 
-<sup>3&#160;</sup>behold, Yahweh’s hand is on your livestock which are in the field, on the horses, on the donkeys, on the camels, on the herds, and on the flocks with a very grievous pestilence. 
-<sup>4&#160;</sup>Yahweh will make a distinction between the livestock of Israel and the livestock of Egypt; and nothing shall die of all that belongs to the children of Israel.”&#160;’&#160;” 
-<sup>5&#160;</sup>Yahweh appointed a set time, saying, “Tomorrow Yahweh shall do this thing in the land.” 
-<sup>6&#160;</sup>Yahweh did that thing on the next day; and all the livestock of Egypt died, but of the livestock of the children of Israel, not one died. 
+<sup>3&#160;</sup>behold, Yahuah’s hand is on your livestock which are in the field, on the horses, on the donkeys, on the camels, on the herds, and on the flocks with a very grievous pestilence. 
+<sup>4&#160;</sup>Yahuah will make a distinction between the livestock of Israel and the livestock of Egypt; and nothing shall die of all that belongs to the children of Israel.”&#160;’&#160;” 
+<sup>5&#160;</sup>Yahuah appointed a set time, saying, “Tomorrow Yahuah shall do this thing in the land.” 
+<sup>6&#160;</sup>Yahuah did that thing on the next day; and all the livestock of Egypt died, but of the livestock of the children of Israel, not one died. 
 <sup>7&#160;</sup>Pharaoh sent, and, behold, there was not so much as one of the livestock of the Israelites dead. But the heart of Pharaoh was stubborn, and he didn’t let the people go. 
 </p><p>
-<sup>8&#160;</sup>Yahweh said to Moses and to Aaron, “Take handfuls of ashes of the furnace, and let Moses sprinkle it toward the sky in the sight of Pharaoh. 
+<sup>8&#160;</sup>Yahuah said to Moses and to Aaron, “Take handfuls of ashes of the furnace, and let Moses sprinkle it toward the sky in the sight of Pharaoh. 
 <sup>9&#160;</sup>It shall become small dust over all the land of Egypt, and shall be boils and blisters breaking out on man and on animal, throughout all the land of Egypt.” 
 </p><p>
 <sup>10&#160;</sup>They took ashes of the furnace, and stood before Pharaoh; and Moses sprinkled it up toward the sky; and it became boils and blisters breaking out on man and on animal. 
 <sup>11&#160;</sup>The magicians couldn’t stand before Moses because of the boils; for the boils were on the magicians and on all the Egyptians. 
-<sup>12&#160;</sup>Yahweh hardened the heart of Pharaoh, and he didn’t listen to them, as Yahweh had spoken to Moses. 
+<sup>12&#160;</sup>Yahuah hardened the heart of Pharaoh, and he didn’t listen to them, as Yahuah had spoken to Moses. 
 </p><p>
-<sup>13&#160;</sup>Yahweh said to Moses, “Rise up early in the morning, and stand before Pharaoh, and tell him, ‘This is what Yahweh, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
+<sup>13&#160;</sup>Yahuah said to Moses, “Rise up early in the morning, and stand before Pharaoh, and tell him, ‘This is what Yahuah, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
 <sup>14&#160;</sup>For this time I will send all my plagues against your heart, against your officials, and against your people; that you may know that there is no one like me in all the earth. 
 <sup>15&#160;</sup>For now I would have stretched out my hand, and struck you and your people with pestilence, and you would have been cut off from the earth; 
 <sup>16&#160;</sup>but indeed for this cause I have made you stand: to show you my power, and that my name may be declared throughout all the earth, 
@@ -429,87 +429,87 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>Behold, tomorrow about this time I will cause it to rain a very grievous hail, such as has not been in Egypt since the day it was founded even until now. 
 <sup>19&#160;</sup>Now therefore command that all of your livestock and all that you have in the field be brought into shelter. The hail will come down on every man and animal that is found in the field, and isn’t brought home, and they will die.”&#160;’&#160;” 
 </p><p>
-<sup>20&#160;</sup>Those who feared Yahweh’s word among the servants of Pharaoh made their servants and their livestock flee into the houses. 
-<sup>21&#160;</sup>Whoever didn’t respect Yahweh’s word left his servants and his livestock in the field. 
+<sup>20&#160;</sup>Those who feared Yahuah’s word among the servants of Pharaoh made their servants and their livestock flee into the houses. 
+<sup>21&#160;</sup>Whoever didn’t respect Yahuah’s word left his servants and his livestock in the field. 
 </p><p>
-<sup>22&#160;</sup>Yahweh said to Moses, “Stretch out your hand toward the sky, that there may be hail in all the land of Egypt, on man, and on animal, and on every herb of the field, throughout the land of Egypt.” 
+<sup>22&#160;</sup>Yahuah said to Moses, “Stretch out your hand toward the sky, that there may be hail in all the land of Egypt, on man, and on animal, and on every herb of the field, throughout the land of Egypt.” 
 </p><p>
-<sup>23&#160;</sup>Moses stretched out his rod toward the heavens, and Yahweh sent thunder and hail; and lightning flashed down to the earth. Yahweh rained hail on the land of Egypt. 
+<sup>23&#160;</sup>Moses stretched out his rod toward the heavens, and Yahuah sent thunder and hail; and lightning flashed down to the earth. Yahuah rained hail on the land of Egypt. 
 <sup>24&#160;</sup>So there was very severe hail, and lightning mixed with the hail, such as had not been in all the land of Egypt since it became a nation. 
 <sup>25&#160;</sup>The hail struck throughout all the land of Egypt all that was in the field, both man and animal; and the hail struck every herb of the field, and broke every tree of the field. 
 <sup>26&#160;</sup>Only in the land of Goshen, where the children of Israel were, there was no hail. 
 </p><p>
-<sup>27&#160;</sup>Pharaoh sent and called for Moses and Aaron, and said to them, “I have sinned this time. Yahweh is righteous, and I and my people are wicked. 
-<sup>28&#160;</sup>Pray to Yahweh; for there has been enough of mighty thunderings and hail. I will let you go, and you shall stay no longer.” 
+<sup>27&#160;</sup>Pharaoh sent and called for Moses and Aaron, and said to them, “I have sinned this time. Yahuah is righteous, and I and my people are wicked. 
+<sup>28&#160;</sup>Pray to Yahuah; for there has been enough of mighty thunderings and hail. I will let you go, and you shall stay no longer.” 
 </p><p>
-<sup>29&#160;</sup>Moses said to him, “As soon as I have gone out of the city, I will spread out my hands to Yahweh. The thunders shall cease, and there will not be any more hail; that you may know that the earth is Yahweh’s. 
-<sup>30&#160;</sup>But as for you and your servants, I know that you don’t yet fear Yahweh Elohim.” 
+<sup>29&#160;</sup>Moses said to him, “As soon as I have gone out of the city, I will spread out my hands to Yahuah. The thunders shall cease, and there will not be any more hail; that you may know that the earth is Yahuah’s. 
+<sup>30&#160;</sup>But as for you and your servants, I know that you don’t yet fear Yahuah Elohim.” 
 </p><p>
 <sup>31&#160;</sup>The flax and the barley were struck, for the barley had ripened and the flax was blooming. 
 <sup>32&#160;</sup>But the wheat and the spelt were not struck, for they had not grown up. 
-<sup>33&#160;</sup>Moses went out of the city from Pharaoh, and spread out his hands to Yahweh; and the thunders and hail ceased, and the rain was not poured on the earth. 
+<sup>33&#160;</sup>Moses went out of the city from Pharaoh, and spread out his hands to Yahuah; and the thunders and hail ceased, and the rain was not poured on the earth. 
 <sup>34&#160;</sup>When Pharaoh saw that the rain and the hail and the thunders had ceased, he sinned yet more, and hardened his heart, he and his servants. 
-<sup>35&#160;</sup>The heart of Pharaoh was hardened, and he didn’t let the children of Israel go, just as Yahweh had spoken through Moses. 
+<sup>35&#160;</sup>The heart of Pharaoh was hardened, and he didn’t let the children of Israel go, just as Yahuah had spoken through Moses. 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Moses, “Go in to Pharaoh, for I have hardened his heart and the heart of his servants, that I may show these my signs among them; 
-<sup>2&#160;</sup>and that you may tell in the hearing of your son, and of your son’s son, what things I have done to Egypt, and my signs which I have done among them; that you may know that I am Yahweh.” 
+<sup>1&#160;</sup>Yahuah said to Moses, “Go in to Pharaoh, for I have hardened his heart and the heart of his servants, that I may show these my signs among them; 
+<sup>2&#160;</sup>and that you may tell in the hearing of your son, and of your son’s son, what things I have done to Egypt, and my signs which I have done among them; that you may know that I am Yahuah.” 
 </p><p>
-<sup>3&#160;</sup>Moses and Aaron went in to Pharaoh, and said to him, “This is what Yahweh, the Elohim of the Hebrews, says: ‘How long will you refuse to humble yourself before me? Let my people go, that they may serve me. 
+<sup>3&#160;</sup>Moses and Aaron went in to Pharaoh, and said to him, “This is what Yahuah, the Elohim of the Hebrews, says: ‘How long will you refuse to humble yourself before me? Let my people go, that they may serve me. 
 <sup>4&#160;</sup>Or else, if you refuse to let my people go, behold, tomorrow I will bring locusts into your country, 
 <sup>5&#160;</sup>and they shall cover the surface of the earth, so that one won’t be able to see the earth. They shall eat the residue of that which has escaped, which remains to you from the hail, and shall eat every tree which grows for you out of the field. 
 <sup>6&#160;</sup>Your houses shall be filled, and the houses of all your servants, and the houses of all the Egyptians, as neither your fathers nor your fathers’ fathers have seen, since the day that they were on the earth to this day.’&#160;” He turned, and went out from Pharaoh. 
 </p><p>
-<sup>7&#160;</sup>Pharaoh’s servants said to him, “How long will this man be a snare to us? Let the men go, that they may serve Yahweh, their Elohim. Don’t you yet know that Egypt is destroyed?” 
+<sup>7&#160;</sup>Pharaoh’s servants said to him, “How long will this man be a snare to us? Let the men go, that they may serve Yahuah, their Elohim. Don’t you yet know that Egypt is destroyed?” 
 </p><p>
-<sup>8&#160;</sup>Moses and Aaron were brought again to Pharaoh, and he said to them, “Go, serve Yahweh your Elohim; but who are those who will go?” 
+<sup>8&#160;</sup>Moses and Aaron were brought again to Pharaoh, and he said to them, “Go, serve Yahuah your Elohim; but who are those who will go?” 
 </p><p>
-<sup>9&#160;</sup>Moses said, “We will go with our young and with our old. We will go with our sons and with our daughters, with our flocks and with our herds; for we must hold a feast to Yahweh.” 
+<sup>9&#160;</sup>Moses said, “We will go with our young and with our old. We will go with our sons and with our daughters, with our flocks and with our herds; for we must hold a feast to Yahuah.” 
 </p><p>
-<sup>10&#160;</sup>He said to them, “Yahweh be with you if I let you go with your little ones! See, evil is clearly before your faces. 
-<sup>11&#160;</sup>Not so! Go now you who are men, and serve Yahweh; for that is what you desire!” Then they were driven out from Pharaoh’s presence. 
+<sup>10&#160;</sup>He said to them, “Yahuah be with you if I let you go with your little ones! See, evil is clearly before your faces. 
+<sup>11&#160;</sup>Not so! Go now you who are men, and serve Yahuah; for that is what you desire!” Then they were driven out from Pharaoh’s presence. 
 </p><p>
-<sup>12&#160;</sup>Yahweh said to Moses, “Stretch out your hand over the land of Egypt for the locusts, that they may come up on the land of Egypt, and eat every herb of the land, even all that the hail has left.” 
-<sup>13&#160;</sup>Moses stretched out his rod over the land of Egypt, and Yahweh brought an east wind on the land all that day, and all night; and when it was morning, the east wind brought the locusts. 
+<sup>12&#160;</sup>Yahuah said to Moses, “Stretch out your hand over the land of Egypt for the locusts, that they may come up on the land of Egypt, and eat every herb of the land, even all that the hail has left.” 
+<sup>13&#160;</sup>Moses stretched out his rod over the land of Egypt, and Yahuah brought an east wind on the land all that day, and all night; and when it was morning, the east wind brought the locusts. 
 <sup>14&#160;</sup>The locusts went up over all the land of Egypt, and rested in all the borders of Egypt. They were very grievous. Before them there were no such locusts as they, nor will there ever be again. 
 <sup>15&#160;</sup>For they covered the surface of the whole earth, so that the land was darkened, and they ate every herb of the land, and all the fruit of the trees which the hail had left. There remained nothing green, either tree or herb of the field, through all the land of Egypt. 
-<sup>16&#160;</sup>Then Pharaoh called for Moses and Aaron in haste, and he said, “I have sinned against Yahweh your Elohim, and against you. 
-<sup>17&#160;</sup>Now therefore please forgive my sin again, and pray to Yahweh your Elohim, that he may also take away from me this death.” 
+<sup>16&#160;</sup>Then Pharaoh called for Moses and Aaron in haste, and he said, “I have sinned against Yahuah your Elohim, and against you. 
+<sup>17&#160;</sup>Now therefore please forgive my sin again, and pray to Yahuah your Elohim, that he may also take away from me this death.” 
 </p><p>
-<sup>18&#160;</sup>Moses went out from Pharaoh, and prayed to Yahweh. 
-<sup>19&#160;</sup>Yahweh sent an exceedingly strong west wind, which took up the locusts, and drove them into the Red Sea. There remained not one locust in all the borders of Egypt. 
-<sup>20&#160;</sup>But Yahweh hardened Pharaoh’s heart, and he didn’t let the children of Israel go. 
+<sup>18&#160;</sup>Moses went out from Pharaoh, and prayed to Yahuah. 
+<sup>19&#160;</sup>Yahuah sent an exceedingly strong west wind, which took up the locusts, and drove them into the Red Sea. There remained not one locust in all the borders of Egypt. 
+<sup>20&#160;</sup>But Yahuah hardened Pharaoh’s heart, and he didn’t let the children of Israel go. 
 </p><p>
-<sup>21&#160;</sup>Yahweh said to Moses, “Stretch out your hand toward the sky, that there may be darkness over the land of Egypt, even darkness which may be felt.” 
+<sup>21&#160;</sup>Yahuah said to Moses, “Stretch out your hand toward the sky, that there may be darkness over the land of Egypt, even darkness which may be felt.” 
 <sup>22&#160;</sup>Moses stretched out his hand toward the sky, and there was a thick darkness in all the land of Egypt for three days. 
 <sup>23&#160;</sup>They didn’t see one another, and nobody rose from his place for three days; but all the children of Israel had light in their dwellings. 
 </p><p>
-<sup>24&#160;</sup>Pharaoh called to Moses, and said, “Go, serve Yahweh. Only let your flocks and your herds stay behind. Let your little ones also go with you.” 
+<sup>24&#160;</sup>Pharaoh called to Moses, and said, “Go, serve Yahuah. Only let your flocks and your herds stay behind. Let your little ones also go with you.” 
 </p><p>
-<sup>25&#160;</sup>Moses said, “You must also give into our hand sacrifices and burnt offerings, that we may sacrifice to Yahweh our Elohim. 
-<sup>26&#160;</sup>Our livestock also shall go with us. Not a hoof shall be left behind, for of it we must take to serve Yahweh our Elohim; and we don’t know with what we must serve Yahweh, until we come there.” 
+<sup>25&#160;</sup>Moses said, “You must also give into our hand sacrifices and burnt offerings, that we may sacrifice to Yahuah our Elohim. 
+<sup>26&#160;</sup>Our livestock also shall go with us. Not a hoof shall be left behind, for of it we must take to serve Yahuah our Elohim; and we don’t know with what we must serve Yahuah, until we come there.” 
 </p><p>
-<sup>27&#160;</sup>But Yahweh hardened Pharaoh’s heart, and he wouldn’t let them go. 
+<sup>27&#160;</sup>But Yahuah hardened Pharaoh’s heart, and he wouldn’t let them go. 
 <sup>28&#160;</sup>Pharaoh said to him, “Get away from me! Be careful to see my face no more; for in the day you see my face you shall die!” 
 </p><p>
 <sup>29&#160;</sup>Moses said, “You have spoken well. I will see your face again no more.” 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Moses, “I will bring yet one more plague on Pharaoh, and on Egypt; afterwards he will let you go. When he lets you go, he will surely thrust you out altogether. 
+<sup>1&#160;</sup>Yahuah said to Moses, “I will bring yet one more plague on Pharaoh, and on Egypt; afterwards he will let you go. When he lets you go, he will surely thrust you out altogether. 
 <sup>2&#160;</sup>Speak now in the ears of the people, and let every man ask of his neighbor, and every woman of her neighbor, jewels of silver, and jewels of gold.” 
-<sup>3&#160;</sup>Yahweh gave the people favor in the sight of the Egyptians. Moreover, the man Moses was very great in the land of Egypt, in the sight of Pharaoh’s servants, and in the sight of the people. 
+<sup>3&#160;</sup>Yahuah gave the people favor in the sight of the Egyptians. Moreover, the man Moses was very great in the land of Egypt, in the sight of Pharaoh’s servants, and in the sight of the people. 
 </p><p>
-<sup>4&#160;</sup>Moses said, “This is what Yahweh says: ‘About midnight I will go out into the middle of Egypt, 
+<sup>4&#160;</sup>Moses said, “This is what Yahuah says: ‘About midnight I will go out into the middle of Egypt, 
 <sup>5&#160;</sup>and all the firstborn in the land of Egypt shall die, from the firstborn of Pharaoh who sits on his throne, even to the firstborn of the female servant who is behind the mill, and all the firstborn of livestock. 
 <sup>6&#160;</sup>There will be a great cry throughout all the land of Egypt, such as there has not been, nor will be any more. 
-<sup>7&#160;</sup>But against any of the children of Israel a dog won’t even bark or move its tongue, against man or animal, that you may know that Yahweh makes a distinction between the Egyptians and Israel. 
+<sup>7&#160;</sup>But against any of the children of Israel a dog won’t even bark or move its tongue, against man or animal, that you may know that Yahuah makes a distinction between the Egyptians and Israel. 
 <sup>8&#160;</sup>All these servants of yours will come down to me, and bow down themselves to me, saying, “Get out, with all the people who follow you;” and after that I will go out.’&#160;” He went out from Pharaoh in hot anger. 
 </p><p>
-<sup>9&#160;</sup>Yahweh said to Moses, “Pharaoh won’t listen to you, that my wonders may be multiplied in the land of Egypt.” 
-<sup>10&#160;</sup>Moses and Aaron did all these wonders before Pharaoh, but Yahweh hardened Pharaoh’s heart, and he didn’t let the children of Israel go out of his land. 
+<sup>9&#160;</sup>Yahuah said to Moses, “Pharaoh won’t listen to you, that my wonders may be multiplied in the land of Egypt.” 
+<sup>10&#160;</sup>Moses and Aaron did all these wonders before Pharaoh, but Yahuah hardened Pharaoh’s heart, and he didn’t let the children of Israel go out of his land. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses and Aaron in the land of Egypt, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses and Aaron in the land of Egypt, saying, 
 <sup>2&#160;</sup>“This month shall be to you the beginning of months. It shall be the first month of the year to you. 
 <sup>3&#160;</sup>Speak to all the congregation of Israel, saying, ‘On the tenth day of this month, they shall take to them every man a lamb, according to their fathers’ houses, a lamb for a household; 
 <sup>4&#160;</sup>and if the household is too little for a lamb, then he and his neighbor next to his house shall take one according to the number of the souls. You shall make your count for the lamb according to what everyone can eat. 
@@ -519,10 +519,10 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>They shall eat the meat in that night, roasted with fire, with unleavened bread. They shall eat it with bitter herbs. 
 <sup>9&#160;</sup>Don’t eat it raw, nor boiled at all with water, but roasted with fire; with its head, its legs and its inner parts. 
 <sup>10&#160;</sup>You shall let nothing of it remain until the morning; but that which remains of it until the morning you shall burn with fire. 
-<sup>11&#160;</sup>This is how you shall eat it: with your belt on your waist, your sandals on your feet, and your staff in your hand; and you shall eat it in haste: it is Yahweh’s Passover. 
-<sup>12&#160;</sup>For I will go through the land of Egypt in that night, and will strike all the firstborn in the land of Egypt, both man and animal. I will execute judgments against all the elohims of Egypt. I am Yahweh. 
+<sup>11&#160;</sup>This is how you shall eat it: with your belt on your waist, your sandals on your feet, and your staff in your hand; and you shall eat it in haste: it is Yahuah’s Passover. 
+<sup>12&#160;</sup>For I will go through the land of Egypt in that night, and will strike all the firstborn in the land of Egypt, both man and animal. I will execute judgments against all the elohims of Egypt. I am Yahuah. 
 <sup>13&#160;</sup>The blood shall be to you for a token on the houses where you are. When I see the blood, I will pass over you, and no plague will be on you to destroy you when I strike the land of Egypt. 
-<sup>14&#160;</sup>This day shall be a memorial for you. You shall keep it as a feast to Yahweh. You shall keep it as a feast throughout your generations by an ordinance forever. 
+<sup>14&#160;</sup>This day shall be a memorial for you. You shall keep it as a feast to Yahuah. You shall keep it as a feast throughout your generations by an ordinance forever. 
 </p><p>
 <sup>15&#160;</sup>“&#160;‘Seven days you shall eat unleavened bread; even the first day you shall put away yeast out of your houses, for whoever eats leavened bread from the first day until the seventh day, that soul shall be cut off from Israel. 
 <sup>16&#160;</sup>In the first day there shall be to you a set-apart convocation, and in the seventh day a set-apart convocation; no kind of work shall be done in them, except that which every man must eat, only that may be done by you. 
@@ -533,110 +533,110 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>21&#160;</sup>Then Moses called for all the elders of Israel, and said to them, “Draw out, and take lambs according to your families, and kill the Passover. 
 <sup>22&#160;</sup>You shall take a bunch of hyssop, and dip it in the blood that is in the basin, and strike the lintel and the two door posts with the blood that is in the basin. None of you shall go out of the door of his house until the morning. 
-<sup>23&#160;</sup>For Yahweh will pass through to strike the Egyptians; and when he sees the blood on the lintel, and on the two door posts, Yahweh will pass over the door, and will not allow the destroyer to come in to your houses to strike you. 
+<sup>23&#160;</sup>For Yahuah will pass through to strike the Egyptians; and when he sees the blood on the lintel, and on the two door posts, Yahuah will pass over the door, and will not allow the destroyer to come in to your houses to strike you. 
 <sup>24&#160;</sup>You shall observe this thing for an ordinance to you and to your sons forever. 
-<sup>25&#160;</sup>It shall happen when you have come to the land which Yahweh will give you, as he has promised, that you shall keep this service. 
+<sup>25&#160;</sup>It shall happen when you have come to the land which Yahuah will give you, as he has promised, that you shall keep this service. 
 <sup>26&#160;</sup>It will happen, when your children ask you, ‘What do you mean by this service?’ 
-<sup>27&#160;</sup>that you shall say, ‘It is the sacrifice of Yahweh’s Passover, who passed over the houses of the children of Israel in Egypt, when he struck the Egyptians, and spared our houses.’&#160;” 
+<sup>27&#160;</sup>that you shall say, ‘It is the sacrifice of Yahuah’s Passover, who passed over the houses of the children of Israel in Egypt, when he struck the Egyptians, and spared our houses.’&#160;” 
 </p><p>The people bowed their heads and worshiped. 
-<sup>28&#160;</sup>The children of Israel went and did so; as Yahweh had commanded Moses and Aaron, so they did. 
+<sup>28&#160;</sup>The children of Israel went and did so; as Yahuah had commanded Moses and Aaron, so they did. 
 </p><p>
-<sup>29&#160;</sup>At midnight, Yahweh struck all the firstborn in the land of Egypt, from the firstborn of Pharaoh who sat on his throne to the firstborn of the captive who was in the dungeon, and all the firstborn of livestock. 
+<sup>29&#160;</sup>At midnight, Yahuah struck all the firstborn in the land of Egypt, from the firstborn of Pharaoh who sat on his throne to the firstborn of the captive who was in the dungeon, and all the firstborn of livestock. 
 <sup>30&#160;</sup>Pharaoh rose up in the night, he, and all his servants, and all the Egyptians; and there was a great cry in Egypt, for there was not a house where there was not one dead. 
-<sup>31&#160;</sup>He called for Moses and Aaron by night, and said, “Rise up, get out from among my people, both you and the children of Israel; and go, serve Yahweh, as you have said! 
+<sup>31&#160;</sup>He called for Moses and Aaron by night, and said, “Rise up, get out from among my people, both you and the children of Israel; and go, serve Yahuah, as you have said! 
 <sup>32&#160;</sup>Take both your flocks and your herds, as you have said, and be gone; and bless me also!” 
 </p><p>
 <sup>33&#160;</sup>The Egyptians were urgent with the people, to send them out of the land in haste, for they said, “We are all dead men.” 
 <sup>34&#160;</sup>The people took their dough before it was leavened, their kneading troughs being bound up in their clothes on their shoulders. 
 <sup>35&#160;</sup>The children of Israel did according to the word of Moses; and they asked of the Egyptians jewels of silver, and jewels of gold, and clothing. 
-<sup>36&#160;</sup>Yahweh gave the people favor in the sight of the Egyptians, so that they let them have what they asked. They plundered the Egyptians. 
+<sup>36&#160;</sup>Yahuah gave the people favor in the sight of the Egyptians, so that they let them have what they asked. They plundered the Egyptians. 
 </p><p>
 <sup>37&#160;</sup>The children of Israel traveled from Rameses to Succoth, about six hundred thousand on foot who were men, in addition to children. 
 <sup>38&#160;</sup>A mixed multitude went up also with them, with flocks, herds, and even very much livestock. 
 <sup>39&#160;</sup>They baked unleavened cakes of the dough which they brought out of Egypt; for it wasn’t leavened, because they were thrust out of Egypt, and couldn’t wait, and they had not prepared any food for themselves. 
 <sup>40&#160;</sup>Now the time that the children of Israel lived in Egypt was four hundred thirty years. 
-<sup>41&#160;</sup>At the end of four hundred thirty years, to the day, all of Yahweh’s armies went out from the land of Egypt. 
-<sup>42&#160;</sup>It is a night to be much observed to Yahweh for bringing them out from the land of Egypt. This is that night of Yahweh, to be much observed by all the children of Israel throughout their generations. 
+<sup>41&#160;</sup>At the end of four hundred thirty years, to the day, all of Yahuah’s armies went out from the land of Egypt. 
+<sup>42&#160;</sup>It is a night to be much observed to Yahuah for bringing them out from the land of Egypt. This is that night of Yahuah, to be much observed by all the children of Israel throughout their generations. 
 </p><p>
-<sup>43&#160;</sup>Yahweh said to Moses and Aaron, “This is the ordinance of the Passover. No foreigner shall eat of it, 
+<sup>43&#160;</sup>Yahuah said to Moses and Aaron, “This is the ordinance of the Passover. No foreigner shall eat of it, 
 <sup>44&#160;</sup>but every man’s servant who is bought for money, when you have circumcised him, then shall he eat of it. 
 <sup>45&#160;</sup>A foreigner and a hired servant shall not eat of it. 
 <sup>46&#160;</sup>It must be eaten in one house. You shall not carry any of the meat outside of the house. Do not break any of its bones. 
 <sup>47&#160;</sup>All the congregation of Israel shall keep it. 
-<sup>48&#160;</sup>When a stranger lives as a foreigner with you, and would like to keep the Passover to Yahweh, let all his males be circumcised, and then let him come near and keep it. He shall be as one who is born in the land; but no uncircumcised person shall eat of it. 
+<sup>48&#160;</sup>When a stranger lives as a foreigner with you, and would like to keep the Passover to Yahuah, let all his males be circumcised, and then let him come near and keep it. He shall be as one who is born in the land; but no uncircumcised person shall eat of it. 
 <sup>49&#160;</sup>One law shall be to him who is born at home, and to the stranger who lives as a foreigner among you.” 
-<sup>50&#160;</sup>All the children of Israel did so. As Yahweh commanded Moses and Aaron, so they did. 
-<sup>51&#160;</sup>That same day, Yahweh brought the children of Israel out of the land of Egypt by their armies. 
+<sup>50&#160;</sup>All the children of Israel did so. As Yahuah commanded Moses and Aaron, so they did. 
+<sup>51&#160;</sup>That same day, Yahuah brought the children of Israel out of the land of Egypt by their armies. 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Sanctify to me all the firstborn, whatever opens the womb among the children of Israel, both of man and of animal. It is mine.” 
 </p><p>
-<sup>3&#160;</sup>Moses said to the people, “Remember this day, in which you came out of Egypt, out of the house of bondage; for by strength of hand Yahweh brought you out from this place. No leavened bread shall be eaten. 
+<sup>3&#160;</sup>Moses said to the people, “Remember this day, in which you came out of Egypt, out of the house of bondage; for by strength of hand Yahuah brought you out from this place. No leavened bread shall be eaten. 
 <sup>4&#160;</sup>Today you go out in the month Abib. 
-<sup>5&#160;</sup>It shall be, when Yahweh brings you into the land of the Canaanite, and the Hittite, and the Amorite, and the Hivite, and the Jebusite, which he swore to your fathers to give you, a land flowing with milk and honey, that you shall keep this service in this month. 
-<sup>6&#160;</sup>Seven days you shall eat unleavened bread, and in the seventh day shall be a feast to Yahweh. 
+<sup>5&#160;</sup>It shall be, when Yahuah brings you into the land of the Canaanite, and the Hittite, and the Amorite, and the Hivite, and the Jebusite, which he swore to your fathers to give you, a land flowing with milk and honey, that you shall keep this service in this month. 
+<sup>6&#160;</sup>Seven days you shall eat unleavened bread, and in the seventh day shall be a feast to Yahuah. 
 <sup>7&#160;</sup>Unleavened bread shall be eaten throughout the seven days; and no leavened bread shall be seen with you. No yeast shall be seen with you, within all your borders. 
-<sup>8&#160;</sup>You shall tell your son in that day, saying, ‘It is because of that which Yahweh did for me when I came out of Egypt.’ 
-<sup>9&#160;</sup>It shall be for a sign to you on your hand, and for a memorial between your eyes, that Yahweh’s law may be in your mouth; for with a strong hand Yahweh has brought you out of Egypt. 
+<sup>8&#160;</sup>You shall tell your son in that day, saying, ‘It is because of that which Yahuah did for me when I came out of Egypt.’ 
+<sup>9&#160;</sup>It shall be for a sign to you on your hand, and for a memorial between your eyes, that Yahuah’s law may be in your mouth; for with a strong hand Yahuah has brought you out of Egypt. 
 <sup>10&#160;</sup>You shall therefore keep this ordinance in its season from year to year. 
 </p><p>
-<sup>11&#160;</sup>“It shall be, when Yahweh brings you into the land of the Canaanite, as he swore to you and to your fathers, and will give it to you, 
-<sup>12&#160;</sup>that you shall set apart to Yahweh all that opens the womb, and every firstborn that comes from an animal which you have. The males shall be Yahweh’s. 
+<sup>11&#160;</sup>“It shall be, when Yahuah brings you into the land of the Canaanite, as he swore to you and to your fathers, and will give it to you, 
+<sup>12&#160;</sup>that you shall set apart to Yahuah all that opens the womb, and every firstborn that comes from an animal which you have. The males shall be Yahuah’s. 
 <sup>13&#160;</sup>Every firstborn of a donkey you shall redeem with a lamb; and if you will not redeem it, then you shall break its neck; and you shall redeem all the firstborn of man among your sons. 
-<sup>14&#160;</sup>It shall be, when your son asks you in time to come, saying, ‘What is this?’ that you shall tell him, ‘By strength of hand Yahweh brought us out from Egypt, from the house of bondage. 
-<sup>15&#160;</sup>When Pharaoh stubbornly refused to let us go, Yahweh killed all the firstborn in the land of Egypt, both the firstborn of man, and the firstborn of livestock. Therefore I sacrifice to Yahweh all that opens the womb, being males; but all the firstborn of my sons I redeem.’ 
-<sup>16&#160;</sup>It shall be for a sign on your hand, and for symbols between your eyes; for by strength of hand Yahweh brought us out of Egypt.” 
+<sup>14&#160;</sup>It shall be, when your son asks you in time to come, saying, ‘What is this?’ that you shall tell him, ‘By strength of hand Yahuah brought us out from Egypt, from the house of bondage. 
+<sup>15&#160;</sup>When Pharaoh stubbornly refused to let us go, Yahuah killed all the firstborn in the land of Egypt, both the firstborn of man, and the firstborn of livestock. Therefore I sacrifice to Yahuah all that opens the womb, being males; but all the firstborn of my sons I redeem.’ 
+<sup>16&#160;</sup>It shall be for a sign on your hand, and for symbols between your eyes; for by strength of hand Yahuah brought us out of Egypt.” 
 </p><p>
 <sup>17&#160;</sup>When Pharaoh had let the people go, Elohim didn’t lead them by the way of the land of the Philistines, although that was near; for Elohim said, “Lest perhaps the people change their minds when they see war, and they return to Egypt”; 
 <sup>18&#160;</sup>but Elohim led the people around by the way of the wilderness by the Red Sea; and the children of Israel went up armed out of the land of Egypt. 
 <sup>19&#160;</sup>Moses took the bones of Joseph with him, for he had made the children of Israel swear, saying, “Elohim will surely visit you, and you shall carry up my bones away from here with you.” 
 <sup>20&#160;</sup>They took their journey from Succoth, and encamped in Etham, in the edge of the wilderness. 
-<sup>21&#160;</sup>Yahweh went before them by day in a pillar of cloud, to lead them on their way, and by night in a pillar of fire, to give them light, that they might go by day and by night: 
+<sup>21&#160;</sup>Yahuah went before them by day in a pillar of cloud, to lead them on their way, and by night in a pillar of fire, to give them light, that they might go by day and by night: 
 <sup>22&#160;</sup>the pillar of cloud by day, and the pillar of fire by night, didn’t depart from before the people. 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Speak to the children of Israel, that they turn back and encamp before Pihahiroth, between Migdol and the sea, before Baal Zephon. You shall encamp opposite it by the sea. 
 <sup>3&#160;</sup>Pharaoh will say of the children of Israel, ‘They are entangled in the land. The wilderness has shut them in.’ 
-<sup>4&#160;</sup>I will harden Pharaoh’s heart, and he will follow after them; and I will get honor over Pharaoh, and over all his armies; and the Egyptians shall know that I am Yahweh.” They did so. 
+<sup>4&#160;</sup>I will harden Pharaoh’s heart, and he will follow after them; and I will get honor over Pharaoh, and over all his armies; and the Egyptians shall know that I am Yahuah.” They did so. 
 </p><p>
 <sup>5&#160;</sup>The king of Egypt was told that the people had fled; and the heart of Pharaoh and of his servants was changed toward the people, and they said, “What is this we have done, that we have let Israel go from serving us?” 
 <sup>6&#160;</sup>He prepared his chariot, and took his army with him; 
 <sup>7&#160;</sup>and he took six hundred chosen chariots, and all the chariots of Egypt, with captains over all of them. 
-<sup>8&#160;</sup>Yahweh hardened the heart of Pharaoh king of Egypt, and he pursued the children of Israel; for the children of Israel went out with a high hand. 
+<sup>8&#160;</sup>Yahuah hardened the heart of Pharaoh king of Egypt, and he pursued the children of Israel; for the children of Israel went out with a high hand. 
 <sup>9&#160;</sup>The Egyptians pursued them. All the horses and chariots of Pharaoh, his horsemen, and his army overtook them encamping by the sea, beside Pihahiroth, before Baal Zephon. 
 </p><p>
-<sup>10&#160;</sup>When Pharaoh came near, the children of Israel lifted up their eyes, and behold, the Egyptians were marching after them; and they were very afraid. The children of Israel cried out to Yahweh. 
+<sup>10&#160;</sup>When Pharaoh came near, the children of Israel lifted up their eyes, and behold, the Egyptians were marching after them; and they were very afraid. The children of Israel cried out to Yahuah. 
 <sup>11&#160;</sup>They said to Moses, “Because there were no graves in Egypt, have you taken us away to die in the wilderness? Why have you treated us this way, to bring us out of Egypt? 
 <sup>12&#160;</sup>Isn’t this the word that we spoke to you in Egypt, saying, ‘Leave us alone, that we may serve the Egyptians’? For it would have been better for us to serve the Egyptians than to die in the wilderness.” 
 </p><p>
-<sup>13&#160;</sup>Moses said to the people, “Don’t be afraid. Stand still, and see the salvation of Yahweh, which he will work for you today; for you will never again see the Egyptians whom you have seen today. 
-<sup>14&#160;</sup>Yahweh will fight for you, and you shall be still.” 
+<sup>13&#160;</sup>Moses said to the people, “Don’t be afraid. Stand still, and see the salvation of Yahuah, which he will work for you today; for you will never again see the Egyptians whom you have seen today. 
+<sup>14&#160;</sup>Yahuah will fight for you, and you shall be still.” 
 </p><p>
-<sup>15&#160;</sup>Yahweh said to Moses, “Why do you cry to me? Speak to the children of Israel, that they go forward. 
+<sup>15&#160;</sup>Yahuah said to Moses, “Why do you cry to me? Speak to the children of Israel, that they go forward. 
 <sup>16&#160;</sup>Lift up your rod, and stretch out your hand over the sea and divide it. Then the children of Israel shall go into the middle of the sea on dry ground. 
 <sup>17&#160;</sup>Behold, I myself will harden the hearts of the Egyptians, and they will go in after them. I will get myself honor over Pharaoh, and over all his armies, over his chariots, and over his horsemen. 
-<sup>18&#160;</sup>The Egyptians shall know that I am Yahweh when I have gotten myself honor over Pharaoh, over his chariots, and over his horsemen.” 
+<sup>18&#160;</sup>The Egyptians shall know that I am Yahuah when I have gotten myself honor over Pharaoh, over his chariots, and over his horsemen.” 
 <sup>19&#160;</sup>The angel of Elohim, who went before the camp of Israel, moved and went behind them; and the pillar of cloud moved from before them, and stood behind them. 
 <sup>20&#160;</sup>It came between the camp of Egypt and the camp of Israel. There was the cloud and the darkness, yet it gave light by night. One didn’t come near the other all night. 
 </p><p>
-<sup>21&#160;</sup>Moses stretched out his hand over the sea, and Yahweh caused the sea to go back by a strong east wind all night, and made the sea dry land, and the waters were divided. 
+<sup>21&#160;</sup>Moses stretched out his hand over the sea, and Yahuah caused the sea to go back by a strong east wind all night, and made the sea dry land, and the waters were divided. 
 <sup>22&#160;</sup>The children of Israel went into the middle of the sea on the dry ground; and the waters were a wall to them on their right hand and on their left. 
 <sup>23&#160;</sup>The Egyptians pursued, and went in after them into the middle of the sea: all of Pharaoh’s horses, his chariots, and his horsemen. 
-<sup>24&#160;</sup>In the morning watch, Yahweh looked out on the Egyptian army through the pillar of fire and of cloud, and confused the Egyptian army. 
-<sup>25&#160;</sup>He took off their chariot wheels, and they drove them heavily; so that the Egyptians said, “Let’s flee from the face of Israel, for Yahweh fights for them against the Egyptians!” 
+<sup>24&#160;</sup>In the morning watch, Yahuah looked out on the Egyptian army through the pillar of fire and of cloud, and confused the Egyptian army. 
+<sup>25&#160;</sup>He took off their chariot wheels, and they drove them heavily; so that the Egyptians said, “Let’s flee from the face of Israel, for Yahuah fights for them against the Egyptians!” 
 </p><p>
-<sup>26&#160;</sup>Yahweh said to Moses, “Stretch out your hand over the sea, that the waters may come again on the Egyptians, on their chariots, and on their horsemen.” 
-<sup>27&#160;</sup>Moses stretched out his hand over the sea, and the sea returned to its strength when the morning appeared; and the Egyptians fled against it. Yahweh overthrew the Egyptians in the middle of the sea. 
+<sup>26&#160;</sup>Yahuah said to Moses, “Stretch out your hand over the sea, that the waters may come again on the Egyptians, on their chariots, and on their horsemen.” 
+<sup>27&#160;</sup>Moses stretched out his hand over the sea, and the sea returned to its strength when the morning appeared; and the Egyptians fled against it. Yahuah overthrew the Egyptians in the middle of the sea. 
 <sup>28&#160;</sup>The waters returned, and covered the chariots and the horsemen, even all Pharaoh’s army that went in after them into the sea. There remained not so much as one of them. 
 <sup>29&#160;</sup>But the children of Israel walked on dry land in the middle of the sea, and the waters were a wall to them on their right hand and on their left. 
-<sup>30&#160;</sup>Thus Yahweh saved Israel that day out of the hand of the Egyptians; and Israel saw the Egyptians dead on the seashore. 
-<sup>31&#160;</sup>Israel saw the great work which Yahweh did to the Egyptians, and the people feared Yahweh; and they believed in Yahweh and in his servant Moses. 
+<sup>30&#160;</sup>Thus Yahuah saved Israel that day out of the hand of the Egyptians; and Israel saw the Egyptians dead on the seashore. 
+<sup>31&#160;</sup>Israel saw the great work which Yahuah did to the Egyptians, and the people feared Yahuah; and they believed in Yahuah and in his servant Moses. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
-<sup>1&#160;</sup>Then Moses and the children of Israel sang this song to Yahweh, and said, 
-</p><p class="q1">“I will sing to Yahweh, for he has triumphed gloriously. 
+<sup>1&#160;</sup>Then Moses and the children of Israel sang this song to Yahuah, and said, 
+</p><p class="q1">“I will sing to Yahuah, for he has triumphed gloriously. 
 </p><p class="q2">He has thrown the horse and his rider into the sea. 
 </p><p class="q1">
 <sup>2&#160;</sup>Yah is my strength and song. 
@@ -644,8 +644,8 @@ html[dir=ltr] .q2 {
 </p><p class="q1">This is my Elohim, and I will praise him; 
 </p><p class="q2">my father’s Elohim, and I will exalt him. 
 </p><p class="q1">
-<sup>3&#160;</sup>Yahweh is a man of war. 
-</p><p class="q2">Yahweh is his name. 
+<sup>3&#160;</sup>Yahuah is a man of war. 
+</p><p class="q2">Yahuah is his name. 
 </p><p class="q1">
 <sup>4&#160;</sup>He has cast Pharaoh’s chariots and his army into the sea. 
 </p><p class="q2">His chosen captains are sunk in the Red Sea. 
@@ -653,8 +653,8 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>The deeps cover them. 
 </p><p class="q2">They went down into the depths like a stone. 
 </p><p class="q1">
-<sup>6&#160;</sup>Your right hand, Yahweh, is glorious in power. 
-</p><p class="q2">Your right hand, Yahweh, dashes the enemy in pieces. 
+<sup>6&#160;</sup>Your right hand, Yahuah, is glorious in power. 
+</p><p class="q2">Your right hand, Yahuah, dashes the enemy in pieces. 
 </p><p class="q1">
 <sup>7&#160;</sup>In the greatness of your excellency, you overthrow those who rise up against you. 
 </p><p class="q2">You send out your wrath. It consumes them as stubble. 
@@ -671,7 +671,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">The sea covered them. 
 </p><p class="q2">They sank like lead in the mighty waters. 
 </p><p class="q1">
-<sup>11&#160;</sup>Who is like you, Yahweh, among the elohims? 
+<sup>11&#160;</sup>Who is like you, Yahuah, among the elohims? 
 </p><p class="q2">Who is like you, glorious in set-apartness, 
 </p><p class="q2">fearful in praises, doing wonders? 
 </p><p class="q1">
@@ -691,83 +691,83 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>16&#160;</sup>Terror and dread falls on them. 
 </p><p class="q2">By the greatness of your arm they are as still as a stone, 
-</p><p class="q2">until your people pass over, Yahweh, 
+</p><p class="q2">until your people pass over, Yahuah, 
 </p><p class="q2">until the people you have purchased pass over. 
 </p><p class="q2">
 <sup>17&#160;</sup>You will bring them in, and plant them in the mountain of your inheritance, 
-</p><p class="q2">the place, Yahweh, which you have made for yourself to dwell in: 
+</p><p class="q2">the place, Yahuah, which you have made for yourself to dwell in: 
 </p><p class="q2">the sanctuary, Lord, which your hands have established. 
 </p><p class="q1">
-<sup>18&#160;</sup>Yahweh will reign forever and ever.” 
+<sup>18&#160;</sup>Yahuah will reign forever and ever.” 
 </p><p>
-<sup>19&#160;</sup>For the horses of Pharaoh went in with his chariots and with his horsemen into the sea, and Yahweh brought back the waters of the sea on them; but the children of Israel walked on dry land in the middle of the sea. 
+<sup>19&#160;</sup>For the horses of Pharaoh went in with his chariots and with his horsemen into the sea, and Yahuah brought back the waters of the sea on them; but the children of Israel walked on dry land in the middle of the sea. 
 <sup>20&#160;</sup>Miriam the prophetess, the sister of Aaron, took a tambourine in her hand; and all the women went out after her with tambourines and with dances. 
 <sup>21&#160;</sup>Miriam answered them, 
-</p><p class="q1">“Sing to Yahweh, for he has triumphed gloriously. 
+</p><p class="q1">“Sing to Yahuah, for he has triumphed gloriously. 
 </p><p class="q1">He has thrown the horse and his rider into the sea.” 
 </p><p>
 <sup>22&#160;</sup>Moses led Israel onward from the Red Sea, and they went out into the wilderness of Shur; and they went three days in the wilderness, and found no water. 
 <sup>23&#160;</sup>When they came to Marah, they couldn’t drink from the waters of Marah, for they were bitter. Therefore its name was called Marah. 
 <sup>24&#160;</sup>The people murmured against Moses, saying, “What shall we drink?” 
-<sup>25&#160;</sup>Then he cried to Yahweh. Yahweh showed him a tree, and he threw it into the waters, and the waters were made sweet. There he made a statute and an ordinance for them, and there he tested them. 
-<sup>26&#160;</sup>He said, “If you will diligently listen to Yahweh your Elohim’s voice, and will do that which is right in his eyes, and will pay attention to his commandments, and keep all his statutes, I will put none of the diseases on you which I have put on the Egyptians; for I am Yahweh who heals you.” 
+<sup>25&#160;</sup>Then he cried to Yahuah. Yahuah showed him a tree, and he threw it into the waters, and the waters were made sweet. There he made a statute and an ordinance for them, and there he tested them. 
+<sup>26&#160;</sup>He said, “If you will diligently listen to Yahuah your Elohim’s voice, and will do that which is right in his eyes, and will pay attention to his commandments, and keep all his statutes, I will put none of the diseases on you which I have put on the Egyptians; for I am Yahuah who heals you.” 
 </p><p>
 <sup>27&#160;</sup>They came to Elim, where there were twelve springs of water and seventy palm trees. They encamped there by the waters. 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
 <sup>1&#160;</sup>They took their journey from Elim, and all the congregation of the children of Israel came to the wilderness of Sin, which is between Elim and Sinai, on the fifteenth day of the second month after their departing out of the land of Egypt. 
 <sup>2&#160;</sup>The whole congregation of the children of Israel murmured against Moses and against Aaron in the wilderness; 
-<sup>3&#160;</sup>and the children of Israel said to them, “We wish that we had died by Yahweh’s hand in the land of Egypt, when we sat by the meat pots, when we ate our fill of bread, for you have brought us out into this wilderness to kill this whole assembly with hunger.” 
+<sup>3&#160;</sup>and the children of Israel said to them, “We wish that we had died by Yahuah’s hand in the land of Egypt, when we sat by the meat pots, when we ate our fill of bread, for you have brought us out into this wilderness to kill this whole assembly with hunger.” 
 </p><p>
-<sup>4&#160;</sup>Then Yahweh said to Moses, “Behold, I will rain bread from the sky for you, and the people shall go out and gather a day’s portion every day, that I may test them, whether they will walk in my law or not. 
+<sup>4&#160;</sup>Then Yahuah said to Moses, “Behold, I will rain bread from the sky for you, and the people shall go out and gather a day’s portion every day, that I may test them, whether they will walk in my law or not. 
 <sup>5&#160;</sup>It shall come to pass on the sixth day, that they shall prepare that which they bring in, and it shall be twice as much as they gather daily.” 
 </p><p>
-<sup>6&#160;</sup>Moses and Aaron said to all the children of Israel, “At evening, you shall know that Yahweh has brought you out from the land of Egypt. 
-<sup>7&#160;</sup>In the morning, you shall see Yahweh’s glory; because he hears your murmurings against Yahweh. Who are we, that you murmur against us?” 
-<sup>8&#160;</sup>Moses said, “Now Yahweh will give you meat to eat in the evening, and in the morning bread to satisfy you, because Yahweh hears your murmurings which you murmur against him. And who are we? Your murmurings are not against us, but against Yahweh.” 
-<sup>9&#160;</sup>Moses said to Aaron, “Tell all the congregation of the children of Israel, ‘Come close to Yahweh, for he has heard your murmurings.’&#160;” 
-<sup>10&#160;</sup>As Aaron spoke to the whole congregation of the children of Israel, they looked toward the wilderness, and behold, Yahweh’s glory appeared in the cloud. 
-<sup>11&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>12&#160;</sup>“I have heard the murmurings of the children of Israel. Speak to them, saying, ‘At evening you shall eat meat, and in the morning you shall be filled with bread. Then you will know that I am Yahweh your Elohim.’&#160;” 
+<sup>6&#160;</sup>Moses and Aaron said to all the children of Israel, “At evening, you shall know that Yahuah has brought you out from the land of Egypt. 
+<sup>7&#160;</sup>In the morning, you shall see Yahuah’s glory; because he hears your murmurings against Yahuah. Who are we, that you murmur against us?” 
+<sup>8&#160;</sup>Moses said, “Now Yahuah will give you meat to eat in the evening, and in the morning bread to satisfy you, because Yahuah hears your murmurings which you murmur against him. And who are we? Your murmurings are not against us, but against Yahuah.” 
+<sup>9&#160;</sup>Moses said to Aaron, “Tell all the congregation of the children of Israel, ‘Come close to Yahuah, for he has heard your murmurings.’&#160;” 
+<sup>10&#160;</sup>As Aaron spoke to the whole congregation of the children of Israel, they looked toward the wilderness, and behold, Yahuah’s glory appeared in the cloud. 
+<sup>11&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>12&#160;</sup>“I have heard the murmurings of the children of Israel. Speak to them, saying, ‘At evening you shall eat meat, and in the morning you shall be filled with bread. Then you will know that I am Yahuah your Elohim.’&#160;” 
 </p><p>
 <sup>13&#160;</sup>In the evening, quail came up and covered the camp; and in the morning the dew lay around the camp. 
 <sup>14&#160;</sup>When the dew that lay had gone, behold, on the surface of the wilderness was a small round thing, small as the frost on the ground. 
-<sup>15&#160;</sup>When the children of Israel saw it, they said to one another, “What is it?” For they didn’t know what it was. Moses said to them, “It is the bread which Yahweh has given you to eat. 
-<sup>16&#160;</sup>This is the thing which Yahweh has commanded: ‘Gather of it everyone according to his eating; an omer a head, according to the number of your persons, you shall take it, every man for those who are in his tent.’&#160;” 
+<sup>15&#160;</sup>When the children of Israel saw it, they said to one another, “What is it?” For they didn’t know what it was. Moses said to them, “It is the bread which Yahuah has given you to eat. 
+<sup>16&#160;</sup>This is the thing which Yahuah has commanded: ‘Gather of it everyone according to his eating; an omer a head, according to the number of your persons, you shall take it, every man for those who are in his tent.’&#160;” 
 <sup>17&#160;</sup>The children of Israel did so, and some gathered more, some less. 
 <sup>18&#160;</sup>When they measured it with an omer, he who gathered much had nothing over, and he who gathered little had no lack. They each gathered according to his eating. 
 <sup>19&#160;</sup>Moses said to them, “Let no one leave of it until the morning.” 
 <sup>20&#160;</sup>Notwithstanding they didn’t listen to Moses, but some of them left of it until the morning, so it bred worms and became foul; and Moses was angry with them. 
 <sup>21&#160;</sup>They gathered it morning by morning, everyone according to his eating. When the sun grew hot, it melted. 
 <sup>22&#160;</sup>On the sixth day, they gathered twice as much bread, two omers for each one; and all the rulers of the congregation came and told Moses. 
-<sup>23&#160;</sup>He said to them, “This is that which Yahweh has spoken, ‘Tomorrow is a solemn rest, a set-apart Sabbath to Yahweh. Bake that which you want to bake, and boil that which you want to boil; and all that remains over lay up for yourselves to be kept until the morning.’&#160;” 
+<sup>23&#160;</sup>He said to them, “This is that which Yahuah has spoken, ‘Tomorrow is a solemn rest, a set-apart Sabbath to Yahuah. Bake that which you want to bake, and boil that which you want to boil; and all that remains over lay up for yourselves to be kept until the morning.’&#160;” 
 <sup>24&#160;</sup>They laid it up until the morning, as Moses ordered, and it didn’t become foul, and there were no worms in it. 
-<sup>25&#160;</sup>Moses said, “Eat that today, for today is a Sabbath to Yahweh. Today you shall not find it in the field. 
+<sup>25&#160;</sup>Moses said, “Eat that today, for today is a Sabbath to Yahuah. Today you shall not find it in the field. 
 <sup>26&#160;</sup>Six days you shall gather it, but on the seventh day is the Sabbath. In it there shall be none.” 
 <sup>27&#160;</sup>On the seventh day, some of the people went out to gather, and they found none. 
-<sup>28&#160;</sup>Yahweh said to Moses, “How long do you refuse to keep my commandments and my laws? 
-<sup>29&#160;</sup>Behold, because Yahweh has given you the Sabbath, therefore he gives you on the sixth day the bread of two days. Everyone stay in his place. Let no one go out of his place on the seventh day.” 
+<sup>28&#160;</sup>Yahuah said to Moses, “How long do you refuse to keep my commandments and my laws? 
+<sup>29&#160;</sup>Behold, because Yahuah has given you the Sabbath, therefore he gives you on the sixth day the bread of two days. Everyone stay in his place. Let no one go out of his place on the seventh day.” 
 <sup>30&#160;</sup>So the people rested on the seventh day. 
 </p><p>
 <sup>31&#160;</sup>The house of Israel called its name “Manna”, and it was like coriander seed, white; and its taste was like wafers with honey. 
-<sup>32&#160;</sup>Moses said, “This is the thing which Yahweh has commanded, ‘Let an omer-full of it be kept throughout your generations, that they may see the bread with which I fed you in the wilderness, when I brought you out of the land of Egypt.’&#160;” 
-<sup>33&#160;</sup>Moses said to Aaron, “Take a pot, and put an omer-full of manna in it, and lay it up before Yahweh, to be kept throughout your generations.” 
-<sup>34&#160;</sup>As Yahweh commanded Moses, so Aaron laid it up before the Testimony, to be kept. 
+<sup>32&#160;</sup>Moses said, “This is the thing which Yahuah has commanded, ‘Let an omer-full of it be kept throughout your generations, that they may see the bread with which I fed you in the wilderness, when I brought you out of the land of Egypt.’&#160;” 
+<sup>33&#160;</sup>Moses said to Aaron, “Take a pot, and put an omer-full of manna in it, and lay it up before Yahuah, to be kept throughout your generations.” 
+<sup>34&#160;</sup>As Yahuah commanded Moses, so Aaron laid it up before the Testimony, to be kept. 
 <sup>35&#160;</sup>The children of Israel ate the manna forty years, until they came to an inhabited land. They ate the manna until they came to the borders of the land of Canaan. 
 <sup>36&#160;</sup>Now an omer is one tenth of an ephah. 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
-<sup>1&#160;</sup>All the congregation of the children of Israel traveled from the wilderness of Sin, starting according to Yahweh’s commandment, and encamped in Rephidim; but there was no water for the people to drink. 
+<sup>1&#160;</sup>All the congregation of the children of Israel traveled from the wilderness of Sin, starting according to Yahuah’s commandment, and encamped in Rephidim; but there was no water for the people to drink. 
 <sup>2&#160;</sup>Therefore the people quarreled with Moses, and said, “Give us water to drink.” 
-</p><p>Moses said to them, “Why do you quarrel with me? Why do you test Yahweh?” 
+</p><p>Moses said to them, “Why do you quarrel with me? Why do you test Yahuah?” 
 </p><p>
 <sup>3&#160;</sup>The people were thirsty for water there; so the people murmured against Moses, and said, “Why have you brought us up out of Egypt, to kill us, our children, and our livestock with thirst?” 
 </p><p>
-<sup>4&#160;</sup>Moses cried to Yahweh, saying, “What shall I do with these people? They are almost ready to stone me.” 
+<sup>4&#160;</sup>Moses cried to Yahuah, saying, “What shall I do with these people? They are almost ready to stone me.” 
 </p><p>
-<sup>5&#160;</sup>Yahweh said to Moses, “Walk on before the people, and take the elders of Israel with you, and take the rod in your hand with which you struck the Nile, and go. 
+<sup>5&#160;</sup>Yahuah said to Moses, “Walk on before the people, and take the elders of Israel with you, and take the rod in your hand with which you struck the Nile, and go. 
 <sup>6&#160;</sup>Behold, I will stand before you there on the rock in Horeb. You shall strike the rock, and water will come out of it, that the people may drink.” Moses did so in the sight of the elders of Israel. 
-<sup>7&#160;</sup>He called the name of the place Massah, and Meribah, because the children of Israel quarreled, and because they tested Yahweh, saying, “Is Yahweh among us, or not?” 
+<sup>7&#160;</sup>He called the name of the place Massah, and Meribah, because the children of Israel quarreled, and because they tested Yahuah, saying, “Is Yahuah among us, or not?” 
 </p><p>
 <sup>8&#160;</sup>Then Amalek came and fought with Israel in Rephidim. 
 <sup>9&#160;</sup>Moses said to Joshua, “Choose men for us, and go out to fight with Amalek. Tomorrow I will stand on the top of the hill with Elohim’s rod in my hand.” 
@@ -775,12 +775,12 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>When Moses held up his hand, Israel prevailed. When he let down his hand, Amalek prevailed. 
 <sup>12&#160;</sup>But Moses’ hands were heavy; so they took a stone, and put it under him, and he sat on it. Aaron and Hur held up his hands, the one on the one side, and the other on the other side. His hands were steady until sunset. 
 <sup>13&#160;</sup>Joshua defeated Amalek and his people with the edge of the sword. 
-<sup>14&#160;</sup>Yahweh said to Moses, “Write this for a memorial in a book, and rehearse it in the ears of Joshua: that I will utterly blot out the memory of Amalek from under the sky.” 
-<sup>15&#160;</sup>Moses built an altar, and called its name “Yahweh our Banner”. 
-<sup>16&#160;</sup>He said, “Yah has sworn: ‘Yahweh will have war with Amalek from generation to generation.’&#160;” 
+<sup>14&#160;</sup>Yahuah said to Moses, “Write this for a memorial in a book, and rehearse it in the ears of Joshua: that I will utterly blot out the memory of Amalek from under the sky.” 
+<sup>15&#160;</sup>Moses built an altar, and called its name “Yahuah our Banner”. 
+<sup>16&#160;</sup>He said, “Yah has sworn: ‘Yahuah will have war with Amalek from generation to generation.’&#160;” 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
-<sup>1&#160;</sup>Now Jethro, the priest of Midian, Moses’ father-in-law, heard of all that Elohim had done for Moses and for Israel his people, how Yahweh had brought Israel out of Egypt. 
+<sup>1&#160;</sup>Now Jethro, the priest of Midian, Moses’ father-in-law, heard of all that Elohim had done for Moses and for Israel his people, how Yahuah had brought Israel out of Egypt. 
 <sup>2&#160;</sup>Jethro, Moses’ father-in-law, received Zipporah, Moses’ woman, after he had sent her away, 
 <sup>3&#160;</sup>and her two sons. The name of one son was Gershom, for Moses said, “I have lived as a foreigner in a foreign land”. 
 <sup>4&#160;</sup>The name of the other was Eliezer, for he said, “My father’s Elohim was my help and delivered me from Pharaoh’s sword.” 
@@ -788,10 +788,10 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>He said to Moses, “I, your father-in-law Jethro, have come to you with your woman, and her two sons with her.” 
 </p><p>
 <sup>7&#160;</sup>Moses went out to meet his father-in-law, and bowed and kissed him. They asked each other of their welfare, and they came into the tent. 
-<sup>8&#160;</sup>Moses told his father-in-law all that Yahweh had done to Pharaoh and to the Egyptians for Israel’s sake, all the hardships that had come on them on the way, and how Yahweh delivered them. 
-<sup>9&#160;</sup>Jethro rejoiced for all the goodness which Yahweh had done to Israel, in that he had delivered them out of the hand of the Egyptians. 
-<sup>10&#160;</sup>Jethro said, “Blessed be Yahweh, who has delivered you out of the hand of the Egyptians, and out of the hand of Pharaoh; who has delivered the people from under the hand of the Egyptians. 
-<sup>11&#160;</sup>Now I know that Yahweh is greater than all elohims because of the way that they treated people arrogantly.” 
+<sup>8&#160;</sup>Moses told his father-in-law all that Yahuah had done to Pharaoh and to the Egyptians for Israel’s sake, all the hardships that had come on them on the way, and how Yahuah delivered them. 
+<sup>9&#160;</sup>Jethro rejoiced for all the goodness which Yahuah had done to Israel, in that he had delivered them out of the hand of the Egyptians. 
+<sup>10&#160;</sup>Jethro said, “Blessed be Yahuah, who has delivered you out of the hand of the Egyptians, and out of the hand of Pharaoh; who has delivered the people from under the hand of the Egyptians. 
+<sup>11&#160;</sup>Now I know that Yahuah is greater than all elohims because of the way that they treated people arrogantly.” 
 <sup>12&#160;</sup>Jethro, Moses’ father-in-law, took a burnt offering and sacrifices for Elohim. Aaron came with all the elders of Israel, to eat bread with Moses’ father-in-law before Elohim. 
 </p><p>
 <sup>13&#160;</sup>On the next day, Moses sat to judge the people, and the people stood around Moses from the morning to the evening. 
@@ -815,17 +815,17 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>In the third month after the children of Israel had gone out of the land of Egypt, on that same day they came into the wilderness of Sinai. 
 <sup>2&#160;</sup>When they had departed from Rephidim, and had come to the wilderness of Sinai, they encamped in the wilderness; and there Israel encamped before the mountain. 
-<sup>3&#160;</sup>Moses went up to Elohim, and Yahweh called to him out of the mountain, saying, “This is what you shall tell the house of Jacob, and tell the children of Israel: 
+<sup>3&#160;</sup>Moses went up to Elohim, and Yahuah called to him out of the mountain, saying, “This is what you shall tell the house of Jacob, and tell the children of Israel: 
 <sup>4&#160;</sup>‘You have seen what I did to the Egyptians, and how I bore you on eagles’ wings, and brought you to myself. 
 <sup>5&#160;</sup>Now therefore, if you will indeed obey my voice and keep my covenant, then you shall be my own possession from among all peoples; for all the earth is mine; 
 <sup>6&#160;</sup>and you shall be to me a kingdom of priests and a set-apart nation.’ These are the words which you shall speak to the children of Israel.” 
 </p><p>
-<sup>7&#160;</sup>Moses came and called for the elders of the people, and set before them all these words which Yahweh commanded him. 
-<sup>8&#160;</sup>All the people answered together, and said, “All that Yahweh has spoken we will do.” 
-</p><p>Moses reported the words of the people to Yahweh. 
-<sup>9&#160;</sup>Yahweh said to Moses, “Behold, I come to you in a thick cloud, that the people may hear when I speak with you, and may also believe you forever.” Moses told the words of the people to Yahweh. 
-<sup>10&#160;</sup>Yahweh said to Moses, “Go to the people, and sanctify them today and tomorrow, and let them wash their garments, 
-<sup>11&#160;</sup>and be ready for the third day; for on the third day Yahweh will come down in the sight of all the people on Mount Sinai. 
+<sup>7&#160;</sup>Moses came and called for the elders of the people, and set before them all these words which Yahuah commanded him. 
+<sup>8&#160;</sup>All the people answered together, and said, “All that Yahuah has spoken we will do.” 
+</p><p>Moses reported the words of the people to Yahuah. 
+<sup>9&#160;</sup>Yahuah said to Moses, “Behold, I come to you in a thick cloud, that the people may hear when I speak with you, and may also believe you forever.” Moses told the words of the people to Yahuah. 
+<sup>10&#160;</sup>Yahuah said to Moses, “Go to the people, and sanctify them today and tomorrow, and let them wash their garments, 
+<sup>11&#160;</sup>and be ready for the third day; for on the third day Yahuah will come down in the sight of all the people on Mount Sinai. 
 <sup>12&#160;</sup>You shall set bounds to the people all around, saying, ‘Be careful that you don’t go up onto the mountain, or touch its border. Whoever touches the mountain shall be surely put to death. 
 <sup>13&#160;</sup>No hand shall touch him, but he shall surely be stoned or shot through; whether it is animal or man, he shall not live.’ When the trumpet sounds long, they shall come up to the mountain.” 
 </p><p>
@@ -834,37 +834,37 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>16&#160;</sup>On the third day, when it was morning, there were thunders and lightnings, and a thick cloud on the mountain, and the sound of an exceedingly loud trumpet; and all the people who were in the camp trembled. 
 <sup>17&#160;</sup>Moses led the people out of the camp to meet Elohim; and they stood at the lower part of the mountain. 
-<sup>18&#160;</sup>All of Mount Sinai smoked, because Yahweh descended on it in fire; and its smoke ascended like the smoke of a furnace, and the whole mountain quaked greatly. 
+<sup>18&#160;</sup>All of Mount Sinai smoked, because Yahuah descended on it in fire; and its smoke ascended like the smoke of a furnace, and the whole mountain quaked greatly. 
 <sup>19&#160;</sup>When the sound of the trumpet grew louder and louder, Moses spoke, and Elohim answered him by a voice. 
-<sup>20&#160;</sup>Yahweh came down on Mount Sinai, to the top of the mountain. Yahweh called Moses to the top of the mountain, and Moses went up. 
+<sup>20&#160;</sup>Yahuah came down on Mount Sinai, to the top of the mountain. Yahuah called Moses to the top of the mountain, and Moses went up. 
 </p><p>
-<sup>21&#160;</sup>Yahweh said to Moses, “Go down, warn the people, lest they break through to Yahweh to gaze, and many of them perish. 
-<sup>22&#160;</sup>Let the priests also, who come near to Yahweh, sanctify themselves, lest Yahweh break out on them.” 
+<sup>21&#160;</sup>Yahuah said to Moses, “Go down, warn the people, lest they break through to Yahuah to gaze, and many of them perish. 
+<sup>22&#160;</sup>Let the priests also, who come near to Yahuah, sanctify themselves, lest Yahuah break out on them.” 
 </p><p>
-<sup>23&#160;</sup>Moses said to Yahweh, “The people can’t come up to Mount Sinai, for you warned us, saying, ‘Set bounds around the mountain, and sanctify it.’&#160;” 
+<sup>23&#160;</sup>Moses said to Yahuah, “The people can’t come up to Mount Sinai, for you warned us, saying, ‘Set bounds around the mountain, and sanctify it.’&#160;” 
 </p><p>
-<sup>24&#160;</sup>Yahweh said to him, “Go down! You shall bring Aaron up with you, but don’t let the priests and the people break through to come up to Yahweh, lest he break out against them.” 
+<sup>24&#160;</sup>Yahuah said to him, “Go down! You shall bring Aaron up with you, but don’t let the priests and the people break through to come up to Yahuah, lest he break out against them.” 
 </p><p>
 <sup>25&#160;</sup>So Moses went down to the people, and told them. 
 </p><h2 class="chapterlabel" id="20">20</h2>
 <p>
 <sup>1&#160;</sup>Elohim spoke all these words, saying, 
-<sup>2&#160;</sup>“I am Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
+<sup>2&#160;</sup>“I am Yahuah your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
 </p><p>
 <sup>3&#160;</sup>“You shall have no other elohims before me. 
 </p><p>
 <sup>4&#160;</sup>“You shall not make for yourselves an idol, nor any image of anything that is in the heavens above, or that is in the earth beneath, or that is in the water under the earth: 
-<sup>5&#160;</sup>you shall not bow yourself down to them, nor serve them, for I, Yahweh your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children, on the third and on the fourth generation of those who hate me, 
+<sup>5&#160;</sup>you shall not bow yourself down to them, nor serve them, for I, Yahuah your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children, on the third and on the fourth generation of those who hate me, 
 <sup>6&#160;</sup>and showing loving kindness to thousands of those who love me and keep my commandments. 
 </p><p>
-<sup>7&#160;</sup>“You shall not misuse the name of Yahweh your Elohim, for Yahweh will not hold him guiltless who misuses his name. 
+<sup>7&#160;</sup>“You shall not misuse the name of Yahuah your Elohim, for Yahuah will not hold him guiltless who misuses his name. 
 </p><p>
 <sup>8&#160;</sup>“Remember the Sabbath day, to keep it set-apart. 
 <sup>9&#160;</sup>You shall labor six days, and do all your work, 
-<sup>10&#160;</sup>but the seventh day is a Sabbath to Yahweh your Elohim. You shall not do any work in it, you, nor your son, nor your daughter, your male servant, nor your female servant, nor your livestock, nor your stranger who is within your gates; 
-<sup>11&#160;</sup>for in six days Yahweh made heaven and earth, the sea, and all that is in them, and rested the seventh day; therefore Yahweh blessed the Sabbath day, and made it set-apart. 
+<sup>10&#160;</sup>but the seventh day is a Sabbath to Yahuah your Elohim. You shall not do any work in it, you, nor your son, nor your daughter, your male servant, nor your female servant, nor your livestock, nor your stranger who is within your gates; 
+<sup>11&#160;</sup>for in six days Yahuah made heaven and earth, the sea, and all that is in them, and rested the seventh day; therefore Yahuah blessed the Sabbath day, and made it set-apart. 
 </p><p>
-<sup>12&#160;</sup>“Honor your father and your mother, that your days may be long in the land which Yahweh your Elohim gives you. 
+<sup>12&#160;</sup>“Honor your father and your mother, that your days may be long in the land which Yahuah your Elohim gives you. 
 </p><p>
 <sup>13&#160;</sup>“You shall not murder. 
 </p><p>
@@ -882,7 +882,7 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>Moses said to the people, “Don’t be afraid, for Elohim has come to test you, and that his fear may be before you, that you won’t sin.” 
 <sup>21&#160;</sup>The people stayed at a distance, and Moses came near to the thick darkness where Elohim was. 
 </p><p>
-<sup>22&#160;</sup>Yahweh said to Moses, “This is what you shall tell the children of Israel: ‘You yourselves have seen that I have talked with you from heaven. 
+<sup>22&#160;</sup>Yahuah said to Moses, “This is what you shall tell the children of Israel: ‘You yourselves have seen that I have talked with you from heaven. 
 <sup>23&#160;</sup>You shall most certainly not make elohims of silver or elohims of gold for yourselves to be alongside me. 
 <sup>24&#160;</sup>You shall make an altar of earth for me, and shall sacrifice on it your burnt offerings and your peace offerings, your sheep and your cattle. In every place where I record my name I will come to you and I will bless you. 
 <sup>25&#160;</sup>If you make me an altar of stone, you shall not build it of cut stones; for if you lift up your tool on it, you have polluted it. 
@@ -954,7 +954,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>For every matter of trespass, whether it is for ox, for donkey, for sheep, for clothing, or for any kind of lost thing, about which one says, ‘This is mine,’ the cause of both parties shall come before Elohim. He whom Elohim condemns shall pay double to his neighbor. 
 </p><p>
 <sup>10&#160;</sup>“If a man delivers to his neighbor a donkey, an ox, a sheep, or any animal to keep, and it dies or is injured, or driven away, no man seeing it; 
-<sup>11&#160;</sup>the oath of Yahweh shall be between them both, he has not put his hand on his neighbor’s goods; and its owner shall accept it, and he shall not make restitution. 
+<sup>11&#160;</sup>the oath of Yahuah shall be between them both, he has not put his hand on his neighbor’s goods; and its owner shall accept it, and he shall not make restitution. 
 <sup>12&#160;</sup>But if it is stolen from him, the one who stole shall make restitution to its owner. 
 <sup>13&#160;</sup>If it is torn in pieces, let him bring it for evidence. He shall not make good that which was torn. 
 </p><p>
@@ -968,7 +968,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>19&#160;</sup>“Whoever has sex with an animal shall surely be put to death. 
 </p><p>
-<sup>20&#160;</sup>“He who sacrifices to any elohim, except to Yahweh only, shall be utterly destroyed. 
+<sup>20&#160;</sup>“He who sacrifices to any elohim, except to Yahuah only, shall be utterly destroyed. 
 </p><p>
 <sup>21&#160;</sup>“You shall not wrong an alien or oppress him, for you were aliens in the land of Egypt. 
 </p><p>
@@ -1015,11 +1015,11 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>“You shall observe a feast to me three times a year. 
 <sup>15&#160;</sup>You shall observe the feast of unleavened bread. Seven days you shall eat unleavened bread, as I commanded you, at the time appointed in the month Abib (for in it you came out of Egypt), and no one shall appear before me empty. 
 <sup>16&#160;</sup>And the feast of harvest, the first fruits of your labors, which you sow in the field; and the feast of ingathering, at the end of the year, when you gather in your labors out of the field. 
-<sup>17&#160;</sup>Three times in the year all your males shall appear before the Lord Yahweh. 
+<sup>17&#160;</sup>Three times in the year all your males shall appear before the Lord Yahuah. 
 </p><p>
 <sup>18&#160;</sup>“You shall not offer the blood of my sacrifice with leavened bread. The fat of my feast shall not remain all night until the morning. 
 </p><p>
-<sup>19&#160;</sup>You shall bring the first of the first fruits of your ground into the house of Yahweh your Elohim. 
+<sup>19&#160;</sup>You shall bring the first of the first fruits of your ground into the house of Yahuah your Elohim. 
 </p><p>“You shall not boil a young goat in its mother’s milk. 
 </p><p>
 <sup>20&#160;</sup>“Behold, I send an angel before you, to keep you by the way, and to bring you into the place which I have prepared. 
@@ -1027,7 +1027,7 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>But if you indeed listen to his voice, and do all that I speak, then I will be an enemy to your enemies, and an adversary to your adversaries. 
 <sup>23&#160;</sup>For my angel shall go before you, and bring you in to the Amorite, the Hittite, the Perizzite, the Canaanite, the Hivite, and the Jebusite; and I will cut them off. 
 <sup>24&#160;</sup>You shall not bow down to their elohims, nor serve them, nor follow their practices, but you shall utterly overthrow them and demolish their pillars. 
-<sup>25&#160;</sup>You shall serve Yahweh your Elohim, and he will bless your bread and your water, and I will take sickness away from among you. 
+<sup>25&#160;</sup>You shall serve Yahuah your Elohim, and he will bless your bread and your water, and I will take sickness away from among you. 
 <sup>26&#160;</sup>No one will miscarry or be barren in your land. I will fulfill the number of your days. 
 <sup>27&#160;</sup>I will send my terror before you, and will confuse all the people to whom you come, and I will make all your enemies turn their backs to you. 
 <sup>28&#160;</sup>I will send the hornet before you, which will drive out the Hivite, the Canaanite, and the Hittite, from before you. 
@@ -1038,34 +1038,34 @@ html[dir=ltr] .q2 {
 <sup>33&#160;</sup>They shall not dwell in your land, lest they make you sin against me, for if you serve their elohims, it will surely be a snare to you.” 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
-<sup>1&#160;</sup>He said to Moses, “Come up to Yahweh, you, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel; and worship from a distance. 
-<sup>2&#160;</sup>Moses alone shall come near to Yahweh, but they shall not come near. The people shall not go up with him.” 
+<sup>1&#160;</sup>He said to Moses, “Come up to Yahuah, you, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel; and worship from a distance. 
+<sup>2&#160;</sup>Moses alone shall come near to Yahuah, but they shall not come near. The people shall not go up with him.” 
 </p><p>
-<sup>3&#160;</sup>Moses came and told the people all Yahweh’s words, and all the ordinances; and all the people answered with one voice, and said, “All the words which Yahweh has spoken will we do.” 
+<sup>3&#160;</sup>Moses came and told the people all Yahuah’s words, and all the ordinances; and all the people answered with one voice, and said, “All the words which Yahuah has spoken will we do.” 
 </p><p>
-<sup>4&#160;</sup>Moses wrote all Yahweh’s words, then rose up early in the morning and built an altar at the base of the mountain, with twelve pillars for the twelve tribes of Israel. 
-<sup>5&#160;</sup>He sent young men of the children of Israel, who offered burnt offerings and sacrificed peace offerings of cattle to Yahweh. 
+<sup>4&#160;</sup>Moses wrote all Yahuah’s words, then rose up early in the morning and built an altar at the base of the mountain, with twelve pillars for the twelve tribes of Israel. 
+<sup>5&#160;</sup>He sent young men of the children of Israel, who offered burnt offerings and sacrificed peace offerings of cattle to Yahuah. 
 <sup>6&#160;</sup>Moses took half of the blood and put it in basins, and half of the blood he sprinkled on the altar. 
-<sup>7&#160;</sup>He took the book of the covenant and read it in the hearing of the people, and they said, “We will do all that Yahweh has said, and be obedient.” 
+<sup>7&#160;</sup>He took the book of the covenant and read it in the hearing of the people, and they said, “We will do all that Yahuah has said, and be obedient.” 
 </p><p>
-<sup>8&#160;</sup>Moses took the blood, and sprinkled it on the people, and said, “Look, this is the blood of the covenant, which Yahweh has made with you concerning all these words.” 
+<sup>8&#160;</sup>Moses took the blood, and sprinkled it on the people, and said, “Look, this is the blood of the covenant, which Yahuah has made with you concerning all these words.” 
 </p><p>
 <sup>9&#160;</sup>Then Moses, Aaron, Nadab, Abihu, and seventy of the elders of Israel went up. 
 <sup>10&#160;</sup>They saw the Elohim of Israel. Under his feet was like a paved work of sapphire stone, like the skies for clearness. 
 <sup>11&#160;</sup>He didn’t lay his hand on the nobles of the children of Israel. They saw Elohim, and ate and drank. 
 </p><p>
-<sup>12&#160;</sup>Yahweh said to Moses, “Come up to me on the mountain, and stay here, and I will give you the stone tablets with the law and the commands that I have written, that you may teach them.” 
+<sup>12&#160;</sup>Yahuah said to Moses, “Come up to me on the mountain, and stay here, and I will give you the stone tablets with the law and the commands that I have written, that you may teach them.” 
 </p><p>
 <sup>13&#160;</sup>Moses rose up with Joshua, his servant, and Moses went up onto Elohim’s Mountain. 
 <sup>14&#160;</sup>He said to the elders, “Wait here for us, until we come again to you. Behold, Aaron and Hur are with you. Whoever is involved in a dispute can go to them.” 
 </p><p>
 <sup>15&#160;</sup>Moses went up on the mountain, and the cloud covered the mountain. 
-<sup>16&#160;</sup>Yahweh’s glory settled on Mount Sinai, and the cloud covered it six days. The seventh day he called to Moses out of the middle of the cloud. 
-<sup>17&#160;</sup>The appearance of Yahweh’s glory was like devouring fire on the top of the mountain in the eyes of the children of Israel. 
+<sup>16&#160;</sup>Yahuah’s glory settled on Mount Sinai, and the cloud covered it six days. The seventh day he called to Moses out of the middle of the cloud. 
+<sup>17&#160;</sup>The appearance of Yahuah’s glory was like devouring fire on the top of the mountain in the eyes of the children of Israel. 
 <sup>18&#160;</sup>Moses entered into the middle of the cloud, and went up on the mountain; and Moses was on the mountain forty days and forty nights. 
 </p><h2 class="chapterlabel" id="25">25</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Speak to the children of Israel, that they take an offering for me. From everyone whose heart makes him willing you shall take my offering. 
 <sup>3&#160;</sup>This is the offering which you shall take from them: gold, silver, bronze, 
 <sup>4&#160;</sup>blue, purple, scarlet, fine linen, goats’ hair, 
@@ -1176,7 +1176,7 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>All the instruments of the tabernacle in all its service, and all its pins, and all the pins of the court, shall be of bronze. 
 </p><p>
 <sup>20&#160;</sup>“You shall command the children of Israel, that they bring to you pure olive oil beaten for the light, to cause a lamp to burn continually. 
-<sup>21&#160;</sup>In the Tent of Meeting, outside the veil which is before the covenant, Aaron and his sons shall keep it in order from evening to morning before Yahweh: it shall be a statute forever throughout their generations on the behalf of the children of Israel. 
+<sup>21&#160;</sup>In the Tent of Meeting, outside the veil which is before the covenant, Aaron and his sons shall keep it in order from evening to morning before Yahuah: it shall be a statute forever throughout their generations on the behalf of the children of Israel. 
 </p><h2 class="chapterlabel" id="28">28</h2>
 <p>
 <sup>1&#160;</sup>“Bring Aaron your brother, and his sons with him, near to you from among the children of Israel, that he may minister to me in the priest’s office: Aaron, with Nadab, Abihu, Eleazar, and Ithamar, Aaron’s sons. 
@@ -1191,7 +1191,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>You shall take two onyx stones, and engrave on them the names of the children of Israel. 
 <sup>10&#160;</sup>Six of their names on the one stone, and the names of the six that remain on the other stone, in the order of their birth. 
 <sup>11&#160;</sup>With the work of an engraver in stone, like the engravings of a signet, you shall engrave the two stones, according to the names of the children of Israel. You shall make them to be enclosed in settings of gold. 
-<sup>12&#160;</sup>You shall put the two stones on the shoulder straps of the ephod, to be stones of memorial for the children of Israel. Aaron shall bear their names before Yahweh on his two shoulders for a memorial. 
+<sup>12&#160;</sup>You shall put the two stones on the shoulder straps of the ephod, to be stones of memorial for the children of Israel. Aaron shall bear their names before Yahuah on his two shoulders for a memorial. 
 <sup>13&#160;</sup>You shall make settings of gold, 
 <sup>14&#160;</sup>and two chains of pure gold; you shall make them like cords of braided work. You shall put the braided chains on the settings. 
 </p><p>
@@ -1209,18 +1209,18 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>You shall make two rings of gold, and you shall put them on the two ends of the breastplate, on its edge, which is toward the side of the ephod inward. 
 <sup>27&#160;</sup>You shall make two rings of gold, and shall put them on the two shoulder straps of the ephod underneath, in its forepart, close by its coupling, above the skillfully woven band of the ephod. 
 <sup>28&#160;</sup>They shall bind the breastplate by its rings to the rings of the ephod with a lace of blue, that it may be on the skillfully woven band of the ephod, and that the breastplate may not swing out from the ephod. 
-<sup>29&#160;</sup>Aaron shall bear the names of the children of Israel in the breastplate of judgment on his heart, when he goes in to the set-apart place, for a memorial before Yahweh continually. 
-<sup>30&#160;</sup>You shall put in the breastplate of judgment the Urim and the Thummim; and they shall be on Aaron’s heart, when he goes in before Yahweh. Aaron shall bear the judgment of the children of Israel on his heart before Yahweh continually. 
+<sup>29&#160;</sup>Aaron shall bear the names of the children of Israel in the breastplate of judgment on his heart, when he goes in to the set-apart place, for a memorial before Yahuah continually. 
+<sup>30&#160;</sup>You shall put in the breastplate of judgment the Urim and the Thummim; and they shall be on Aaron’s heart, when he goes in before Yahuah. Aaron shall bear the judgment of the children of Israel on his heart before Yahuah continually. 
 </p><p>
 <sup>31&#160;</sup>“You shall make the robe of the ephod all of blue. 
 <sup>32&#160;</sup>It shall have a hole for the head in the middle of it. It shall have a binding of woven work around its hole, as it were the hole of a coat of mail, that it not be torn. 
 <sup>33&#160;</sup>On its hem you shall make pomegranates of blue, and of purple, and of scarlet, all around its hem; with bells of gold between and around them: 
 <sup>34&#160;</sup>a golden bell and a pomegranate, a golden bell and a pomegranate, around the hem of the robe. 
-<sup>35&#160;</sup>It shall be on Aaron to minister: and its sound shall be heard when he goes in to the set-apart place before Yahweh, and when he comes out, that he not die. 
+<sup>35&#160;</sup>It shall be on Aaron to minister: and its sound shall be heard when he goes in to the set-apart place before Yahuah, and when he comes out, that he not die. 
 </p><p>
-<sup>36&#160;</sup>“You shall make a plate of pure gold, and engrave on it, like the engravings of a signet, ‘SET-APART TO YAHWEH.’ 
+<sup>36&#160;</sup>“You shall make a plate of pure gold, and engrave on it, like the engravings of a signet, ‘SET-APART TO YAHUAH.’ 
 <sup>37&#160;</sup>You shall put it on a lace of blue, and it shall be on the sash. It shall be on the front of the sash. 
-<sup>38&#160;</sup>It shall be on Aaron’s forehead, and Aaron shall bear the iniquity of the set-apart things, which the children of Israel shall make set-apart in all their set-apart gifts; and it shall be always on his forehead, that they may be accepted before Yahweh. 
+<sup>38&#160;</sup>It shall be on Aaron’s forehead, and Aaron shall bear the iniquity of the set-apart things, which the children of Israel shall make set-apart in all their set-apart gifts; and it shall be always on his forehead, that they may be accepted before Yahuah. 
 <sup>39&#160;</sup>You shall weave the tunic with fine linen. You shall make a turban of fine linen. You shall make a sash, the work of the embroiderer. 
 </p><p>
 <sup>40&#160;</sup>“You shall make tunics for Aaron’s sons. You shall make sashes for them. You shall make headbands for them, for glory and for beauty. 
@@ -1240,7 +1240,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>You shall clothe them with belts, Aaron and his sons, and bind headbands on them. They shall have the priesthood by a perpetual statute. You shall consecrate Aaron and his sons. 
 </p><p>
 <sup>10&#160;</sup>“You shall bring the bull before the Tent of Meeting; and Aaron and his sons shall lay their hands on the head of the bull. 
-<sup>11&#160;</sup>You shall kill the bull before Yahweh at the door of the Tent of Meeting. 
+<sup>11&#160;</sup>You shall kill the bull before Yahuah at the door of the Tent of Meeting. 
 <sup>12&#160;</sup>You shall take of the blood of the bull, and put it on the horns of the altar with your finger; and you shall pour out all the blood at the base of the altar. 
 <sup>13&#160;</sup>You shall take all the fat that covers the innards, the cover of the liver, the two kidneys, and the fat that is on them, and burn them on the altar. 
 <sup>14&#160;</sup>But the meat of the bull, and its skin, and its dung, you shall burn with fire outside of the camp. It is a sin offering. 
@@ -1248,19 +1248,19 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>“You shall also take the one ram, and Aaron and his sons shall lay their hands on the head of the ram. 
 <sup>16&#160;</sup>You shall kill the ram, and you shall take its blood, and sprinkle it around on the altar. 
 <sup>17&#160;</sup>You shall cut the ram into its pieces, and wash its innards, and its legs, and put them with its pieces, and with its head. 
-<sup>18&#160;</sup>You shall burn the whole ram on the altar: it is a burnt offering to Yahweh; it is a pleasant aroma, an offering made by fire to Yahweh. 
+<sup>18&#160;</sup>You shall burn the whole ram on the altar: it is a burnt offering to Yahuah; it is a pleasant aroma, an offering made by fire to Yahuah. 
 </p><p>
 <sup>19&#160;</sup>“You shall take the other ram, and Aaron and his sons shall lay their hands on the head of the ram. 
 <sup>20&#160;</sup>Then you shall kill the ram, and take some of its blood, and put it on the tip of the right ear of Aaron, and on the tip of the right ear of his sons, and on the thumb of their right hand, and on the big toe of their right foot; and sprinkle the blood around on the altar. 
 <sup>21&#160;</sup>You shall take of the blood that is on the altar, and of the anointing oil, and sprinkle it on Aaron, and on his garments, and on his sons, and on the garments of his sons with him: and he shall be made set-apart, and his garments, and his sons, and his sons’ garments with him. 
 <sup>22&#160;</sup>Also you shall take some of the ram’s fat, the fat tail, the fat that covers the innards, the cover of the liver, the two kidneys, the fat that is on them, and the right thigh (for it is a ram of consecration), 
-<sup>23&#160;</sup>and one loaf of bread, one cake of oiled bread, and one wafer out of the basket of unleavened bread that is before Yahweh. 
-<sup>24&#160;</sup>You shall put all of this in Aaron’s hands, and in his sons’ hands, and shall wave them for a wave offering before Yahweh. 
-<sup>25&#160;</sup>You shall take them from their hands, and burn them on the altar on the burnt offering, for a pleasant aroma before Yahweh: it is an offering made by fire to Yahweh. 
+<sup>23&#160;</sup>and one loaf of bread, one cake of oiled bread, and one wafer out of the basket of unleavened bread that is before Yahuah. 
+<sup>24&#160;</sup>You shall put all of this in Aaron’s hands, and in his sons’ hands, and shall wave them for a wave offering before Yahuah. 
+<sup>25&#160;</sup>You shall take them from their hands, and burn them on the altar on the burnt offering, for a pleasant aroma before Yahuah: it is an offering made by fire to Yahuah. 
 </p><p>
-<sup>26&#160;</sup>“You shall take the breast of Aaron’s ram of consecration, and wave it for a wave offering before Yahweh. It shall be your portion. 
+<sup>26&#160;</sup>“You shall take the breast of Aaron’s ram of consecration, and wave it for a wave offering before Yahuah. It shall be your portion. 
 <sup>27&#160;</sup>You shall sanctify the breast of the wave offering and the thigh of the wave offering, which is waved, and which is raised up, of the ram of consecration, even of that which is for Aaron, and of that which is for his sons. 
-<sup>28&#160;</sup>It shall be for Aaron and his sons as their portion forever from the children of Israel; for it is a wave offering. It shall be a wave offering from the children of Israel of the sacrifices of their peace offerings, even their wave offering to Yahweh. 
+<sup>28&#160;</sup>It shall be for Aaron and his sons as their portion forever from the children of Israel; for it is a wave offering. It shall be a wave offering from the children of Israel of the sacrifices of their peace offerings, even their wave offering to Yahuah. 
 </p><p>
 <sup>29&#160;</sup>“The set-apart garments of Aaron shall be for his sons after him, to be anointed in them, and to be consecrated in them. 
 <sup>30&#160;</sup>Seven days shall the son who is priest in his place put them on, when he comes into the Tent of Meeting to minister in the set-apart place. 
@@ -1277,12 +1277,12 @@ html[dir=ltr] .q2 {
 <sup>38&#160;</sup>“Now this is that which you shall offer on the altar: two lambs a year old day by day continually. 
 <sup>39&#160;</sup>The one lamb you shall offer in the morning; and the other lamb you shall offer at evening; 
 <sup>40&#160;</sup>and with the one lamb a tenth part of an ephah of fine flour mixed with the fourth part of a hin of beaten oil, and the fourth part of a hin of wine for a drink offering. 
-<sup>41&#160;</sup>The other lamb you shall offer at evening, and shall do to it according to the meal offering of the morning and according to its drink offering, for a pleasant aroma, an offering made by fire to Yahweh. 
-<sup>42&#160;</sup>It shall be a continual burnt offering throughout your generations at the door of the Tent of Meeting before Yahweh, where I will meet with you, to speak there to you. 
+<sup>41&#160;</sup>The other lamb you shall offer at evening, and shall do to it according to the meal offering of the morning and according to its drink offering, for a pleasant aroma, an offering made by fire to Yahuah. 
+<sup>42&#160;</sup>It shall be a continual burnt offering throughout your generations at the door of the Tent of Meeting before Yahuah, where I will meet with you, to speak there to you. 
 <sup>43&#160;</sup>There I will meet with the children of Israel; and the place shall be sanctified by my glory. 
 <sup>44&#160;</sup>I will sanctify the Tent of Meeting and the altar. I will also sanctify Aaron and his sons to minister to me in the priest’s office. 
 <sup>45&#160;</sup>I will dwell among the children of Israel, and will be their Elohim. 
-<sup>46&#160;</sup>They shall know that I am Yahweh their Elohim, who brought them out of the land of Egypt, that I might dwell among them: I am Yahweh their Elohim. 
+<sup>46&#160;</sup>They shall know that I am Yahuah their Elohim, who brought them out of the land of Egypt, that I might dwell among them: I am Yahuah their Elohim. 
 </p><h2 class="chapterlabel" id="30">30</h2>
 <p>
 <sup>1&#160;</sup>“You shall make an altar to burn incense on. You shall make it of acacia wood. 
@@ -1292,24 +1292,24 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>You shall make the poles of acacia wood, and overlay them with gold. 
 <sup>6&#160;</sup>You shall put it before the veil that is by the ark of the covenant, before the mercy seat that is over the covenant, where I will meet with you. 
 <sup>7&#160;</sup>Aaron shall burn incense of sweet spices on it every morning. When he tends the lamps, he shall burn it. 
-<sup>8&#160;</sup>When Aaron lights the lamps at evening, he shall burn it, a perpetual incense before Yahweh throughout your generations. 
+<sup>8&#160;</sup>When Aaron lights the lamps at evening, he shall burn it, a perpetual incense before Yahuah throughout your generations. 
 <sup>9&#160;</sup>You shall offer no strange incense on it, nor burnt offering, nor meal offering; and you shall pour no drink offering on it. 
-<sup>10&#160;</sup>Aaron shall make atonement on its horns once in the year; with the blood of the sin offering of atonement once in the year he shall make atonement for it throughout your generations. It is most set-apart to Yahweh.” 
+<sup>10&#160;</sup>Aaron shall make atonement on its horns once in the year; with the blood of the sin offering of atonement once in the year he shall make atonement for it throughout your generations. It is most set-apart to Yahuah.” 
 </p><p>
-<sup>11&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>12&#160;</sup>“When you take a census of the children of Israel, according to those who are counted among them, then each man shall give a ransom for his soul to Yahweh when you count them, that there be no plague among them when you count them. 
-<sup>13&#160;</sup>They shall give this, everyone who passes over to those who are counted, half a shekel according to the shekel of the sanctuary (the shekel is twenty gerahs); half a shekel for an offering to Yahweh. 
-<sup>14&#160;</sup>Everyone who passes over to those who are counted, from twenty years old and upward, shall give the offering to Yahweh. 
-<sup>15&#160;</sup>The rich shall not give more, and the poor shall not give less, than the half shekel, when they give the offering of Yahweh, to make atonement for your souls. 
-<sup>16&#160;</sup>You shall take the atonement money from the children of Israel, and shall appoint it for the service of the Tent of Meeting; that it may be a memorial for the children of Israel before Yahweh, to make atonement for your souls.” 
+<sup>11&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>12&#160;</sup>“When you take a census of the children of Israel, according to those who are counted among them, then each man shall give a ransom for his soul to Yahuah when you count them, that there be no plague among them when you count them. 
+<sup>13&#160;</sup>They shall give this, everyone who passes over to those who are counted, half a shekel according to the shekel of the sanctuary (the shekel is twenty gerahs); half a shekel for an offering to Yahuah. 
+<sup>14&#160;</sup>Everyone who passes over to those who are counted, from twenty years old and upward, shall give the offering to Yahuah. 
+<sup>15&#160;</sup>The rich shall not give more, and the poor shall not give less, than the half shekel, when they give the offering of Yahuah, to make atonement for your souls. 
+<sup>16&#160;</sup>You shall take the atonement money from the children of Israel, and shall appoint it for the service of the Tent of Meeting; that it may be a memorial for the children of Israel before Yahuah, to make atonement for your souls.” 
 </p><p>
-<sup>17&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>17&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>18&#160;</sup>“You shall also make a basin of bronze, and its base of bronze, in which to wash. You shall put it between the Tent of Meeting and the altar, and you shall put water in it. 
 <sup>19&#160;</sup>Aaron and his sons shall wash their hands and their feet in it. 
-<sup>20&#160;</sup>When they go into the Tent of Meeting, they shall wash with water, that they not die; or when they come near to the altar to minister, to burn an offering made by fire to Yahweh. 
+<sup>20&#160;</sup>When they go into the Tent of Meeting, they shall wash with water, that they not die; or when they come near to the altar to minister, to burn an offering made by fire to Yahuah. 
 <sup>21&#160;</sup>So they shall wash their hands and their feet, that they not die. This shall be a statute forever to them, even to him and to his descendants throughout their generations.” 
 </p><p>
-<sup>22&#160;</sup>Moreover Yahweh spoke to Moses, saying, 
+<sup>22&#160;</sup>Moreover Yahuah spoke to Moses, saying, 
 <sup>23&#160;</sup>“Also take fine spices: of liquid myrrh, five hundred shekels; and of fragrant cinnamon half as much, even two hundred and fifty; and of fragrant cane, two hundred and fifty; 
 <sup>24&#160;</sup>and of cassia five hundred, according to the shekel of the sanctuary; and a hin of olive oil. 
 <sup>25&#160;</sup>You shall make it into a set-apart anointing oil, a perfume compounded after the art of the perfumer: it shall be a set-apart anointing oil. 
@@ -1322,14 +1322,14 @@ html[dir=ltr] .q2 {
 <sup>32&#160;</sup>It shall not be poured on man’s flesh, and do not make any like it, according to its composition. It is set-apart. It shall be set-apart to you. 
 <sup>33&#160;</sup>Whoever compounds any like it, or whoever puts any of it on a stranger, he shall be cut off from his people.’&#160;” 
 </p><p>
-<sup>34&#160;</sup>Yahweh said to Moses, “Take to yourself sweet spices, gum resin, onycha, and galbanum: sweet spices with pure frankincense. There shall be an equal weight of each. 
+<sup>34&#160;</sup>Yahuah said to Moses, “Take to yourself sweet spices, gum resin, onycha, and galbanum: sweet spices with pure frankincense. There shall be an equal weight of each. 
 <sup>35&#160;</sup>You shall make incense of it, a perfume after the art of the perfumer, seasoned with salt, pure and set-apart. 
 <sup>36&#160;</sup>You shall beat some of it very small, and put some of it before the covenant in the Tent of Meeting, where I will meet with you. It shall be to you most set-apart. 
-<sup>37&#160;</sup>You shall not make this incense, according to its composition, for yourselves: it shall be to you set-apart for Yahweh. 
+<sup>37&#160;</sup>You shall not make this incense, according to its composition, for yourselves: it shall be to you set-apart for Yahuah. 
 <sup>38&#160;</sup>Whoever shall make any like that, to smell of it, he shall be cut off from his people.” 
 </p><h2 class="chapterlabel" id="31">31</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Behold, I have called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah. 
 <sup>3&#160;</sup>I have filled him with the Spirit of Elohim, in wisdom, and in understanding, and in knowledge, and in all kinds of workmanship, 
 <sup>4&#160;</sup>to devise skillful works, to work in gold, and in silver, and in bronze, 
@@ -1340,12 +1340,12 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>the altar of burnt offering with all its vessels, the basin and its base, 
 <sup>10&#160;</sup>the finely worked garments—the set-apart garments for Aaron the priest, the garments of his sons to minister in the priest’s office—<sup>11&#160;</sup>the anointing oil, and the incense of sweet spices for the set-apart place: according to all that I have commanded you they shall do.” 
 </p><p>
-<sup>12&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>13&#160;</sup>“Speak also to the children of Israel, saying, ‘Most certainly you shall keep my Sabbaths; for it is a sign between me and you throughout your generations, that you may know that I am Yahweh who sanctifies you. 
+<sup>12&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>13&#160;</sup>“Speak also to the children of Israel, saying, ‘Most certainly you shall keep my Sabbaths; for it is a sign between me and you throughout your generations, that you may know that I am Yahuah who sanctifies you. 
 <sup>14&#160;</sup>You shall keep the Sabbath therefore, for it is set-apart to you. Everyone who profanes it shall surely be put to death; for whoever does any work therein, that soul shall be cut off from among his people. 
-<sup>15&#160;</sup>Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, set-apart to Yahweh. Whoever does any work on the Sabbath day shall surely be put to death. 
+<sup>15&#160;</sup>Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, set-apart to Yahuah. Whoever does any work on the Sabbath day shall surely be put to death. 
 <sup>16&#160;</sup>Therefore the children of Israel shall keep the Sabbath, to observe the Sabbath throughout their generations, for a perpetual covenant. 
-<sup>17&#160;</sup>It is a sign between me and the children of Israel forever; for in six days Yahweh made heaven and earth, and on the seventh day he rested, and was refreshed.’&#160;” 
+<sup>17&#160;</sup>It is a sign between me and the children of Israel forever; for in six days Yahuah made heaven and earth, and on the seventh day he rested, and was refreshed.’&#160;” 
 </p><p>
 <sup>18&#160;</sup>When he finished speaking with him on Mount Sinai, he gave Moses the two tablets of the covenant, stone tablets, written with Elohim’s finger. 
 </p><h2 class="chapterlabel" id="32">32</h2>
@@ -1357,21 +1357,21 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>All the people took off the golden rings which were in their ears, and brought them to Aaron. 
 <sup>4&#160;</sup>He received what they handed him, fashioned it with an engraving tool, and made it a molded calf. Then they said, “These are your elohims, Israel, which brought you up out of the land of Egypt.” 
 </p><p>
-<sup>5&#160;</sup>When Aaron saw this, he built an altar before it; and Aaron made a proclamation, and said, “Tomorrow shall be a feast to Yahweh.” 
+<sup>5&#160;</sup>When Aaron saw this, he built an altar before it; and Aaron made a proclamation, and said, “Tomorrow shall be a feast to Yahuah.” 
 </p><p>
 <sup>6&#160;</sup>They rose up early on the next day, and offered burnt offerings, and brought peace offerings; and the people sat down to eat and to drink, and rose up to play. 
 </p><p>
-<sup>7&#160;</sup>Yahweh spoke to Moses, “Go, get down; for your people, whom you brought up out of the land of Egypt, have corrupted themselves! 
+<sup>7&#160;</sup>Yahuah spoke to Moses, “Go, get down; for your people, whom you brought up out of the land of Egypt, have corrupted themselves! 
 <sup>8&#160;</sup>They have turned away quickly out of the way which I commanded them. They have made themselves a molded calf, and have worshiped it, and have sacrificed to it, and said, ‘These are your elohims, Israel, which brought you up out of the land of Egypt.’&#160;” 
 </p><p>
-<sup>9&#160;</sup>Yahweh said to Moses, “I have seen these people, and behold, they are a stiff-necked people. 
+<sup>9&#160;</sup>Yahuah said to Moses, “I have seen these people, and behold, they are a stiff-necked people. 
 <sup>10&#160;</sup>Now therefore leave me alone, that my wrath may burn hot against them, and that I may consume them; and I will make of you a great nation.” 
 </p><p>
-<sup>11&#160;</sup>Moses begged Yahweh his Elohim, and said, “Yahweh, why does your wrath burn hot against your people, that you have brought out of the land of Egypt with great power and with a mighty hand? 
+<sup>11&#160;</sup>Moses begged Yahuah his Elohim, and said, “Yahuah, why does your wrath burn hot against your people, that you have brought out of the land of Egypt with great power and with a mighty hand? 
 <sup>12&#160;</sup>Why should the Egyptians talk, saying, ‘He brought them out for evil, to kill them in the mountains, and to consume them from the surface of the earth’? Turn from your fierce wrath, and turn away from this evil against your people. 
 <sup>13&#160;</sup>Remember Abraham, Isaac, and Israel, your servants, to whom you swore by your own self, and said to them, ‘I will multiply your offspring as the stars of the sky, and all this land that I have spoken of I will give to your offspring, and they shall inherit it forever.’&#160;” 
 </p><p>
-<sup>14&#160;</sup>So Yahweh turned away from the evil which he said he would do to his people. 
+<sup>14&#160;</sup>So Yahuah turned away from the evil which he said he would do to his people. 
 </p><p>
 <sup>15&#160;</sup>Moses turned, and went down from the mountain, with the two tablets of the covenant in his hand; tablets that were written on both their sides. They were written on one side and on the other. 
 <sup>16&#160;</sup>The tablets were the work of Elohim, and the writing was the writing of Elohim, engraved on the tablets. 
@@ -1389,39 +1389,39 @@ html[dir=ltr] .q2 {
 <sup>24&#160;</sup>I said to them, ‘Whoever has any gold, let them take it off.’ So they gave it to me; and I threw it into the fire, and out came this calf.” 
 </p><p>
 <sup>25&#160;</sup>When Moses saw that the people were out of control, (for Aaron had let them lose control, causing derision among their enemies), 
-<sup>26&#160;</sup>then Moses stood in the gate of the camp, and said, “Whoever is on Yahweh’s side, come to me!” 
+<sup>26&#160;</sup>then Moses stood in the gate of the camp, and said, “Whoever is on Yahuah’s side, come to me!” 
 </p><p>All the sons of Levi gathered themselves together to him. 
-<sup>27&#160;</sup>He said to them, “Yahweh, the Elohim of Israel, says, ‘Every man put his sword on his thigh, and go back and forth from gate to gate throughout the camp, and every man kill his brother, and every man his companion, and every man his neighbor.’&#160;” 
+<sup>27&#160;</sup>He said to them, “Yahuah, the Elohim of Israel, says, ‘Every man put his sword on his thigh, and go back and forth from gate to gate throughout the camp, and every man kill his brother, and every man his companion, and every man his neighbor.’&#160;” 
 <sup>28&#160;</sup>The sons of Levi did according to the word of Moses. About three thousand men fell of the people that day. 
-<sup>29&#160;</sup>Moses said, “Consecrate yourselves today to Yahweh, for every man was against his son and against his brother, that he may give you a blessing today.” 
+<sup>29&#160;</sup>Moses said, “Consecrate yourselves today to Yahuah, for every man was against his son and against his brother, that he may give you a blessing today.” 
 </p><p>
-<sup>30&#160;</sup>On the next day, Moses said to the people, “You have sinned a great sin. Now I will go up to Yahweh. Perhaps I shall make atonement for your sin.” 
+<sup>30&#160;</sup>On the next day, Moses said to the people, “You have sinned a great sin. Now I will go up to Yahuah. Perhaps I shall make atonement for your sin.” 
 </p><p>
-<sup>31&#160;</sup>Moses returned to Yahweh, and said, “Oh, this people have sinned a great sin, and have made themselves elohims of gold. 
+<sup>31&#160;</sup>Moses returned to Yahuah, and said, “Oh, this people have sinned a great sin, and have made themselves elohims of gold. 
 <sup>32&#160;</sup>Yet now, if you will, forgive their sin—and if not, please blot me out of your book which you have written.” 
 </p><p>
-<sup>33&#160;</sup>Yahweh said to Moses, “Whoever has sinned against me, I will blot him out of my book. 
+<sup>33&#160;</sup>Yahuah said to Moses, “Whoever has sinned against me, I will blot him out of my book. 
 <sup>34&#160;</sup>Now go, lead the people to the place of which I have spoken to you. Behold, my angel shall go before you. Nevertheless, in the day when I punish, I will punish them for their sin.” 
-<sup>35&#160;</sup>Yahweh struck the people, because of what they did with the calf, which Aaron made. 
+<sup>35&#160;</sup>Yahuah struck the people, because of what they did with the calf, which Aaron made. 
 </p><h2 class="chapterlabel" id="33">33</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, “Depart, go up from here, you and the people that you have brought up out of the land of Egypt, to the land of which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ 
+<sup>1&#160;</sup>Yahuah spoke to Moses, “Depart, go up from here, you and the people that you have brought up out of the land of Egypt, to the land of which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ 
 <sup>2&#160;</sup>I will send an angel before you; and I will drive out the Canaanite, the Amorite, and the Hittite, and the Perizzite, the Hivite, and the Jebusite. 
 <sup>3&#160;</sup>Go to a land flowing with milk and honey; but I will not go up among you, for you are a stiff-necked people, lest I consume you on the way.” 
 </p><p>
 <sup>4&#160;</sup>When the people heard this evil news, they mourned; and no one put on his jewelry. 
 </p><p>
-<sup>5&#160;</sup>Yahweh had said to Moses, “Tell the children of Israel, ‘You are a stiff-necked people. If I were to go up among you for one moment, I would consume you. Therefore now take off your jewelry from you, that I may know what to do to you.’&#160;” 
+<sup>5&#160;</sup>Yahuah had said to Moses, “Tell the children of Israel, ‘You are a stiff-necked people. If I were to go up among you for one moment, I would consume you. Therefore now take off your jewelry from you, that I may know what to do to you.’&#160;” 
 </p><p>
 <sup>6&#160;</sup>The children of Israel stripped themselves of their jewelry from Mount Horeb onward. 
 </p><p>
-<sup>7&#160;</sup>Now Moses used to take the tent and pitch it outside the camp, far away from the camp, and he called it “The Tent of Meeting.” Everyone who sought Yahweh went out to the Tent of Meeting, which was outside the camp. 
+<sup>7&#160;</sup>Now Moses used to take the tent and pitch it outside the camp, far away from the camp, and he called it “The Tent of Meeting.” Everyone who sought Yahuah went out to the Tent of Meeting, which was outside the camp. 
 <sup>8&#160;</sup>When Moses went out to the Tent, all the people rose up, and stood, everyone at their tent door, and watched Moses, until he had gone into the Tent. 
-<sup>9&#160;</sup>When Moses entered into the Tent, the pillar of cloud descended, stood at the door of the Tent, and Yahweh spoke with Moses. 
+<sup>9&#160;</sup>When Moses entered into the Tent, the pillar of cloud descended, stood at the door of the Tent, and Yahuah spoke with Moses. 
 <sup>10&#160;</sup>All the people saw the pillar of cloud stand at the door of the Tent, and all the people rose up and worshiped, everyone at their tent door. 
-<sup>11&#160;</sup>Yahweh spoke to Moses face to face, as a man speaks to his friend. He turned again into the camp, but his servant Joshua, the son of Nun, a young man, didn’t depart from the Tent. 
+<sup>11&#160;</sup>Yahuah spoke to Moses face to face, as a man speaks to his friend. He turned again into the camp, but his servant Joshua, the son of Nun, a young man, didn’t depart from the Tent. 
 </p><p>
-<sup>12&#160;</sup>Moses said to Yahweh, “Behold, you tell me, ‘Bring up this people;’ and you haven’t let me know whom you will send with me. Yet you have said, ‘I know you by name, and you have also found favor in my sight.’ 
+<sup>12&#160;</sup>Moses said to Yahuah, “Behold, you tell me, ‘Bring up this people;’ and you haven’t let me know whom you will send with me. Yet you have said, ‘I know you by name, and you have also found favor in my sight.’ 
 <sup>13&#160;</sup>Now therefore, if I have found favor in your sight, please show me your way, now, that I may know you, so that I may find favor in your sight; and consider that this nation is your people.” 
 </p><p>
 <sup>14&#160;</sup>He said, “My presence will go with you, and I will give you rest.” 
@@ -1429,34 +1429,34 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Moses said to him, “If your presence doesn’t go with me, don’t carry us up from here. 
 <sup>16&#160;</sup>For how would people know that I have found favor in your sight, I and your people? Isn’t it that you go with us, so that we are separated, I and your people, from all the people who are on the surface of the earth?” 
 </p><p>
-<sup>17&#160;</sup>Yahweh said to Moses, “I will do this thing also that you have spoken; for you have found favor in my sight, and I know you by name.” 
+<sup>17&#160;</sup>Yahuah said to Moses, “I will do this thing also that you have spoken; for you have found favor in my sight, and I know you by name.” 
 </p><p>
 <sup>18&#160;</sup>Moses said, “Please show me your glory.” 
 </p><p>
-<sup>19&#160;</sup>He said, “I will make all my goodness pass before you, and will proclaim Yahweh’s name before you. I will be gracious to whom I will be gracious, and will show mercy on whom I will show mercy.” 
+<sup>19&#160;</sup>He said, “I will make all my goodness pass before you, and will proclaim Yahuah’s name before you. I will be gracious to whom I will be gracious, and will show mercy on whom I will show mercy.” 
 <sup>20&#160;</sup>He said, “You cannot see my face, for man may not see me and live.” 
-<sup>21&#160;</sup>Yahweh also said, “Behold, there is a place by me, and you shall stand on the rock. 
+<sup>21&#160;</sup>Yahuah also said, “Behold, there is a place by me, and you shall stand on the rock. 
 <sup>22&#160;</sup>It will happen, while my glory passes by, that I will put you in a cleft of the rock, and will cover you with my hand until I have passed by; 
 <sup>23&#160;</sup>then I will take away my hand, and you will see my back; but my face shall not be seen.” 
 </p><h2 class="chapterlabel" id="34">34</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Moses, “Chisel two stone tablets like the first. I will write on the tablets the words that were on the first tablets, which you broke. 
+<sup>1&#160;</sup>Yahuah said to Moses, “Chisel two stone tablets like the first. I will write on the tablets the words that were on the first tablets, which you broke. 
 <sup>2&#160;</sup>Be ready by the morning, and come up in the morning to Mount Sinai, and present yourself there to me on the top of the mountain. 
 <sup>3&#160;</sup>No one shall come up with you or be seen anywhere on the mountain. Do not let the flocks or herds graze in front of that mountain.” 
 </p><p>
-<sup>4&#160;</sup>He chiseled two tablets of stone like the first; then Moses rose up early in the morning, and went up to Mount Sinai, as Yahweh had commanded him, and took in his hand two stone tablets. 
-<sup>5&#160;</sup>Yahweh descended in the cloud, and stood with him there, and proclaimed Yahweh’s name. 
-<sup>6&#160;</sup>Yahweh passed by before him, and proclaimed, “Yahweh! Yahweh, a merciful and gracious Elohim, slow to anger, and abundant in loving kindness and truth, 
+<sup>4&#160;</sup>He chiseled two tablets of stone like the first; then Moses rose up early in the morning, and went up to Mount Sinai, as Yahuah had commanded him, and took in his hand two stone tablets. 
+<sup>5&#160;</sup>Yahuah descended in the cloud, and stood with him there, and proclaimed Yahuah’s name. 
+<sup>6&#160;</sup>Yahuah passed by before him, and proclaimed, “Yahuah! Yahuah, a merciful and gracious Elohim, slow to anger, and abundant in loving kindness and truth, 
 <sup>7&#160;</sup>keeping loving kindness for thousands, forgiving iniquity and disobedience and sin; and who will by no means clear the guilty, visiting the iniquity of the fathers on the children, and on the children’s children, on the third and on the fourth generation.” 
 </p><p>
 <sup>8&#160;</sup>Moses hurried and bowed his head toward the earth, and worshiped. 
 <sup>9&#160;</sup>He said, “If now I have found favor in your sight, Lord, please let the Lord go among us, even though this is a stiff-necked people; pardon our iniquity and our sin, and take us for your inheritance.” 
 </p><p>
-<sup>10&#160;</sup>He said, “Behold, I make a covenant: before all your people I will do marvels, such as have not been worked in all the earth, nor in any nation; and all the people among whom you are shall see the work of Yahweh; for it is an awesome thing that I do with you. 
+<sup>10&#160;</sup>He said, “Behold, I make a covenant: before all your people I will do marvels, such as have not been worked in all the earth, nor in any nation; and all the people among whom you are shall see the work of Yahuah; for it is an awesome thing that I do with you. 
 <sup>11&#160;</sup>Observe that which I command you today. Behold, I will drive out before you the Amorite, the Canaanite, the Hittite, the Perizzite, the Hivite, and the Jebusite. 
 <sup>12&#160;</sup>Be careful, lest you make a covenant with the inhabitants of the land where you are going, lest it be for a snare among you; 
 <sup>13&#160;</sup>but you shall break down their altars, and dash in pieces their pillars, and you shall cut down their Asherah poles; 
-<sup>14&#160;</sup>for you shall worship no other elohim; for Yahweh, whose name is Jealous, is a jealous Elohim. 
+<sup>14&#160;</sup>for you shall worship no other elohim; for Yahuah, whose name is Jealous, is a jealous Elohim. 
 </p><p>
 <sup>15&#160;</sup>“Don’t make a covenant with the inhabitants of the land, lest they play the prostitute after their elohims, and sacrifice to their elohims, and one call you and you eat of his sacrifice; 
 <sup>16&#160;</sup>and you take of their daughters to your sons, and their daughters play the prostitute after their elohims, and make your sons play the prostitute after their elohims. 
@@ -1471,39 +1471,39 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>“Six days you shall work, but on the seventh day you shall rest: in plowing time and in harvest you shall rest. 
 </p><p>
 <sup>22&#160;</sup>“You shall observe the feast of weeks with the first fruits of wheat harvest, and the feast of harvest at the year’s end. 
-<sup>23&#160;</sup>Three times in the year all your males shall appear before the Lord Yahweh, the Elohim of Israel. 
-<sup>24&#160;</sup>For I will drive out nations before you and enlarge your borders; neither shall any man desire your land when you go up to appear before Yahweh, your Elohim, three times in the year. 
+<sup>23&#160;</sup>Three times in the year all your males shall appear before the Lord Yahuah, the Elohim of Israel. 
+<sup>24&#160;</sup>For I will drive out nations before you and enlarge your borders; neither shall any man desire your land when you go up to appear before Yahuah, your Elohim, three times in the year. 
 </p><p>
 <sup>25&#160;</sup>“You shall not offer the blood of my sacrifice with leavened bread. The sacrifice of the feast of the Passover shall not be left to the morning. 
 </p><p>
-<sup>26&#160;</sup>“You shall bring the first of the first fruits of your ground to the house of Yahweh your Elohim. 
+<sup>26&#160;</sup>“You shall bring the first of the first fruits of your ground to the house of Yahuah your Elohim. 
 </p><p>“You shall not boil a young goat in its mother’s milk.” 
 </p><p>
-<sup>27&#160;</sup>Yahweh said to Moses, “Write these words; for in accordance with these words I have made a covenant with you and with Israel.” 
+<sup>27&#160;</sup>Yahuah said to Moses, “Write these words; for in accordance with these words I have made a covenant with you and with Israel.” 
 </p><p>
-<sup>28&#160;</sup>He was there with Yahweh forty days and forty nights; he neither ate bread, nor drank water. He wrote on the tablets the words of the covenant, the ten commandments. 
+<sup>28&#160;</sup>He was there with Yahuah forty days and forty nights; he neither ate bread, nor drank water. He wrote on the tablets the words of the covenant, the ten commandments. 
 </p><p>
 <sup>29&#160;</sup>When Moses came down from Mount Sinai with the two tablets of the covenant in Moses’ hand, when he came down from the mountain, Moses didn’t know that the skin of his face shone by reason of his speaking with him. 
 <sup>30&#160;</sup>When Aaron and all the children of Israel saw Moses, behold, the skin of his face shone; and they were afraid to come near him. 
 <sup>31&#160;</sup>Moses called to them, and Aaron and all the rulers of the congregation returned to him; and Moses spoke to them. 
-<sup>32&#160;</sup>Afterward all the children of Israel came near, and he gave them all the commandments that Yahweh had spoken with him on Mount Sinai. 
+<sup>32&#160;</sup>Afterward all the children of Israel came near, and he gave them all the commandments that Yahuah had spoken with him on Mount Sinai. 
 <sup>33&#160;</sup>When Moses was done speaking with them, he put a veil on his face. 
-<sup>34&#160;</sup>But when Moses went in before Yahweh to speak with him, he took the veil off, until he came out; and he came out, and spoke to the children of Israel that which he was commanded. 
+<sup>34&#160;</sup>But when Moses went in before Yahuah to speak with him, he took the veil off, until he came out; and he came out, and spoke to the children of Israel that which he was commanded. 
 <sup>35&#160;</sup>The children of Israel saw Moses’ face, that the skin of Moses’ face shone; so Moses put the veil on his face again, until he went in to speak with him. 
 </p><h2 class="chapterlabel" id="35">35</h2>
 <p>
-<sup>1&#160;</sup>Moses assembled all the congregation of the children of Israel, and said to them, “These are the words which Yahweh has commanded, that you should do them. 
-<sup>2&#160;</sup>‘Six days shall work be done, but on the seventh day there shall be a set-apart day for you, a Sabbath of solemn rest to Yahweh: whoever does any work in it shall be put to death. 
+<sup>1&#160;</sup>Moses assembled all the congregation of the children of Israel, and said to them, “These are the words which Yahuah has commanded, that you should do them. 
+<sup>2&#160;</sup>‘Six days shall work be done, but on the seventh day there shall be a set-apart day for you, a Sabbath of solemn rest to Yahuah: whoever does any work in it shall be put to death. 
 <sup>3&#160;</sup>You shall kindle no fire throughout your habitations on the Sabbath day.’&#160;” 
 </p><p>
-<sup>4&#160;</sup>Moses spoke to all the congregation of the children of Israel, saying, “This is the thing which Yahweh commanded, saying, 
-<sup>5&#160;</sup>‘Take from among you an offering to Yahweh. Whoever is of a willing heart, let him bring it as Yahweh’s offering: gold, silver, bronze, 
+<sup>4&#160;</sup>Moses spoke to all the congregation of the children of Israel, saying, “This is the thing which Yahuah commanded, saying, 
+<sup>5&#160;</sup>‘Take from among you an offering to Yahuah. Whoever is of a willing heart, let him bring it as Yahuah’s offering: gold, silver, bronze, 
 <sup>6&#160;</sup>blue, purple, scarlet, fine linen, goats’ hair, 
 <sup>7&#160;</sup>rams’ skins dyed red, sea cow hides, acacia wood, 
 <sup>8&#160;</sup>oil for the light, spices for the anointing oil and for the sweet incense, 
 <sup>9&#160;</sup>onyx stones, and stones to be set for the ephod and for the breastplate. 
 </p><p>
-<sup>10&#160;</sup>“&#160;‘Let every wise-hearted man among you come, and make all that Yahweh has commanded: 
+<sup>10&#160;</sup>“&#160;‘Let every wise-hearted man among you come, and make all that Yahuah has commanded: 
 <sup>11&#160;</sup>the tabernacle, its outer covering, its roof, its clasps, its boards, its bars, its pillars, and its sockets; 
 <sup>12&#160;</sup>the ark, and its poles, the mercy seat, the veil of the screen; 
 <sup>13&#160;</sup>the table with its poles and all its vessels, and the show bread; 
@@ -1515,17 +1515,17 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>the finely worked garments for ministering in the set-apart place—the set-apart garments for Aaron the priest, and the garments of his sons—to minister in the priest’s office.’&#160;” 
 </p><p>
 <sup>20&#160;</sup>All the congregation of the children of Israel departed from the presence of Moses. 
-<sup>21&#160;</sup>They came, everyone whose heart stirred him up, and everyone whom his spirit made willing, and brought Yahweh’s offering for the work of the Tent of Meeting, and for all of its service, and for the set-apart garments. 
-<sup>22&#160;</sup>They came, both men and women, as many as were willing-hearted, and brought brooches, earrings, signet rings, and armlets, all jewels of gold; even every man who offered an offering of gold to Yahweh. 
+<sup>21&#160;</sup>They came, everyone whose heart stirred him up, and everyone whom his spirit made willing, and brought Yahuah’s offering for the work of the Tent of Meeting, and for all of its service, and for the set-apart garments. 
+<sup>22&#160;</sup>They came, both men and women, as many as were willing-hearted, and brought brooches, earrings, signet rings, and armlets, all jewels of gold; even every man who offered an offering of gold to Yahuah. 
 <sup>23&#160;</sup>Everyone with whom was found blue, purple, scarlet, fine linen, goats’ hair, rams’ skins dyed red, and sea cow hides, brought them. 
-<sup>24&#160;</sup>Everyone who offered an offering of silver and bronze brought Yahweh’s offering; and everyone with whom was found acacia wood for any work of the service, brought it. 
+<sup>24&#160;</sup>Everyone who offered an offering of silver and bronze brought Yahuah’s offering; and everyone with whom was found acacia wood for any work of the service, brought it. 
 <sup>25&#160;</sup>All the women who were wise-hearted spun with their hands, and brought that which they had spun: the blue, the purple, the scarlet, and the fine linen. 
 <sup>26&#160;</sup>All the women whose heart stirred them up in wisdom spun the goats’ hair. 
 <sup>27&#160;</sup>The rulers brought the onyx stones and the stones to be set for the ephod and for the breastplate; 
 <sup>28&#160;</sup>with the spice and the oil for the light, for the anointing oil, and for the sweet incense. 
-<sup>29&#160;</sup>The children of Israel brought a free will offering to Yahweh; every man and woman whose heart made them willing to bring for all the work, which Yahweh had commanded to be made by Moses. 
+<sup>29&#160;</sup>The children of Israel brought a free will offering to Yahuah; every man and woman whose heart made them willing to bring for all the work, which Yahuah had commanded to be made by Moses. 
 </p><p>
-<sup>30&#160;</sup>Moses said to the children of Israel, “Behold, Yahweh has called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah. 
+<sup>30&#160;</sup>Moses said to the children of Israel, “Behold, Yahuah has called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah. 
 <sup>31&#160;</sup>He has filled him with the Spirit of Elohim, in wisdom, in understanding, in knowledge, and in all kinds of workmanship; 
 <sup>32&#160;</sup>and to make skillful works, to work in gold, in silver, in bronze, 
 <sup>33&#160;</sup>in cutting of stones for setting, and in carving of wood, to work in all kinds of skillful workmanship. 
@@ -1533,12 +1533,12 @@ html[dir=ltr] .q2 {
 <sup>35&#160;</sup>He has filled them with wisdom of heart to work all kinds of workmanship, of the engraver, of the skillful workman, and of the embroiderer, in blue, in purple, in scarlet, and in fine linen, and of the weaver, even of those who do any workmanship, and of those who make skillful works. 
 </p><h2 class="chapterlabel" id="36">36</h2>
 <p>
-<sup>1&#160;</sup>“Bezalel and Oholiab shall work with every wise-hearted man, in whom Yahweh has put wisdom and understanding to know how to do all the work for the service of the sanctuary, according to all that Yahweh has commanded.” 
+<sup>1&#160;</sup>“Bezalel and Oholiab shall work with every wise-hearted man, in whom Yahuah has put wisdom and understanding to know how to do all the work for the service of the sanctuary, according to all that Yahuah has commanded.” 
 </p><p>
-<sup>2&#160;</sup>Moses called Bezalel and Oholiab, and every wise-hearted man, in whose heart Yahweh had put wisdom, even everyone whose heart stirred him up to come to the work to do it. 
+<sup>2&#160;</sup>Moses called Bezalel and Oholiab, and every wise-hearted man, in whose heart Yahuah had put wisdom, even everyone whose heart stirred him up to come to the work to do it. 
 <sup>3&#160;</sup>They received from Moses all the offering which the children of Israel had brought for the work of the service of the sanctuary, with which to make it. They kept bringing free will offerings to him every morning. 
 <sup>4&#160;</sup>All the wise men, who performed all the work of the sanctuary, each came from his work which he did. 
-<sup>5&#160;</sup>They spoke to Moses, saying, “The people have brought much more than enough for the service of the work which Yahweh commanded to make.” 
+<sup>5&#160;</sup>They spoke to Moses, saying, “The people have brought much more than enough for the service of the work which Yahuah commanded to make.” 
 </p><p>
 <sup>6&#160;</sup>Moses gave a commandment, and they caused it to be proclaimed throughout the camp, saying, “Let neither man nor woman make anything else for the offering for the sanctuary.” So the people were restrained from bringing. 
 <sup>7&#160;</sup>For the stuff they had was sufficient to do all the work, and too much. 
@@ -1638,7 +1638,7 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>All the pins of the tabernacle, and around the court, were of bronze. 
 </p><p>
 <sup>21&#160;</sup>These are the amounts of materials used for the tabernacle, even the Tabernacle of the Testimony, as they were counted, according to the commandment of Moses, for the service of the Levites, by the hand of Ithamar, the son of Aaron the priest. 
-<sup>22&#160;</sup>Bezalel the son of Uri, the son of Hur, of the tribe of Judah, made all that Yahweh commanded Moses. 
+<sup>22&#160;</sup>Bezalel the son of Uri, the son of Hur, of the tribe of Judah, made all that Yahuah commanded Moses. 
 <sup>23&#160;</sup>With him was Oholiab, the son of Ahisamach, of the tribe of Dan, an engraver, and a skillful workman, and an embroiderer in blue, in purple, in scarlet, and in fine linen. 
 </p><p>
 <sup>24&#160;</sup>All the gold that was used for the work in all the work of the sanctuary, even the gold of the offering, was twenty-nine talents and seven hundred thirty shekels, according to the shekel of the sanctuary. 
@@ -1651,15 +1651,15 @@ html[dir=ltr] .q2 {
 <sup>31&#160;</sup>the sockets around the court, the sockets of the gate of the court, all the pins of the tabernacle, and all the pins around the court. 
 </p><h2 class="chapterlabel" id="39">39</h2>
 <p>
-<sup>1&#160;</sup>Of the blue, purple, and scarlet, they made finely worked garments for ministering in the set-apart place, and made the set-apart garments for Aaron, as Yahweh commanded Moses. 
+<sup>1&#160;</sup>Of the blue, purple, and scarlet, they made finely worked garments for ministering in the set-apart place, and made the set-apart garments for Aaron, as Yahuah commanded Moses. 
 </p><p>
 <sup>2&#160;</sup>He made the ephod of gold, blue, purple, scarlet, and fine twined linen. 
 <sup>3&#160;</sup>They beat the gold into thin plates, and cut it into wires, to work it in with the blue, the purple, the scarlet, and the fine linen, the work of the skillful workman. 
 <sup>4&#160;</sup>They made shoulder straps for it, joined together. It was joined together at the two ends. 
-<sup>5&#160;</sup>The skillfully woven band that was on it, with which to fasten it on, was of the same piece, like its work: of gold, of blue, purple, scarlet, and fine twined linen, as Yahweh commanded Moses. 
+<sup>5&#160;</sup>The skillfully woven band that was on it, with which to fasten it on, was of the same piece, like its work: of gold, of blue, purple, scarlet, and fine twined linen, as Yahuah commanded Moses. 
 </p><p>
 <sup>6&#160;</sup>They worked the onyx stones, enclosed in settings of gold, engraved with the engravings of a signet, according to the names of the children of Israel. 
-<sup>7&#160;</sup>He put them on the shoulder straps of the ephod, to be stones of memorial for the children of Israel, as Yahweh commanded Moses. 
+<sup>7&#160;</sup>He put them on the shoulder straps of the ephod, to be stones of memorial for the children of Israel, as Yahuah commanded Moses. 
 </p><p>
 <sup>8&#160;</sup>He made the breastplate, the work of a skillful workman, like the work of the ephod: of gold, of blue, purple, scarlet, and fine twined linen. 
 <sup>9&#160;</sup>It was square. They made the breastplate double. Its length was a span, and its width a span, being double. 
@@ -1674,22 +1674,22 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>The other two ends of the two braided chains they put on the two settings, and put them on the shoulder straps of the ephod, in its front. 
 <sup>19&#160;</sup>They made two rings of gold, and put them on the two ends of the breastplate, on its edge, which was toward the side of the ephod inward. 
 <sup>20&#160;</sup>They made two more rings of gold, and put them on the two shoulder straps of the ephod underneath, in its front, close by its coupling, above the skillfully woven band of the ephod. 
-<sup>21&#160;</sup>They bound the breastplate by its rings to the rings of the ephod with a lace of blue, that it might be on the skillfully woven band of the ephod, and that the breastplate might not come loose from the ephod, as Yahweh commanded Moses. 
+<sup>21&#160;</sup>They bound the breastplate by its rings to the rings of the ephod with a lace of blue, that it might be on the skillfully woven band of the ephod, and that the breastplate might not come loose from the ephod, as Yahuah commanded Moses. 
 </p><p>
 <sup>22&#160;</sup>He made the robe of the ephod of woven work, all of blue. 
 <sup>23&#160;</sup>The opening of the robe in the middle of it was like the opening of a coat of mail, with a binding around its opening, that it should not be torn. 
 <sup>24&#160;</sup>They made on the skirts of the robe pomegranates of blue, purple, scarlet, and twined linen. 
 <sup>25&#160;</sup>They made bells of pure gold, and put the bells between the pomegranates around the skirts of the robe, between the pomegranates; 
-<sup>26&#160;</sup>a bell and a pomegranate, a bell and a pomegranate, around the skirts of the robe, to minister in, as Yahweh commanded Moses. 
+<sup>26&#160;</sup>a bell and a pomegranate, a bell and a pomegranate, around the skirts of the robe, to minister in, as Yahuah commanded Moses. 
 </p><p>
 <sup>27&#160;</sup>They made the tunics of fine linen of woven work for Aaron and for his sons, 
 <sup>28&#160;</sup>the turban of fine linen, the linen headbands of fine linen, the linen trousers of fine twined linen, 
-<sup>29&#160;</sup>the sash of fine twined linen, blue, purple, and scarlet, the work of the embroiderer, as Yahweh commanded Moses. 
+<sup>29&#160;</sup>the sash of fine twined linen, blue, purple, and scarlet, the work of the embroiderer, as Yahuah commanded Moses. 
 </p><p>
-<sup>30&#160;</sup>They made the plate of the set-apart crown of pure gold, and wrote on it an inscription, like the engravings of a signet: “SET-APART TO YAHWEH”. 
-<sup>31&#160;</sup>They tied to it a lace of blue, to fasten it on the turban above, as Yahweh commanded Moses. 
+<sup>30&#160;</sup>They made the plate of the set-apart crown of pure gold, and wrote on it an inscription, like the engravings of a signet: “SET-APART TO YAHUAH”. 
+<sup>31&#160;</sup>They tied to it a lace of blue, to fasten it on the turban above, as Yahuah commanded Moses. 
 </p><p>
-<sup>32&#160;</sup>Thus all the work of the tabernacle of the Tent of Meeting was finished. The children of Israel did according to all that Yahweh commanded Moses; so they did. 
+<sup>32&#160;</sup>Thus all the work of the tabernacle of the Tent of Meeting was finished. The children of Israel did according to all that Yahuah commanded Moses; so they did. 
 <sup>33&#160;</sup>They brought the tabernacle to Moses: the tent, with all its furniture, its clasps, its boards, its bars, its pillars, its sockets, 
 <sup>34&#160;</sup>the covering of rams’ skins dyed red, the covering of sea cow hides, the veil of the screen, 
 <sup>35&#160;</sup>the ark of the covenant with its poles, the mercy seat, 
@@ -1699,11 +1699,11 @@ html[dir=ltr] .q2 {
 <sup>39&#160;</sup>the bronze altar, its grating of bronze, its poles, all of its vessels, the basin and its base, 
 <sup>40&#160;</sup>the hangings of the court, its pillars, its sockets, the screen for the gate of the court, its cords, its pins, and all the instruments of the service of the tabernacle, for the Tent of Meeting, 
 <sup>41&#160;</sup>the finely worked garments for ministering in the set-apart place, the set-apart garments for Aaron the priest, and the garments of his sons, to minister in the priest’s office. 
-<sup>42&#160;</sup>According to all that Yahweh commanded Moses, so the children of Israel did all the work. 
-<sup>43&#160;</sup>Moses saw all the work, and behold, they had done it as Yahweh had commanded. They had done so; and Moses blessed them. 
+<sup>42&#160;</sup>According to all that Yahuah commanded Moses, so the children of Israel did all the work. 
+<sup>43&#160;</sup>Moses saw all the work, and behold, they had done it as Yahuah had commanded. They had done so; and Moses blessed them. 
 </p><h2 class="chapterlabel" id="40">40</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“On the first day of the first month you shall raise up the tabernacle of the Tent of Meeting. 
 <sup>3&#160;</sup>You shall put the ark of the covenant in it, and you shall screen the ark with the veil. 
 <sup>4&#160;</sup>You shall bring in the table, and set in order the things that are on it. You shall bring in the lamp stand, and light its lamps. 
@@ -1721,28 +1721,28 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>You shall put on Aaron the set-apart garments; and you shall anoint him, and sanctify him, that he may minister to me in the priest’s office. 
 <sup>14&#160;</sup>You shall bring his sons, and put tunics on them. 
 <sup>15&#160;</sup>You shall anoint them, as you anointed their father, that they may minister to me in the priest’s office. Their anointing shall be to them for an everlasting priesthood throughout their generations.” 
-<sup>16&#160;</sup>Moses did so. According to all that Yahweh commanded him, so he did. 
+<sup>16&#160;</sup>Moses did so. According to all that Yahuah commanded him, so he did. 
 </p><p>
 <sup>17&#160;</sup>In the first month in the second year, on the first day of the month, the tabernacle was raised up. 
 <sup>18&#160;</sup>Moses raised up the tabernacle, and laid its sockets, and set up its boards, and put in its bars, and raised up its pillars. 
-<sup>19&#160;</sup>He spread the covering over the tent, and put the roof of the tabernacle above on it, as Yahweh commanded Moses. 
+<sup>19&#160;</sup>He spread the covering over the tent, and put the roof of the tabernacle above on it, as Yahuah commanded Moses. 
 <sup>20&#160;</sup>He took and put the covenant into the ark, and set the poles on the ark, and put the mercy seat above on the ark. 
-<sup>21&#160;</sup>He brought the ark into the tabernacle, and set up the veil of the screen, and screened the ark of the covenant, as Yahweh commanded Moses. 
+<sup>21&#160;</sup>He brought the ark into the tabernacle, and set up the veil of the screen, and screened the ark of the covenant, as Yahuah commanded Moses. 
 <sup>22&#160;</sup>He put the table in the Tent of Meeting, on the north side of the tabernacle, outside of the veil. 
-<sup>23&#160;</sup>He set the bread in order on it before Yahweh, as Yahweh commanded Moses. 
+<sup>23&#160;</sup>He set the bread in order on it before Yahuah, as Yahuah commanded Moses. 
 <sup>24&#160;</sup>He put the lamp stand in the Tent of Meeting, opposite the table, on the south side of the tabernacle. 
-<sup>25&#160;</sup>He lit the lamps before Yahweh, as Yahweh commanded Moses. 
+<sup>25&#160;</sup>He lit the lamps before Yahuah, as Yahuah commanded Moses. 
 <sup>26&#160;</sup>He put the golden altar in the Tent of Meeting before the veil; 
-<sup>27&#160;</sup>and he burned incense of sweet spices on it, as Yahweh commanded Moses. 
+<sup>27&#160;</sup>and he burned incense of sweet spices on it, as Yahuah commanded Moses. 
 <sup>28&#160;</sup>He put up the screen of the door to the tabernacle. 
-<sup>29&#160;</sup>He set the altar of burnt offering at the door of the tabernacle of the Tent of Meeting, and offered on it the burnt offering and the meal offering, as Yahweh commanded Moses. 
+<sup>29&#160;</sup>He set the altar of burnt offering at the door of the tabernacle of the Tent of Meeting, and offered on it the burnt offering and the meal offering, as Yahuah commanded Moses. 
 <sup>30&#160;</sup>He set the basin between the Tent of Meeting and the altar, and put water therein, with which to wash. 
 <sup>31&#160;</sup>Moses, Aaron, and his sons washed their hands and their feet there. 
-<sup>32&#160;</sup>When they went into the Tent of Meeting, and when they came near to the altar, they washed, as Yahweh commanded Moses. 
+<sup>32&#160;</sup>When they went into the Tent of Meeting, and when they came near to the altar, they washed, as Yahuah commanded Moses. 
 <sup>33&#160;</sup>He raised up the court around the tabernacle and the altar, and set up the screen of the gate of the court. So Moses finished the work. 
 </p><p>
-<sup>34&#160;</sup>Then the cloud covered the Tent of Meeting, and Yahweh’s glory filled the tabernacle. 
-<sup>35&#160;</sup>Moses wasn’t able to enter into the Tent of Meeting, because the cloud stayed on it, and Yahweh’s glory filled the tabernacle. 
+<sup>34&#160;</sup>Then the cloud covered the Tent of Meeting, and Yahuah’s glory filled the tabernacle. 
+<sup>35&#160;</sup>Moses wasn’t able to enter into the Tent of Meeting, because the cloud stayed on it, and Yahuah’s glory filled the tabernacle. 
 <sup>36&#160;</sup>When the cloud was taken up from over the tabernacle, the children of Israel went onward, throughout all their journeys; 
 <sup>37&#160;</sup>but if the cloud wasn’t taken up, then they didn’t travel until the day that it was taken up. 
-<sup>38&#160;</sup>For the cloud of Yahweh was on the tabernacle by day, and there was fire in the cloud by night, in the sight of all the house of Israel, throughout all their journeys. </p></div><script src="../main.js"></script></body></html>
+<sup>38&#160;</sup>For the cloud of Yahuah was on the tabernacle by day, and there was fire in the cloud by night, in the sight of all the house of Israel, throughout all their journeys. </p></div><script src="../main.js"></script></body></html>

--- a/book/ezekiel.html
+++ b/book/ezekiel.html
@@ -110,7 +110,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>Now in the thirtieth year, in the fourth month, in the fifth day of the month, as I was among the captives by the river Chebar, the heavens were opened, and I saw visions of Elohim. 
 </p><p>
 <sup>2&#160;</sup>In the fifth of the month, which was the fifth year of King Jehoiachin’s captivity, 
-<sup>3&#160;</sup>Yahweh’s word came to Ezekiel the priest, the son of Buzi, in the land of the Chaldeans by the river Chebar; and Yahweh’s hand was there on him. 
+<sup>3&#160;</sup>Yahuah’s word came to Ezekiel the priest, the son of Buzi, in the land of the Chaldeans by the river Chebar; and Yahuah’s hand was there on him. 
 </p><p>
 <sup>4&#160;</sup>I looked, and behold, a stormy wind came out of the north: a great cloud, with flashing lightning, and a brightness around it, and out of the middle of it as it were glowing metal, out of the middle of the fire. 
 <sup>5&#160;</sup>Out of its center came the likeness of four living creatures. This was their appearance: They had the likeness of a man. 
@@ -142,14 +142,14 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>Above the expanse that was over their heads was the likeness of a throne, as the appearance of a sapphire stone. On the likeness of the throne was a likeness as the appearance of a man on it above. 
 <sup>27&#160;</sup>I saw as it were glowing metal, as the appearance of fire within it all around, from the appearance of his waist and upward; and from the appearance of his waist and downward I saw as it were the appearance of fire, and there was brightness around him. 
 <sup>28&#160;</sup>As the appearance of the rainbow that is in the cloud in the day of rain, so was the appearance of the brightness all around. 
-</p><p>This was the appearance of the likeness of Yahweh’s glory. When I saw it, I fell on my face, and I heard a voice of one that spoke. 
+</p><p>This was the appearance of the likeness of Yahuah’s glory. When I saw it, I fell on my face, and I heard a voice of one that spoke. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
 <sup>1&#160;</sup>He said to me, “Son of man, stand on your feet, and I will speak with you.” 
 <sup>2&#160;</sup>The Spirit entered into me when he spoke to me, and set me on my feet; and I heard him who spoke to me. 
 </p><p>
 <sup>3&#160;</sup>He said to me, “Son of man, I send you to the children of Israel, to a nation of rebels who have rebelled against me. They and their fathers have transgressed against me even to this very day. 
-<sup>4&#160;</sup>The children are impudent and stiff-hearted. I am sending you to them, and you shall tell them, ‘This is what the Lord Yahweh says.’ 
+<sup>4&#160;</sup>The children are impudent and stiff-hearted. I am sending you to them, and you shall tell them, ‘This is what the Lord Yahuah says.’ 
 <sup>5&#160;</sup>They, whether they will hear, or whether they will refuse—for they are a rebellious house—yet they will know that there has been a prophet among them. 
 <sup>6&#160;</sup>You, son of man, don’t be afraid of them, neither be afraid of their words, though briers and thorns are with you, and you dwell among scorpions. Don’t be afraid of their words, nor be dismayed at their looks, though they are a rebellious house. 
 <sup>7&#160;</sup>You shall speak my words to them, whether they will hear or whether they will refuse; for they are most rebellious. 
@@ -173,14 +173,14 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>I have made your forehead as a diamond, harder than flint. Don’t be afraid of them, neither be dismayed at their looks, though they are a rebellious house.” 
 </p><p>
 <sup>10&#160;</sup>Moreover he said to me, “Son of man, receive in your heart and hear with your ears all my words that I speak to you. 
-<sup>11&#160;</sup>Go to them of the captivity, to the children of your people, and speak to them, and tell them, ‘This is what the Lord Yahweh says,’ whether they will hear, or whether they will refuse.” 
+<sup>11&#160;</sup>Go to them of the captivity, to the children of your people, and speak to them, and tell them, ‘This is what the Lord Yahuah says,’ whether they will hear, or whether they will refuse.” 
 </p><p>
-<sup>12&#160;</sup>Then the Spirit lifted me up, and I heard behind me the voice of a great rushing, saying, “Blessed be Yahweh’s glory from his place.” 
+<sup>12&#160;</sup>Then the Spirit lifted me up, and I heard behind me the voice of a great rushing, saying, “Blessed be Yahuah’s glory from his place.” 
 <sup>13&#160;</sup>I heard the noise of the wings of the living creatures as they touched one another, and the noise of the wheels beside them, even the noise of a great rushing. 
-<sup>14&#160;</sup>So the Spirit lifted me up, and took me away; and I went in bitterness, in the heat of my spirit; and Yahweh’s hand was strong on me. 
+<sup>14&#160;</sup>So the Spirit lifted me up, and took me away; and I went in bitterness, in the heat of my spirit; and Yahuah’s hand was strong on me. 
 <sup>15&#160;</sup>Then I came to them of the captivity at Tel Aviv who lived by the river Chebar, and to where they lived; and I sat there overwhelmed among them seven days. 
 </p><p>
-<sup>16&#160;</sup>At the end of seven days, Yahweh’s word came to me, saying, 
+<sup>16&#160;</sup>At the end of seven days, Yahuah’s word came to me, saying, 
 <sup>17&#160;</sup>“Son of man, I have made you a watchman to the house of Israel. Therefore hear the word from my mouth, and warn them from me. 
 <sup>18&#160;</sup>When I tell the wicked, ‘You will surely die;’ and you give him no warning, nor speak to warn the wicked from his wicked way, to save his life, that wicked man will die in his iniquity; but I will require his blood at your hand. 
 <sup>19&#160;</sup>Yet if you warn the wicked, and he doesn’t turn from his wickedness, nor from his wicked way, he will die in his iniquity; but you have delivered your soul.” 
@@ -188,14 +188,14 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>“Again, when a righteous man turns from his righteousness and commits iniquity, and I lay a stumbling block before him, he will die. Because you have not given him warning, he will die in his sin, and his righteous deeds which he has done will not be remembered; but I will require his blood at your hand. 
 <sup>21&#160;</sup>Nevertheless if you warn the righteous man, that the righteous not sin, and he does not sin, he will surely live, because he took warning; and you have delivered your soul.” 
 </p><p>
-<sup>22&#160;</sup>Yahweh’s hand was there on me; and he said to me, “Arise, go out into the plain, and I will talk with you there.” 
+<sup>22&#160;</sup>Yahuah’s hand was there on me; and he said to me, “Arise, go out into the plain, and I will talk with you there.” 
 </p><p>
-<sup>23&#160;</sup>Then I arose, and went out into the plain, and behold, Yahweh’s glory stood there, like the glory which I saw by the river Chebar. Then I fell on my face. 
+<sup>23&#160;</sup>Then I arose, and went out into the plain, and behold, Yahuah’s glory stood there, like the glory which I saw by the river Chebar. Then I fell on my face. 
 </p><p>
 <sup>24&#160;</sup>Then the Spirit entered into me and set me on my feet. He spoke with me, and said to me, “Go, shut yourself inside your house. 
 <sup>25&#160;</sup>But you, son of man, behold, they will put ropes on you, and will bind you with them, and you will not go out among them. 
 <sup>26&#160;</sup>I will make your tongue stick to the roof of your mouth so that you will be mute and will not be able to correct them, for they are a rebellious house. 
-<sup>27&#160;</sup>But when I speak with you, I will open your mouth, and you shall tell them, ‘This is what the Lord Yahweh says.’ He who hears, let him hear; and he who refuses, let him refuse; for they are a rebellious house.” 
+<sup>27&#160;</sup>But when I speak with you, I will open your mouth, and you shall tell them, ‘This is what the Lord Yahuah says.’ He who hears, let him hear; and he who refuses, let him refuse; for they are a rebellious house.” 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
 <sup>1&#160;</sup>“You also, son of man, take a tile, and lay it before yourself, and portray on it a city, even Jerusalem. 
@@ -213,9 +213,9 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>Your food which you shall eat shall be by weight, twenty shekels a day. From time to time you shall eat it. 
 <sup>11&#160;</sup>You shall drink water by measure, the sixth part of a hin. From time to time you shall drink. 
 <sup>12&#160;</sup>You shall eat it as barley cakes, and you shall bake it in their sight with dung that comes out of man.” 
-<sup>13&#160;</sup>Yahweh said, “Even thus will the children of Israel eat their bread unclean, among the nations where I will drive them.” 
+<sup>13&#160;</sup>Yahuah said, “Even thus will the children of Israel eat their bread unclean, among the nations where I will drive them.” 
 </p><p>
-<sup>14&#160;</sup>Then I said, “Ah Lord Yahweh! Behold, my soul has not been polluted; for from my youth up even until now I have not eaten of that which dies of itself, or is torn of animals. No abominable meat has come into my mouth!” 
+<sup>14&#160;</sup>Then I said, “Ah Lord Yahuah! Behold, my soul has not been polluted; for from my youth up even until now I have not eaten of that which dies of itself, or is torn of animals. No abominable meat has come into my mouth!” 
 </p><p>
 <sup>15&#160;</sup>Then he said to me, “Behold, I have given you cow’s dung for man’s dung, and you shall prepare your bread on it.” 
 </p><p>
@@ -228,52 +228,52 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>You shall take a small number of these and bind them in the folds of your robe. 
 <sup>4&#160;</sup>Of these again you shall take, and cast them into the middle of the fire, and burn them in the fire. From it a fire will come out into all the house of Israel. 
 </p><p>
-<sup>5&#160;</sup>“The Lord Yahweh says: ‘This is Jerusalem. I have set her in the middle of the nations, and countries are around her. 
+<sup>5&#160;</sup>“The Lord Yahuah says: ‘This is Jerusalem. I have set her in the middle of the nations, and countries are around her. 
 <sup>6&#160;</sup>She has rebelled against my ordinances in doing wickedness more than the nations, and against my statutes more than the countries that are around her; for they have rejected my ordinances, and as for my statutes, they have not walked in them.’ 
 </p><p>
-<sup>7&#160;</sup>“Therefore the Lord Yahweh says: ‘Because you are more turbulent than the nations that are around you, and have not walked in my statutes, neither have kept my ordinances, neither have followed the ordinances of the nations that are around you; 
-<sup>8&#160;</sup>therefore the Lord Yahweh says: ‘Behold, I, even I, am against you; and I will execute judgments among you in the sight of the nations. 
+<sup>7&#160;</sup>“Therefore the Lord Yahuah says: ‘Because you are more turbulent than the nations that are around you, and have not walked in my statutes, neither have kept my ordinances, neither have followed the ordinances of the nations that are around you; 
+<sup>8&#160;</sup>therefore the Lord Yahuah says: ‘Behold, I, even I, am against you; and I will execute judgments among you in the sight of the nations. 
 <sup>9&#160;</sup>I will do in you that which I have not done, and which I will not do anything like it any more, because of all your abominations. 
 <sup>10&#160;</sup>Therefore the fathers will eat the sons within you, and the sons will eat their fathers. I will execute judgments on you; and I will scatter the whole remnant of you to all the winds. 
-<sup>11&#160;</sup>Therefore as I live,’ says the Lord Yahweh, ‘surely, because you have defiled my sanctuary with all your detestable things, and with all your abominations, therefore I will also diminish you. My eye won’t spare, and I will have no pity. 
+<sup>11&#160;</sup>Therefore as I live,’ says the Lord Yahuah, ‘surely, because you have defiled my sanctuary with all your detestable things, and with all your abominations, therefore I will also diminish you. My eye won’t spare, and I will have no pity. 
 <sup>12&#160;</sup>A third part of you will die with the pestilence, and they will be consumed with famine within you. A third part will fall by the sword around you. A third part I will scatter to all the winds, and will draw out a sword after them. 
 </p><p>
-<sup>13&#160;</sup>“&#160;‘Thus my anger will be accomplished, and I will cause my wrath toward them to rest, and I will be comforted. They will know that I, Yahweh, have spoken in my zeal, when I have accomplished my wrath on them. 
+<sup>13&#160;</sup>“&#160;‘Thus my anger will be accomplished, and I will cause my wrath toward them to rest, and I will be comforted. They will know that I, Yahuah, have spoken in my zeal, when I have accomplished my wrath on them. 
 </p><p>
 <sup>14&#160;</sup>“&#160;‘Moreover I will make you a desolation and a reproach among the nations that are around you, in the sight of all that pass by. 
-<sup>15&#160;</sup>So it will be a reproach and a taunt, an instruction and an astonishment, to the nations that are around you, when I execute judgments on you in anger and in wrath, and in wrathful rebukes—I, Yahweh, have spoken it—<sup>16&#160;</sup>when I send on them the evil arrows of famine that are for destruction, which I will send to destroy you. I will increase the famine on you and will break your staff of bread. 
-<sup>17&#160;</sup>I will send on you famine and evil animals, and they will bereave you. Pestilence and blood will pass through you. I will bring the sword on you. I, Yahweh, have spoken it.’&#160;” 
+<sup>15&#160;</sup>So it will be a reproach and a taunt, an instruction and an astonishment, to the nations that are around you, when I execute judgments on you in anger and in wrath, and in wrathful rebukes—I, Yahuah, have spoken it—<sup>16&#160;</sup>when I send on them the evil arrows of famine that are for destruction, which I will send to destroy you. I will increase the famine on you and will break your staff of bread. 
+<sup>17&#160;</sup>I will send on you famine and evil animals, and they will bereave you. Pestilence and blood will pass through you. I will bring the sword on you. I, Yahuah, have spoken it.’&#160;” 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, set your face toward the mountains of Israel, and prophesy to them, 
-<sup>3&#160;</sup>and say, ‘You mountains of Israel, hear the word of the Lord Yahweh! The Lord Yahweh says to the mountains and to the hills, to the watercourses and to the valleys: “Behold, I, even I, will bring a sword on you, and I will destroy your high places. 
+<sup>3&#160;</sup>and say, ‘You mountains of Israel, hear the word of the Lord Yahuah! The Lord Yahuah says to the mountains and to the hills, to the watercourses and to the valleys: “Behold, I, even I, will bring a sword on you, and I will destroy your high places. 
 <sup>4&#160;</sup>Your altars will become desolate, and your incense altars will be broken. I will cast down your slain men before your idols. 
 <sup>5&#160;</sup>I will lay the dead bodies of the children of Israel before their idols. I will scatter your bones around your altars. 
 <sup>6&#160;</sup>In all your dwelling places, the cities will be laid waste and the high places will be desolate, so that your altars may be laid waste and made desolate, and your idols may be broken and cease, and your incense altars may be cut down, and your works may be abolished. 
-<sup>7&#160;</sup>The slain will fall among you, and you will know that I am Yahweh. 
+<sup>7&#160;</sup>The slain will fall among you, and you will know that I am Yahuah. 
 </p><p>
 <sup>8&#160;</sup>“&#160;‘&#160;“Yet I will leave a remnant, in that you will have some that escape the sword among the nations, when you are scattered through the countries. 
 <sup>9&#160;</sup>Those of you that escape will remember me among the nations where they are carried captive, how I have been broken with their lewd heart, which has departed from me, and with their eyes, which play the prostitute after their idols. Then they will loathe themselves in their own sight for the evils which they have committed in all their abominations. 
-<sup>10&#160;</sup>They will know that I am Yahweh. I have not said in vain that I would do this evil to them.”&#160;’ 
+<sup>10&#160;</sup>They will know that I am Yahuah. I have not said in vain that I would do this evil to them.”&#160;’ 
 </p><p>
-<sup>11&#160;</sup>“The Lord Yahweh says: ‘Strike with your hand, and stamp with your foot, and say, “Alas!”, because of all the evil abominations of the house of Israel; for they will fall by the sword, by the famine, and by the pestilence. 
+<sup>11&#160;</sup>“The Lord Yahuah says: ‘Strike with your hand, and stamp with your foot, and say, “Alas!”, because of all the evil abominations of the house of Israel; for they will fall by the sword, by the famine, and by the pestilence. 
 <sup>12&#160;</sup>He who is far off will die of the pestilence. He who is near will fall by the sword. He who remains and is besieged will die by the famine. Thus I will accomplish my wrath on them. 
-<sup>13&#160;</sup>You will know that I am Yahweh when their slain men are among their idols around their altars, on every high hill, on all the tops of the mountains, under every green tree, and under every thick oak—the places where they offered pleasant aroma to all their idols. 
-<sup>14&#160;</sup>I will stretch out my hand on them and make the land desolate and waste, from the wilderness toward Diblah, throughout all their habitations. Then they will know that I am Yahweh.’&#160;” 
+<sup>13&#160;</sup>You will know that I am Yahuah when their slain men are among their idols around their altars, on every high hill, on all the tops of the mountains, under every green tree, and under every thick oak—the places where they offered pleasant aroma to all their idols. 
+<sup>14&#160;</sup>I will stretch out my hand on them and make the land desolate and waste, from the wilderness toward Diblah, throughout all their habitations. Then they will know that I am Yahuah.’&#160;” 
 </p><p class="b"> &#160; </p>
 <h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>Moreover Yahweh’s word came to me, saying, 
-<sup>2&#160;</sup>“You, son of man, the Lord Yahweh says to the land of Israel, ‘An end! The end has come on the four corners of the land. 
+<sup>1&#160;</sup>Moreover Yahuah’s word came to me, saying, 
+<sup>2&#160;</sup>“You, son of man, the Lord Yahuah says to the land of Israel, ‘An end! The end has come on the four corners of the land. 
 <sup>3&#160;</sup>Now the end is on you, and I will send my anger on you, and will judge you according to your ways. I will bring on you all your abominations. 
-<sup>4&#160;</sup>My eye will not spare you, neither will I have pity; but I will bring your ways on you, and your abominations will be among you. Then you will know that I am Yahweh.’ 
+<sup>4&#160;</sup>My eye will not spare you, neither will I have pity; but I will bring your ways on you, and your abominations will be among you. Then you will know that I am Yahuah.’ 
 </p><p>
-<sup>5&#160;</sup>“The Lord Yahweh says: ‘A disaster! A unique disaster! Behold, it comes. 
+<sup>5&#160;</sup>“The Lord Yahuah says: ‘A disaster! A unique disaster! Behold, it comes. 
 <sup>6&#160;</sup>An end has come. The end has come! It awakes against you. Behold, it comes. 
 <sup>7&#160;</sup>Your doom has come to you, inhabitant of the land! The time has come! The day is near, a day of tumult, and not of joyful shouting, on the mountains. 
 <sup>8&#160;</sup>Now I will shortly pour out my wrath on you, and accomplish my anger against you, and will judge you according to your ways. I will bring on you all your abominations. 
-<sup>9&#160;</sup>My eye won’t spare, neither will I have pity. I will punish you according to your ways. Your abominations will be among you. Then you will know that I, Yahweh, strike. 
+<sup>9&#160;</sup>My eye won’t spare, neither will I have pity. I will punish you according to your ways. Your abominations will be among you. Then you will know that I, Yahuah, strike. 
 </p><p>
 <sup>10&#160;</sup>“&#160;‘Behold, the day! Behold, it comes! Your doom has gone out. The rod has blossomed. Pride has budded. 
 <sup>11&#160;</sup>Violence has risen up into a rod of wickedness. None of them will remain, nor of their multitude, nor of their wealth. There will be nothing of value among them. 
@@ -285,7 +285,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>But of those who escape, they will escape and will be on the mountains like doves of the valleys, all of them moaning, everyone in his iniquity. 
 <sup>17&#160;</sup>All hands will be feeble, and all knees will be weak as water. 
 <sup>18&#160;</sup>They will also clothe themselves with sackcloth, and horror will cover them. Shame will be on all faces, and baldness on all their heads. 
-<sup>19&#160;</sup>They will cast their silver in the streets, and their gold will be as an unclean thing. Their silver and their gold won’t be able to deliver them in the day of Yahweh’s wrath. They won’t satisfy their souls or fill their bellies; because it has been the stumbling block of their iniquity. 
+<sup>19&#160;</sup>They will cast their silver in the streets, and their gold will be as an unclean thing. Their silver and their gold won’t be able to deliver them in the day of Yahuah’s wrath. They won’t satisfy their souls or fill their bellies; because it has been the stumbling block of their iniquity. 
 <sup>20&#160;</sup>As for the beauty of his ornament, he set it in majesty; but they made the images of their abominations and their detestable things therein. Therefore I have made it to them as an unclean thing. 
 <sup>21&#160;</sup>I will give it into the hands of the strangers for a prey, and to the wicked of the earth for a plunder; and they will profane it. 
 <sup>22&#160;</sup>I will also turn my face from them, and they will profane my secret place. Robbers will enter into it, and profane it. 
@@ -294,10 +294,10 @@ html[dir=ltr] .q2 {
 <sup>24&#160;</sup>Therefore I will bring the worst of the nations, and they will possess their houses. I will also make the pride of the strong to cease. Their set-apart places will be profaned. 
 <sup>25&#160;</sup>Destruction comes! They will seek peace, and there will be none. 
 <sup>26&#160;</sup>Mischief will come on mischief, and rumor will be on rumor. They will seek a vision of the prophet; but the law will perish from the priest, and counsel from the elders. 
-<sup>27&#160;</sup>The king will mourn, and the prince will be clothed with desolation. The hands of the people of the land will be troubled. I will do to them after their way, and according to their own judgments I will judge them. Then they will know that I am Yahweh.’&#160;” 
+<sup>27&#160;</sup>The king will mourn, and the prince will be clothed with desolation. The hands of the people of the land will be troubled. I will do to them after their way, and according to their own judgments I will judge them. Then they will know that I am Yahuah.’&#160;” 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>In the sixth year, in the sixth month, in the fifth day of the month, as I sat in my house, and the elders of Judah sat before me, the Lord Yahweh’s hand fell on me there. 
+<sup>1&#160;</sup>In the sixth year, in the sixth month, in the fifth day of the month, as I sat in my house, and the elders of Judah sat before me, the Lord Yahuah’s hand fell on me there. 
 <sup>2&#160;</sup>Then I saw, and behold, a likeness as the appearance of fire—from the appearance of his waist and downward, fire, and from his waist and upward, as the appearance of brightness, as it were glowing metal. 
 <sup>3&#160;</sup>He stretched out the form of a hand, and took me by a lock of my head; and the Spirit lifted me up between earth and the sky, and brought me in the visions of Elohim to Jerusalem, to the door of the gate of the inner court that looks toward the north, where there was the seat of the image of jealousy, which provokes to jealousy. 
 <sup>4&#160;</sup>Behold, the glory of the Elohim of Israel was there, according to the appearance that I saw in the plain. 
@@ -316,13 +316,13 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>So I went in and looked, and saw every form of creeping things, abominable animals, and all the idols of the house of Israel, portrayed around on the wall. 
 <sup>11&#160;</sup>Seventy men of the elders of the house of Israel stood before them. In the middle of them Jaazaniah the son of Shaphan stood, every man with his censer in his hand; and the smell of the cloud of incense went up. 
 </p><p>
-<sup>12&#160;</sup>Then he said to me, “Son of man, have you seen what the elders of the house of Israel do in the dark, every man in his rooms of imagery? For they say, ‘Yahweh doesn’t see us. Yahweh has forsaken the land.’&#160;” 
+<sup>12&#160;</sup>Then he said to me, “Son of man, have you seen what the elders of the house of Israel do in the dark, every man in his rooms of imagery? For they say, ‘Yahuah doesn’t see us. Yahuah has forsaken the land.’&#160;” 
 <sup>13&#160;</sup>He said also to me, “You will again see more of the great abominations which they do.” 
 </p><p>
-<sup>14&#160;</sup>Then he brought me to the door of the gate of Yahweh’s house which was toward the north; and I saw the women sit there weeping for Tammuz. 
+<sup>14&#160;</sup>Then he brought me to the door of the gate of Yahuah’s house which was toward the north; and I saw the women sit there weeping for Tammuz. 
 <sup>15&#160;</sup>Then he said to me, “Have you seen this, son of man? You will again see yet greater abominations than these.” 
 </p><p>
-<sup>16&#160;</sup>He brought me into the inner court of Yahweh’s house; and I saw at the door of Yahweh’s temple, between the porch and the altar, there were about twenty-five men with their backs toward Yahweh’s temple and their faces toward the east. They were worshiping the sun toward the east. 
+<sup>16&#160;</sup>He brought me into the inner court of Yahuah’s house; and I saw at the door of Yahuah’s temple, between the porch and the altar, there were about twenty-five men with their backs toward Yahuah’s temple and their faces toward the east. They were worshiping the sun toward the east. 
 </p><p>
 <sup>17&#160;</sup>Then he said to me, “Have you seen this, son of man? Is it a light thing to the house of Judah that they commit the abominations which they commit here? For they have filled the land with violence, and have turned again to provoke me to anger. Behold, they put the branch to their nose. 
 <sup>18&#160;</sup>Therefore I will also deal in wrath. My eye won’t spare, neither will I have pity. Though they cry in my ears with a loud voice, yet I will not hear them.” 
@@ -332,7 +332,7 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>Behold, six men came from the way of the upper gate, which lies toward the north, every man with his slaughter weapon in his hand. One man in the middle of them was clothed in linen, with a writer’s inkhorn by his side. They went in, and stood beside the bronze altar. 
 </p><p>
 <sup>3&#160;</sup>The glory of the Elohim of Israel went up from the cherub, whereupon it was, to the threshold of the house; and he called to the man clothed in linen, who had the writer’s inkhorn by his side. 
-<sup>4&#160;</sup>Yahweh said to him, “Go through the middle of the city, through the middle of Jerusalem, and set a mark on the foreheads of the men that sigh and that cry over all the abominations that are done within it.” 
+<sup>4&#160;</sup>Yahuah said to him, “Go through the middle of the city, through the middle of Jerusalem, and set a mark on the foreheads of the men that sigh and that cry over all the abominations that are done within it.” 
 </p><p>
 <sup>5&#160;</sup>To the others he said in my hearing, “Go through the city after him, and strike. Don’t let your eye spare, neither have pity. 
 <sup>6&#160;</sup>Kill utterly the old man, the young man, the virgin, little children and women; but don’t come near any man on whom is the mark. Begin at my sanctuary.” 
@@ -341,9 +341,9 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>He said to them, “Defile the house, and fill the courts with the slain. Go out!” 
 </p><p>They went out, and struck in the city. 
 </p><p>
-<sup>8&#160;</sup>While they were killing, and I was left, I fell on my face, and cried, and said, “Ah Lord Yahweh! Will you destroy all the residue of Israel in your pouring out of your wrath on Jerusalem?” 
+<sup>8&#160;</sup>While they were killing, and I was left, I fell on my face, and cried, and said, “Ah Lord Yahuah! Will you destroy all the residue of Israel in your pouring out of your wrath on Jerusalem?” 
 </p><p>
-<sup>9&#160;</sup>Then he said to me, “The iniquity of the house of Israel and Judah is exceedingly great, and the land is full of blood, and the city full of perversion; for they say, ‘Yahweh has forsaken the land, and Yahweh doesn’t see.’ 
+<sup>9&#160;</sup>Then he said to me, “The iniquity of the house of Israel and Judah is exceedingly great, and the land is full of blood, and the city full of perversion; for they say, ‘Yahuah has forsaken the land, and Yahuah doesn’t see.’ 
 <sup>10&#160;</sup>As for me also, my eye won’t spare, neither will I have pity, but I will bring their way on their head.” 
 </p><p>
 <sup>11&#160;</sup>Behold, the man clothed in linen, who had the inkhorn by his side, reported the matter, saying, “I have done as you have commanded me.” 
@@ -353,7 +353,7 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>He spoke to the man clothed in linen, and said, “Go in between the whirling wheels, even under the cherub, and fill both your hands with coals of fire from between the cherubim, and scatter them over the city.” 
 </p><p>He went in as I watched. 
 <sup>3&#160;</sup>Now the cherubim stood on the right side of the house when the man went in; and the cloud filled the inner court. 
-<sup>4&#160;</sup>Yahweh’s glory mounted up from the cherub, and stood over the threshold of the house; and the house was filled with the cloud, and the court was full of the brightness of Yahweh’s glory. 
+<sup>4&#160;</sup>Yahuah’s glory mounted up from the cherub, and stood over the threshold of the house; and the house was filled with the cloud, and the court was full of the brightness of Yahuah’s glory. 
 <sup>5&#160;</sup>The sound of the wings of the cherubim was heard even to the outer court, as the voice of Elohim Almighty when he speaks. 
 </p><p>
 <sup>6&#160;</sup>It came to pass, when he commanded the man clothed in linen, saying, “Take fire from between the whirling wheels, from between the cherubim,” that he went in and stood beside a wheel. 
@@ -371,51 +371,51 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>When the cherubim went, the wheels went beside them; and when the cherubim lifted up their wings to mount up from the earth, the wheels also didn’t turn from beside them. 
 <sup>17&#160;</sup>When they stood, these stood. When they mounted up, these mounted up with them; for the spirit of the living creature was in them. 
 </p><p>
-<sup>18&#160;</sup>Yahweh’s glory went out from over the threshold of the house and stood over the cherubim. 
-<sup>19&#160;</sup>The cherubim lifted up their wings and mounted up from the earth in my sight when they went out, with the wheels beside them. Then they stood at the door of the east gate of Yahweh’s house; and the glory of the Elohim of Israel was over them above. 
+<sup>18&#160;</sup>Yahuah’s glory went out from over the threshold of the house and stood over the cherubim. 
+<sup>19&#160;</sup>The cherubim lifted up their wings and mounted up from the earth in my sight when they went out, with the wheels beside them. Then they stood at the door of the east gate of Yahuah’s house; and the glory of the Elohim of Israel was over them above. 
 </p><p>
 <sup>20&#160;</sup>This is the living creature that I saw under the Elohim of Israel by the river Chebar; and I knew that they were cherubim. 
 <sup>21&#160;</sup>Every one had four faces, and every one four wings. The likeness of the hands of a man was under their wings. 
 <sup>22&#160;</sup>As for the likeness of their faces, they were the faces which I saw by the river Chebar, their appearances and themselves. They each went straight forward. 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p>
-<sup>1&#160;</sup>Moreover the Spirit lifted me up and brought me to the east gate of Yahweh’s house, which looks eastward. Behold, twenty-five men were at the door of the gate; and I saw among them Jaazaniah the son of Azzur, and Pelatiah the son of Benaiah, princes of the people. 
+<sup>1&#160;</sup>Moreover the Spirit lifted me up and brought me to the east gate of Yahuah’s house, which looks eastward. Behold, twenty-five men were at the door of the gate; and I saw among them Jaazaniah the son of Azzur, and Pelatiah the son of Benaiah, princes of the people. 
 <sup>2&#160;</sup>He said to me, “Son of man, these are the men who devise iniquity, and who give wicked counsel in this city; 
 <sup>3&#160;</sup>who say, ‘The time is not near to build houses. This is the cauldron, and we are the meat.’ 
 <sup>4&#160;</sup>Therefore prophesy against them. Prophesy, son of man.” 
 </p><p>
-<sup>5&#160;</sup>Yahweh’s Spirit fell on me, and he said to me, “Speak, ‘Yahweh says: “Thus you have said, house of Israel; for I know the things that come into your mind. 
+<sup>5&#160;</sup>Yahuah’s Spirit fell on me, and he said to me, “Speak, ‘Yahuah says: “Thus you have said, house of Israel; for I know the things that come into your mind. 
 <sup>6&#160;</sup>You have multiplied your slain in this city, and you have filled its streets with the slain.” 
 </p><p>
-<sup>7&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: “Your slain whom you have laid in the middle of it, they are the meat, and this is the cauldron; but you will be brought out of the middle of it. 
-<sup>8&#160;</sup>You have feared the sword; and I will bring the sword on you,” says the Lord Yahweh. 
+<sup>7&#160;</sup>“&#160;‘Therefore the Lord Yahuah says: “Your slain whom you have laid in the middle of it, they are the meat, and this is the cauldron; but you will be brought out of the middle of it. 
+<sup>8&#160;</sup>You have feared the sword; and I will bring the sword on you,” says the Lord Yahuah. 
 <sup>9&#160;</sup>“I will bring you out of the middle of it, and deliver you into the hands of strangers, and will execute judgments among you. 
-<sup>10&#160;</sup>You will fall by the sword. I will judge you in the border of Israel. Then you will know that I am Yahweh. 
+<sup>10&#160;</sup>You will fall by the sword. I will judge you in the border of Israel. Then you will know that I am Yahuah. 
 <sup>11&#160;</sup>This will not be your cauldron, neither will you be the meat in the middle of it. I will judge you in the border of Israel. 
-<sup>12&#160;</sup>You will know that I am Yahweh, for you have not walked in my statutes. You have not executed my ordinances, but have done after the ordinances of the nations that are around you.”&#160;’&#160;” 
+<sup>12&#160;</sup>You will know that I am Yahuah, for you have not walked in my statutes. You have not executed my ordinances, but have done after the ordinances of the nations that are around you.”&#160;’&#160;” 
 </p><p>
-<sup>13&#160;</sup>When I prophesied, Pelatiah the son of Benaiah died. Then I fell down on my face, and cried with a loud voice, and said, “Ah Lord Yahweh! Will you make a full end of the remnant of Israel?” 
+<sup>13&#160;</sup>When I prophesied, Pelatiah the son of Benaiah died. Then I fell down on my face, and cried with a loud voice, and said, “Ah Lord Yahuah! Will you make a full end of the remnant of Israel?” 
 </p><p>
-<sup>14&#160;</sup>Yahweh’s word came to me, saying, 
-<sup>15&#160;</sup>“Son of man, your brothers, even your brothers, the men of your relatives, and all the house of Israel, all of them, are the ones to whom the inhabitants of Jerusalem have said, ‘Go far away from Yahweh. This land has been given to us for a possession.’ 
+<sup>14&#160;</sup>Yahuah’s word came to me, saying, 
+<sup>15&#160;</sup>“Son of man, your brothers, even your brothers, the men of your relatives, and all the house of Israel, all of them, are the ones to whom the inhabitants of Jerusalem have said, ‘Go far away from Yahuah. This land has been given to us for a possession.’ 
 </p><p>
-<sup>16&#160;</sup>“Therefore say, ‘The Lord Yahweh says: “Whereas I have removed them far off among the nations, and whereas I have scattered them among the countries, yet I will be to them a sanctuary for a little while in the countries where they have come.”&#160;’ 
+<sup>16&#160;</sup>“Therefore say, ‘The Lord Yahuah says: “Whereas I have removed them far off among the nations, and whereas I have scattered them among the countries, yet I will be to them a sanctuary for a little while in the countries where they have come.”&#160;’ 
 </p><p>
-<sup>17&#160;</sup>“Therefore say, ‘The Lord Yahweh says: “I will gather you from the peoples, and assemble you out of the countries where you have been scattered, and I will give you the land of Israel.” 
+<sup>17&#160;</sup>“Therefore say, ‘The Lord Yahuah says: “I will gather you from the peoples, and assemble you out of the countries where you have been scattered, and I will give you the land of Israel.” 
 </p><p>
 <sup>18&#160;</sup>“&#160;‘They will come there, and they will take away all its detestable things and all its abominations from there. 
 <sup>19&#160;</sup>I will give them one heart, and I will put a new spirit within them. I will take the stony heart out of their flesh, and will give them a heart of flesh, 
 <sup>20&#160;</sup>that they may walk in my statutes, and keep my ordinances, and do them. They will be my people, and I will be their Elohim. 
-<sup>21&#160;</sup>But as for them whose heart walks after the heart of their detestable things and their abominations, I will bring their way on their own heads,’ says the Lord Yahweh.” 
+<sup>21&#160;</sup>But as for them whose heart walks after the heart of their detestable things and their abominations, I will bring their way on their own heads,’ says the Lord Yahuah.” 
 </p><p>
 <sup>22&#160;</sup>Then the cherubim lifted up their wings, and the wheels were beside them. The glory of the Elohim of Israel was over them above. 
-<sup>23&#160;</sup>Yahweh’s glory went up from the middle of the city, and stood on the mountain which is on the east side of the city. 
+<sup>23&#160;</sup>Yahuah’s glory went up from the middle of the city, and stood on the mountain which is on the east side of the city. 
 <sup>24&#160;</sup>The Spirit lifted me up, and brought me in the vision by the Spirit of Elohim into Chaldea, to the captives. 
 </p><p>So the vision that I had seen went up from me. 
-<sup>25&#160;</sup>Then I spoke to the captives all the things that Yahweh had shown me. 
+<sup>25&#160;</sup>Then I spoke to the captives all the things that Yahuah had shown me. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word also came to me, saying, 
+<sup>1&#160;</sup>Yahuah’s word also came to me, saying, 
 <sup>2&#160;</sup>“Son of man, you dwell in the middle of the rebellious house, who have eyes to see, and don’t see, who have ears to hear, and don’t hear; for they are a rebellious house. 
 </p><p>
 <sup>3&#160;</sup>“Therefore, you son of man, prepare your baggage for moving, and move by day in their sight. You shall move from your place to another place in their sight. It may be they will consider, though they are a rebellious house. 
@@ -425,10 +425,10 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>7&#160;</sup>I did so as I was commanded. I brought out my baggage by day, as baggage for moving, and in the evening I dug through the wall with my hand. I brought it out in the dark, and bore it on my shoulder in their sight. 
 </p><p>
-<sup>8&#160;</sup>In the morning, Yahweh’s word came to me, saying, 
+<sup>8&#160;</sup>In the morning, Yahuah’s word came to me, saying, 
 <sup>9&#160;</sup>“Son of man, hasn’t the house of Israel, the rebellious house, said to you, ‘What are you doing?’ 
 </p><p>
-<sup>10&#160;</sup>“Say to them, ‘The Lord Yahweh says: “This burden concerns the prince in Jerusalem, and all the house of Israel among whom they are.”&#160;’ 
+<sup>10&#160;</sup>“Say to them, ‘The Lord Yahuah says: “This burden concerns the prince in Jerusalem, and all the house of Israel among whom they are.”&#160;’ 
 </p><p>
 <sup>11&#160;</sup>“Say, ‘I am your sign. As I have done, so will it be done to them. They will go into exile, into captivity. 
 </p><p>
@@ -436,139 +436,139 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>I will also spread my net on him, and he will be taken in my snare. I will bring him to Babylon to the land of the Chaldeans; yet he will not see it, though he will die there. 
 <sup>14&#160;</sup>I will scatter toward every wind all who are around him to help him, and all his bands. I will draw out the sword after them. 
 </p><p>
-<sup>15&#160;</sup>“&#160;‘They will know that I am Yahweh when I disperse them among the nations and scatter them through the countries. 
-<sup>16&#160;</sup>But I will leave a few men of them from the sword, from the famine, and from the pestilence, that they may declare all their abominations among the nations where they come. Then they will know that I am Yahweh.’&#160;” 
+<sup>15&#160;</sup>“&#160;‘They will know that I am Yahuah when I disperse them among the nations and scatter them through the countries. 
+<sup>16&#160;</sup>But I will leave a few men of them from the sword, from the famine, and from the pestilence, that they may declare all their abominations among the nations where they come. Then they will know that I am Yahuah.’&#160;” 
 </p><p>
-<sup>17&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>17&#160;</sup>Moreover Yahuah’s word came to me, saying, 
 <sup>18&#160;</sup>“Son of man, eat your bread with quaking, and drink your water with trembling and with fearfulness. 
-<sup>19&#160;</sup>Tell the people of the land, ‘The Lord Yahweh says concerning the inhabitants of Jerusalem and the land of Israel: “They will eat their bread with fearfulness and drink their water in dismay, that her land may be desolate, and all that is therein, because of the violence of all those who dwell therein. 
-<sup>20&#160;</sup>The cities that are inhabited will be laid waste, and the land will be a desolation. Then you will know that I am Yahweh.”&#160;’&#160;” 
+<sup>19&#160;</sup>Tell the people of the land, ‘The Lord Yahuah says concerning the inhabitants of Jerusalem and the land of Israel: “They will eat their bread with fearfulness and drink their water in dismay, that her land may be desolate, and all that is therein, because of the violence of all those who dwell therein. 
+<sup>20&#160;</sup>The cities that are inhabited will be laid waste, and the land will be a desolation. Then you will know that I am Yahuah.”&#160;’&#160;” 
 </p><p>
-<sup>21&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>21&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>22&#160;</sup>“Son of man, what is this proverb that you have in the land of Israel, saying, ‘The days are prolonged, and every vision fails’? 
-<sup>23&#160;</sup>Tell them therefore, ‘The Lord Yahweh says: “I will make this proverb to cease, and they will no more use it as a proverb in Israel;”&#160;’ but tell them, ‘&#160;“The days are at hand, and the fulfillment of every vision. 
+<sup>23&#160;</sup>Tell them therefore, ‘The Lord Yahuah says: “I will make this proverb to cease, and they will no more use it as a proverb in Israel;”&#160;’ but tell them, ‘&#160;“The days are at hand, and the fulfillment of every vision. 
 <sup>24&#160;</sup>For there will be no more any false vision nor flattering divination within the house of Israel. 
-<sup>25&#160;</sup>For I am Yahweh. I will speak, and the word that I speak will be performed. It will be no more deferred; for in your days, rebellious house, I will speak the word and will perform it,” says the Lord Yahweh.’&#160;” 
+<sup>25&#160;</sup>For I am Yahuah. I will speak, and the word that I speak will be performed. It will be no more deferred; for in your days, rebellious house, I will speak the word and will perform it,” says the Lord Yahuah.’&#160;” 
 </p><p>
-<sup>26&#160;</sup>Again Yahweh’s word came to me, saying, 
+<sup>26&#160;</sup>Again Yahuah’s word came to me, saying, 
 <sup>27&#160;</sup>“Son of man, behold, they of the house of Israel say, ‘The vision that he sees is for many days to come, and he prophesies of times that are far off.’ 
 </p><p>
-<sup>28&#160;</sup>“Therefore tell them, ‘The Lord Yahweh says: “None of my words will be deferred any more, but the word which I speak will be performed,” says the Lord Yahweh.’&#160;” 
+<sup>28&#160;</sup>“Therefore tell them, ‘The Lord Yahuah says: “None of my words will be deferred any more, but the word which I speak will be performed,” says the Lord Yahuah.’&#160;” 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
-<sup>2&#160;</sup>“Son of man, prophesy against the prophets of Israel who prophesy, and say to those who prophesy out of their own heart, ‘Hear Yahweh’s word: 
-<sup>3&#160;</sup>The Lord Yahweh says, “Woe to the foolish prophets, who follow their own spirit, and have seen nothing! 
+<sup>1&#160;</sup>Yahuah’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, prophesy against the prophets of Israel who prophesy, and say to those who prophesy out of their own heart, ‘Hear Yahuah’s word: 
+<sup>3&#160;</sup>The Lord Yahuah says, “Woe to the foolish prophets, who follow their own spirit, and have seen nothing! 
 <sup>4&#160;</sup>Israel, your prophets have been like foxes in the waste places. 
-<sup>5&#160;</sup>You have not gone up into the gaps or built up the wall for the house of Israel, to stand in the battle in Yahweh’s day. 
-<sup>6&#160;</sup>They have seen falsehood and lying divination, who say, ‘Yahweh says;’ but Yahweh has not sent them. They have made men to hope that the word would be confirmed. 
-<sup>7&#160;</sup>Haven’t you seen a false vision, and haven’t you spoken a lying divination, in that you say, ‘Yahweh says;’ but I have not spoken?” 
+<sup>5&#160;</sup>You have not gone up into the gaps or built up the wall for the house of Israel, to stand in the battle in Yahuah’s day. 
+<sup>6&#160;</sup>They have seen falsehood and lying divination, who say, ‘Yahuah says;’ but Yahuah has not sent them. They have made men to hope that the word would be confirmed. 
+<sup>7&#160;</sup>Haven’t you seen a false vision, and haven’t you spoken a lying divination, in that you say, ‘Yahuah says;’ but I have not spoken?” 
 </p><p>
-<sup>8&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: “Because you have spoken falsehood and seen lies, therefore, behold, I am against you,” says the Lord Yahweh. 
-<sup>9&#160;</sup>“My hand will be against the prophets who see false visions and who utter lying divinations. They will not be in the council of my people, neither will they be written in the writing of the house of Israel, neither will they enter into the land of Israel. Then you will know that I am the Lord Yahweh.” 
+<sup>8&#160;</sup>“&#160;‘Therefore the Lord Yahuah says: “Because you have spoken falsehood and seen lies, therefore, behold, I am against you,” says the Lord Yahuah. 
+<sup>9&#160;</sup>“My hand will be against the prophets who see false visions and who utter lying divinations. They will not be in the council of my people, neither will they be written in the writing of the house of Israel, neither will they enter into the land of Israel. Then you will know that I am the Lord Yahuah.” 
 </p><p>
 <sup>10&#160;</sup>“&#160;‘Because, even because they have seduced my people, saying, “Peace;” and there is no peace. When one builds up a wall, behold, they plaster it with whitewash. 
 <sup>11&#160;</sup>Tell those who plaster it with whitewash that it will fall. There will be an overflowing shower; and you, great hailstones, will fall. A stormy wind will tear it. 
 <sup>12&#160;</sup>Behold, when the wall has fallen, won’t it be said to you, “Where is the plaster with which you have plastered it?” 
 </p><p>
-<sup>13&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: “I will even tear it with a stormy wind in my wrath. There will be an overflowing shower in my anger, and great hailstones in wrath to consume it. 
-<sup>14&#160;</sup>So I will break down the wall that you have plastered with whitewash, and bring it down to the ground, so that its foundation will be uncovered. It will fall, and you will be consumed in the middle of it. Then you will know that I am Yahweh. 
-<sup>15&#160;</sup>Thus I will accomplish my wrath on the wall, and on those who have plastered it with whitewash. I will tell you, ‘The wall is no more, nor those who plastered it—<sup>16&#160;</sup>to wit, the prophets of Israel who prophesy concerning Jerusalem, and who see visions of peace for her, and there is no peace,’&#160;” says the Lord Yahweh.’&#160;” 
+<sup>13&#160;</sup>“&#160;‘Therefore the Lord Yahuah says: “I will even tear it with a stormy wind in my wrath. There will be an overflowing shower in my anger, and great hailstones in wrath to consume it. 
+<sup>14&#160;</sup>So I will break down the wall that you have plastered with whitewash, and bring it down to the ground, so that its foundation will be uncovered. It will fall, and you will be consumed in the middle of it. Then you will know that I am Yahuah. 
+<sup>15&#160;</sup>Thus I will accomplish my wrath on the wall, and on those who have plastered it with whitewash. I will tell you, ‘The wall is no more, nor those who plastered it—<sup>16&#160;</sup>to wit, the prophets of Israel who prophesy concerning Jerusalem, and who see visions of peace for her, and there is no peace,’&#160;” says the Lord Yahuah.’&#160;” 
 </p><p>
 <sup>17&#160;</sup>You, son of man, set your face against the daughters of your people, who prophesy out of their own heart; and prophesy against them, 
-<sup>18&#160;</sup>and say, “The Lord Yahweh says: ‘Woe to the women who sew magic bands on all elbows and make veils for the head of persons of every stature to hunt souls! Will you hunt the souls of my people and save souls alive for yourselves? 
+<sup>18&#160;</sup>and say, “The Lord Yahuah says: ‘Woe to the women who sew magic bands on all elbows and make veils for the head of persons of every stature to hunt souls! Will you hunt the souls of my people and save souls alive for yourselves? 
 <sup>19&#160;</sup>You have profaned me among my people for handfuls of barley and for pieces of bread, to kill the souls who should not die and to save the souls alive who should not live, by your lying to my people who listen to lies.’ 
 </p><p>
-<sup>20&#160;</sup>“Therefore the Lord Yahweh says: ‘Behold, I am against your magic bands, with which you hunt the souls to make them fly, and I will tear them from your arms. I will let the souls fly free, even the souls whom you ensnare like birds. 
-<sup>21&#160;</sup>I will also tear your veils and deliver my people out of your hand; and they will no longer be in your hand to be ensnared. Then you will know that I am Yahweh. 
+<sup>20&#160;</sup>“Therefore the Lord Yahuah says: ‘Behold, I am against your magic bands, with which you hunt the souls to make them fly, and I will tear them from your arms. I will let the souls fly free, even the souls whom you ensnare like birds. 
+<sup>21&#160;</sup>I will also tear your veils and deliver my people out of your hand; and they will no longer be in your hand to be ensnared. Then you will know that I am Yahuah. 
 <sup>22&#160;</sup>Because with lies you have grieved the heart of the righteous, whom I have not made sad; and strengthened the hands of the wicked, that he should not return from his wicked way, and be saved alive. 
-<sup>23&#160;</sup>Therefore you shall no more see false visions nor practice divination. I will deliver my people out of your hand. Then you will know that I am Yahweh.’&#160;” 
+<sup>23&#160;</sup>Therefore you shall no more see false visions nor practice divination. I will deliver my people out of your hand. Then you will know that I am Yahuah.’&#160;” 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
 <sup>1&#160;</sup>Then some of the elders of Israel came to me and sat before me. 
-<sup>2&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>3&#160;</sup>“Son of man, these men have taken their idols into their heart, and put the stumbling block of their iniquity before their face. Should I be inquired of at all by them? 
-<sup>4&#160;</sup>Therefore speak to them and tell them, ‘The Lord Yahweh says: “Every man of the house of Israel who takes his idols into his heart and puts the stumbling block of his iniquity before his face then comes to the prophet, I Yahweh will answer him there according to the multitude of his idols, 
+<sup>4&#160;</sup>Therefore speak to them and tell them, ‘The Lord Yahuah says: “Every man of the house of Israel who takes his idols into his heart and puts the stumbling block of his iniquity before his face then comes to the prophet, I Yahuah will answer him there according to the multitude of his idols, 
 <sup>5&#160;</sup>that I may take the house of Israel in their own heart, because they are all estranged from me through their idols.”&#160;’ 
 </p><p>
-<sup>6&#160;</sup>“Therefore tell the house of Israel, ‘The Lord Yahweh says: “Return, and turn yourselves from your idols! Turn away your faces from all your abominations. 
+<sup>6&#160;</sup>“Therefore tell the house of Israel, ‘The Lord Yahuah says: “Return, and turn yourselves from your idols! Turn away your faces from all your abominations. 
 </p><p>
-<sup>7&#160;</sup>“&#160;‘&#160;“For everyone of the house of Israel, or of the strangers who live in Israel, who separates himself from me and takes his idols into his heart, and puts the stumbling block of his iniquity before his face, and comes to the prophet to inquire for himself of me, I Yahweh will answer him by myself. 
-<sup>8&#160;</sup>I will set my face against that man and will make him an astonishment, for a sign and a proverb, and I will cut him off from among my people. Then you will know that I am Yahweh. 
+<sup>7&#160;</sup>“&#160;‘&#160;“For everyone of the house of Israel, or of the strangers who live in Israel, who separates himself from me and takes his idols into his heart, and puts the stumbling block of his iniquity before his face, and comes to the prophet to inquire for himself of me, I Yahuah will answer him by myself. 
+<sup>8&#160;</sup>I will set my face against that man and will make him an astonishment, for a sign and a proverb, and I will cut him off from among my people. Then you will know that I am Yahuah. 
 </p><p>
-<sup>9&#160;</sup>“&#160;‘&#160;“If the prophet is deceived and speaks a word, I, Yahweh, have deceived that prophet, and I will stretch out my hand on him, and will destroy him from among my people Israel. 
+<sup>9&#160;</sup>“&#160;‘&#160;“If the prophet is deceived and speaks a word, I, Yahuah, have deceived that prophet, and I will stretch out my hand on him, and will destroy him from among my people Israel. 
 <sup>10&#160;</sup>They will bear their iniquity. The iniquity of the prophet will be even as the iniquity of him who seeks him, 
-<sup>11&#160;</sup>that the house of Israel may no more go astray from me, neither defile themselves any more with all their transgressions; but that they may be my people, and I may be their Elohim,” says the Lord Yahweh.’&#160;” 
+<sup>11&#160;</sup>that the house of Israel may no more go astray from me, neither defile themselves any more with all their transgressions; but that they may be my people, and I may be their Elohim,” says the Lord Yahuah.’&#160;” 
 </p><p>
-<sup>12&#160;</sup>Yahweh’s word came to me, saying, 
-<sup>13&#160;</sup>“Son of man, when a land sins against me by committing a trespass, and I stretch out my hand on it, and break the staff of its bread and send famine on it, and cut off from it man and animal—<sup>14&#160;</sup>though these three men, Noah, Daniel, and Job, were in it, they would deliver only their own souls by their righteousness,” says the Lord Yahweh. 
+<sup>12&#160;</sup>Yahuah’s word came to me, saying, 
+<sup>13&#160;</sup>“Son of man, when a land sins against me by committing a trespass, and I stretch out my hand on it, and break the staff of its bread and send famine on it, and cut off from it man and animal—<sup>14&#160;</sup>though these three men, Noah, Daniel, and Job, were in it, they would deliver only their own souls by their righteousness,” says the Lord Yahuah. 
 </p><p>
-<sup>15&#160;</sup>“If I cause evil animals to pass through the land, and they ravage it and it is made desolate, so that no man may pass through because of the animals—<sup>16&#160;</sup>though these three men were in it, as I live,” says the Lord Yahweh, “they would deliver neither sons nor daughters. They only would be delivered, but the land would be desolate. 
+<sup>15&#160;</sup>“If I cause evil animals to pass through the land, and they ravage it and it is made desolate, so that no man may pass through because of the animals—<sup>16&#160;</sup>though these three men were in it, as I live,” says the Lord Yahuah, “they would deliver neither sons nor daughters. They only would be delivered, but the land would be desolate. 
 </p><p>
-<sup>17&#160;</sup>“Or if I bring a sword on that land, and say, ‘Sword, go through the land, so that I cut off from it man and animal’—<sup>18&#160;</sup>though these three men were in it, as I live,” says the Lord Yahweh, “they would deliver neither sons nor daughters, but they only would be delivered themselves. 
+<sup>17&#160;</sup>“Or if I bring a sword on that land, and say, ‘Sword, go through the land, so that I cut off from it man and animal’—<sup>18&#160;</sup>though these three men were in it, as I live,” says the Lord Yahuah, “they would deliver neither sons nor daughters, but they only would be delivered themselves. 
 </p><p>
-<sup>19&#160;</sup>“Or if I send a pestilence into that land, and pour out my wrath on it in blood, to cut off from it man and animal—<sup>20&#160;</sup>though Noah, Daniel, and Job, were in it, as I live,” says the Lord Yahweh, “they would deliver neither son nor daughter; they would deliver only their own souls by their righteousness.” 
+<sup>19&#160;</sup>“Or if I send a pestilence into that land, and pour out my wrath on it in blood, to cut off from it man and animal—<sup>20&#160;</sup>though Noah, Daniel, and Job, were in it, as I live,” says the Lord Yahuah, “they would deliver neither son nor daughter; they would deliver only their own souls by their righteousness.” 
 </p><p>
-<sup>21&#160;</sup>For the Lord Yahweh says: “How much more when I send my four severe judgments on Jerusalem—the sword, the famine, the evil animals, and the pestilence—to cut off from it man and animal! 
+<sup>21&#160;</sup>For the Lord Yahuah says: “How much more when I send my four severe judgments on Jerusalem—the sword, the famine, the evil animals, and the pestilence—to cut off from it man and animal! 
 <sup>22&#160;</sup>Yet, behold, there will be left a remnant in it that will be carried out, both sons and daughters. Behold, they will come out to you, and you will see their way and their doings. Then you will be comforted concerning the evil that I have brought on Jerusalem, even concerning all that I have brought on it. 
-<sup>23&#160;</sup>They will comfort you, when you see their way and their doings; then you will know that I have not done all that I have done in it without cause,” says the Lord Yahweh. 
+<sup>23&#160;</sup>They will comfort you, when you see their way and their doings; then you will know that I have not done all that I have done in it without cause,” says the Lord Yahuah. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, what is the vine tree more than any tree, the vine branch which is among the trees of the forest? 
 <sup>3&#160;</sup>Will wood be taken of it to make anything? Will men take a pin of it to hang any vessel on it? 
 <sup>4&#160;</sup>Behold, it is cast into the fire for fuel; the fire has devoured both its ends, and the middle of it is burned. Is it profitable for any work? 
 <sup>5&#160;</sup>Behold, when it was whole, it was suitable for no work. How much less, when the fire has devoured it, and it has been burned, will it yet be suitable for any work?” 
 </p><p>
-<sup>6&#160;</sup>Therefore the Lord Yahweh says: “As the vine wood among the trees of the forest, which I have given to the fire for fuel, so I will give the inhabitants of Jerusalem. 
-<sup>7&#160;</sup>I will set my face against them. They will go out from the fire, but the fire will still devour them. Then you will know that I am Yahweh, when I set my face against them. 
-<sup>8&#160;</sup>I will make the land desolate, because they have acted unfaithfully,” says the Lord Yahweh. 
+<sup>6&#160;</sup>Therefore the Lord Yahuah says: “As the vine wood among the trees of the forest, which I have given to the fire for fuel, so I will give the inhabitants of Jerusalem. 
+<sup>7&#160;</sup>I will set my face against them. They will go out from the fire, but the fire will still devour them. Then you will know that I am Yahuah, when I set my face against them. 
+<sup>8&#160;</sup>I will make the land desolate, because they have acted unfaithfully,” says the Lord Yahuah. 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
-<sup>1&#160;</sup>Again Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Again Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, cause Jerusalem to know her abominations; 
-<sup>3&#160;</sup>and say, ‘The Lord Yahweh says to Jerusalem: “Your origin and your birth is of the land of the Canaanite. An Amorite was your father, and your mother was a Hittite. 
+<sup>3&#160;</sup>and say, ‘The Lord Yahuah says to Jerusalem: “Your origin and your birth is of the land of the Canaanite. An Amorite was your father, and your mother was a Hittite. 
 <sup>4&#160;</sup>As for your birth, in the day you were born your navel was not cut. You weren’t washed in water to cleanse you. You weren’t salted at all, nor wrapped in blankets at all. 
 <sup>5&#160;</sup>No eye pitied you, to do any of these things to you, to have compassion on you; but you were cast out in the open field, because you were abhorred in the day that you were born. 
 </p><p>
 <sup>6&#160;</sup>“&#160;‘&#160;“When I passed by you, and saw you wallowing in your blood, I said to you, ‘Though you are in your blood, live!’ Yes, I said to you, ‘Though you are in your blood, live!’ 
 <sup>7&#160;</sup>I caused you to multiply as that which grows in the field, and you increased and grew great, and you attained to excellent beauty. Your breasts were formed, and your hair grew; yet you were naked and bare. 
 </p><p>
-<sup>8&#160;</sup>“&#160;‘&#160;“Now when I passed by you, and looked at you, behold, your time was the time of love; and I spread my garment over you and covered your nakedness. Yes, I pledged myself to you and entered into a covenant with you,” says the Lord Yahweh, “and you became mine. 
+<sup>8&#160;</sup>“&#160;‘&#160;“Now when I passed by you, and looked at you, behold, your time was the time of love; and I spread my garment over you and covered your nakedness. Yes, I pledged myself to you and entered into a covenant with you,” says the Lord Yahuah, “and you became mine. 
 </p><p>
 <sup>9&#160;</sup>“&#160;‘&#160;“Then I washed you with water. Yes, I thoroughly washed away your blood from you, and I anointed you with oil. 
 <sup>10&#160;</sup>I clothed you also with embroidered work and put leather sandals on you. I dressed you with fine linen and covered you with silk. 
 <sup>11&#160;</sup>I decked you with ornaments, put bracelets on your hands, and put a chain on your neck. 
 <sup>12&#160;</sup>I put a ring on your nose, earrings in your ears, and a beautiful crown on your head. 
 <sup>13&#160;</sup>Thus you were decked with gold and silver. Your clothing was of fine linen, silk, and embroidered work. You ate fine flour, honey, and oil. You were exceedingly beautiful, and you prospered to royal estate. 
-<sup>14&#160;</sup>Your renown went out among the nations for your beauty; for it was perfect, through my majesty which I had put on you,” says the Lord Yahweh. 
+<sup>14&#160;</sup>Your renown went out among the nations for your beauty; for it was perfect, through my majesty which I had put on you,” says the Lord Yahuah. 
 </p><p>
 <sup>15&#160;</sup>“&#160;‘&#160;“But you trusted in your beauty, and played the prostitute because of your renown, and poured out your prostitution on everyone who passed by. It was his. 
 <sup>16&#160;</sup>You took some of your garments, and made for yourselves high places decked with various colors, and played the prostitute on them. This shouldn’t happen, neither shall it be. 
 <sup>17&#160;</sup>You also took your beautiful jewels of my gold and of my silver, which I had given you, and made for yourself images of men, and played the prostitute with them. 
 <sup>18&#160;</sup>You took your embroidered garments, covered them, and set my oil and my incense before them. 
-<sup>19&#160;</sup>My bread also which I gave you, fine flour, oil, and honey, with which I fed you, you even set it before them for a pleasant aroma; and so it was,” says the Lord Yahweh. 
+<sup>19&#160;</sup>My bread also which I gave you, fine flour, oil, and honey, with which I fed you, you even set it before them for a pleasant aroma; and so it was,” says the Lord Yahuah. 
 </p><p>
 <sup>20&#160;</sup>“&#160;‘&#160;“Moreover you have taken your sons and your daughters, whom you have borne to me, and you have sacrificed these to them to be devoured. Was your prostitution a small matter, 
 <sup>21&#160;</sup>that you have slain my children and delivered them up, in causing them to pass through the fire to them? 
 <sup>22&#160;</sup>In all your abominations and your prostitution you have not remembered the days of your youth, when you were naked and bare, and were wallowing in your blood. 
 </p><p>
-<sup>23&#160;</sup>“&#160;‘&#160;“It has happened after all your wickedness—woe, woe to you!” says the Lord Yahweh—<sup>24&#160;</sup>“that you have built for yourselves a vaulted place, and have made yourselves a lofty place in every street. 
+<sup>23&#160;</sup>“&#160;‘&#160;“It has happened after all your wickedness—woe, woe to you!” says the Lord Yahuah—<sup>24&#160;</sup>“that you have built for yourselves a vaulted place, and have made yourselves a lofty place in every street. 
 <sup>25&#160;</sup>You have built your lofty place at the head of every way, and have made your beauty an abomination, and have opened your feet to everyone who passed by, and multiplied your prostitution. 
 <sup>26&#160;</sup>You have also committed sexual immorality with the Egyptians, your neighbors, great of flesh; and have multiplied your prostitution, to provoke me to anger. 
 <sup>27&#160;</sup>See therefore, I have stretched out my hand over you, and have diminished your portion, and delivered you to the will of those who hate you, the daughters of the Philistines, who are ashamed of your lewd way. 
 <sup>28&#160;</sup>You have played the prostitute also with the Assyrians, because you were insatiable; yes, you have played the prostitute with them, and yet you weren’t satisfied. 
 <sup>29&#160;</sup>You have moreover multiplied your prostitution to the land of merchants, to Chaldea; and yet you weren’t satisfied with this. 
 </p><p>
-<sup>30&#160;</sup>“&#160;‘&#160;“How weak is your heart,” says the Lord Yahweh, “since you do all these things, the work of an impudent prostitute; 
+<sup>30&#160;</sup>“&#160;‘&#160;“How weak is your heart,” says the Lord Yahuah, “since you do all these things, the work of an impudent prostitute; 
 <sup>31&#160;</sup>in that you build your vaulted place at the head of every way, and make your lofty place in every street, and have not been as a prostitute, in that you scorn pay. 
 </p><p>
 <sup>32&#160;</sup>“&#160;‘&#160;“Adulterous woman, who takes strangers instead of her man! 
 <sup>33&#160;</sup>People give gifts to all prostitutes; but you give your gifts to all your lovers, and bribe them, that they may come to you on every side for your prostitution. 
 <sup>34&#160;</sup>You are different from other women in your prostitution, in that no one follows you to play the prostitute; and whereas you give hire, and no hire is given to you, therefore you are different.”&#160;’ 
 </p><p>
-<sup>35&#160;</sup>“Therefore, prostitute, hear Yahweh’s word: 
-<sup>36&#160;</sup>‘The Lord Yahweh says, “Because your filthiness was poured out, and your nakedness uncovered through your prostitution with your lovers; and because of all the idols of your abominations, and for the blood of your children, that you gave to them; 
+<sup>35&#160;</sup>“Therefore, prostitute, hear Yahuah’s word: 
+<sup>36&#160;</sup>‘The Lord Yahuah says, “Because your filthiness was poured out, and your nakedness uncovered through your prostitution with your lovers; and because of all the idols of your abominations, and for the blood of your children, that you gave to them; 
 <sup>37&#160;</sup>therefore see, I will gather all your lovers, with whom you have taken pleasure, and all those whom you have loved, with all those whom you have hated. I will even gather them against you on every side, and will uncover your nakedness to them, that they may see all your nakedness. 
 <sup>38&#160;</sup>I will judge you as women who break wedlock and shed blood are judged; and I will bring on you the blood of wrath and jealousy. 
 <sup>39&#160;</sup>I will also give you into their hand, and they will throw down your vaulted place, and break down your lofty places. They will strip you of your clothes and take your beautiful jewels. They will leave you naked and bare. 
@@ -576,13 +576,13 @@ html[dir=ltr] .q2 {
 <sup>41&#160;</sup>They will burn your houses with fire, and execute judgments on you in the sight of many women. I will cause you to cease from playing the prostitute, and you will also give no hire any more. 
 <sup>42&#160;</sup>So I will cause my wrath toward you to rest, and my jealousy will depart from you. I will be quiet, and will not be angry any more. 
 </p><p>
-<sup>43&#160;</sup>“&#160;‘&#160;“Because you have not remembered the days of your youth, but have raged against me in all these things; therefore, behold, I also will bring your way on your head,” says the Lord Yahweh: “and you shall not commit this lewdness with all your abominations. 
+<sup>43&#160;</sup>“&#160;‘&#160;“Because you have not remembered the days of your youth, but have raged against me in all these things; therefore, behold, I also will bring your way on your head,” says the Lord Yahuah: “and you shall not commit this lewdness with all your abominations. 
 </p><p>
 <sup>44&#160;</sup>“&#160;‘&#160;“Behold, everyone who uses proverbs will use this proverb against you, saying, ‘As is the mother, so is her daughter.’ 
 <sup>45&#160;</sup>You are the daughter of your mother, who loathes her man and her children; and you are the sister of your sisters, who loathed their men and their children. Your mother was a Hittite, and your father an Amorite. 
 <sup>46&#160;</sup>Your elder sister is Samaria, who dwells at your left hand, she and her daughters; and your younger sister, who dwells at your right hand, is Sodom with her daughters. 
 <sup>47&#160;</sup>Yet you have not walked in their ways, nor done their abominations; but soon you were more corrupt than they in all your ways. 
-<sup>48&#160;</sup>As I live,” says the Lord Yahweh, “Sodom your sister has not done, she nor her daughters, as you have done, you and your daughters. 
+<sup>48&#160;</sup>As I live,” says the Lord Yahuah, “Sodom your sister has not done, she nor her daughters, as you have done, you and your daughters. 
 </p><p>
 <sup>49&#160;</sup>“&#160;‘&#160;“Behold, this was the iniquity of your sister Sodom: pride, fullness of bread, and prosperous ease was in her and in her daughters. She also didn’t strengthen the hand of the poor and needy. 
 <sup>50&#160;</sup>They were arrogant and committed abomination before me. Therefore I took them away when I saw it. 
@@ -594,18 +594,18 @@ html[dir=ltr] .q2 {
 <sup>55&#160;</sup>Your sisters, Sodom and her daughters, will return to their former estate; and Samaria and her daughters will return to their former estate; and you and your daughters will return to your former estate. 
 <sup>56&#160;</sup>For your sister Sodom was not mentioned by your mouth in the day of your pride, 
 <sup>57&#160;</sup>before your wickedness was uncovered, as at the time of the reproach of the daughters of Syria, and of all who are around her, the daughters of the Philistines, who despise you all around. 
-<sup>58&#160;</sup>You have borne your lewdness and your abominations,” says Yahweh. 
+<sup>58&#160;</sup>You have borne your lewdness and your abominations,” says Yahuah. 
 </p><p>
-<sup>59&#160;</sup>“&#160;‘For the Lord Yahweh says: “I will also deal with you as you have done, who have despised the oath in breaking the covenant. 
+<sup>59&#160;</sup>“&#160;‘For the Lord Yahuah says: “I will also deal with you as you have done, who have despised the oath in breaking the covenant. 
 <sup>60&#160;</sup>Nevertheless I will remember my covenant with you in the days of your youth, and I will establish an everlasting covenant with you. 
 <sup>61&#160;</sup>Then you will remember your ways and be ashamed when you receive your sisters, your elder sisters and your younger; and I will give them to you for daughters, but not by your covenant. 
-<sup>62&#160;</sup>I will establish my covenant with you. Then you will know that I am Yahweh; 
-<sup>63&#160;</sup>that you may remember, and be confounded, and never open your mouth any more because of your shame, when I have forgiven you all that you have done,” says the Lord Yahweh.’&#160;” 
+<sup>62&#160;</sup>I will establish my covenant with you. Then you will know that I am Yahuah; 
+<sup>63&#160;</sup>that you may remember, and be confounded, and never open your mouth any more because of your shame, when I have forgiven you all that you have done,” says the Lord Yahuah.’&#160;” 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, tell a riddle, and speak a parable to the house of Israel; 
-<sup>3&#160;</sup>and say, ‘The Lord Yahweh says: “A great eagle with great wings and long feathers, full of feathers which had various colors, came to Lebanon and took the top of the cedar. 
+<sup>3&#160;</sup>and say, ‘The Lord Yahuah says: “A great eagle with great wings and long feathers, full of feathers which had various colors, came to Lebanon and took the top of the cedar. 
 <sup>4&#160;</sup>He cropped off the topmost of its young twigs, and carried it to a land of traffic. He planted it in a city of merchants. 
 </p><p>
 <sup>5&#160;</sup>“&#160;‘&#160;“He also took some of the seed of the land and planted it in fruitful soil. He placed it beside many waters. He set it as a willow tree. 
@@ -614,35 +614,35 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>“&#160;‘&#160;“There was also another great eagle with great wings and many feathers. Behold, this vine bent its roots toward him, and shot out its branches toward him, from the ground where it was planted, that he might water it. 
 <sup>8&#160;</sup>It was planted in a good soil by many waters, that it might produce branches and that it might bear fruit, that it might be a good vine.”&#160;’ 
 </p><p>
-<sup>9&#160;</sup>“Say, ‘The Lord Yahweh says: “Will it prosper? Won’t he pull up its roots and cut off its fruit, that it may wither, that all its fresh springing leaves may wither? It can’t be raised from its roots by a strong arm or many people. 
+<sup>9&#160;</sup>“Say, ‘The Lord Yahuah says: “Will it prosper? Won’t he pull up its roots and cut off its fruit, that it may wither, that all its fresh springing leaves may wither? It can’t be raised from its roots by a strong arm or many people. 
 <sup>10&#160;</sup>Yes, behold, being planted, will it prosper? Won’t it utterly wither when the east wind touches it? It will wither in the ground where it grew.”&#160;’&#160;” 
 </p><p>
-<sup>11&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>11&#160;</sup>Moreover Yahuah’s word came to me, saying, 
 <sup>12&#160;</sup>“Say now to the rebellious house, ‘Don’t you know what these things mean?’ Tell them, ‘Behold, the king of Babylon came to Jerusalem, and took its king, and its princes, and brought them to him to Babylon. 
 <sup>13&#160;</sup>He took one of the royal offspring, and made a covenant with him. He also brought him under an oath, and took away the mighty of the land, 
 <sup>14&#160;</sup>that the kingdom might be brought low, that it might not lift itself up, but that by keeping his covenant it might stand. 
 <sup>15&#160;</sup>But he rebelled against him in sending his ambassadors into Egypt, that they might give him horses and many people. Will he prosper? Will he who does such things escape? Will he break the covenant, and still escape? 
 </p><p>
-<sup>16&#160;</sup>“&#160;‘As I live,’ says the Lord Yahweh, ‘surely in the place where the king dwells who made him king, whose oath he despised, and whose covenant he broke, even with him in the middle of Babylon he will die. 
+<sup>16&#160;</sup>“&#160;‘As I live,’ says the Lord Yahuah, ‘surely in the place where the king dwells who made him king, whose oath he despised, and whose covenant he broke, even with him in the middle of Babylon he will die. 
 <sup>17&#160;</sup>Pharaoh with his mighty army and great company won’t help him in the war, when they cast up mounds and build forts to cut off many persons. 
 <sup>18&#160;</sup>For he has despised the oath by breaking the covenant; and behold, he had given his hand, and yet has done all these things. He won’t escape. 
 </p><p>
-<sup>19&#160;</sup>“Therefore the Lord Yahweh says: ‘As I live, I will surely bring on his own head my oath that he has despised and my covenant that he has broken. 
+<sup>19&#160;</sup>“Therefore the Lord Yahuah says: ‘As I live, I will surely bring on his own head my oath that he has despised and my covenant that he has broken. 
 <sup>20&#160;</sup>I will spread my net on him, and he will be taken in my snare. I will bring him to Babylon, and will enter into judgment with him there for his trespass that he has trespassed against me. 
-<sup>21&#160;</sup>All his fugitives in all his bands will fall by the sword, and those who remain will be scattered toward every wind. Then you will know that I, Yahweh, have spoken it.’ 
+<sup>21&#160;</sup>All his fugitives in all his bands will fall by the sword, and those who remain will be scattered toward every wind. Then you will know that I, Yahuah, have spoken it.’ 
 </p><p>
-<sup>22&#160;</sup>“The Lord Yahweh says: ‘I will also take some of the lofty top of the cedar, and will plant it. I will crop off from the topmost of its young twigs a tender one, and I will plant it on a high and lofty mountain. 
+<sup>22&#160;</sup>“The Lord Yahuah says: ‘I will also take some of the lofty top of the cedar, and will plant it. I will crop off from the topmost of its young twigs a tender one, and I will plant it on a high and lofty mountain. 
 <sup>23&#160;</sup>I will plant it in the mountain of the height of Israel; and it will produce boughs, and bear fruit, and be a good cedar. Birds of every kind will dwell in the shade of its branches. 
-<sup>24&#160;</sup>All the trees of the field will know that I, Yahweh, have brought down the high tree, have exalted the low tree, have dried up the green tree, and have made the dry tree flourish. 
-</p><p>“&#160;‘I, Yahweh, have spoken and have done it.’&#160;” 
+<sup>24&#160;</sup>All the trees of the field will know that I, Yahuah, have brought down the high tree, have exalted the low tree, have dried up the green tree, and have made the dry tree flourish. 
+</p><p>“&#160;‘I, Yahuah, have spoken and have done it.’&#160;” 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me again, saying, 
+<sup>1&#160;</sup>Yahuah’s word came to me again, saying, 
 <sup>2&#160;</sup>“What do you mean, that you use this proverb concerning the land of Israel, saying, 
 </p><p class="q1">‘The fathers have eaten sour grapes, 
 </p><p class="q2">and the children’s teeth are set on edge’? 
 </p><p>
-<sup>3&#160;</sup>“As I live,” says the Lord Yahweh, “you shall not use this proverb any more in Israel. 
+<sup>3&#160;</sup>“As I live,” says the Lord Yahuah, “you shall not use this proverb any more in Israel. 
 <sup>4&#160;</sup>Behold, all souls are mine; as the soul of the father, so also the soul of the son is mine. The soul who sins, he shall die. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -669,7 +669,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and has kept my ordinances, 
 </p><p class="q2">to deal truly; 
 </p><p class="q1">he is just, 
-</p><p class="q2">he shall surely live,” says the Lord Yahweh. 
+</p><p class="q2">he shall surely live,” says the Lord Yahuah. 
 </p><p class="b"> &#160; </p>
 <p>
 <sup>10&#160;</sup>“If he fathers a son who is a robber who sheds blood, and who does any one of these things, 
@@ -711,7 +711,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>21&#160;</sup>“But if the wicked turns from all his sins that he has committed, and keeps all my statutes, and does that which is lawful and right, he shall surely live. He shall not die. 
 <sup>22&#160;</sup>None of his transgressions that he has committed will be remembered against him. In his righteousness that he has done, he shall live. 
-<sup>23&#160;</sup>Have I any pleasure in the death of the wicked?” says the Lord Yahweh, “and not rather that he should return from his way, and live? 
+<sup>23&#160;</sup>Have I any pleasure in the death of the wicked?” says the Lord Yahuah, “and not rather that he should return from his way, and live? 
 </p><p>
 <sup>24&#160;</sup>“But when the righteous turns away from his righteousness, and commits iniquity, and does according to all the abominations that the wicked man does, should he live? None of his righteous deeds that he has done will be remembered. In his trespass that he has trespassed, and in his sin that he has sinned, in them he shall die. 
 </p><p>
@@ -721,9 +721,9 @@ html[dir=ltr] .q2 {
 <sup>28&#160;</sup>Because he considers, and turns away from all his transgressions that he has committed, he shall surely live. He shall not die. 
 <sup>29&#160;</sup>Yet the house of Israel says, ‘The way of the Lord is not fair.’ House of Israel, aren’t my ways fair? Aren’t your ways unfair? 
 </p><p>
-<sup>30&#160;</sup>“Therefore I will judge you, house of Israel, everyone according to his ways,” says the Lord Yahweh. “Return, and turn yourselves from all your transgressions, so iniquity will not be your ruin. 
+<sup>30&#160;</sup>“Therefore I will judge you, house of Israel, everyone according to his ways,” says the Lord Yahuah. “Return, and turn yourselves from all your transgressions, so iniquity will not be your ruin. 
 <sup>31&#160;</sup>Cast away from you all your transgressions in which you have transgressed; and make yourself a new heart and a new spirit. For why will you die, house of Israel? 
-<sup>32&#160;</sup>For I have no pleasure in the death of him who dies,” says the Lord Yahweh. “Therefore turn yourselves, and live! 
+<sup>32&#160;</sup>For I have no pleasure in the death of him who dies,” says the Lord Yahuah. “Therefore turn yourselves, and live! 
 </p><h2 class="chapterlabel" id="19">19</h2>
 <p>
 <sup>1&#160;</sup>“Moreover, take up a lamentation for the princes of Israel, 
@@ -791,21 +791,21 @@ html[dir=ltr] .q2 {
 </p><p class="m">This is a lamentation, and shall be for a lamentation.” 
 </p><h2 class="chapterlabel" id="20">20</h2>
 <p>
-<sup>1&#160;</sup>In the seventh year, in the fifth month, the tenth day of the month, some of the elders of Israel came to inquire of Yahweh, and sat before me. 
+<sup>1&#160;</sup>In the seventh year, in the fifth month, the tenth day of the month, some of the elders of Israel came to inquire of Yahuah, and sat before me. 
 </p><p>
-<sup>2&#160;</sup>Yahweh’s word came to me, saying, 
-<sup>3&#160;</sup>“Son of man, speak to the elders of Israel, and tell them, ‘The Lord Yahweh says: “Is it to inquire of me that you have come? As I live,” says the Lord Yahweh, “I will not be inquired of by you.”&#160;’ 
+<sup>2&#160;</sup>Yahuah’s word came to me, saying, 
+<sup>3&#160;</sup>“Son of man, speak to the elders of Israel, and tell them, ‘The Lord Yahuah says: “Is it to inquire of me that you have come? As I live,” says the Lord Yahuah, “I will not be inquired of by you.”&#160;’ 
 </p><p>
 <sup>4&#160;</sup>“Will you judge them, son of man? Will you judge them? Cause them to know the abominations of their fathers. 
-<sup>5&#160;</sup>Tell them, ‘The Lord Yahweh says: “In the day when I chose Israel, and swore to the offspring of the house of Jacob, and made myself known to them in the land of Egypt, when I swore to them, saying, ‘I am Yahweh your Elohim;’ 
+<sup>5&#160;</sup>Tell them, ‘The Lord Yahuah says: “In the day when I chose Israel, and swore to the offspring of the house of Jacob, and made myself known to them in the land of Egypt, when I swore to them, saying, ‘I am Yahuah your Elohim;’ 
 <sup>6&#160;</sup>in that day I swore to them to bring them out of the land of Egypt into a land that I had searched out for them, flowing with milk and honey, which is the glory of all lands. 
-<sup>7&#160;</sup>I said to them, ‘Each of you throw away the abominations of his eyes. Don’t defile yourselves with the idols of Egypt. I am Yahweh your Elohim.’ 
+<sup>7&#160;</sup>I said to them, ‘Each of you throw away the abominations of his eyes. Don’t defile yourselves with the idols of Egypt. I am Yahuah your Elohim.’ 
 </p><p>
 <sup>8&#160;</sup>“&#160;‘&#160;“But they rebelled against me and wouldn’t listen to me. They didn’t all throw away the abominations of their eyes. They also didn’t forsake the idols of Egypt. Then I said I would pour out my wrath on them, to accomplish my anger against them in the middle of the land of Egypt. 
 <sup>9&#160;</sup>But I worked for my name’s sake, that it should not be profaned in the sight of the nations among which they were, in whose sight I made myself known to them in bringing them out of the land of Egypt. 
 <sup>10&#160;</sup>So I caused them to go out of the land of Egypt and brought them into the wilderness. 
 <sup>11&#160;</sup>I gave them my statutes and showed them my ordinances, which if a man does, he will live in them. 
-<sup>12&#160;</sup>Moreover also I gave them my Sabbaths, to be a sign between me and them, that they might know that I am Yahweh who sanctifies them. 
+<sup>12&#160;</sup>Moreover also I gave them my Sabbaths, to be a sign between me and them, that they might know that I am Yahuah who sanctifies them. 
 </p><p>
 <sup>13&#160;</sup>“&#160;‘&#160;“But the house of Israel rebelled against me in the wilderness. They didn’t walk in my statutes and they rejected my ordinances, which if a man keeps, he shall live in them. They greatly profaned my Sabbaths. Then I said I would pour out my wrath on them in the wilderness, to consume them. 
 <sup>14&#160;</sup>But I worked for my name’s sake, that it should not be profaned in the sight of the nations, in whose sight I brought them out. 
@@ -813,57 +813,57 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>because they rejected my ordinances, and didn’t walk in my statutes, and profaned my Sabbaths; for their heart went after their idols. 
 <sup>17&#160;</sup>Nevertheless my eye spared them, and I didn’t destroy them. I didn’t make a full end of them in the wilderness. 
 <sup>18&#160;</sup>I said to their children in the wilderness, ‘Don’t walk in the statutes of your fathers. Don’t observe their ordinances or defile yourselves with their idols. 
-<sup>19&#160;</sup>I am Yahweh your Elohim. Walk in my statutes, keep my ordinances, and do them. 
-<sup>20&#160;</sup>Make my Sabbaths set-apart. They shall be a sign between me and you, that you may know that I am Yahweh your Elohim.’ 
+<sup>19&#160;</sup>I am Yahuah your Elohim. Walk in my statutes, keep my ordinances, and do them. 
+<sup>20&#160;</sup>Make my Sabbaths set-apart. They shall be a sign between me and you, that you may know that I am Yahuah your Elohim.’ 
 </p><p>
 <sup>21&#160;</sup>“&#160;‘&#160;“But the children rebelled against me. They didn’t walk in my statutes, and didn’t keep my ordinances to do them, which if a man does, he shall live in them. They profaned my Sabbaths. Then I said I would pour out my wrath on them, to accomplish my anger against them in the wilderness. 
 <sup>22&#160;</sup>Nevertheless I withdrew my hand and worked for my name’s sake, that it should not be profaned in the sight of the nations, in whose sight I brought them out. 
 <sup>23&#160;</sup>Moreover I swore to them in the wilderness, that I would scatter them among the nations and disperse them through the countries, 
 <sup>24&#160;</sup>because they had not executed my ordinances, but had rejected my statutes, and had profaned my Sabbaths, and their eyes were after their fathers’ idols. 
 <sup>25&#160;</sup>Moreover also I gave them statutes that were not good, and ordinances in which they couldn’t live. 
-<sup>26&#160;</sup>I polluted them in their own gifts, in that they caused all that opens the womb to pass through the fire, that I might make them desolate, to the end that they might know that I am Yahweh.”&#160;’ 
+<sup>26&#160;</sup>I polluted them in their own gifts, in that they caused all that opens the womb to pass through the fire, that I might make them desolate, to the end that they might know that I am Yahuah.”&#160;’ 
 </p><p>
-<sup>27&#160;</sup>“Therefore, son of man, speak to the house of Israel, and tell them, ‘The Lord Yahweh says: “Moreover, in this your fathers have blasphemed me, in that they have committed a trespass against me. 
+<sup>27&#160;</sup>“Therefore, son of man, speak to the house of Israel, and tell them, ‘The Lord Yahuah says: “Moreover, in this your fathers have blasphemed me, in that they have committed a trespass against me. 
 <sup>28&#160;</sup>For when I had brought them into the land which I swore to give to them, then they saw every high hill and every thick tree, and they offered there their sacrifices, and there they presented the provocation of their offering. There they also made their pleasant aroma, and there they poured out their drink offerings. 
 <sup>29&#160;</sup>Then I said to them, ‘What does the high place where you go mean?’ So its name is called Bamah to this day.”&#160;’ 
 </p><p>
-<sup>30&#160;</sup>“Therefore tell the house of Israel, ‘The Lord Yahweh says: “Do you pollute yourselves in the way of your fathers? Do you play the prostitute after their abominations? 
-<sup>31&#160;</sup>When you offer your gifts, when you make your sons pass through the fire, do you pollute yourselves with all your idols to this day? Should I be inquired of by you, house of Israel? As I live, says the Lord Yahweh, I will not be inquired of by you! 
+<sup>30&#160;</sup>“Therefore tell the house of Israel, ‘The Lord Yahuah says: “Do you pollute yourselves in the way of your fathers? Do you play the prostitute after their abominations? 
+<sup>31&#160;</sup>When you offer your gifts, when you make your sons pass through the fire, do you pollute yourselves with all your idols to this day? Should I be inquired of by you, house of Israel? As I live, says the Lord Yahuah, I will not be inquired of by you! 
 </p><p>
 <sup>32&#160;</sup>“&#160;‘&#160;“That which comes into your mind will not be at all, in that you say, ‘We will be as the nations, as the families of the countries, to serve wood and stone.’ 
-<sup>33&#160;</sup>As I live,” says the Lord Yahweh, “surely with a mighty hand, with an outstretched arm, and with wrath poured out, I will be king over you. 
+<sup>33&#160;</sup>As I live,” says the Lord Yahuah, “surely with a mighty hand, with an outstretched arm, and with wrath poured out, I will be king over you. 
 <sup>34&#160;</sup>I will bring you out from the peoples, and will gather you out of the countries in which you are scattered with a mighty hand, with an outstretched arm, and with wrath poured out. 
 <sup>35&#160;</sup>I will bring you into the wilderness of the peoples, and there I will enter into judgment with you face to face. 
-<sup>36&#160;</sup>Just as I entered into judgment with your fathers in the wilderness of the land of Egypt, so I will enter into judgment with you,” says the Lord Yahweh. 
+<sup>36&#160;</sup>Just as I entered into judgment with your fathers in the wilderness of the land of Egypt, so I will enter into judgment with you,” says the Lord Yahuah. 
 <sup>37&#160;</sup>“I will cause you to pass under the rod, and I will bring you into the bond of the covenant. 
-<sup>38&#160;</sup>I will purge out from among you the rebels and those who disobey me. I will bring them out of the land where they live, but they shall not enter into the land of Israel. Then you will know that I am Yahweh.” 
+<sup>38&#160;</sup>I will purge out from among you the rebels and those who disobey me. I will bring them out of the land where they live, but they shall not enter into the land of Israel. Then you will know that I am Yahuah.” 
 </p><p>
-<sup>39&#160;</sup>“&#160;‘As for you, house of Israel, the Lord Yahweh says: “Go, everyone serve his idols, and hereafter also, if you will not listen to me; but you shall no more profane my set-apart name with your gifts and with your idols. 
-<sup>40&#160;</sup>For in my set-apart mountain, in the mountain of the height of Israel,” says the Lord Yahweh, “there all the house of Israel, all of them, shall serve me in the land. There I will accept them, and there I will require your offerings and the first fruits of your offerings, with all your set-apart things. 
+<sup>39&#160;</sup>“&#160;‘As for you, house of Israel, the Lord Yahuah says: “Go, everyone serve his idols, and hereafter also, if you will not listen to me; but you shall no more profane my set-apart name with your gifts and with your idols. 
+<sup>40&#160;</sup>For in my set-apart mountain, in the mountain of the height of Israel,” says the Lord Yahuah, “there all the house of Israel, all of them, shall serve me in the land. There I will accept them, and there I will require your offerings and the first fruits of your offerings, with all your set-apart things. 
 <sup>41&#160;</sup>I will accept you as a pleasant aroma when I bring you out from the peoples and gather you out of the countries in which you have been scattered. I will be sanctified in you in the sight of the nations. 
-<sup>42&#160;</sup>You will know that I am Yahweh when I bring you into the land of Israel, into the country which I swore to give to your fathers. 
+<sup>42&#160;</sup>You will know that I am Yahuah when I bring you into the land of Israel, into the country which I swore to give to your fathers. 
 <sup>43&#160;</sup>There you will remember your ways, and all your deeds in which you have polluted yourselves. Then you will loathe yourselves in your own sight for all your evils that you have committed. 
-<sup>44&#160;</sup>You will know that I am Yahweh, when I have dealt with you for my name’s sake, not according to your evil ways, nor according to your corrupt doings, you house of Israel,” says the Lord Yahweh.’&#160;” 
+<sup>44&#160;</sup>You will know that I am Yahuah, when I have dealt with you for my name’s sake, not according to your evil ways, nor according to your corrupt doings, you house of Israel,” says the Lord Yahuah.’&#160;” 
 </p><p>
-<sup>45&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>45&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>46&#160;</sup>“Son of man, set your face toward the south, and preach toward the south, and prophesy against the forest of the field in the south. 
-<sup>47&#160;</sup>Tell the forest of the south, ‘Hear Yahweh’s word: The Lord Yahweh says, “Behold, I will kindle a fire in you, and it will devour every green tree in you, and every dry tree. The burning flame will not be quenched, and all faces from the south to the north will be burned by it. 
-<sup>48&#160;</sup>All flesh will see that I, Yahweh, have kindled it. It will not be quenched.”&#160;’&#160;” 
+<sup>47&#160;</sup>Tell the forest of the south, ‘Hear Yahuah’s word: The Lord Yahuah says, “Behold, I will kindle a fire in you, and it will devour every green tree in you, and every dry tree. The burning flame will not be quenched, and all faces from the south to the north will be burned by it. 
+<sup>48&#160;</sup>All flesh will see that I, Yahuah, have kindled it. It will not be quenched.”&#160;’&#160;” 
 </p><p>
-<sup>49&#160;</sup>Then I said, “Ah Lord Yahweh! They say of me, ‘Isn’t he a speaker of parables?’&#160;” 
+<sup>49&#160;</sup>Then I said, “Ah Lord Yahuah! They say of me, ‘Isn’t he a speaker of parables?’&#160;” 
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, set your face toward Jerusalem, and preach toward the sanctuaries, and prophesy against the land of Israel. 
-<sup>3&#160;</sup>Tell the land of Israel, ‘Yahweh says: “Behold, I am against you, and will draw my sword out of its sheath, and will cut off from you the righteous and the wicked. 
+<sup>3&#160;</sup>Tell the land of Israel, ‘Yahuah says: “Behold, I am against you, and will draw my sword out of its sheath, and will cut off from you the righteous and the wicked. 
 <sup>4&#160;</sup>Seeing then that I will cut off from you the righteous and the wicked, therefore my sword will go out of its sheath against all flesh from the south to the north. 
-<sup>5&#160;</sup>All flesh will know that I, Yahweh, have drawn my sword out of its sheath. It will not return any more.”&#160;’ 
+<sup>5&#160;</sup>All flesh will know that I, Yahuah, have drawn my sword out of its sheath. It will not return any more.”&#160;’ 
 </p><p>
 <sup>6&#160;</sup>“Therefore sigh, you son of man. You shall sigh before their eyes with a broken heart and with bitterness. 
-<sup>7&#160;</sup>It shall be, when they ask you, ‘Why do you sigh?’ that you shall say, ‘Because of the news, for it comes! Every heart will melt, all hands will be feeble, every spirit will faint, and all knees will be weak as water. Behold, it comes, and it shall be done, says the Lord Yahweh.’&#160;” 
+<sup>7&#160;</sup>It shall be, when they ask you, ‘Why do you sigh?’ that you shall say, ‘Because of the news, for it comes! Every heart will melt, all hands will be feeble, every spirit will faint, and all knees will be weak as water. Behold, it comes, and it shall be done, says the Lord Yahuah.’&#160;” 
 </p><p>
-<sup>8&#160;</sup>Yahweh’s word came to me, saying, 
-<sup>9&#160;</sup>“Son of man, prophesy, and say, ‘Yahweh says: 
+<sup>8&#160;</sup>Yahuah’s word came to me, saying, 
+<sup>9&#160;</sup>“Son of man, prophesy, and say, ‘Yahuah says: 
 </p><p class="q1">“A sword! A sword! 
 </p><p class="q2">It is sharpened, 
 </p><p class="q2">and also polished. 
@@ -886,7 +886,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Therefore beat your thigh. 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>13&#160;</sup>“For there is a trial. What if even the rod that condemns will be no more?” says the Lord Yahweh. 
+<sup>13&#160;</sup>“For there is a trial. What if even the rod that condemns will be no more?” says the Lord Yahuah. 
 </p><p class="q1">
 <sup>14&#160;</sup>“You therefore, son of man, prophesy, 
 </p><p class="q2">and strike your hands together. 
@@ -909,22 +909,22 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>17&#160;</sup>I will also strike my hands together, 
 </p><p class="q2">and I will cause my wrath to rest. 
-</p><p class="q2">I, Yahweh, have spoken it.” 
+</p><p class="q2">I, Yahuah, have spoken it.” 
 </p><p>
-<sup>18&#160;</sup>Yahweh’s word came to me again, saying, 
+<sup>18&#160;</sup>Yahuah’s word came to me again, saying, 
 <sup>19&#160;</sup>“Also, you son of man, appoint two ways, that the sword of the king of Babylon may come. They both will come out of one land, and mark out a place. Mark it out at the head of the way to the city. 
 <sup>20&#160;</sup>You shall appoint a way for the sword to come to Rabbah of the children of Ammon, and to Judah in Jerusalem the fortified. 
 <sup>21&#160;</sup>For the king of Babylon stood at the parting of the way, at the head of the two ways, to use divination. He shook the arrows back and forth. He consulted the teraphim. He looked in the liver. 
 <sup>22&#160;</sup>In his right hand was the lot for Jerusalem, to set battering rams, to open the mouth in the slaughter, to lift up the voice with shouting, to set battering rams against the gates, to cast up mounds, and to build forts. 
 <sup>23&#160;</sup>It will be to them as a false divination in their sight, who have sworn oaths to them; but he brings iniquity to memory, that they may be taken. 
 </p><p>
-<sup>24&#160;</sup>“Therefore the Lord Yahweh says: ‘Because you have caused your iniquity to be remembered, in that your transgressions are uncovered, so that in all your doings your sins appear; because you have come to memory, you will be taken with the hand. 
+<sup>24&#160;</sup>“Therefore the Lord Yahuah says: ‘Because you have caused your iniquity to be remembered, in that your transgressions are uncovered, so that in all your doings your sins appear; because you have come to memory, you will be taken with the hand. 
 </p><p>
 <sup>25&#160;</sup>“&#160;‘You, deadly wounded wicked one, the prince of Israel, whose day has come, in the time of the iniquity of the end, 
-<sup>26&#160;</sup>the Lord Yahweh says: “Remove the turban, and take off the crown. This will not be as it was. Exalt that which is low, and humble that which is high. 
+<sup>26&#160;</sup>the Lord Yahuah says: “Remove the turban, and take off the crown. This will not be as it was. Exalt that which is low, and humble that which is high. 
 <sup>27&#160;</sup>I will overturn, overturn, overturn it. This also will be no more, until he comes whose right it is; and I will give it.”&#160;’ 
 </p><p>
-<sup>28&#160;</sup>“You, son of man, prophesy and say, ‘The Lord Yahweh says this concerning the children of Ammon, and concerning their reproach: 
+<sup>28&#160;</sup>“You, son of man, prophesy and say, ‘The Lord Yahuah says this concerning the children of Ammon, and concerning their reproach: 
 </p><p class="q1">“A sword! A sword is drawn! 
 </p><p class="q2">It is polished for the slaughter, 
 </p><p class="q1">to cause it to devour, 
@@ -947,12 +947,12 @@ html[dir=ltr] .q2 {
 <sup>32&#160;</sup>You will be for fuel to the fire. 
 </p><p class="q2">Your blood will be in the middle of the land. 
 </p><p class="q1">You will be remembered no more; 
-</p><p class="q2">for I, Yahweh, have spoken it.”&#160;’&#160;” 
+</p><p class="q2">for I, Yahuah, have spoken it.”&#160;’&#160;” 
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
-<sup>1&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Moreover Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“You, son of man, will you judge? Will you judge the bloody city? Then cause her to know all her abominations. 
-<sup>3&#160;</sup>You shall say, ‘The Lord Yahweh says: “A city that sheds blood within herself, that her time may come, and that makes idols against herself to defile her! 
+<sup>3&#160;</sup>You shall say, ‘The Lord Yahuah says: “A city that sheds blood within herself, that her time may come, and that makes idols against herself to defile her! 
 <sup>4&#160;</sup>You have become guilty in your blood that you have shed, and are defiled in your idols which you have made! You have caused your days to draw near, and have come to the end of your years. Therefore I have made you a reproach to the nations, and a mocking to all the countries. 
 <sup>5&#160;</sup>Those who are near and those who are far from you will mock you, you infamous one, full of tumult. 
 </p><p>
@@ -962,33 +962,33 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Slanderous men have been in you to shed blood. In you they have eaten on the mountains. They have committed lewdness among you. 
 <sup>10&#160;</sup>In you have they uncovered their fathers’ nakedness. In you have they humbled her who was unclean in her impurity. 
 <sup>11&#160;</sup>One has committed abomination with his neighbor’s woman, and another has lewdly defiled his daughter-in-law. Another in you has humbled his sister, his father’s daughter. 
-<sup>12&#160;</sup>In you have they taken bribes to shed blood. You have taken interest and increase, and you have greedily gained of your neighbors by oppression, and have forgotten me,” says the Lord Yahweh. 
+<sup>12&#160;</sup>In you have they taken bribes to shed blood. You have taken interest and increase, and you have greedily gained of your neighbors by oppression, and have forgotten me,” says the Lord Yahuah. 
 </p><p>
 <sup>13&#160;</sup>“&#160;‘&#160;“Behold, therefore I have struck my hand at your dishonest gain which you have made, and at the blood which has been shed within you. 
-<sup>14&#160;</sup>Can your heart endure, or can your hands be strong, in the days that I will deal with you? I, Yahweh, have spoken it, and will do it. 
+<sup>14&#160;</sup>Can your heart endure, or can your hands be strong, in the days that I will deal with you? I, Yahuah, have spoken it, and will do it. 
 <sup>15&#160;</sup>I will scatter you among the nations, and disperse you through the countries. I will purge your filthiness out of you. 
-<sup>16&#160;</sup>You will be profaned in yourself in the sight of the nations. Then you will know that I am Yahweh.”&#160;’&#160;” 
+<sup>16&#160;</sup>You will be profaned in yourself in the sight of the nations. Then you will know that I am Yahuah.”&#160;’&#160;” 
 </p><p>
-<sup>17&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>17&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>18&#160;</sup>“Son of man, the house of Israel has become dross to me. All of them are bronze, tin, iron, and lead in the middle of the furnace. They are the dross of silver. 
-<sup>19&#160;</sup>Therefore the Lord Yahweh says: ‘Because you have all become dross, therefore, behold, I will gather you into the middle of Jerusalem. 
+<sup>19&#160;</sup>Therefore the Lord Yahuah says: ‘Because you have all become dross, therefore, behold, I will gather you into the middle of Jerusalem. 
 <sup>20&#160;</sup>As they gather silver, bronze, iron, lead, and tin into the middle of the furnace, to blow the fire on it, to melt it, so I will gather you in my anger and in my wrath, and I will lay you there and melt you. 
 <sup>21&#160;</sup>Yes, I will gather you, and blow on you with the fire of my wrath, and you will be melted in the middle of it. 
-<sup>22&#160;</sup>As silver is melted in the middle of the furnace, so you will be melted in the middle of it; and you will know that I, Yahweh, have poured out my wrath on you.’&#160;” 
+<sup>22&#160;</sup>As silver is melted in the middle of the furnace, so you will be melted in the middle of it; and you will know that I, Yahuah, have poured out my wrath on you.’&#160;” 
 </p><p>
-<sup>23&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>23&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>24&#160;</sup>“Son of man, tell her, ‘You are a land that is not cleansed nor rained on in the day of indignation.’ 
 <sup>25&#160;</sup>There is a conspiracy of her prophets within it, like a roaring lion ravening the prey. They have devoured souls. They take treasure and precious things. They have made many widows within it. 
 <sup>26&#160;</sup>Her priests have done violence to my law and have profaned my set-apart things. They have made no distinction between the set-apart and the common, neither have they caused men to discern between the unclean and the clean, and have hidden their eyes from my Sabbaths. So I am profaned among them. 
 <sup>27&#160;</sup>Her princes within it are like wolves ravening the prey, to shed blood and to destroy souls, that they may get dishonest gain. 
-<sup>28&#160;</sup>Her prophets have plastered for them with whitewash, seeing false visions, and divining lies to them, saying, ‘The Lord Yahweh says,’ when Yahweh has not spoken. 
+<sup>28&#160;</sup>Her prophets have plastered for them with whitewash, seeing false visions, and divining lies to them, saying, ‘The Lord Yahuah says,’ when Yahuah has not spoken. 
 <sup>29&#160;</sup>The people of the land have used oppression and exercised robbery. Yes, they have troubled the poor and needy, and have oppressed the foreigner wrongfully. 
 </p><p>
 <sup>30&#160;</sup>“I sought for a man among them who would build up the wall and stand in the gap before me for the land, that I would not destroy it; but I found no one. 
-<sup>31&#160;</sup>Therefore I have poured out my indignation on them. I have consumed them with the fire of my wrath. I have brought their own way on their heads,” says the Lord Yahweh. 
+<sup>31&#160;</sup>Therefore I have poured out my indignation on them. I have consumed them with the fire of my wrath. I have brought their own way on their heads,” says the Lord Yahuah. 
 </p><h2 class="chapterlabel" id="23">23</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came again to me, saying, 
+<sup>1&#160;</sup>Yahuah’s word came again to me, saying, 
 <sup>2&#160;</sup>“Son of man, there were two women, the daughters of one mother. 
 <sup>3&#160;</sup>They played the prostitute in Egypt. They played the prostitute in their youth. Their breasts were fondled there, and their youthful nipples were caressed there. 
 <sup>4&#160;</sup>Their names were Oholah the elder, and Oholibah her sister. They became mine, and they bore sons and daughters. As for their names, Samaria is Oholah, and Jerusalem Oholibah. 
@@ -1014,19 +1014,19 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>She lusted after their lovers, whose flesh is as the flesh of donkeys, and whose issue is like the issue of horses. 
 <sup>21&#160;</sup>Thus you called to memory the lewdness of your youth, in the caressing of your nipples by the Egyptians because of your youthful breasts. 
 </p><p>
-<sup>22&#160;</sup>“Therefore, Oholibah, the Lord Yahweh says: ‘Behold, I will raise up your lovers against you, from whom your soul is alienated, and I will bring them against you on every side: 
+<sup>22&#160;</sup>“Therefore, Oholibah, the Lord Yahuah says: ‘Behold, I will raise up your lovers against you, from whom your soul is alienated, and I will bring them against you on every side: 
 <sup>23&#160;</sup>the Babylonians and all the Chaldeans, Pekod, Shoa, Koa, and all the Assyrians with them; all of them desirable young men, governors and rulers, princes and men of renown, all of them riding on horses. 
 <sup>24&#160;</sup>They will come against you with weapons, chariots, and wagons, and with a company of peoples. They will set themselves against you with buckler, shield, and helmet all around. I will commit the judgment to them, and they will judge you according to their judgments. 
 <sup>25&#160;</sup>I will set my jealousy against you, and they will deal with you in fury. They will take away your nose and your ears. Your remnant will fall by the sword. They will take your sons and your daughters; and the rest of you will be devoured by the fire. 
 <sup>26&#160;</sup>They will also strip you of your clothes and take away your beautiful jewels. 
 <sup>27&#160;</sup>Thus I will make your lewdness to cease from you, and remove your prostitution from the land of Egypt, so that you will not lift up your eyes to them, nor remember Egypt any more.’ 
 </p><p>
-<sup>28&#160;</sup>“For the Lord Yahweh says: ‘Behold, I will deliver you into the hand of them whom you hate, into the hand of them from whom your soul is alienated. 
+<sup>28&#160;</sup>“For the Lord Yahuah says: ‘Behold, I will deliver you into the hand of them whom you hate, into the hand of them from whom your soul is alienated. 
 <sup>29&#160;</sup>They will deal with you in hatred, and will take away all your labor, and will leave you naked and bare. The nakedness of your prostitution will be uncovered, both your lewdness and your prostitution. 
 <sup>30&#160;</sup>These things will be done to you because you have played the prostitute after the nations, and because you are polluted with their idols. 
 <sup>31&#160;</sup>You have walked in the way of your sister; therefore I will give her cup into your hand.’ 
 </p><p>
-<sup>32&#160;</sup>“The Lord Yahweh says: 
+<sup>32&#160;</sup>“The Lord Yahuah says: 
 </p><p class="q1">‘You will drink of your sister’s cup, 
 </p><p class="q2">which is deep and large. 
 </p><p class="q1">You will be ridiculed and held in derision. 
@@ -1039,11 +1039,11 @@ html[dir=ltr] .q2 {
 <sup>34&#160;</sup>You will even drink it and drain it out. 
 </p><p class="q2">You will gnaw the broken pieces of it, 
 </p><p class="q2">and will tear your breasts; 
-</p><p class="m">for I have spoken it,’ says the Lord Yahweh. 
+</p><p class="m">for I have spoken it,’ says the Lord Yahuah. 
 </p><p>
-<sup>35&#160;</sup>“Therefore the Lord Yahweh says: ‘Because you have forgotten me and cast me behind your back, therefore you also bear your lewdness and your prostitution.’&#160;” 
+<sup>35&#160;</sup>“Therefore the Lord Yahuah says: ‘Because you have forgotten me and cast me behind your back, therefore you also bear your lewdness and your prostitution.’&#160;” 
 </p><p>
-<sup>36&#160;</sup>Yahweh said moreover to me: “Son of man, will you judge Oholah and Oholibah? Then declare to them their abominations. 
+<sup>36&#160;</sup>Yahuah said moreover to me: “Son of man, will you judge Oholah and Oholibah? Then declare to them their abominations. 
 <sup>37&#160;</sup>For they have committed adultery, and blood is in their hands. They have committed adultery with their idols. They have also caused their sons, whom they bore to me, to pass through the fire to them to be devoured. 
 <sup>38&#160;</sup>Moreover this they have done to me: they have defiled my sanctuary in the same day, and have profaned my Sabbaths. 
 <sup>39&#160;</sup>For when they had slain their children to their idols, then they came the same day into my sanctuary to profane it; and behold, they have done this in the middle of my house. 
@@ -1056,16 +1056,16 @@ html[dir=ltr] .q2 {
 <sup>44&#160;</sup>They went in to her, as they go in to a prostitute. So they went in to Oholah and to Oholibah, the lewd women. 
 <sup>45&#160;</sup>Righteous men will judge them with the judgment of adulteresses and with the judgment of women who shed blood, because they are adulteresses, and blood is in their hands. 
 </p><p>
-<sup>46&#160;</sup>“For the Lord Yahweh says: ‘I will bring up a mob against them, and will give them to be tossed back and forth and robbed. 
+<sup>46&#160;</sup>“For the Lord Yahuah says: ‘I will bring up a mob against them, and will give them to be tossed back and forth and robbed. 
 <sup>47&#160;</sup>The company will stone them with stones and dispatch them with their swords. They will kill their sons and their daughters, and burn up their houses with fire. 
 </p><p>
 <sup>48&#160;</sup>“&#160;‘Thus I will cause lewdness to cease out of the land, that all women may be taught not to be lewd like you. 
-<sup>49&#160;</sup>They will recompense your lewdness on you, and you will bear the sins of your idols. Then you will know that I am the Lord Yahweh.’&#160;” 
+<sup>49&#160;</sup>They will recompense your lewdness on you, and you will bear the sins of your idols. Then you will know that I am the Lord Yahuah.’&#160;” 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
-<sup>1&#160;</sup>Again, in the ninth year, in the tenth month, in the tenth day of the month, Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Again, in the ninth year, in the tenth month, in the tenth day of the month, Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, write the name of the day, this same day. The king of Babylon drew close to Jerusalem this same day. 
-<sup>3&#160;</sup>Utter a parable to the rebellious house, and tell them, ‘The Lord Yahweh says, 
+<sup>3&#160;</sup>Utter a parable to the rebellious house, and tell them, ‘The Lord Yahuah says, 
 </p><p class="q1">“Put the cauldron on the fire. 
 </p><p class="q2">Put it on, 
 </p><p class="q2">and also pour water into it. 
@@ -1080,7 +1080,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Make it boil well. 
 </p><p class="q2">Yes, let its bones be boiled within it.” 
 </p><p class="m">
-<sup>6&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: 
+<sup>6&#160;</sup>“&#160;‘Therefore the Lord Yahuah says: 
 </p><p class="q1">“Woe to the bloody city, 
 </p><p class="q2">to the cauldron whose rust is in it, 
 </p><p class="q2">and whose rust hasn’t gone out of it! 
@@ -1097,7 +1097,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I have set her blood on the bare rock, 
 </p><p class="q2">that it should not be covered.” 
 </p><p class="m">
-<sup>9&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: 
+<sup>9&#160;</sup>“&#160;‘Therefore the Lord Yahuah says: 
 </p><p class="q1">“Woe to the bloody city! 
 </p><p class="q2">I also will make the pile great. 
 </p><p class="q1">
@@ -1119,9 +1119,9 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>13&#160;</sup>“&#160;‘&#160;“In your filthiness is lewdness. Because I have cleansed you and you weren’t cleansed, you won’t be cleansed from your filthiness any more, until I have caused my wrath toward you to rest. 
 </p><p>
-<sup>14&#160;</sup>“&#160;‘&#160;“I, Yahweh, have spoken it. It will happen, and I will do it. I won’t go back. I won’t spare. I won’t repent. According to your ways and according to your doings, they will judge you,” says the Lord Yahweh.’&#160;” 
+<sup>14&#160;</sup>“&#160;‘&#160;“I, Yahuah, have spoken it. It will happen, and I will do it. I won’t go back. I won’t spare. I won’t repent. According to your ways and according to your doings, they will judge you,” says the Lord Yahuah.’&#160;” 
 </p><p>
-<sup>15&#160;</sup>Also Yahweh’s word came to me, saying, 
+<sup>15&#160;</sup>Also Yahuah’s word came to me, saying, 
 <sup>16&#160;</sup>“Son of man, behold, I will take away from you the desire of your eyes with one stroke; yet you shall neither mourn nor weep, neither shall your tears run down. 
 <sup>17&#160;</sup>Sigh, but not aloud. Make no mourning for the dead. Bind your headdress on you, and put your sandals on your feet. Don’t cover your lips, and don’t eat mourner’s bread.” 
 </p><p>
@@ -1129,55 +1129,55 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>19&#160;</sup>The people asked me, “Won’t you tell us what these things mean to us, that you act like this?” 
 </p><p>
-<sup>20&#160;</sup>Then I said to them, “Yahweh’s word came to me, saying, 
-<sup>21&#160;</sup>‘Speak to the house of Israel, “The Lord Yahweh says: ‘Behold, I will profane my sanctuary, the pride of your power, the desire of your eyes, and that which your soul pities; and your sons and your daughters whom you have left behind will fall by the sword. 
+<sup>20&#160;</sup>Then I said to them, “Yahuah’s word came to me, saying, 
+<sup>21&#160;</sup>‘Speak to the house of Israel, “The Lord Yahuah says: ‘Behold, I will profane my sanctuary, the pride of your power, the desire of your eyes, and that which your soul pities; and your sons and your daughters whom you have left behind will fall by the sword. 
 <sup>22&#160;</sup>You will do as I have done. You won’t cover your lips or eat mourner’s bread. 
 <sup>23&#160;</sup>Your turbans will be on your heads, and your sandals on your feet. You won’t mourn or weep; but you will pine away in your iniquities, and moan one toward another. 
-<sup>24&#160;</sup>Thus Ezekiel will be a sign to you; according to all that he has done, you will do. When this comes, then you will know that I am the Lord Yahweh.’&#160;”&#160;’&#160;” 
+<sup>24&#160;</sup>Thus Ezekiel will be a sign to you; according to all that he has done, you will do. When this comes, then you will know that I am the Lord Yahuah.’&#160;”&#160;’&#160;” 
 </p><p>
 <sup>25&#160;</sup>“You, son of man, shouldn’t it be in the day when I take from them their strength, the joy of their glory, the desire of their eyes, and that whereupon they set their heart—their sons and their daughters—<sup>26&#160;</sup>that in that day he who escapes will come to you, to cause you to hear it with your ears? 
-<sup>27&#160;</sup>In that day your mouth will be opened to him who has escaped, and you will speak and be no more mute. So you will be a sign to them. Then they will know that I am Yahweh.” 
+<sup>27&#160;</sup>In that day your mouth will be opened to him who has escaped, and you will speak and be no more mute. So you will be a sign to them. Then they will know that I am Yahuah.” 
 </p><h2 class="chapterlabel" id="25">25</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, set your face toward the children of Ammon, and prophesy against them. 
-<sup>3&#160;</sup>Tell the children of Ammon, ‘Hear the word of the Lord Yahweh! The Lord Yahweh says, “Because you said, ‘Aha!’ against my sanctuary when it was profaned, and against the land of Israel when it was made desolate, and against the house of Judah when they went into captivity, 
+<sup>3&#160;</sup>Tell the children of Ammon, ‘Hear the word of the Lord Yahuah! The Lord Yahuah says, “Because you said, ‘Aha!’ against my sanctuary when it was profaned, and against the land of Israel when it was made desolate, and against the house of Judah when they went into captivity, 
 <sup>4&#160;</sup>therefore, behold, I will deliver you to the children of the east for a possession. They will set their encampments in you and make their dwellings in you. They will eat your fruit and they will drink your milk. 
-<sup>5&#160;</sup>I will make Rabbah a stable for camels and the children of Ammon a resting place for flocks. Then you will know that I am Yahweh.” 
-<sup>6&#160;</sup>For the Lord Yahweh says: “Because you have clapped your hands, stamped with the feet, and rejoiced with all the contempt of your soul against the land of Israel, 
-<sup>7&#160;</sup>therefore, behold, I have stretched out my hand on you, and will deliver you for a plunder to the nations. I will cut you off from the peoples, and I will cause you to perish out of the countries. I will destroy you. Then you will know that I am Yahweh.” 
+<sup>5&#160;</sup>I will make Rabbah a stable for camels and the children of Ammon a resting place for flocks. Then you will know that I am Yahuah.” 
+<sup>6&#160;</sup>For the Lord Yahuah says: “Because you have clapped your hands, stamped with the feet, and rejoiced with all the contempt of your soul against the land of Israel, 
+<sup>7&#160;</sup>therefore, behold, I have stretched out my hand on you, and will deliver you for a plunder to the nations. I will cut you off from the peoples, and I will cause you to perish out of the countries. I will destroy you. Then you will know that I am Yahuah.” 
 </p><p>
-<sup>8&#160;</sup>“&#160;‘The Lord Yahweh says: “Because Moab and Seir say, ‘Behold, the house of Judah is like all the nations,’ 
+<sup>8&#160;</sup>“&#160;‘The Lord Yahuah says: “Because Moab and Seir say, ‘Behold, the house of Judah is like all the nations,’ 
 <sup>9&#160;</sup>therefore, behold, I will open the side of Moab from the cities, from his cities which are on its frontiers, the glory of the country, Beth Jeshimoth, Baal Meon, and Kiriathaim, 
 <sup>10&#160;</sup>to the children of the east, to go against the children of Ammon; and I will give them for a possession, that the children of Ammon may not be remembered among the nations. 
-<sup>11&#160;</sup>I will execute judgments on Moab. Then they will know that I am Yahweh.” 
+<sup>11&#160;</sup>I will execute judgments on Moab. Then they will know that I am Yahuah.” 
 </p><p>
-<sup>12&#160;</sup>“&#160;‘The Lord Yahweh says: “Because Edom has dealt against the house of Judah by taking vengeance, and has greatly offended, and taken revenge on them,” 
-<sup>13&#160;</sup>therefore the Lord Yahweh says, “I will stretch out my hand on Edom, and will cut off man and animal from it; and I will make it desolate from Teman. They will fall by the sword even to Dedan. 
-<sup>14&#160;</sup>I will lay my vengeance on Edom by the hand of my people Israel. They will do in Edom according to my anger and according to my wrath. Then they will know my vengeance,” says the Lord Yahweh. 
+<sup>12&#160;</sup>“&#160;‘The Lord Yahuah says: “Because Edom has dealt against the house of Judah by taking vengeance, and has greatly offended, and taken revenge on them,” 
+<sup>13&#160;</sup>therefore the Lord Yahuah says, “I will stretch out my hand on Edom, and will cut off man and animal from it; and I will make it desolate from Teman. They will fall by the sword even to Dedan. 
+<sup>14&#160;</sup>I will lay my vengeance on Edom by the hand of my people Israel. They will do in Edom according to my anger and according to my wrath. Then they will know my vengeance,” says the Lord Yahuah. 
 </p><p>
-<sup>15&#160;</sup>“&#160;‘The Lord Yahweh says: “Because the Philistines have taken revenge, and have taken vengeance with contempt of soul to destroy with perpetual hostility,” 
-<sup>16&#160;</sup>therefore the Lord Yahweh says, “Behold, I will stretch out my hand on the Philistines, and I will cut off the Cherethites, and destroy the remnant of the sea coast. 
-<sup>17&#160;</sup>I will execute great vengeance on them with wrathful rebukes. Then they will know that I am Yahweh, when I lay my vengeance on them.”&#160;’&#160;” 
+<sup>15&#160;</sup>“&#160;‘The Lord Yahuah says: “Because the Philistines have taken revenge, and have taken vengeance with contempt of soul to destroy with perpetual hostility,” 
+<sup>16&#160;</sup>therefore the Lord Yahuah says, “Behold, I will stretch out my hand on the Philistines, and I will cut off the Cherethites, and destroy the remnant of the sea coast. 
+<sup>17&#160;</sup>I will execute great vengeance on them with wrathful rebukes. Then they will know that I am Yahuah, when I lay my vengeance on them.”&#160;’&#160;” 
 </p><h2 class="chapterlabel" id="26">26</h2>
 <p>
-<sup>1&#160;</sup>In the eleventh year, in the first of the month, Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>In the eleventh year, in the first of the month, Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, because Tyre has said against Jerusalem, ‘Aha! She is broken! She who was the gateway of the peoples has been returned to me. I will be replenished, now that she is laid waste;’ 
-<sup>3&#160;</sup>therefore the Lord Yahweh says, ‘Behold, I am against you, Tyre, and will cause many nations to come up against you, as the sea causes its waves to come up. 
+<sup>3&#160;</sup>therefore the Lord Yahuah says, ‘Behold, I am against you, Tyre, and will cause many nations to come up against you, as the sea causes its waves to come up. 
 <sup>4&#160;</sup>They will destroy the walls of Tyre, and break down her towers. I will also scrape her dust from her, and make her a bare rock. 
-<sup>5&#160;</sup>She will be a place for the spreading of nets in the middle of the sea; for I have spoken it,’ says the Lord Yahweh. ‘She will become plunder for the nations. 
-<sup>6&#160;</sup>Her daughters who are in the field will be slain with the sword. Then they will know that I am Yahweh.’ 
+<sup>5&#160;</sup>She will be a place for the spreading of nets in the middle of the sea; for I have spoken it,’ says the Lord Yahuah. ‘She will become plunder for the nations. 
+<sup>6&#160;</sup>Her daughters who are in the field will be slain with the sword. Then they will know that I am Yahuah.’ 
 </p><p>
-<sup>7&#160;</sup>“For the Lord Yahweh says: ‘Behold, I will bring on Tyre Nebuchadnezzar king of Babylon, king of kings, from the north, with horses, with chariots, with horsemen, and an army with many people. 
+<sup>7&#160;</sup>“For the Lord Yahuah says: ‘Behold, I will bring on Tyre Nebuchadnezzar king of Babylon, king of kings, from the north, with horses, with chariots, with horsemen, and an army with many people. 
 <sup>8&#160;</sup>He will kill your daughters in the field with the sword. He will make forts against you, cast up a mound against you, and raise up the buckler against you. 
 <sup>9&#160;</sup>He will set his battering engines against your walls, and with his axes he will break down your towers. 
 <sup>10&#160;</sup>By reason of the abundance of his horses, their dust will cover you. Your walls will shake at the noise of the horsemen, of the wagons, and of the chariots, when he enters into your gates, as men enter into a city which is broken open. 
 <sup>11&#160;</sup>He will tread down all your streets with the hoofs of his horses. He will kill your people with the sword. The pillars of your strength will go down to the ground. 
 <sup>12&#160;</sup>They will make a plunder of your riches and make a prey of your merchandise. They will break down your walls and destroy your pleasant houses. They will lay your stones, your timber, and your dust in the middle of the waters. 
 <sup>13&#160;</sup>I will cause the noise of your songs to cease. The sound of your harps won’t be heard any more. 
-<sup>14&#160;</sup>I will make you a bare rock. You will be a place for the spreading of nets. You will be built no more; for I Yahweh have spoken it,’ says the Lord Yahweh. 
+<sup>14&#160;</sup>I will make you a bare rock. You will be a place for the spreading of nets. You will be built no more; for I Yahuah have spoken it,’ says the Lord Yahuah. 
 </p><p>
-<sup>15&#160;</sup>“The Lord Yahweh says to Tyre: ‘Won’t the islands shake at the sound of your fall, when the wounded groan, when the slaughter is made within you? 
+<sup>15&#160;</sup>“The Lord Yahuah says to Tyre: ‘Won’t the islands shake at the sound of your fall, when the wounded groan, when the slaughter is made within you? 
 <sup>16&#160;</sup>Then all the princes of the sea will come down from their thrones, and lay aside their robes, and strip off their embroidered garments. They will clothe themselves with trembling. They will sit on the ground, and will tremble every moment, and be astonished at you. 
 <sup>17&#160;</sup>They will take up a lamentation over you, and tell you, 
 </p><p class="q1">“How you are destroyed, 
@@ -1190,14 +1190,14 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>Now the islands will tremble in the day of your fall. 
 </p><p class="q2">Yes, the islands that are in the sea will be dismayed at your departure.’ 
 </p><p>
-<sup>19&#160;</sup>“For the Lord Yahweh says: ‘When I make you a desolate city, like the cities that are not inhabited, when I bring up the deep on you, and the great waters cover you, 
+<sup>19&#160;</sup>“For the Lord Yahuah says: ‘When I make you a desolate city, like the cities that are not inhabited, when I bring up the deep on you, and the great waters cover you, 
 <sup>20&#160;</sup>then I will bring you down with those who descend into the pit, to the people of old time, and will make you dwell in the lower parts of the earth, in the places that are desolate of old, with those who go down to the pit, that you be not inhabited; and I will set glory in the land of the living. 
-<sup>21&#160;</sup>I will make you a terror, and you will no more have any being. Though you are sought for, yet you will never be found again,’ says the Lord Yahweh.” 
+<sup>21&#160;</sup>I will make you a terror, and you will no more have any being. Though you are sought for, yet you will never be found again,’ says the Lord Yahuah.” 
 </p><h2 class="chapterlabel" id="27">27</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came again to me, saying, 
+<sup>1&#160;</sup>Yahuah’s word came again to me, saying, 
 <sup>2&#160;</sup>“You, son of man, take up a lamentation over Tyre; 
-<sup>3&#160;</sup>and tell Tyre, ‘You who dwell at the entry of the sea, who are the merchant of the peoples to many islands, the Lord Yahweh says: 
+<sup>3&#160;</sup>and tell Tyre, ‘You who dwell at the entry of the sea, who are the merchant of the peoples to many islands, the Lord Yahuah says: 
 </p><p class="q1">“You, Tyre, have said, 
 </p><p class="q2">‘I am perfect in beauty.’ 
 </p><p class="q1">
@@ -1314,8 +1314,8 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and you will be no more.”&#160;’&#160;” 
 </p><h2 class="chapterlabel" id="28">28</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came again to me, saying, 
-<sup>2&#160;</sup>“Son of man, tell the prince of Tyre, ‘The Lord Yahweh says: 
+<sup>1&#160;</sup>Yahuah’s word came again to me, saying, 
+<sup>2&#160;</sup>“Son of man, tell the prince of Tyre, ‘The Lord Yahuah says: 
 </p><p class="q1">“Because your heart is lifted up, 
 </p><p class="q2">and you have said, ‘I am an elohim, 
 </p><p class="q1">I sit in the seat of Elohim, 
@@ -1333,7 +1333,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and by your trading you have increased your riches, 
 </p><p class="q2">and your heart is lifted up because of your riches—” 
 </p><p>
-<sup>6&#160;</sup>“&#160;‘therefore the Lord Yahweh says: 
+<sup>6&#160;</sup>“&#160;‘therefore the Lord Yahuah says: 
 </p><p class="q1">“Because you have set your heart as the heart of Elohim, 
 </p><p class="q2">
 <sup>7&#160;</sup>therefore, behold, I will bring strangers on you, 
@@ -1351,11 +1351,11 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>10&#160;</sup>You will die the death of the uncircumcised 
 </p><p class="q2">by the hand of strangers; 
-</p><p class="q2">for I have spoken it,” says the Lord Yahweh.’&#160;” 
+</p><p class="q2">for I have spoken it,” says the Lord Yahuah.’&#160;” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>11&#160;</sup>Moreover Yahweh’s word came to me, saying, 
-<sup>12&#160;</sup>“Son of man, take up a lamentation over the king of Tyre, and tell him, ‘The Lord Yahweh says: 
+<sup>11&#160;</sup>Moreover Yahuah’s word came to me, saying, 
+<sup>12&#160;</sup>“Son of man, take up a lamentation over the king of Tyre, and tell him, ‘The Lord Yahuah says: 
 </p><p class="q1">“You were the seal of full measure, 
 </p><p class="q2">full of wisdom, 
 </p><p class="q2">and perfect in beauty. 
@@ -1402,12 +1402,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and you will exist no more.”&#160;’&#160;” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>20&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>20&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>21&#160;</sup>“Son of man, set your face toward Sidon, and prophesy against it, 
-<sup>22&#160;</sup>and say, ‘The Lord Yahweh says: 
+<sup>22&#160;</sup>and say, ‘The Lord Yahuah says: 
 </p><p class="q1">“Behold, I am against you, Sidon. 
 </p><p class="q2">I will be glorified among you. 
-</p><p class="q1">Then they will know that I am Yahweh, 
+</p><p class="q1">Then they will know that I am Yahuah, 
 </p><p class="q2">when I have executed judgments in her, 
 </p><p class="q2">and am sanctified in her. 
 </p><p class="q1">
@@ -1415,17 +1415,17 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and blood into her streets. 
 </p><p class="q1">The wounded will fall within her, 
 </p><p class="q2">with the sword on her on every side. 
-</p><p class="q2">Then they will know that I am Yahweh. 
+</p><p class="q2">Then they will know that I am Yahuah. 
 </p><p>
-<sup>24&#160;</sup>“&#160;‘&#160;“There will no longer be a pricking brier to the house of Israel, nor a hurting thorn of any that are around them that scorned them. Then they will know that I am the Lord Yahweh.” 
+<sup>24&#160;</sup>“&#160;‘&#160;“There will no longer be a pricking brier to the house of Israel, nor a hurting thorn of any that are around them that scorned them. Then they will know that I am the Lord Yahuah.” 
 </p><p>
-<sup>25&#160;</sup>“&#160;‘The Lord Yahweh says: “When I have gathered the house of Israel from the peoples among whom they are scattered, and am shown as set-apart among them in the sight of the nations, then they will dwell in their own land which I gave to my servant Jacob. 
-<sup>26&#160;</sup>They will dwell in it securely. Yes, they will build houses, plant vineyards, and will dwell securely when I have executed judgments on all those around them who have treated them with contempt. Then they will know that I am Yahweh their Elohim.”&#160;’&#160;” 
+<sup>25&#160;</sup>“&#160;‘The Lord Yahuah says: “When I have gathered the house of Israel from the peoples among whom they are scattered, and am shown as set-apart among them in the sight of the nations, then they will dwell in their own land which I gave to my servant Jacob. 
+<sup>26&#160;</sup>They will dwell in it securely. Yes, they will build houses, plant vineyards, and will dwell securely when I have executed judgments on all those around them who have treated them with contempt. Then they will know that I am Yahuah their Elohim.”&#160;’&#160;” 
 </p><h2 class="chapterlabel" id="29">29</h2>
 <p>
-<sup>1&#160;</sup>In the tenth year, in the tenth month, on the twelfth day of the month, Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>In the tenth year, in the tenth month, on the twelfth day of the month, Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, set your face against Pharaoh king of Egypt, and prophesy against him and against all Egypt. 
-<sup>3&#160;</sup>Speak and say, ‘The Lord Yahweh says: 
+<sup>3&#160;</sup>Speak and say, ‘The Lord Yahuah says: 
 </p><p class="q1">“Behold, I am against you, Pharaoh king of Egypt, 
 </p><p class="q2">the great monster that lies in the middle of his rivers, 
 </p><p class="q1">that has said, ‘My river is my own, 
@@ -1443,36 +1443,36 @@ html[dir=ltr] .q2 {
 </p><p class="q1">I have given you for food to the animals of the earth 
 </p><p class="q2">and to the birds of the sky. 
 </p><p>
-<sup>6&#160;</sup>“&#160;‘&#160;“All the inhabitants of Egypt will know that I am Yahweh, because they have been a staff of reed to the house of Israel. 
+<sup>6&#160;</sup>“&#160;‘&#160;“All the inhabitants of Egypt will know that I am Yahuah, because they have been a staff of reed to the house of Israel. 
 <sup>7&#160;</sup>When they took hold of you by your hand, you broke and tore all their shoulders. When they leaned on you, you broke and paralyzed all of their thighs.” 
 </p><p>
-<sup>8&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: “Behold, I will bring a sword on you, and will cut off man and animal from you. 
-<sup>9&#160;</sup>The land of Egypt will be a desolation and a waste. Then they will know that I am Yahweh. 
+<sup>8&#160;</sup>“&#160;‘Therefore the Lord Yahuah says: “Behold, I will bring a sword on you, and will cut off man and animal from you. 
+<sup>9&#160;</sup>The land of Egypt will be a desolation and a waste. Then they will know that I am Yahuah. 
 </p><p>“&#160;‘&#160;“Because he has said, ‘The river is mine, and I have made it,’ 
 <sup>10&#160;</sup>therefore, behold, I am against you and against your rivers. I will make the land of Egypt an utter waste and desolation, from the tower of Seveneh even to the border of Ethiopia. 
 <sup>11&#160;</sup>No foot of man will pass through it, nor will any animal foot pass through it. It won’t be inhabited for forty years. 
 <sup>12&#160;</sup>I will make the land of Egypt a desolation in the middle of the countries that are desolate. Her cities among the cities that are laid waste will be a desolation forty years. I will scatter the Egyptians among the nations, and will disperse them through the countries.” 
 </p><p>
-<sup>13&#160;</sup>“&#160;‘For the Lord Yahweh says: “At the end of forty years I will gather the Egyptians from the peoples where they were scattered. 
+<sup>13&#160;</sup>“&#160;‘For the Lord Yahuah says: “At the end of forty years I will gather the Egyptians from the peoples where they were scattered. 
 <sup>14&#160;</sup>I will reverse the captivity of Egypt, and will cause them to return into the land of Pathros, into the land of their birth. There they will be a lowly kingdom. 
 <sup>15&#160;</sup>It will be the lowest of the kingdoms. It won’t lift itself up above the nations any more. I will diminish them so that they will no longer rule over the nations. 
-<sup>16&#160;</sup>It will no longer be the confidence of the house of Israel, bringing iniquity to memory, when they turn to look after them. Then they will know that I am the Lord Yahweh.”&#160;’&#160;” 
+<sup>16&#160;</sup>It will no longer be the confidence of the house of Israel, bringing iniquity to memory, when they turn to look after them. Then they will know that I am the Lord Yahuah.”&#160;’&#160;” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>17&#160;</sup>It came to pass in the twenty-seventh year, in the first month, in the first day of the month, Yahweh’s word came to me, saying, 
+<sup>17&#160;</sup>It came to pass in the twenty-seventh year, in the first month, in the first day of the month, Yahuah’s word came to me, saying, 
 <sup>18&#160;</sup>“Son of man, Nebuchadnezzar king of Babylon caused his army to serve a great service against Tyre. Every head was made bald, and every shoulder was worn; yet he had no wages, nor did his army, from Tyre, for the service that he had served against it. 
-<sup>19&#160;</sup>Therefore the Lord Yahweh says: ‘Behold, I will give the land of Egypt to Nebuchadnezzar king of Babylon. He will carry off her multitude, take her plunder, and take her prey. That will be the wages for his army. 
-<sup>20&#160;</sup>I have given him the land of Egypt as his payment for which he served, because they worked for me,’ says the Lord Yahweh. 
+<sup>19&#160;</sup>Therefore the Lord Yahuah says: ‘Behold, I will give the land of Egypt to Nebuchadnezzar king of Babylon. He will carry off her multitude, take her plunder, and take her prey. That will be the wages for his army. 
+<sup>20&#160;</sup>I have given him the land of Egypt as his payment for which he served, because they worked for me,’ says the Lord Yahuah. 
 </p><p>
-<sup>21&#160;</sup>“In that day I will cause a horn to sprout for the house of Israel, and I will open your mouth among them. Then they will know that I am Yahweh.” 
+<sup>21&#160;</sup>“In that day I will cause a horn to sprout for the house of Israel, and I will open your mouth among them. Then they will know that I am Yahuah.” 
 </p><h2 class="chapterlabel" id="30">30</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came again to me, saying, 
-<sup>2&#160;</sup>“Son of man, prophesy, and say, ‘The Lord Yahweh says: 
+<sup>1&#160;</sup>Yahuah’s word came again to me, saying, 
+<sup>2&#160;</sup>“Son of man, prophesy, and say, ‘The Lord Yahuah says: 
 </p><p class="q1">“Wail, ‘Alas for the day!’ 
 </p><p class="q2">
 <sup>3&#160;</sup>For the day is near, 
-</p><p class="q2">even Yahweh’s day is near. 
+</p><p class="q2">even Yahuah’s day is near. 
 </p><p class="q1">It will be a day of clouds, 
 </p><p class="q2">a time of the nations. 
 </p><p class="q1">
@@ -1484,22 +1484,22 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>5&#160;</sup>“&#160;‘&#160;“Ethiopia, Put, Lud, all the mixed people, Cub, and the children of the land that is allied with them, will fall with them by the sword.” 
 </p><p>
-<sup>6&#160;</sup>“&#160;‘Yahweh says: 
+<sup>6&#160;</sup>“&#160;‘Yahuah says: 
 </p><p class="q1">“They also who uphold Egypt will fall. 
 </p><p class="q2">The pride of her power will come down. 
 </p><p class="q1">They will fall by the sword in it from the tower of Seveneh,” 
-</p><p class="q2">says the Lord Yahweh. 
+</p><p class="q2">says the Lord Yahuah. 
 </p><p class="q1">
 <sup>7&#160;</sup>“They will be desolate in the middle of the countries that are desolate. 
 </p><p class="q2">Her cities will be among the cities that are wasted. 
 </p><p class="q1">
-<sup>8&#160;</sup>They will know that I am Yahweh 
+<sup>8&#160;</sup>They will know that I am Yahuah 
 </p><p class="q2">when I have set a fire in Egypt, 
 </p><p class="q2">and all her helpers are destroyed. 
 </p><p>
 <sup>9&#160;</sup>“&#160;‘&#160;“In that day messengers will go out from before me in ships to make the careless Ethiopians afraid. There will be anguish on them, as in the day of Egypt; for, behold, it comes.” 
 </p><p>
-<sup>10&#160;</sup>“&#160;‘The Lord Yahweh says: 
+<sup>10&#160;</sup>“&#160;‘The Lord Yahuah says: 
 </p><p class="q1">“I will also make the multitude of Egypt to cease, 
 </p><p class="q2">by the hand of Nebuchadnezzar king of Babylon. 
 </p><p class="q1">
@@ -1514,9 +1514,9 @@ html[dir=ltr] .q2 {
 </p><p class="q1">I will make the land desolate, 
 </p><p class="q2">and all that is therein, 
 </p><p class="q2">by the hand of foreigners. 
-</p><p class="q2">I, Yahweh, have spoken it.” 
+</p><p class="q2">I, Yahuah, have spoken it.” 
 </p><p>
-<sup>13&#160;</sup>“&#160;‘The Lord Yahweh says: 
+<sup>13&#160;</sup>“&#160;‘The Lord Yahuah says: 
 </p><p class="q1">“I will also destroy the idols, 
 </p><p class="q2">and I will cause the images to cease from Memphis. 
 </p><p class="q1">There will be no more a prince from the land of Egypt. 
@@ -1545,19 +1545,19 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and her daughters will go into captivity. 
 </p><p class="q1">
 <sup>19&#160;</sup>Thus I will execute judgments on Egypt. 
-</p><p class="q2">Then they will know that I am Yahweh.”&#160;’&#160;” 
+</p><p class="q2">Then they will know that I am Yahuah.”&#160;’&#160;” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>20&#160;</sup>In the eleventh year, in the first month, in the seventh day of the month, Yahweh’s word came to me, saying, 
+<sup>20&#160;</sup>In the eleventh year, in the first month, in the seventh day of the month, Yahuah’s word came to me, saying, 
 <sup>21&#160;</sup>“Son of man, I have broken the arm of Pharaoh king of Egypt. Behold, it has not been bound up, to apply medicines, to put a bandage to bind it, that it may become strong to hold the sword. 
-<sup>22&#160;</sup>Therefore the Lord Yahweh says: ‘Behold, I am against Pharaoh king of Egypt, and will break his arms, the strong arm, and that which was broken. I will cause the sword to fall out of his hand. 
+<sup>22&#160;</sup>Therefore the Lord Yahuah says: ‘Behold, I am against Pharaoh king of Egypt, and will break his arms, the strong arm, and that which was broken. I will cause the sword to fall out of his hand. 
 <sup>23&#160;</sup>I will scatter the Egyptians among the nations, and will disperse them through the countries. 
 <sup>24&#160;</sup>I will strengthen the arms of the king of Babylon, and put my sword in his hand; but I will break the arms of Pharaoh, and he will groan before the king of Babylon with the groaning of a mortally wounded man. 
-<sup>25&#160;</sup>I will hold up the arms of the king of Babylon, but the arms of Pharaoh will fall down. Then they will know that I am Yahweh when I put my sword into the hand of the king of Babylon, and he stretches it out on the land of Egypt. 
-<sup>26&#160;</sup>I will scatter the Egyptians among the nations and disperse them through the countries. Then they will know that I am Yahweh.’&#160;” 
+<sup>25&#160;</sup>I will hold up the arms of the king of Babylon, but the arms of Pharaoh will fall down. Then they will know that I am Yahuah when I put my sword into the hand of the king of Babylon, and he stretches it out on the land of Egypt. 
+<sup>26&#160;</sup>I will scatter the Egyptians among the nations and disperse them through the countries. Then they will know that I am Yahuah.’&#160;” 
 </p><h2 class="chapterlabel" id="31">31</h2>
 <p>
-<sup>1&#160;</sup>In the eleventh year, in the third month, in the first day of the month, Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>In the eleventh year, in the third month, in the first day of the month, Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, tell Pharaoh king of Egypt and his multitude: 
 </p><p class="q1">‘Whom are you like in your greatness? 
 </p><p class="q1">
@@ -1594,21 +1594,21 @@ html[dir=ltr] .q2 {
 </p><p class="q2">so that all the trees of Eden, 
 </p><p class="q2">that were in the garden of Elohim, envied it.’ 
 </p><p>
-<sup>10&#160;</sup>“Therefore thus said the Lord Yahweh: ‘Because he is exalted in stature, and he has set his top among the thick branches, and his heart is lifted up in his height, 
+<sup>10&#160;</sup>“Therefore thus said the Lord Yahuah: ‘Because he is exalted in stature, and he has set his top among the thick branches, and his heart is lifted up in his height, 
 <sup>11&#160;</sup>I will deliver him into the hand of the mighty one of the nations. He will surely deal with him. I have driven him out for his wickedness. 
 <sup>12&#160;</sup>Foreigners, the tyrants of the nations, have cut him off and have left him. His branches have fallen on the mountains and in all the valleys, and his boughs are broken by all the watercourses of the land. All the peoples of the earth have gone down from his shadow and have left him. 
 <sup>13&#160;</sup>All the birds of the sky will dwell on his ruin, and all the animals of the field will be on his branches, 
 <sup>14&#160;</sup>to the end that none of all the trees by the waters exalt themselves in their stature, and don’t set their top among the thick boughs. Their mighty ones don’t stand up on their height, even all who drink water; for they are all delivered to death, to the lower parts of the earth, among the children of men, with those who go down to the pit.’ 
 </p><p>
-<sup>15&#160;</sup>“The Lord Yahweh says: ‘In the day when he went down to Sheol, I caused a mourning. I covered the deep for him, and I restrained its rivers. The great waters were stopped. I caused Lebanon to mourn for him, and all the trees of the field fainted for him. 
+<sup>15&#160;</sup>“The Lord Yahuah says: ‘In the day when he went down to Sheol, I caused a mourning. I covered the deep for him, and I restrained its rivers. The great waters were stopped. I caused Lebanon to mourn for him, and all the trees of the field fainted for him. 
 <sup>16&#160;</sup>I made the nations to shake at the sound of his fall, when I cast him down to Sheol with those who descend into the pit. All the trees of Eden, the choice and best of Lebanon, all that drink water, were comforted in the lower parts of the earth. 
 <sup>17&#160;</sup>They also went down into Sheol with him to those who are slain by the sword; yes, those who were his arm, who lived under his shadow in the middle of the nations. 
 </p><p>
 <sup>18&#160;</sup>“&#160;‘To whom are you thus like in glory and in greatness among the trees of Eden? Yet you will be brought down with the trees of Eden to the lower parts of the earth. You will lie in the middle of the uncircumcised, with those who are slain by the sword. 
-</p><p>“&#160;‘This is Pharaoh and all his multitude,’ says the Lord Yahweh.” 
+</p><p>“&#160;‘This is Pharaoh and all his multitude,’ says the Lord Yahuah.” 
 </p><h2 class="chapterlabel" id="32">32</h2>
 <p>
-<sup>1&#160;</sup>In the twelfth year, in the twelfth month, in the first day of the month, “Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>In the twelfth year, in the twelfth month, in the first day of the month, “Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>‘Son of man, take up a lamentation over Pharaoh king of Egypt, and tell him, 
 </p><p class="q1">“You were likened to a young lion of the nations; 
 </p><p class="q2">yet you are as a monster in the seas. 
@@ -1616,7 +1616,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and troubled the waters with your feet, 
 </p><p class="q2">and fouled their rivers.” 
 </p><p class="q1">
-<sup>3&#160;</sup>The Lord Yahweh says: 
+<sup>3&#160;</sup>The Lord Yahuah says: 
 </p><p class="q2">“I will spread out my net on you with a company of many peoples. 
 </p><p class="q2">They will bring you up in my net. 
 </p><p class="q1">
@@ -1638,7 +1638,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and the moon won’t give its light. 
 </p><p class="q1">
 <sup>8&#160;</sup>I will make all the bright lights of the sky dark over you, 
-</p><p class="q2">and set darkness on your land,” says the Lord Yahweh. 
+</p><p class="q2">and set darkness on your land,” says the Lord Yahuah. 
 </p><p class="q1">
 <sup>9&#160;</sup>“I will also trouble the hearts of many peoples, 
 </p><p class="q2">when I bring your destruction among the nations, 
@@ -1651,7 +1651,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">every man for his own life, 
 </p><p class="q2">in the day of your fall.” 
 </p><p class="q1">
-<sup>11&#160;</sup>For the Lord Yahweh says: 
+<sup>11&#160;</sup>For the Lord Yahuah says: 
 </p><p class="q2">“The sword of the king of Babylon will come on you. 
 </p><p class="q1">
 <sup>12&#160;</sup>I will cause your multitude to fall by the swords of the mighty. 
@@ -1665,17 +1665,17 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>14&#160;</sup>Then I will make their waters clear, 
 </p><p class="q2">and cause their rivers to run like oil,” 
-</p><p class="q2">says the Lord Yahweh. 
+</p><p class="q2">says the Lord Yahuah. 
 </p><p class="q1">
 <sup>15&#160;</sup>“When I make the land of Egypt desolate and waste, 
 </p><p class="q2">a land destitute of that of which it was full, 
 </p><p class="q1">when I strike all those who dwell therein, 
-</p><p class="q2">then they will know that I am Yahweh. 
+</p><p class="q2">then they will know that I am Yahuah. 
 </p><p>
-<sup>16&#160;</sup>“&#160;‘&#160;“This is the lamentation with which they will lament. The daughters of the nations will lament with this. They will lament with it over Egypt, and over all her multitude,” says the Lord Yahweh.’&#160;” 
+<sup>16&#160;</sup>“&#160;‘&#160;“This is the lamentation with which they will lament. The daughters of the nations will lament with this. They will lament with it over Egypt, and over all her multitude,” says the Lord Yahuah.’&#160;” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>17&#160;</sup>Also in the twelfth year, in the fifteenth day of the month, Yahweh’s word came to me, saying, 
+<sup>17&#160;</sup>Also in the twelfth year, in the fifteenth day of the month, Yahuah’s word came to me, saying, 
 <sup>18&#160;</sup>“Son of man, wail for the multitude of Egypt, and cast them down, even her and the daughters of the famous nations, to the lower parts of the earth, with those who go down into the pit. 
 <sup>19&#160;</sup>Whom do you pass in beauty? Go down, and be laid with the uncircumcised. 
 <sup>20&#160;</sup>They will fall among those who are slain by the sword. She is delivered to the sword. Draw her away with all her multitudes. 
@@ -1696,11 +1696,11 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>30&#160;</sup>“There are the princes of the north, all of them, and all the Sidonians, who have gone down with the slain. They are put to shame in the terror which they caused by their might. They lie uncircumcised with those who are slain by the sword, and bear their shame with those who go down to the pit. 
 </p><p>
-<sup>31&#160;</sup>“Pharaoh will see them and will be comforted over all his multitude, even Pharaoh and all his army, slain by the sword,” says the Lord Yahweh. 
-<sup>32&#160;</sup>“For I have put his terror in the land of the living. He will be laid among the uncircumcised, with those who are slain by the sword, even Pharaoh and all his multitude,” says the Lord Yahweh. 
+<sup>31&#160;</sup>“Pharaoh will see them and will be comforted over all his multitude, even Pharaoh and all his army, slain by the sword,” says the Lord Yahuah. 
+<sup>32&#160;</sup>“For I have put his terror in the land of the living. He will be laid among the uncircumcised, with those who are slain by the sword, even Pharaoh and all his multitude,” says the Lord Yahuah. 
 </p><h2 class="chapterlabel" id="33">33</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, speak to the children of your people, and tell them, ‘When I bring the sword on a land, and the people of the land take a man from among them, and set him for their watchman, 
 <sup>3&#160;</sup>if, when he sees the sword come on the land, he blows the trumpet and warns the people, 
 <sup>4&#160;</sup>then whoever hears the sound of the trumpet and doesn’t heed the warning, if the sword comes and takes him away, his blood will be on his own head. 
@@ -1712,7 +1712,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Nevertheless, if you warn the wicked of his way to turn from it, and he doesn’t turn from his way; he will die in his iniquity, but you have delivered your soul. 
 </p><p>
 <sup>10&#160;</sup>“You, son of man, tell the house of Israel: ‘You say this, “Our transgressions and our sins are on us, and we pine away in them. How then can we live?”&#160;’ 
-<sup>11&#160;</sup>Tell them, ‘&#160;“As I live,” says the Lord Yahweh, “I have no pleasure in the death of the wicked, but that the wicked turn from his way and live. Turn, turn from your evil ways! For why will you die, house of Israel?”&#160;’ 
+<sup>11&#160;</sup>Tell them, ‘&#160;“As I live,” says the Lord Yahuah, “I have no pleasure in the death of the wicked, but that the wicked turn from his way and live. Turn, turn from your evil ways! For why will you die, house of Israel?”&#160;’ 
 </p><p>
 <sup>12&#160;</sup>“You, son of man, tell the children of your people, ‘The righteousness of the righteous will not deliver him in the day of his disobedience. And as for the wickedness of the wicked, he will not fall by it in the day that he turns from his wickedness; neither will he who is righteous be able to live by it in the day that he sins. 
 <sup>13&#160;</sup>When I tell the righteous that he will surely live, if he trusts in his righteousness and commits iniquity, none of his righteous deeds will be remembered; but he will die in his iniquity that he has committed. 
@@ -1727,108 +1727,108 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p>
 <sup>21&#160;</sup>In the twelfth year of our captivity, in the tenth month, in the fifth day of the month, one who had escaped out of Jerusalem came to me, saying, “The city has been defeated!” 
-<sup>22&#160;</sup>Now Yahweh’s hand had been on me in the evening, before he who had escaped came; and he had opened my mouth until he came to me in the morning; and my mouth was opened, and I was no longer mute. 
+<sup>22&#160;</sup>Now Yahuah’s hand had been on me in the evening, before he who had escaped came; and he had opened my mouth until he came to me in the morning; and my mouth was opened, and I was no longer mute. 
 </p><p>
-<sup>23&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>23&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>24&#160;</sup>“Son of man, those who inhabit the waste places in the land of Israel speak, saying, ‘Abraham was one, and he inherited the land; but we are many. The land is given us for inheritance.’ 
-<sup>25&#160;</sup>Therefore tell them, ‘The Lord Yahweh says: “You eat with the blood, and lift up your eyes to your idols, and shed blood. So should you possess the land? 
+<sup>25&#160;</sup>Therefore tell them, ‘The Lord Yahuah says: “You eat with the blood, and lift up your eyes to your idols, and shed blood. So should you possess the land? 
 <sup>26&#160;</sup>You stand on your sword, you work abomination, and every one of you defiles his neighbor’s woman. So should you possess the land?”&#160;’ 
 </p><p>
-<sup>27&#160;</sup>“You shall tell them, ‘The Lord Yahweh says: “As I live, surely those who are in the waste places will fall by the sword. I will give whoever is in the open field to the animals to be devoured, and those who are in the strongholds and in the caves will die of the pestilence. 
+<sup>27&#160;</sup>“You shall tell them, ‘The Lord Yahuah says: “As I live, surely those who are in the waste places will fall by the sword. I will give whoever is in the open field to the animals to be devoured, and those who are in the strongholds and in the caves will die of the pestilence. 
 <sup>28&#160;</sup>I will make the land a desolation and an astonishment. The pride of her power will cease. The mountains of Israel will be desolate, so that no one will pass through. 
-<sup>29&#160;</sup>Then they will know that I am Yahweh, when I have made the land a desolation and an astonishment because of all their abominations which they have committed.”&#160;’ 
+<sup>29&#160;</sup>Then they will know that I am Yahuah, when I have made the land a desolation and an astonishment because of all their abominations which they have committed.”&#160;’ 
 </p><p>
-<sup>30&#160;</sup>“As for you, son of man, the children of your people talk about you by the walls and in the doors of the houses, and speak to one another, everyone to his brother, saying, ‘Please come and hear what the word is that comes out from Yahweh.’ 
+<sup>30&#160;</sup>“As for you, son of man, the children of your people talk about you by the walls and in the doors of the houses, and speak to one another, everyone to his brother, saying, ‘Please come and hear what the word is that comes out from Yahuah.’ 
 <sup>31&#160;</sup>They come to you as the people come, and they sit before you as my people, and they hear your words, but don’t do them; for with their mouth they show much love, but their heart goes after their gain. 
 <sup>32&#160;</sup>Behold, you are to them as a very lovely song of one who has a pleasant voice, and can play well on an instrument; for they hear your words, but they don’t do them. 
 </p><p>
 <sup>33&#160;</sup>“When this comes to pass—behold, it comes—then they will know that a prophet has been among them.” 
 </p><h2 class="chapterlabel" id="34">34</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
-<sup>2&#160;</sup>“Son of man, prophesy against the shepherds of Israel. Prophesy, and tell them, even the shepherds, ‘The Lord Yahweh says: “Woe to the shepherds of Israel who feed themselves! Shouldn’t the shepherds feed the sheep? 
+<sup>1&#160;</sup>Yahuah’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, prophesy against the shepherds of Israel. Prophesy, and tell them, even the shepherds, ‘The Lord Yahuah says: “Woe to the shepherds of Israel who feed themselves! Shouldn’t the shepherds feed the sheep? 
 <sup>3&#160;</sup>You eat the fat. You clothe yourself with the wool. You kill the fatlings, but you don’t feed the sheep. 
 <sup>4&#160;</sup>You haven’t strengthened the diseased. You haven’t healed that which was sick. You haven’t bound up that which was broken. You haven’t brought back that which was driven away. You haven’t sought that which was lost, but you have ruled over them with force and with rigor. 
 <sup>5&#160;</sup>They were scattered, because there was no shepherd. They became food to all the animals of the field, and were scattered. 
 <sup>6&#160;</sup>My sheep wandered through all the mountains and on every high hill. Yes, my sheep were scattered on all the surface of the earth. There was no one who searched or sought.” 
 </p><p>
-<sup>7&#160;</sup>“&#160;‘Therefore, you shepherds, hear Yahweh’s word: 
-<sup>8&#160;</sup>“As I live,” says the Lord Yahweh, “surely because my sheep became a prey, and my sheep became food to all the animals of the field, because there was no shepherd, and my shepherds didn’t search for my sheep, but the shepherds fed themselves, and didn’t feed my sheep, 
-<sup>9&#160;</sup>therefore, you shepherds, hear Yahweh’s word!” 
-<sup>10&#160;</sup>The Lord Yahweh says: “Behold, I am against the shepherds. I will require my sheep at their hand, and cause them to cease from feeding the sheep. The shepherds won’t feed themselves any more. I will deliver my sheep from their mouth, that they may not be food for them.” 
+<sup>7&#160;</sup>“&#160;‘Therefore, you shepherds, hear Yahuah’s word: 
+<sup>8&#160;</sup>“As I live,” says the Lord Yahuah, “surely because my sheep became a prey, and my sheep became food to all the animals of the field, because there was no shepherd, and my shepherds didn’t search for my sheep, but the shepherds fed themselves, and didn’t feed my sheep, 
+<sup>9&#160;</sup>therefore, you shepherds, hear Yahuah’s word!” 
+<sup>10&#160;</sup>The Lord Yahuah says: “Behold, I am against the shepherds. I will require my sheep at their hand, and cause them to cease from feeding the sheep. The shepherds won’t feed themselves any more. I will deliver my sheep from their mouth, that they may not be food for them.” 
 </p><p>
-<sup>11&#160;</sup>“&#160;‘For the Lord Yahweh says: “Behold, I myself, even I, will search for my sheep, and will seek them out. 
+<sup>11&#160;</sup>“&#160;‘For the Lord Yahuah says: “Behold, I myself, even I, will search for my sheep, and will seek them out. 
 <sup>12&#160;</sup>As a shepherd seeks out his flock in the day that he is among his sheep that are scattered abroad, so I will seek out my sheep. I will deliver them out of all places where they have been scattered in the cloudy and dark day. 
 <sup>13&#160;</sup>I will bring them out from the peoples, and gather them from the countries, and will bring them into their own land. I will feed them on the mountains of Israel, by the watercourses, and in all the inhabited places of the country. 
 <sup>14&#160;</sup>I will feed them with good pasture, and their fold will be on the mountains of the height of Israel. There they will lie down in a good fold. They will feed on rich pasture on the mountains of Israel. 
-<sup>15&#160;</sup>I myself will be the shepherd of my sheep, and I will cause them to lie down,” says the Lord Yahweh. 
+<sup>15&#160;</sup>I myself will be the shepherd of my sheep, and I will cause them to lie down,” says the Lord Yahuah. 
 <sup>16&#160;</sup>“I will seek that which was lost, and will bring back that which was driven away, and will bind up that which was broken, and will strengthen that which was sick; but I will destroy the fat and the strong. I will feed them in justice.”&#160;’ 
 </p><p>
-<sup>17&#160;</sup>“As for you, O my flock, the Lord Yahweh says: ‘Behold, I judge between sheep and sheep, the rams and the male goats. 
+<sup>17&#160;</sup>“As for you, O my flock, the Lord Yahuah says: ‘Behold, I judge between sheep and sheep, the rams and the male goats. 
 <sup>18&#160;</sup>Does it seem a small thing to you to have fed on the good pasture, but you must tread down with your feet the residue of your pasture? And to have drunk of the clear waters, but must you foul the residue with your feet? 
 <sup>19&#160;</sup>As for my sheep, they eat that which you have trodden with your feet, and they drink that which you have fouled with your feet.’ 
 </p><p>
-<sup>20&#160;</sup>“Therefore the Lord Yahweh says to them: ‘Behold, I, even I, will judge between the fat sheep and the lean sheep. 
+<sup>20&#160;</sup>“Therefore the Lord Yahuah says to them: ‘Behold, I, even I, will judge between the fat sheep and the lean sheep. 
 <sup>21&#160;</sup>Because you thrust with side and with shoulder, and push all the diseased with your horns, until you have scattered them abroad, 
 <sup>22&#160;</sup>therefore I will save my flock, and they will no more be a prey. I will judge between sheep and sheep. 
 <sup>23&#160;</sup>I will set up one shepherd over them, and he will feed them, even my servant David. He will feed them, and he will be their shepherd. 
-<sup>24&#160;</sup>I, Yahweh, will be their Elohim, and my servant David prince among them. I, Yahweh, have spoken it. 
+<sup>24&#160;</sup>I, Yahuah, will be their Elohim, and my servant David prince among them. I, Yahuah, have spoken it. 
 </p><p>
 <sup>25&#160;</sup>“&#160;‘I will make with them a covenant of peace, and will cause evil animals to cease out of the land. They will dwell securely in the wilderness and sleep in the woods. 
 <sup>26&#160;</sup>I will make them and the places around my hill a blessing. I will cause the shower to come down in its season. There will be showers of blessing. 
-<sup>27&#160;</sup>The tree of the field will yield its fruit, and the earth will yield its increase, and they will be secure in their land. Then they will know that I am Yahweh, when I have broken the bars of their yoke, and have delivered them out of the hand of those who made slaves of them. 
+<sup>27&#160;</sup>The tree of the field will yield its fruit, and the earth will yield its increase, and they will be secure in their land. Then they will know that I am Yahuah, when I have broken the bars of their yoke, and have delivered them out of the hand of those who made slaves of them. 
 <sup>28&#160;</sup>They will no more be a prey to the nations, neither will the animals of the earth devour them; but they will dwell securely, and no one will make them afraid. 
 <sup>29&#160;</sup>I will raise up to them a plantation for renown, and they will no more be consumed with famine in the land, and not bear the shame of the nations any more. 
-<sup>30&#160;</sup>They will know that I, Yahweh, their Elohim am with them, and that they, the house of Israel, are my people, says the Lord Yahweh. 
-<sup>31&#160;</sup>You my sheep, the sheep of my pasture, are men, and I am your Elohim,’ says the Lord Yahweh.” 
+<sup>30&#160;</sup>They will know that I, Yahuah, their Elohim am with them, and that they, the house of Israel, are my people, says the Lord Yahuah. 
+<sup>31&#160;</sup>You my sheep, the sheep of my pasture, are men, and I am your Elohim,’ says the Lord Yahuah.” 
 </p><h2 class="chapterlabel" id="35">35</h2>
 <p>
-<sup>1&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Moreover Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, set your face against Mount Seir, and prophesy against it, 
-<sup>3&#160;</sup>and tell it, ‘The Lord Yahweh says: “Behold, I am against you, Mount Seir, and I will stretch out my hand against you. I will make you a desolation and an astonishment. 
-<sup>4&#160;</sup>I will lay your cities waste, and you will be desolate. Then you will know that I am Yahweh. 
+<sup>3&#160;</sup>and tell it, ‘The Lord Yahuah says: “Behold, I am against you, Mount Seir, and I will stretch out my hand against you. I will make you a desolation and an astonishment. 
+<sup>4&#160;</sup>I will lay your cities waste, and you will be desolate. Then you will know that I am Yahuah. 
 </p><p>
 <sup>5&#160;</sup>“&#160;‘&#160;“Because you have had a perpetual hostility, and have given over the children of Israel to the power of the sword in the time of their calamity, in the time of the iniquity of the end, 
-<sup>6&#160;</sup>therefore, as I live,” says the Lord Yahweh, “I will prepare you for blood, and blood will pursue you. Since you have not hated blood, therefore blood will pursue you. 
+<sup>6&#160;</sup>therefore, as I live,” says the Lord Yahuah, “I will prepare you for blood, and blood will pursue you. Since you have not hated blood, therefore blood will pursue you. 
 <sup>7&#160;</sup>Thus I will make Mount Seir an astonishment and a desolation. I will cut off from it him who passes through and him who returns. 
 <sup>8&#160;</sup>I will fill its mountains with its slain. The slain with the sword will fall in your hills and in your valleys and in all your watercourses. 
-<sup>9&#160;</sup>I will make you a perpetual desolation, and your cities will not be inhabited. Then you will know that I am Yahweh. 
+<sup>9&#160;</sup>I will make you a perpetual desolation, and your cities will not be inhabited. Then you will know that I am Yahuah. 
 </p><p>
-<sup>10&#160;</sup>“&#160;‘&#160;“Because you have said, ‘These two nations and these two countries will be mine, and we will possess it,’ although Yahweh was there, 
-<sup>11&#160;</sup>therefore, as I live,” says the Lord Yahweh, “I will do according to your anger, and according to your envy which you have shown out of your hatred against them; and I will make myself known among them when I judge you. 
-<sup>12&#160;</sup>You will know that I, Yahweh, have heard all your insults which you have spoken against the mountains of Israel, saying, ‘They have been laid desolate. They have been given to us to devour.’ 
+<sup>10&#160;</sup>“&#160;‘&#160;“Because you have said, ‘These two nations and these two countries will be mine, and we will possess it,’ although Yahuah was there, 
+<sup>11&#160;</sup>therefore, as I live,” says the Lord Yahuah, “I will do according to your anger, and according to your envy which you have shown out of your hatred against them; and I will make myself known among them when I judge you. 
+<sup>12&#160;</sup>You will know that I, Yahuah, have heard all your insults which you have spoken against the mountains of Israel, saying, ‘They have been laid desolate. They have been given to us to devour.’ 
 <sup>13&#160;</sup>You have magnified yourselves against me with your mouth, and have multiplied your words against me. I have heard it.” 
-<sup>14&#160;</sup>The Lord Yahweh says: “When the whole earth rejoices, I will make you desolate. 
-<sup>15&#160;</sup>As you rejoiced over the inheritance of the house of Israel because it was desolate, so I will do to you. You will be desolate, Mount Seir, and all Edom, even all of it. Then they will know that I am Yahweh.’&#160;” 
+<sup>14&#160;</sup>The Lord Yahuah says: “When the whole earth rejoices, I will make you desolate. 
+<sup>15&#160;</sup>As you rejoiced over the inheritance of the house of Israel because it was desolate, so I will do to you. You will be desolate, Mount Seir, and all Edom, even all of it. Then they will know that I am Yahuah.’&#160;” 
 </p><h2 class="chapterlabel" id="36">36</h2>
 <p>
-<sup>1&#160;</sup>You, son of man, prophesy to the mountains of Israel, and say, “You mountains of Israel, hear Yahweh’s word. 
-<sup>2&#160;</sup>The Lord Yahweh says: ‘Because the enemy has said against you, “Aha!” and, “The ancient high places are ours in possession!”&#160;’ 
-<sup>3&#160;</sup>therefore prophesy, and say, ‘The Lord Yahweh says: “Because, even because they have made you desolate, and swallowed you up on every side, that you might be a possession to the residue of the nations, and you are taken up in the lips of talkers, and the evil report of the people;” 
-<sup>4&#160;</sup>therefore, you mountains of Israel, hear the word of the Lord Yahweh: The Lord Yahweh says to the mountains and to the hills, to the watercourses and to the valleys, to the desolate wastes and to the cities that are forsaken, which have become a prey and derision to the residue of the nations that are all around; 
-<sup>5&#160;</sup>therefore the Lord Yahweh says: “Surely in the fire of my jealousy I have spoken against the residue of the nations, and against all Edom, that have appointed my land to themselves for a possession with the joy of all their heart, with despite of soul, to cast it out for a prey.”&#160;’ 
-<sup>6&#160;</sup>Therefore prophesy concerning the land of Israel, and tell the mountains, the hills, the watercourses and the valleys, ‘The Lord Yahweh says: “Behold, I have spoken in my jealousy and in my wrath, because you have borne the shame of the nations.” 
-<sup>7&#160;</sup>Therefore the Lord Yahweh says: “I have sworn, ‘Surely the nations that are around you will bear their shame.’ 
+<sup>1&#160;</sup>You, son of man, prophesy to the mountains of Israel, and say, “You mountains of Israel, hear Yahuah’s word. 
+<sup>2&#160;</sup>The Lord Yahuah says: ‘Because the enemy has said against you, “Aha!” and, “The ancient high places are ours in possession!”&#160;’ 
+<sup>3&#160;</sup>therefore prophesy, and say, ‘The Lord Yahuah says: “Because, even because they have made you desolate, and swallowed you up on every side, that you might be a possession to the residue of the nations, and you are taken up in the lips of talkers, and the evil report of the people;” 
+<sup>4&#160;</sup>therefore, you mountains of Israel, hear the word of the Lord Yahuah: The Lord Yahuah says to the mountains and to the hills, to the watercourses and to the valleys, to the desolate wastes and to the cities that are forsaken, which have become a prey and derision to the residue of the nations that are all around; 
+<sup>5&#160;</sup>therefore the Lord Yahuah says: “Surely in the fire of my jealousy I have spoken against the residue of the nations, and against all Edom, that have appointed my land to themselves for a possession with the joy of all their heart, with despite of soul, to cast it out for a prey.”&#160;’ 
+<sup>6&#160;</sup>Therefore prophesy concerning the land of Israel, and tell the mountains, the hills, the watercourses and the valleys, ‘The Lord Yahuah says: “Behold, I have spoken in my jealousy and in my wrath, because you have borne the shame of the nations.” 
+<sup>7&#160;</sup>Therefore the Lord Yahuah says: “I have sworn, ‘Surely the nations that are around you will bear their shame.’ 
 </p><p>
 <sup>8&#160;</sup>“&#160;‘&#160;“But you, mountains of Israel, you shall shoot out your branches and yield your fruit to my people Israel; for they are at hand to come. 
 <sup>9&#160;</sup>For, behold, I am for you, and I will come to you, and you will be tilled and sown. 
 <sup>10&#160;</sup>I will multiply men on you, all the house of Israel, even all of it. The cities will be inhabited and the waste places will be built. 
-<sup>11&#160;</sup>I will multiply man and animal on you. They will increase and be fruitful. I will cause you to be inhabited as you were before, and you will do better than at your beginnings. Then you will know that I am Yahweh. 
+<sup>11&#160;</sup>I will multiply man and animal on you. They will increase and be fruitful. I will cause you to be inhabited as you were before, and you will do better than at your beginnings. Then you will know that I am Yahuah. 
 <sup>12&#160;</sup>Yes, I will cause men to walk on you, even my people Israel. They will possess you, and you will be their inheritance, and you will never again bereave them of their children.” 
 </p><p>
-<sup>13&#160;</sup>“&#160;‘The Lord Yahweh says: “Because they say to you, ‘You are a devourer of men, and have been a bereaver of your nation;’ 
-<sup>14&#160;</sup>therefore you shall devour men no more, and not bereave your nation any more,” says the Lord Yahweh. 
-<sup>15&#160;</sup>“I won’t let you hear the shame of the nations any more. You won’t bear the reproach of the peoples any more, and you won’t cause your nation to stumble any more,” says the Lord Yahweh.’&#160;” 
+<sup>13&#160;</sup>“&#160;‘The Lord Yahuah says: “Because they say to you, ‘You are a devourer of men, and have been a bereaver of your nation;’ 
+<sup>14&#160;</sup>therefore you shall devour men no more, and not bereave your nation any more,” says the Lord Yahuah. 
+<sup>15&#160;</sup>“I won’t let you hear the shame of the nations any more. You won’t bear the reproach of the peoples any more, and you won’t cause your nation to stumble any more,” says the Lord Yahuah.’&#160;” 
 </p><p>
-<sup>16&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>16&#160;</sup>Moreover Yahuah’s word came to me, saying, 
 <sup>17&#160;</sup>“Son of man, when the house of Israel lived in their own land, they defiled it by their ways and by their deeds. Their way before me was as the uncleanness of a woman in her impurity. 
 <sup>18&#160;</sup>Therefore I poured out my wrath on them for the blood which they had poured out on the land, and because they had defiled it with their idols. 
 <sup>19&#160;</sup>I scattered them among the nations, and they were dispersed through the countries. I judged them according to their way and according to their deeds. 
-<sup>20&#160;</sup>When they came to the nations where they went, they profaned my set-apart name, in that men said of them, ‘These are Yahweh’s people, and have left his land.’ 
+<sup>20&#160;</sup>When they came to the nations where they went, they profaned my set-apart name, in that men said of them, ‘These are Yahuah’s people, and have left his land.’ 
 <sup>21&#160;</sup>But I had respect for my set-apart name, which the house of Israel had profaned among the nations where they went. 
 </p><p>
-<sup>22&#160;</sup>“Therefore tell the house of Israel, ‘The Lord Yahweh says: “I don’t do this for your sake, house of Israel, but for my set-apart name, which you have profaned among the nations where you went. 
-<sup>23&#160;</sup>I will sanctify my great name, which has been profaned among the nations, which you have profaned among them. Then the nations will know that I am Yahweh,” says the Lord Yahweh, “when I am proven set-apart in you before their eyes. 
+<sup>22&#160;</sup>“Therefore tell the house of Israel, ‘The Lord Yahuah says: “I don’t do this for your sake, house of Israel, but for my set-apart name, which you have profaned among the nations where you went. 
+<sup>23&#160;</sup>I will sanctify my great name, which has been profaned among the nations, which you have profaned among them. Then the nations will know that I am Yahuah,” says the Lord Yahuah, “when I am proven set-apart in you before their eyes. 
 </p><p>
 <sup>24&#160;</sup>“&#160;‘&#160;“For I will take you from among the nations and gather you out of all the countries, and will bring you into your own land. 
 <sup>25&#160;</sup>I will sprinkle clean water on you, and you will be clean. I will cleanse you from all your filthiness and from all your idols. 
@@ -1839,47 +1839,47 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>I will multiply the fruit of the tree and the increase of the field, that you may receive no more the reproach of famine among the nations. 
 </p><p>
 <sup>31&#160;</sup>“&#160;‘&#160;“Then you will remember your evil ways, and your deeds that were not good; and you will loathe yourselves in your own sight for your iniquities and for your abominations. 
-<sup>32&#160;</sup>I don’t do this for your sake,” says the Lord Yahweh. “Let it be known to you. Be ashamed and confounded for your ways, house of Israel.” 
+<sup>32&#160;</sup>I don’t do this for your sake,” says the Lord Yahuah. “Let it be known to you. Be ashamed and confounded for your ways, house of Israel.” 
 </p><p>
-<sup>33&#160;</sup>“&#160;‘The Lord Yahweh says: “In the day that I cleanse you from all your iniquities, I will cause the cities to be inhabited and the waste places will be built. 
+<sup>33&#160;</sup>“&#160;‘The Lord Yahuah says: “In the day that I cleanse you from all your iniquities, I will cause the cities to be inhabited and the waste places will be built. 
 <sup>34&#160;</sup>The land that was desolate will be tilled instead of being a desolation in the sight of all who passed by. 
 <sup>35&#160;</sup>They will say, ‘This land that was desolate has become like the garden of Eden. The waste, desolate, and ruined cities are fortified and inhabited.’ 
-<sup>36&#160;</sup>Then the nations that are left around you will know that I, Yahweh, have built the ruined places and planted that which was desolate. I, Yahweh, have spoken it, and I will do it.” 
+<sup>36&#160;</sup>Then the nations that are left around you will know that I, Yahuah, have built the ruined places and planted that which was desolate. I, Yahuah, have spoken it, and I will do it.” 
 </p><p>
-<sup>37&#160;</sup>“&#160;‘The Lord Yahweh says: “For this, moreover, I will be inquired of by the house of Israel, to do it for them: I will increase them with men like a flock. 
-<sup>38&#160;</sup>As the flock for sacrifice, as the flock of Jerusalem in her appointed feasts, so the waste cities will be filled with flocks of men. Then they will know that I am Yahweh.’&#160;” 
+<sup>37&#160;</sup>“&#160;‘The Lord Yahuah says: “For this, moreover, I will be inquired of by the house of Israel, to do it for them: I will increase them with men like a flock. 
+<sup>38&#160;</sup>As the flock for sacrifice, as the flock of Jerusalem in her appointed feasts, so the waste cities will be filled with flocks of men. Then they will know that I am Yahuah.’&#160;” 
 </p><h2 class="chapterlabel" id="37">37</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s hand was on me, and he brought me out in Yahweh’s Spirit, and set me down in the middle of the valley; and it was full of bones. 
+<sup>1&#160;</sup>Yahuah’s hand was on me, and he brought me out in Yahuah’s Spirit, and set me down in the middle of the valley; and it was full of bones. 
 <sup>2&#160;</sup>He caused me to pass by them all around; and behold, there were very many in the open valley, and behold, they were very dry. 
 <sup>3&#160;</sup>He said to me, “Son of man, can these bones live?” 
-</p><p>I answered, “Lord Yahweh, you know.” 
+</p><p>I answered, “Lord Yahuah, you know.” 
 </p><p>
-<sup>4&#160;</sup>Again he said to me, “Prophesy over these bones, and tell them, ‘You dry bones, hear Yahweh’s word. 
-<sup>5&#160;</sup>The Lord Yahweh says to these bones: “Behold, I will cause breath to enter into you, and you will live. 
-<sup>6&#160;</sup>I will lay sinews on you, and will bring up flesh on you, and cover you with skin, and put breath in you, and you will live. Then you will know that I am Yahweh.”&#160;’&#160;” 
+<sup>4&#160;</sup>Again he said to me, “Prophesy over these bones, and tell them, ‘You dry bones, hear Yahuah’s word. 
+<sup>5&#160;</sup>The Lord Yahuah says to these bones: “Behold, I will cause breath to enter into you, and you will live. 
+<sup>6&#160;</sup>I will lay sinews on you, and will bring up flesh on you, and cover you with skin, and put breath in you, and you will live. Then you will know that I am Yahuah.”&#160;’&#160;” 
 </p><p>
 <sup>7&#160;</sup>So I prophesied as I was commanded. As I prophesied, there was a noise, and behold, there was an earthquake. Then the bones came together, bone to its bone. 
 <sup>8&#160;</sup>I saw, and, behold, there were sinews on them, and flesh came up, and skin covered them above; but there was no breath in them. 
 </p><p>
-<sup>9&#160;</sup>Then he said to me, “Prophesy to the wind, prophesy, son of man, and tell the wind, ‘The Lord Yahweh says: “Come from the four winds, breath, and breathe on these slain, that they may live.”&#160;’&#160;” 
+<sup>9&#160;</sup>Then he said to me, “Prophesy to the wind, prophesy, son of man, and tell the wind, ‘The Lord Yahuah says: “Come from the four winds, breath, and breathe on these slain, that they may live.”&#160;’&#160;” 
 </p><p>
 <sup>10&#160;</sup>So I prophesied as he commanded me, and the breath came into them, and they lived, and stood up on their feet, an exceedingly great army. 
 </p><p>
 <sup>11&#160;</sup>Then he said to me, “Son of man, these bones are the whole house of Israel. Behold, they say, ‘Our bones are dried up, and our hope is lost. We are completely cut off.’ 
-<sup>12&#160;</sup>Therefore prophesy, and tell them, ‘The Lord Yahweh says: “Behold, I will open your graves, and cause you to come up out of your graves, my people; and I will bring you into the land of Israel. 
-<sup>13&#160;</sup>You will know that I am Yahweh, when I have opened your graves and caused you to come up out of your graves, my people. 
-<sup>14&#160;</sup>I will put my Spirit in you, and you will live. Then I will place you in your own land; and you will know that I, Yahweh, have spoken it and performed it,” says Yahweh.’&#160;” 
+<sup>12&#160;</sup>Therefore prophesy, and tell them, ‘The Lord Yahuah says: “Behold, I will open your graves, and cause you to come up out of your graves, my people; and I will bring you into the land of Israel. 
+<sup>13&#160;</sup>You will know that I am Yahuah, when I have opened your graves and caused you to come up out of your graves, my people. 
+<sup>14&#160;</sup>I will put my Spirit in you, and you will live. Then I will place you in your own land; and you will know that I, Yahuah, have spoken it and performed it,” says Yahuah.’&#160;” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>15&#160;</sup>Yahweh’s word came again to me, saying, 
+<sup>15&#160;</sup>Yahuah’s word came again to me, saying, 
 <sup>16&#160;</sup>“You, son of man, take one stick and write on it, ‘For Judah, and for the children of Israel his companions.’ Then take another stick, and write on it, ‘For Joseph, the stick of Ephraim, and for all the house of Israel his companions.’ 
 <sup>17&#160;</sup>Then join them for yourself to one another into one stick, that they may become one in your hand. 
 </p><p>
 <sup>18&#160;</sup>“When the children of your people speak to you, saying, ‘Won’t you show us what you mean by these?’ 
-<sup>19&#160;</sup>tell them, ‘The Lord Yahweh says: “Behold, I will take the stick of Joseph, which is in the hand of Ephraim, and the tribes of Israel his companions; and I will put them with it, with the stick of Judah, and make them one stick, and they will be one in my hand. 
+<sup>19&#160;</sup>tell them, ‘The Lord Yahuah says: “Behold, I will take the stick of Joseph, which is in the hand of Ephraim, and the tribes of Israel his companions; and I will put them with it, with the stick of Judah, and make them one stick, and they will be one in my hand. 
 <sup>20&#160;</sup>The sticks on which you write will be in your hand before their eyes.”&#160;’ 
-<sup>21&#160;</sup>Say to them, ‘The Lord Yahweh says: “Behold, I will take the children of Israel from among the nations where they have gone, and will gather them on every side, and bring them into their own land. 
+<sup>21&#160;</sup>Say to them, ‘The Lord Yahuah says: “Behold, I will take the children of Israel from among the nations where they have gone, and will gather them on every side, and bring them into their own land. 
 <sup>22&#160;</sup>I will make them one nation in the land, on the mountains of Israel. One king will be king to them all. They will no longer be two nations. They won’t be divided into two kingdoms any more at all. 
 <sup>23&#160;</sup>They won’t defile themselves any more with their idols, nor with their detestable things, nor with any of their transgressions; but I will save them out of all their dwelling places in which they have sinned, and will cleanse them. So they will be my people, and I will be their Elohim. 
 </p><p>
@@ -1887,12 +1887,12 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>They will dwell in the land that I have given to Jacob my servant, in which your fathers lived. They will dwell therein, they, and their children, and their children’s children, forever. David my servant will be their prince forever. 
 <sup>26&#160;</sup>Moreover I will make a covenant of peace with them. It will be an everlasting covenant with them. I will place them, multiply them, and will set my sanctuary among them forever more. 
 <sup>27&#160;</sup>My tent also will be with them. I will be their Elohim, and they will be my people. 
-<sup>28&#160;</sup>The nations will know that I am Yahweh who sanctifies Israel, when my sanctuary is among them forever more.”&#160;’&#160;” 
+<sup>28&#160;</sup>The nations will know that I am Yahuah who sanctifies Israel, when my sanctuary is among them forever more.”&#160;’&#160;” 
 </p><h2 class="chapterlabel" id="38">38</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“Son of man, set your face toward Gog, of the land of Magog, the prince of Rosh, Meshech, and Tubal, and prophesy against him, 
-<sup>3&#160;</sup>and say, ‘The Lord Yahweh says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
+<sup>3&#160;</sup>and say, ‘The Lord Yahuah says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
 <sup>4&#160;</sup>I will turn you around, and put hooks into your jaws, and I will bring you out, with all your army, horses and horsemen, all of them clothed in full armor, a great company with buckler and shield, all of them handling swords; 
 <sup>5&#160;</sup>Persia, Cush, and Put with them, all of them with shield and helmet; 
 <sup>6&#160;</sup>Gomer, and all his hordes; the house of Togarmah in the uttermost parts of the north, and all his hordes—even many peoples with you. 
@@ -1901,64 +1901,64 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>After many days you will be visited. In the latter years you will come into the land that is brought back from the sword, that is gathered out of many peoples, on the mountains of Israel, which have been a continual waste; but it is brought out of the peoples and they will dwell securely, all of them. 
 <sup>9&#160;</sup>You will ascend. You will come like a storm. You will be like a cloud to cover the land, you and all your hordes, and many peoples with you.” 
 </p><p>
-<sup>10&#160;</sup>“&#160;‘The Lord Yahweh says: “It will happen in that day that things will come into your mind, and you will devise an evil plan. 
+<sup>10&#160;</sup>“&#160;‘The Lord Yahuah says: “It will happen in that day that things will come into your mind, and you will devise an evil plan. 
 <sup>11&#160;</sup>You will say, ‘I will go up to the land of unwalled villages. I will go to those who are at rest, who dwell securely, all of them dwelling without walls, and having neither bars nor gates, 
 <sup>12&#160;</sup>to take the plunder and to take prey; to turn your hand against the waste places that are inhabited, and against the people who are gathered out of the nations, who have gotten livestock and goods, who dwell in the middle of the earth.’ 
 <sup>13&#160;</sup>Sheba, Dedan, and the merchants of Tarshish, with all its young lions, will ask you, ‘Have you come to take the plunder? Have you assembled your company to take the prey, to carry away silver and gold, to take away livestock and goods, to take great plunder?’&#160;”&#160;’ 
 </p><p>
-<sup>14&#160;</sup>“Therefore, son of man, prophesy, and tell Gog, ‘The Lord Yahweh says: “In that day when my people Israel dwells securely, will you not know it? 
+<sup>14&#160;</sup>“Therefore, son of man, prophesy, and tell Gog, ‘The Lord Yahuah says: “In that day when my people Israel dwells securely, will you not know it? 
 <sup>15&#160;</sup>You will come from your place out of the uttermost parts of the north, you, and many peoples with you, all of them riding on horses, a great company and a mighty army. 
 <sup>16&#160;</sup>You will come up against my people Israel as a cloud to cover the land. It will happen in the latter days that I will bring you against my land, that the nations may know me when I am sanctified in you, Gog, before their eyes.” 
 </p><p>
-<sup>17&#160;</sup>“&#160;‘The Lord Yahweh says: “Are you he of whom I spoke in old time by my servants the prophets of Israel, who prophesied in those days for years that I would bring you against them? 
-<sup>18&#160;</sup>It will happen in that day, when Gog comes against the land of Israel,” says the Lord Yahweh, “that my wrath will come up into my nostrils. 
+<sup>17&#160;</sup>“&#160;‘The Lord Yahuah says: “Are you he of whom I spoke in old time by my servants the prophets of Israel, who prophesied in those days for years that I would bring you against them? 
+<sup>18&#160;</sup>It will happen in that day, when Gog comes against the land of Israel,” says the Lord Yahuah, “that my wrath will come up into my nostrils. 
 <sup>19&#160;</sup>For in my jealousy and in the fire of my wrath I have spoken. Surely in that day there will be a great shaking in the land of Israel, 
 <sup>20&#160;</sup>so that the fish of the sea, the birds of the sky, the animals of the field, all creeping things who creep on the earth, and all the men who are on the surface of the earth will shake at my presence. Then the mountains will be thrown down, the steep places will fall, and every wall will fall to the ground. 
-<sup>21&#160;</sup>I will call for a sword against him to all my mountains,” says the Lord Yahweh. “Every man’s sword will be against his brother. 
+<sup>21&#160;</sup>I will call for a sword against him to all my mountains,” says the Lord Yahuah. “Every man’s sword will be against his brother. 
 <sup>22&#160;</sup>I will enter into judgment with him with pestilence and with blood. I will rain on him, on his hordes, and on the many peoples who are with him, torrential rains with great hailstones, fire, and sulfur. 
-<sup>23&#160;</sup>I will magnify myself and sanctify myself, and I will make myself known in the eyes of many nations. Then they will know that I am Yahweh.”&#160;’ 
+<sup>23&#160;</sup>I will magnify myself and sanctify myself, and I will make myself known in the eyes of many nations. Then they will know that I am Yahuah.”&#160;’ 
 </p><h2 class="chapterlabel" id="39">39</h2>
 <p>
-<sup>1&#160;</sup>“You, son of man, prophesy against Gog, and say, ‘The Lord Yahweh says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
+<sup>1&#160;</sup>“You, son of man, prophesy against Gog, and say, ‘The Lord Yahuah says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
 <sup>2&#160;</sup>I will turn you around, will lead you on, and will cause you to come up from the uttermost parts of the north; and I will bring you onto the mountains of Israel. 
 <sup>3&#160;</sup>I will strike your bow out of your left hand, and will cause your arrows to fall out of your right hand. 
 <sup>4&#160;</sup>You will fall on the mountains of Israel, you, and all your hordes, and the peoples who are with you. I will give you to the ravenous birds of every sort and to the animals of the field to be devoured. 
-<sup>5&#160;</sup>You will fall on the open field, for I have spoken it,” says the Lord Yahweh. 
-<sup>6&#160;</sup>“I will send a fire on Magog and on those who dwell securely in the islands. Then they will know that I am Yahweh. 
+<sup>5&#160;</sup>You will fall on the open field, for I have spoken it,” says the Lord Yahuah. 
+<sup>6&#160;</sup>“I will send a fire on Magog and on those who dwell securely in the islands. Then they will know that I am Yahuah. 
 </p><p>
-<sup>7&#160;</sup>“&#160;‘&#160;“I will make my set-apart name known among my people Israel. I won’t allow my set-apart name to be profaned any more. Then the nations will know that I am Yahweh, the Set-Apart One in Israel. 
-<sup>8&#160;</sup>Behold, it comes, and it will be done,” says the Lord Yahweh. “This is the day about which I have spoken. 
+<sup>7&#160;</sup>“&#160;‘&#160;“I will make my set-apart name known among my people Israel. I won’t allow my set-apart name to be profaned any more. Then the nations will know that I am Yahuah, the Set-Apart One in Israel. 
+<sup>8&#160;</sup>Behold, it comes, and it will be done,” says the Lord Yahuah. “This is the day about which I have spoken. 
 </p><p>
 <sup>9&#160;</sup>“&#160;‘&#160;“Those who dwell in the cities of Israel will go out and will make fires of the weapons and burn them, both the shields and the bucklers, the bows and the arrows, and the war clubs and the spears, and they will make fires with them for seven years; 
-<sup>10&#160;</sup>so that they will take no wood out of the field, and not cut down any out of the forests; for they will make fires with the weapons. They will plunder those who plundered them, and rob those who robbed them,” says the Lord Yahweh. 
+<sup>10&#160;</sup>so that they will take no wood out of the field, and not cut down any out of the forests; for they will make fires with the weapons. They will plunder those who plundered them, and rob those who robbed them,” says the Lord Yahuah. 
 </p><p>
 <sup>11&#160;</sup>“&#160;‘&#160;“It will happen in that day, that I will give to Gog a place for burial in Israel, the valley of those who pass through on the east of the sea; and it will stop those who pass through. They will bury Gog and all his multitude there, and they will call it ‘The valley of Hamon Gog’. 
 </p><p>
 <sup>12&#160;</sup>“&#160;‘&#160;“The house of Israel will be burying them for seven months, that they may cleanse the land. 
-<sup>13&#160;</sup>Yes, all the people of the land will bury them; and they will become famous in the day that I will be glorified,” says the Lord Yahweh. 
+<sup>13&#160;</sup>Yes, all the people of the land will bury them; and they will become famous in the day that I will be glorified,” says the Lord Yahuah. 
 </p><p>
 <sup>14&#160;</sup>“&#160;‘&#160;“They will set apart men of continual employment who will pass through the land. Those who pass through will go with those who bury those who remain on the surface of the land, to cleanse it. After the end of seven months they will search. 
 <sup>15&#160;</sup>Those who search through the land will pass through; and when anyone sees a man’s bone, then he will set up a sign by it, until the undertakers have buried it in the valley of Hamon Gog. 
 <sup>16&#160;</sup>Hamonah will also be the name of a city. Thus they will cleanse the land.”&#160;’ 
 </p><p>
-<sup>17&#160;</sup>“You, son of man, the Lord Yahweh says: ‘Speak to the birds of every sort, and to every animal of the field, “Assemble yourselves, and come; gather yourselves on every side to my sacrifice that I sacrifice for you, even a great sacrifice on the mountains of Israel, that you may eat meat and drink blood. 
+<sup>17&#160;</sup>“You, son of man, the Lord Yahuah says: ‘Speak to the birds of every sort, and to every animal of the field, “Assemble yourselves, and come; gather yourselves on every side to my sacrifice that I sacrifice for you, even a great sacrifice on the mountains of Israel, that you may eat meat and drink blood. 
 <sup>18&#160;</sup>You shall eat the flesh of the mighty, and drink the blood of the princes of the earth, of rams, of lambs, and of goats, of bulls, all of them fatlings of Bashan. 
 <sup>19&#160;</sup>You shall eat fat until you are full, and drink blood until you are drunk, of my sacrifice which I have sacrificed for you. 
-<sup>20&#160;</sup>You shall be filled at my table with horses and charioteers, with mighty men, and with all men of war,” says the Lord Yahweh.’ 
+<sup>20&#160;</sup>You shall be filled at my table with horses and charioteers, with mighty men, and with all men of war,” says the Lord Yahuah.’ 
 </p><p>
 <sup>21&#160;</sup>“I will set my glory among the nations. Then all the nations will see my judgment that I have executed, and my hand that I have laid on them. 
-<sup>22&#160;</sup>So the house of Israel will know that I am Yahweh their Elohim, from that day and forward. 
+<sup>22&#160;</sup>So the house of Israel will know that I am Yahuah their Elohim, from that day and forward. 
 <sup>23&#160;</sup>The nations will know that the house of Israel went into captivity for their iniquity, because they trespassed against me, and I hid my face from them; so I gave them into the hand of their adversaries, and they all fell by the sword. 
 <sup>24&#160;</sup>I did to them according to their uncleanness and according to their transgressions. I hid my face from them. 
 </p><p>
-<sup>25&#160;</sup>“Therefore the Lord Yahweh says: ‘Now I will reverse the captivity of Jacob and have mercy on the whole house of Israel. I will be jealous for my set-apart name. 
+<sup>25&#160;</sup>“Therefore the Lord Yahuah says: ‘Now I will reverse the captivity of Jacob and have mercy on the whole house of Israel. I will be jealous for my set-apart name. 
 <sup>26&#160;</sup>They will forget their shame and all their trespasses by which they have trespassed against me, when they dwell securely in their land. No one will make them afraid 
 <sup>27&#160;</sup>when I have brought them back from the peoples, gathered them out of their enemies’ lands, and am shown set-apart among them in the sight of many nations. 
-<sup>28&#160;</sup>They will know that I am Yahweh their Elohim, in that I caused them to go into captivity among the nations, and have gathered them to their own land. Then I will leave none of them captive any more. 
-<sup>29&#160;</sup>I won’t hide my face from them any more, for I have poured out my Spirit on the house of Israel,’ says the Lord Yahweh.” 
+<sup>28&#160;</sup>They will know that I am Yahuah their Elohim, in that I caused them to go into captivity among the nations, and have gathered them to their own land. Then I will leave none of them captive any more. 
+<sup>29&#160;</sup>I won’t hide my face from them any more, for I have poured out my Spirit on the house of Israel,’ says the Lord Yahuah.” 
 </p><h2 class="chapterlabel" id="40">40</h2>
 <p>
-<sup>1&#160;</sup>In the twenty-fifth year of our captivity, in the beginning of the year, in the tenth day of the month, in the fourteenth year after the city was struck, in the same day, Yahweh’s hand was on me, and he brought me there. 
+<sup>1&#160;</sup>In the twenty-fifth year of our captivity, in the beginning of the year, in the tenth day of the month, in the fourteenth year after the city was struck, in the same day, Yahuah’s hand was on me, and he brought me there. 
 <sup>2&#160;</sup>In the visions of Elohim he brought me into the land of Israel, and set me down on a very high mountain, on which was something like the frame of a city to the south. 
 <sup>3&#160;</sup>He brought me there; and, behold, there was a man whose appearance was like the appearance of bronze, with a line of flax in his hand and a measuring reed; and he stood in the gate. 
 <sup>4&#160;</sup>The man said to me, “Son of man, see with your eyes, and hear with your ears, and set your heart on all that I will show you; for you have been brought here so that I may show them to you. Declare all that you see to the house of Israel.” 
@@ -2014,7 +2014,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>44&#160;</sup>Outside of the inner gate were rooms for the singers in the inner court, which was at the side of the north gate. They faced toward the south. One at the side of the east gate faced toward the north. 
 <sup>45&#160;</sup>He said to me, “This room, which faces toward the south, is for the priests who perform the duty of the house. 
-<sup>46&#160;</sup>The room which faces toward the north is for the priests who perform the duty of the altar. These are the sons of Zadok, who from among the sons of Levi come near to Yahweh to minister to him.” 
+<sup>46&#160;</sup>The room which faces toward the north is for the priests who perform the duty of the altar. These are the sons of Zadok, who from among the sons of Levi come near to Yahuah to minister to him.” 
 <sup>47&#160;</sup>He measured the court, one hundred cubits long and one hundred cubits wide, square. The altar was before the house. 
 </p><p>
 <sup>48&#160;</sup>Then he brought me to the porch of the house, and measured each post of the porch, five cubits on this side, and five cubits on that side. The width of the gate was three cubits on this side and three cubits on that side. 
@@ -2049,7 +2049,7 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>Cherubim and palm trees were made from the ground to above the door. The wall of the temple was like this. 
 </p><p>
 <sup>21&#160;</sup>The door posts of the nave were squared. As for the face of the nave, its appearance was as the appearance of the temple. 
-<sup>22&#160;</sup>The altar was of wood, three cubits high, and its length two cubits. Its corners, its base, and its walls were of wood. He said to me, “This is the table that is before Yahweh.” 
+<sup>22&#160;</sup>The altar was of wood, three cubits high, and its length two cubits. Its corners, its base, and its walls were of wood. He said to me, “This is the table that is before Yahuah.” 
 <sup>23&#160;</sup>The temple and the sanctuary had two doors. 
 <sup>24&#160;</sup>The doors had two leaves each, two turning leaves: two for the one door, and two leaves for the other. 
 <sup>25&#160;</sup>There were made on them, on the doors of the nave, cherubim and palm trees, like those made on the walls. There was a threshold of wood on the face of the porch outside. 
@@ -2070,7 +2070,7 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>The way before them was like the appearance of the rooms which were toward the north. Their length and width were the same. All their exits had the same arrangement and doors. 
 <sup>12&#160;</sup>Like the doors of the rooms that were toward the south was a door at the head of the way, even the way directly before the wall toward the east, as one enters into them. 
 </p><p>
-<sup>13&#160;</sup>Then he said to me, “The north rooms and the south rooms, which are opposite the separate place, are the set-apart rooms, where the priests who are near to Yahweh shall eat the most set-apart things. There they shall lay the most set-apart things, with the meal offering, the sin offering, and the trespass offering; for the place is set-apart. 
+<sup>13&#160;</sup>Then he said to me, “The north rooms and the south rooms, which are opposite the separate place, are the set-apart rooms, where the priests who are near to Yahuah shall eat the most set-apart things. There they shall lay the most set-apart things, with the meal offering, the sin offering, and the trespass offering; for the place is set-apart. 
 <sup>14&#160;</sup>When the priests enter in, then they shall not go out of the set-apart place into the outer court until they lay their garments in which they minister there; for they are set-apart. Then they shall put on other garments, and shall approach that which is for the people.” 
 </p><p>
 <sup>15&#160;</sup>Now when he had finished measuring the inner house, he brought me out by the way of the gate which faces toward the east, and measured it all around. 
@@ -2084,8 +2084,8 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>Afterward he brought me to the gate, even the gate that looks toward the east. 
 <sup>2&#160;</sup>Behold, the glory of the Elohim of Israel came from the way of the east. His voice was like the sound of many waters; and the earth was illuminated with his glory. 
 <sup>3&#160;</sup>It was like the appearance of the vision which I saw, even according to the vision that I saw when I came to destroy the city; and the visions were like the vision that I saw by the river Chebar; and I fell on my face. 
-<sup>4&#160;</sup>Yahweh’s glory came into the house by the way of the gate which faces toward the east. 
-<sup>5&#160;</sup>The Spirit took me up and brought me into the inner court; and behold, Yahweh’s glory filled the house. 
+<sup>4&#160;</sup>Yahuah’s glory came into the house by the way of the gate which faces toward the east. 
+<sup>5&#160;</sup>The Spirit took me up and brought me into the inner court; and behold, Yahuah’s glory filled the house. 
 </p><p>
 <sup>6&#160;</sup>I heard one speaking to me out of the house, and a man stood by me. 
 <sup>7&#160;</sup>He said to me, “Son of man, this is the place of my throne and the place of the soles of my feet, where I will dwell among the children of Israel forever. The house of Israel will no more defile my set-apart name, neither they nor their kings, by their prostitution and by the dead bodies of their kings in their high places; 
@@ -2103,39 +2103,39 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>The altar hearth shall be twelve cubits long by twelve wide, square in its four sides. 
 <sup>17&#160;</sup>The ledge shall be fourteen cubits long by fourteen wide in its four sides; and the border about it shall be half a cubit; and its bottom shall be a cubit around; and its steps shall look toward the east.” 
 </p><p>
-<sup>18&#160;</sup>He said to me, “Son of man, the Lord Yahweh says: ‘These are the ordinances of the altar in the day when they make it, to offer burnt offerings on it, and to sprinkle blood on it. 
-<sup>19&#160;</sup>You shall give to the Levitical priests who are of the offspring of Zadok, who are near to me, to minister to me,’ says the Lord Yahweh, ‘a young bull for a sin offering. 
+<sup>18&#160;</sup>He said to me, “Son of man, the Lord Yahuah says: ‘These are the ordinances of the altar in the day when they make it, to offer burnt offerings on it, and to sprinkle blood on it. 
+<sup>19&#160;</sup>You shall give to the Levitical priests who are of the offspring of Zadok, who are near to me, to minister to me,’ says the Lord Yahuah, ‘a young bull for a sin offering. 
 <sup>20&#160;</sup>You shall take of its blood and put it on its four horns, and on the four corners of the ledge, and on the border all around. You shall cleanse it and make atonement for it that way. 
 <sup>21&#160;</sup>You shall also take the bull of the sin offering, and it shall be burned in the appointed place of the house, outside of the sanctuary. 
 </p><p>
 <sup>22&#160;</sup>“On the second day you shall offer a male goat without defect for a sin offering; and they shall cleanse the altar, as they cleansed it with the bull. 
 <sup>23&#160;</sup>When you have finished cleansing it, you shall offer a young bull without defect and a ram out of the flock without defect. 
-<sup>24&#160;</sup>You shall bring them near to Yahweh, and the priests shall cast salt on them, and they shall offer them up for a burnt offering to Yahweh. 
+<sup>24&#160;</sup>You shall bring them near to Yahuah, and the priests shall cast salt on them, and they shall offer them up for a burnt offering to Yahuah. 
 </p><p>
 <sup>25&#160;</sup>“Seven days you shall prepare every day a goat for a sin offering. They shall also prepare a young bull and a ram out of the flock, without defect. 
 <sup>26&#160;</sup>Seven days shall they make atonement for the altar and purify it. So shall they consecrate it. 
-<sup>27&#160;</sup>When they have accomplished the days, it shall be that on the eighth day and onward, the priests shall make your burnt offerings on the altar and your peace offerings. Then I will accept you,’ says the Lord Yahweh.” 
+<sup>27&#160;</sup>When they have accomplished the days, it shall be that on the eighth day and onward, the priests shall make your burnt offerings on the altar and your peace offerings. Then I will accept you,’ says the Lord Yahuah.” 
 </p><h2 class="chapterlabel" id="44">44</h2>
 <p>
 <sup>1&#160;</sup>Then he brought me back by the way of the outer gate of the sanctuary, which looks toward the east; and it was shut. 
-<sup>2&#160;</sup>Yahweh said to me, “This gate shall be shut. It shall not be opened, no man shall enter in by it; for Yahweh, the Elohim of Israel, has entered in by it. Therefore it shall be shut. 
-<sup>3&#160;</sup>As for the prince, he shall sit in it as prince to eat bread before Yahweh. He shall enter by the way of the porch of the gate, and shall go out the same way.” 
+<sup>2&#160;</sup>Yahuah said to me, “This gate shall be shut. It shall not be opened, no man shall enter in by it; for Yahuah, the Elohim of Israel, has entered in by it. Therefore it shall be shut. 
+<sup>3&#160;</sup>As for the prince, he shall sit in it as prince to eat bread before Yahuah. He shall enter by the way of the porch of the gate, and shall go out the same way.” 
 </p><p>
-<sup>4&#160;</sup>Then he brought me by the way of the north gate before the house; and I looked, and behold, Yahweh’s glory filled Yahweh’s house; so I fell on my face. 
+<sup>4&#160;</sup>Then he brought me by the way of the north gate before the house; and I looked, and behold, Yahuah’s glory filled Yahuah’s house; so I fell on my face. 
 </p><p>
-<sup>5&#160;</sup>Yahweh said to me, “Son of man, mark well, and see with your eyes, and hear with your ears all that I tell you concerning all the ordinances of Yahweh’s house and all its laws; and mark well the entrance of the house, with every exit of the sanctuary. 
-<sup>6&#160;</sup>You shall tell the rebellious, even the house of Israel, ‘The Lord Yahweh says: “You house of Israel, let that be enough of all your abominations, 
+<sup>5&#160;</sup>Yahuah said to me, “Son of man, mark well, and see with your eyes, and hear with your ears all that I tell you concerning all the ordinances of Yahuah’s house and all its laws; and mark well the entrance of the house, with every exit of the sanctuary. 
+<sup>6&#160;</sup>You shall tell the rebellious, even the house of Israel, ‘The Lord Yahuah says: “You house of Israel, let that be enough of all your abominations, 
 <sup>7&#160;</sup>in that you have brought in foreigners, uncircumcised in heart and uncircumcised in flesh, to be in my sanctuary, to profane it, even my house, when you offer my bread, the fat and the blood; and they have broken my covenant, to add to all your abominations. 
 <sup>8&#160;</sup>You have not performed the duty of my set-apart things; but you have set performers of my duty in my sanctuary for yourselves.” 
-<sup>9&#160;</sup>The Lord Yahweh says, “No foreigner, uncircumcised in heart and uncircumcised in flesh, shall enter into my sanctuary, of any foreigners who are among the children of Israel. 
+<sup>9&#160;</sup>The Lord Yahuah says, “No foreigner, uncircumcised in heart and uncircumcised in flesh, shall enter into my sanctuary, of any foreigners who are among the children of Israel. 
 </p><p>
 <sup>10&#160;</sup>“&#160;‘&#160;“But the Levites who went far from me when Israel went astray, who went astray from me after their idols, they will bear their iniquity. 
 <sup>11&#160;</sup>Yet they shall be ministers in my sanctuary, having oversight at the gates of the house, and ministering in the house. They shall kill the burnt offering and the sacrifice for the people, and they shall stand before them to minister to them. 
-<sup>12&#160;</sup>Because they ministered to them before their idols, and became a stumbling block of iniquity to the house of Israel, therefore I have lifted up my hand against them,” says the Lord Yahweh, “and they will bear their iniquity. 
+<sup>12&#160;</sup>Because they ministered to them before their idols, and became a stumbling block of iniquity to the house of Israel, therefore I have lifted up my hand against them,” says the Lord Yahuah, “and they will bear their iniquity. 
 <sup>13&#160;</sup>They shall not come near to me, to execute the office of priest to me, nor to come near to any of my set-apart things, to the things that are most set-apart; but they will bear their shame and their abominations which they have committed. 
 <sup>14&#160;</sup>Yet I will make them performers of the duty of the house, for all its service and for all that will be done therein. 
 </p><p>
-<sup>15&#160;</sup>“&#160;‘&#160;“But the Levitical priests, the sons of Zadok, who performed the duty of my sanctuary when the children of Israel went astray from me, shall come near to me to minister to me. They shall stand before me to offer to me the fat and the blood,” says the Lord Yahweh. 
+<sup>15&#160;</sup>“&#160;‘&#160;“But the Levitical priests, the sons of Zadok, who performed the duty of my sanctuary when the children of Israel went astray from me, shall come near to me to minister to me. They shall stand before me to offer to me the fat and the blood,” says the Lord Yahuah. 
 <sup>16&#160;</sup>“They shall enter into my sanctuary, and they shall come near to my table, to minister to me, and they shall keep my instruction. 
 </p><p>
 <sup>17&#160;</sup>“&#160;‘&#160;“It will be that when they enter in at the gates of the inner court, they shall be clothed with linen garments. No wool shall come on them while they minister in the gates of the inner court, and within. 
@@ -2151,7 +2151,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>25&#160;</sup>“&#160;‘&#160;“They shall go in to no dead person to defile themselves; but for father, or for mother, or for son, or for daughter, for brother, or for sister who has had no man, they may defile themselves. 
 <sup>26&#160;</sup>After he is cleansed, they shall reckon to him seven days. 
-<sup>27&#160;</sup>In the day that he goes into the sanctuary, into the inner court, to minister in the sanctuary, he shall offer his sin offering,” says the Lord Yahweh. 
+<sup>27&#160;</sup>In the day that he goes into the sanctuary, into the inner court, to minister in the sanctuary, he shall offer his sin offering,” says the Lord Yahuah. 
 </p><p>
 <sup>28&#160;</sup>“&#160;‘They shall have an inheritance: I am their inheritance; and you shall give them no possession in Israel. I am their possession. 
 <sup>29&#160;</sup>They shall eat the meal offering, and the sin offering, and the trespass offering; and every devoted thing in Israel shall be theirs. 
@@ -2159,10 +2159,10 @@ html[dir=ltr] .q2 {
 <sup>31&#160;</sup>The priests shall not eat of anything that dies of itself or is torn, whether it is bird or animal. 
 </p><h2 class="chapterlabel" id="45">45</h2>
 <p>
-<sup>1&#160;</sup>“&#160;‘&#160;“Moreover, when you divide by lot the land for inheritance, you shall offer an offering to Yahweh, a set-apart portion of the land. The length shall be the length of twenty-five thousand reeds, and the width shall be ten thousand. It shall be set-apart in all its border all around. 
+<sup>1&#160;</sup>“&#160;‘&#160;“Moreover, when you divide by lot the land for inheritance, you shall offer an offering to Yahuah, a set-apart portion of the land. The length shall be the length of twenty-five thousand reeds, and the width shall be ten thousand. It shall be set-apart in all its border all around. 
 <sup>2&#160;</sup>Of this there shall be a five hundred by five hundred square for the set-apart place, and fifty cubits for its pasture lands all around. 
 <sup>3&#160;</sup>Of this measure you shall measure a length of twenty-five thousand, and a width of ten thousand. In it shall be the sanctuary, which is most set-apart. 
-<sup>4&#160;</sup>It is a set-apart portion of the land; it shall be for the priests, the ministers of the sanctuary, who come near to minister to Yahweh. It shall be a place for their houses and a set-apart place for the sanctuary. 
+<sup>4&#160;</sup>It is a set-apart portion of the land; it shall be for the priests, the ministers of the sanctuary, who come near to minister to Yahuah. It shall be a place for their houses and a set-apart place for the sanctuary. 
 <sup>5&#160;</sup>Twenty-five thousand cubits in length and ten thousand in width shall be for the Levites, the ministers of the house, as a possession for themselves, for twenty rooms. 
 </p><p>
 <sup>6&#160;</sup>“&#160;‘&#160;“You shall appoint the possession of the city five thousand cubits wide and twenty-five thousand long, side by side with the offering of the set-apart portion. It shall be for the whole house of Israel. 
@@ -2170,49 +2170,49 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>“&#160;‘&#160;“What is for the prince shall be on the one side and on the other side of the set-apart allotment and of the possession of the city, in front of the set-apart allotment and in front of the possession of the city, on the west side westward, and on the east side eastward, and in length corresponding to one of the portions, from the west border to the east border. 
 <sup>8&#160;</sup>In the land it shall be to him for a possession in Israel. My princes shall no more oppress my people, but they shall give the land to the house of Israel according to their tribes.” 
 </p><p>
-<sup>9&#160;</sup>“&#160;‘The Lord Yahweh says: “Enough you, princes of Israel! Remove violence and plunder, and execute justice and righteousness! Stop dispossessing my people!” says the Lord Yahweh. 
+<sup>9&#160;</sup>“&#160;‘The Lord Yahuah says: “Enough you, princes of Israel! Remove violence and plunder, and execute justice and righteousness! Stop dispossessing my people!” says the Lord Yahuah. 
 <sup>10&#160;</sup>“You shall have just balances, a just ephah, and a just bath. 
 <sup>11&#160;</sup>The ephah and the bath shall be of one measure, that the bath may contain one tenth of a homer, and the ephah one tenth of a homer. Its measure shall be the same as the homer. 
 <sup>12&#160;</sup>The shekel shall be twenty gerahs. Twenty shekels plus twenty-five shekels plus fifteen shekels shall be your mina. 
 </p><p>
 <sup>13&#160;</sup>“&#160;‘&#160;“This is the offering that you shall offer: the sixth part of an ephah from a homer of wheat, and you shall give the sixth part of an ephah from a homer of barley, 
 <sup>14&#160;</sup>and the set portion of oil, of the bath of oil, one tenth of a bath out of the cor, which is ten baths, even a homer (for ten baths are a homer), 
-<sup>15&#160;</sup>and one lamb of the flock out of two hundred, from the well-watered pastures of Israel—for a meal offering, for a burnt offering, and for peace offerings, to make atonement for them,” says the Lord Yahweh. 
+<sup>15&#160;</sup>and one lamb of the flock out of two hundred, from the well-watered pastures of Israel—for a meal offering, for a burnt offering, and for peace offerings, to make atonement for them,” says the Lord Yahuah. 
 <sup>16&#160;</sup>“All the people of the land shall give to this offering for the prince in Israel. 
 <sup>17&#160;</sup>It shall be the prince’s part to give the burnt offerings, the meal offerings, and the drink offerings, in the feasts, and on the new moons, and on the Sabbaths, in all the appointed feasts of the house of Israel. He shall prepare the sin offering, the meal offering, the burnt offering, and the peace offerings, to make atonement for the house of Israel.” 
 </p><p>
-<sup>18&#160;</sup>“&#160;‘The Lord Yahweh says: “In the first month, on the first day of the month, you shall take a young bull without defect, and you shall cleanse the sanctuary. 
+<sup>18&#160;</sup>“&#160;‘The Lord Yahuah says: “In the first month, on the first day of the month, you shall take a young bull without defect, and you shall cleanse the sanctuary. 
 <sup>19&#160;</sup>The priest shall take of the blood of the sin offering and put it on the door posts of the house, and on the four corners of the ledge of the altar, and on the posts of the gate of the inner court. 
 <sup>20&#160;</sup>So you shall do on the seventh day of the month for everyone who errs, and for him who is simple. So you shall make atonement for the house. 
 </p><p>
 <sup>21&#160;</sup>“&#160;‘&#160;“In the first month, on the fourteenth day of the month, you shall have the Passover, a feast of seven days; unleavened bread shall be eaten. 
 <sup>22&#160;</sup>On that day the prince shall prepare for himself and for all the people of the land a bull for a sin offering. 
-<sup>23&#160;</sup>The seven days of the feast he shall prepare a burnt offering to Yahweh, seven bulls and seven rams without defect daily the seven days; and a male goat daily for a sin offering. 
+<sup>23&#160;</sup>The seven days of the feast he shall prepare a burnt offering to Yahuah, seven bulls and seven rams without defect daily the seven days; and a male goat daily for a sin offering. 
 <sup>24&#160;</sup>He shall prepare a meal offering, an ephah for a bull, an ephah for a ram, and a hin of oil to an ephah. 
 </p><p>
 <sup>25&#160;</sup>“&#160;‘&#160;“In the seventh month, on the fifteenth day of the month, during the feast, he shall do like that for seven days. He shall make the same provision for sin offering, the burnt offering, the meal offering, and the oil.” 
 </p><h2 class="chapterlabel" id="46">46</h2>
 <p>
-<sup>1&#160;</sup>“&#160;‘The Lord Yahweh says: “The gate of the inner court that looks toward the east shall be shut the six working days; but on the Sabbath day it shall be opened, and on the day of the new moon it shall be opened. 
+<sup>1&#160;</sup>“&#160;‘The Lord Yahuah says: “The gate of the inner court that looks toward the east shall be shut the six working days; but on the Sabbath day it shall be opened, and on the day of the new moon it shall be opened. 
 <sup>2&#160;</sup>The prince shall enter by the way of the porch of the gate outside, and shall stand by the post of the gate; and the priests shall prepare his burnt offering and his peace offerings, and he shall worship at the threshold of the gate. Then he shall go out, but the gate shall not be shut until the evening. 
-<sup>3&#160;</sup>The people of the land shall worship at the door of that gate before Yahweh on the Sabbaths and on the new moons. 
-<sup>4&#160;</sup>The burnt offering that the prince shall offer to Yahweh shall be on the Sabbath day, six lambs without defect and a ram without defect; 
+<sup>3&#160;</sup>The people of the land shall worship at the door of that gate before Yahuah on the Sabbaths and on the new moons. 
+<sup>4&#160;</sup>The burnt offering that the prince shall offer to Yahuah shall be on the Sabbath day, six lambs without defect and a ram without defect; 
 <sup>5&#160;</sup>and the meal offering shall be an ephah for the ram, and the meal offering for the lambs as he is able to give, and a hin of oil to an ephah. 
 <sup>6&#160;</sup>On the day of the new moon it shall be a young bull without defect, six lambs, and a ram. They shall be without defect. 
 <sup>7&#160;</sup>He shall prepare a meal offering: an ephah for the bull, and an ephah for the ram, and for the lambs according as he is able, and a hin of oil to an ephah. 
 <sup>8&#160;</sup>When the prince enters, he shall go in by the way of the porch of the gate, and he shall go out by its way. 
 </p><p>
-<sup>9&#160;</sup>“&#160;‘&#160;“But when the people of the land come before Yahweh in the appointed feasts, he who enters by the way of the north gate to worship shall go out by the way of the south gate; and he who enters by the way of the south gate shall go out by the way of the north gate. He shall not return by the way of the gate by which he came in, but shall go out straight before him. 
+<sup>9&#160;</sup>“&#160;‘&#160;“But when the people of the land come before Yahuah in the appointed feasts, he who enters by the way of the north gate to worship shall go out by the way of the south gate; and he who enters by the way of the south gate shall go out by the way of the north gate. He shall not return by the way of the gate by which he came in, but shall go out straight before him. 
 <sup>10&#160;</sup>The prince shall go in with them when they go in. When they go out, he shall go out. 
 </p><p>
 <sup>11&#160;</sup>“&#160;‘&#160;“In the feasts and in the appointed set-apart days, the meal offering shall be an ephah for a bull, and an ephah for a ram, and for the lambs as he is able to give, and a hin of oil to an ephah. 
-<sup>12&#160;</sup>When the prince prepares a free will offering, a burnt offering or peace offerings as a free will offering to Yahweh, one shall open for him the gate that looks toward the east; and he shall prepare his burnt offering and his peace offerings, as he does on the Sabbath day. Then he shall go out; and after his going out one shall shut the gate. 
+<sup>12&#160;</sup>When the prince prepares a free will offering, a burnt offering or peace offerings as a free will offering to Yahuah, one shall open for him the gate that looks toward the east; and he shall prepare his burnt offering and his peace offerings, as he does on the Sabbath day. Then he shall go out; and after his going out one shall shut the gate. 
 </p><p>
-<sup>13&#160;</sup>“&#160;‘&#160;“You shall prepare a lamb a year old without defect for a burnt offering to Yahweh daily. Morning by morning you shall prepare it. 
-<sup>14&#160;</sup>You shall prepare a meal offering with it morning by morning, the sixth part of an ephah, and the third part of a hin of oil to moisten the fine flour; a meal offering to Yahweh continually by a perpetual ordinance. 
+<sup>13&#160;</sup>“&#160;‘&#160;“You shall prepare a lamb a year old without defect for a burnt offering to Yahuah daily. Morning by morning you shall prepare it. 
+<sup>14&#160;</sup>You shall prepare a meal offering with it morning by morning, the sixth part of an ephah, and the third part of a hin of oil to moisten the fine flour; a meal offering to Yahuah continually by a perpetual ordinance. 
 <sup>15&#160;</sup>Thus they shall prepare the lamb, the meal offering, and the oil, morning by morning, for a continual burnt offering.” 
 </p><p>
-<sup>16&#160;</sup>“&#160;‘The Lord Yahweh says: “If the prince gives a gift to any of his sons, it is his inheritance. It shall belong to his sons. It is their possession by inheritance. 
+<sup>16&#160;</sup>“&#160;‘The Lord Yahuah says: “If the prince gives a gift to any of his sons, it is his inheritance. It shall belong to his sons. It is their possession by inheritance. 
 <sup>17&#160;</sup>But if he gives of his inheritance a gift to one of his servants, it shall be his to the year of liberty; then it shall return to the prince; but as for his inheritance, it shall be for his sons. 
 <sup>18&#160;</sup>Moreover the prince shall not take of the people’s inheritance, to thrust them out of their possession. He shall give inheritance to his sons out of his own possession, that my people not each be scattered from his possession.”&#160;’&#160;” 
 </p><p>
@@ -2241,7 +2241,7 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>But its swamps marshes will not be healed. They will be given up to salt. 
 <sup>12&#160;</sup>By the river banks, on both sides, will grow every tree for food, whose leaf won’t wither, neither will its fruit fail. It will produce new fruit every month, because its waters issue out of the sanctuary. Its fruit will be for food, and its leaf for healing.” 
 </p><p>
-<sup>13&#160;</sup>The Lord Yahweh says: “This shall be the border by which you shall divide the land for inheritance according to the twelve tribes of Israel. Joseph shall have two portions. 
+<sup>13&#160;</sup>The Lord Yahuah says: “This shall be the border by which you shall divide the land for inheritance according to the twelve tribes of Israel. Joseph shall have two portions. 
 <sup>14&#160;</sup>You shall inherit it, one as well as another; for I swore to give it to your fathers. This land will fall to you for inheritance. 
 </p><p>
 <sup>15&#160;</sup>“This shall be the border of the land: 
@@ -2257,7 +2257,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>21&#160;</sup>“So you shall divide this land to yourselves according to the tribes of Israel. 
 <sup>22&#160;</sup>You shall divide it by lot for an inheritance to you and to the aliens who live among you, who will father children among you. Then they shall be to you as the native-born among the children of Israel. They shall have inheritance with you among the tribes of Israel. 
-<sup>23&#160;</sup>In whatever tribe the stranger lives, there you shall give him his inheritance,” says the Lord Yahweh. 
+<sup>23&#160;</sup>In whatever tribe the stranger lives, there you shall give him his inheritance,” says the Lord Yahuah. 
 </p><h2 class="chapterlabel" id="48">48</h2>
 <p>
 <sup>1&#160;</sup>“Now these are the names of the tribes: From the north end, beside the way of Hethlon to the entrance of Hamath, Hazar Enan at the border of Damascus, northward beside Hamath (and they shall have their sides east and west), Dan, one portion. 
@@ -2276,13 +2276,13 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>8&#160;</sup>“By the border of Judah, from the east side to the west side, shall be the offering which you shall offer, twenty-five thousand reeds in width, and in length as one of the portions, from the east side to the west side; and the sanctuary shall be in the middle of it. 
 </p><p>
-<sup>9&#160;</sup>“The offering that you shall offer to Yahweh shall be twenty-five thousand reeds in length, and ten thousand in width. 
-<sup>10&#160;</sup>For these, even for the priests, shall be the set-apart offering: toward the north twenty-five thousand in length, and toward the west ten thousand in width, and toward the east ten thousand in width, and toward the south twenty-five thousand in length; and the sanctuary of Yahweh shall be in the middle of it. 
+<sup>9&#160;</sup>“The offering that you shall offer to Yahuah shall be twenty-five thousand reeds in length, and ten thousand in width. 
+<sup>10&#160;</sup>For these, even for the priests, shall be the set-apart offering: toward the north twenty-five thousand in length, and toward the west ten thousand in width, and toward the east ten thousand in width, and toward the south twenty-five thousand in length; and the sanctuary of Yahuah shall be in the middle of it. 
 <sup>11&#160;</sup>It shall be for the priests who are sanctified of the sons of Zadok, who have kept my instruction, who didn’t go astray when the children of Israel went astray, as the Levites went astray. 
 <sup>12&#160;</sup>It shall be to them an offering from the offering of the land, a most set-apart thing, by the border of the Levites. 
 </p><p>
 <sup>13&#160;</sup>“Alongside the border of the priests, the Levites shall have twenty-five thousand cubits in length and ten thousand in width. All the length shall be twenty-five thousand, and the width ten thousand. 
-<sup>14&#160;</sup>They shall sell none of it, nor exchange it, nor shall the first fruits of the land be alienated, for it is set-apart to Yahweh. 
+<sup>14&#160;</sup>They shall sell none of it, nor exchange it, nor shall the first fruits of the land be alienated, for it is set-apart to Yahuah. 
 </p><p>
 <sup>15&#160;</sup>“The five thousand cubits that are left in the width, in front of the twenty-five thousand, shall be for common use, for the city, for dwelling and for pasture lands; and the city shall be in the middle of it. 
 <sup>16&#160;</sup>These shall be its measurements: the north side four thousand and five hundred, and the south side four thousand and five hundred, and on the east side four thousand and five hundred, and the west side four thousand and five hundred. 
@@ -2306,7 +2306,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>28&#160;</sup>“By the border of Gad, at the south side southward, the border shall be even from Tamar to the waters of Meribath Kadesh, to the brook, to the great sea. 
 </p><p>
-<sup>29&#160;</sup>“This is the land which you shall divide by lot to the tribes of Israel for inheritance, and these are their several portions, says the Lord Yahweh. 
+<sup>29&#160;</sup>“This is the land which you shall divide by lot to the tribes of Israel for inheritance, and these are their several portions, says the Lord Yahuah. 
 </p><p>
 <sup>30&#160;</sup>“These are the exits of the city: On the north side four thousand five hundred reeds by measure; 
 <sup>31&#160;</sup>and the gates of the city shall be named after the tribes of Israel, three gates northward: the gate of Reuben, one; the gate of Judah, one; the gate of Levi, one. 
@@ -2317,4 +2317,4 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>34&#160;</sup>“At the west side four thousand five hundred reeds, with their three gates: the gate of Gad, one; the gate of Asher, one; the gate of Naphtali, one. 
 </p><p>
-<sup>35&#160;</sup>“It shall be eighteen thousand reeds in circumference; and the name of the city from that day shall be, ‘Yahweh is there.’ </p></div><script src="../main.js"></script></body></html>
+<sup>35&#160;</sup>“It shall be eighteen thousand reeds in circumference; and the name of the city from that day shall be, ‘Yahuah is there.’ </p></div><script src="../main.js"></script></body></html>

--- a/book/ezra.html
+++ b/book/ezra.html
@@ -69,15 +69,15 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>Now in the first year of Cyrus king of Persia, that Yahweh’s word by Jeremiah’s mouth might be accomplished, Yahweh stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
+<sup>1&#160;</sup>Now in the first year of Cyrus king of Persia, that Yahuah’s word by Jeremiah’s mouth might be accomplished, Yahuah stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
 </p><p class="mi">
-<sup>2&#160;</sup>“Cyrus king of Persia says, ‘Yahweh, the Elohim of heaven, has given me all the kingdoms of the earth; and he has commanded me to build him a house in Jerusalem, which is in Judah. 
-<sup>3&#160;</sup>Whoever there is among you of all his people, may his Elohim be with him, and let him go up to Jerusalem, which is in Judah, and build the house of Yahweh, the Elohim of Israel (he is Elohim), which is in Jerusalem. 
+<sup>2&#160;</sup>“Cyrus king of Persia says, ‘Yahuah, the Elohim of heaven, has given me all the kingdoms of the earth; and he has commanded me to build him a house in Jerusalem, which is in Judah. 
+<sup>3&#160;</sup>Whoever there is among you of all his people, may his Elohim be with him, and let him go up to Jerusalem, which is in Judah, and build the house of Yahuah, the Elohim of Israel (he is Elohim), which is in Jerusalem. 
 <sup>4&#160;</sup>Whoever is left, in any place where he lives, let the men of his place help him with silver, with gold, with goods, and with animals, in addition to the free will offering for Elohim’s house which is in Jerusalem.’&#160;” 
 </p><p>
-<sup>5&#160;</sup>Then the heads of fathers’ households of Judah and Benjamin, the priests and the Levites, all whose spirit Elohim had stirred to go up, rose up to build Yahweh’s house which is in Jerusalem. 
+<sup>5&#160;</sup>Then the heads of fathers’ households of Judah and Benjamin, the priests and the Levites, all whose spirit Elohim had stirred to go up, rose up to build Yahuah’s house which is in Jerusalem. 
 <sup>6&#160;</sup>All those who were around them strengthened their hands with vessels of silver, with gold, with goods, with animals, and with precious things, in addition to all that was willingly offered. 
-<sup>7&#160;</sup>Also Cyrus the king brought out the vessels of Yahweh’s house, which Nebuchadnezzar had brought out of Jerusalem, and had put in the house of his elohims; 
+<sup>7&#160;</sup>Also Cyrus the king brought out the vessels of Yahuah’s house, which Nebuchadnezzar had brought out of Jerusalem, and had put in the house of his elohims; 
 <sup>8&#160;</sup>even those, Cyrus king of Persia brought out by the hand of Mithredath the treasurer, and counted them out to Sheshbazzar the prince of Judah. 
 <sup>9&#160;</sup>This is the number of them: thirty platters of gold, one thousand platters of silver, twenty-nine knives, 
 <sup>10&#160;</sup>thirty bowls of gold, four hundred ten silver bowls of a second kind, and one thousand other vessels. 
@@ -159,7 +159,7 @@ html[dir=ltr] .q2 {
 <sup>66&#160;</sup>Their horses were seven hundred thirty-six; their mules, two hundred forty-five; 
 <sup>67&#160;</sup>their camels, four hundred thirty-five; their donkeys, six thousand seven hundred twenty. 
 </p><p>
-<sup>68&#160;</sup>Some of the heads of fathers’ households, when they came to Yahweh’s house which is in Jerusalem, offered willingly for Elohim’s house to set it up in its place. 
+<sup>68&#160;</sup>Some of the heads of fathers’ households, when they came to Yahuah’s house which is in Jerusalem, offered willingly for Elohim’s house to set it up in its place. 
 <sup>69&#160;</sup>They gave according to their ability into the treasury of the work sixty-one thousand darics of gold, five thousand minas of silver, and one hundred priests’ garments. 
 </p><p>
 <sup>70&#160;</sup>So the priests and the Levites, with some of the people, the singers, the gatekeepers, and the temple servants, lived in their cities, and all Israel in their cities. 
@@ -167,26 +167,26 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>When the seventh month had come, and the children of Israel were in the cities, the people gathered themselves together as one man to Jerusalem. 
 <sup>2&#160;</sup>Then Jeshua the son of Jozadak stood up with his brothers the priests and Zerubbabel the son of Shealtiel and his relatives, and built the altar of the Elohim of Israel, to offer burnt offerings on it, as it is written in the law of Moses the man of Elohim. 
-<sup>3&#160;</sup>In spite of their fear because of the peoples of the surrounding lands, they set the altar on its base; and they offered burnt offerings on it to Yahweh, even burnt offerings morning and evening. 
+<sup>3&#160;</sup>In spite of their fear because of the peoples of the surrounding lands, they set the altar on its base; and they offered burnt offerings on it to Yahuah, even burnt offerings morning and evening. 
 <sup>4&#160;</sup>They kept the feast of booths, as it is written, and offered the daily burnt offerings by number, according to the ordinance, as the duty of every day required; 
-<sup>5&#160;</sup>and afterward the continual burnt offering, the offerings of the new moons, of all the set feasts of Yahweh that were consecrated, and of everyone who willingly offered a free will offering to Yahweh. 
-<sup>6&#160;</sup>From the first day of the seventh month, they began to offer burnt offerings to Yahweh; but the foundation of Yahweh’s temple was not yet laid. 
+<sup>5&#160;</sup>and afterward the continual burnt offering, the offerings of the new moons, of all the set feasts of Yahuah that were consecrated, and of everyone who willingly offered a free will offering to Yahuah. 
+<sup>6&#160;</sup>From the first day of the seventh month, they began to offer burnt offerings to Yahuah; but the foundation of Yahuah’s temple was not yet laid. 
 <sup>7&#160;</sup>They also gave money to the masons and to the carpenters. They also gave food, drink, and oil to the people of Sidon and Tyre to bring cedar trees from Lebanon to the sea, to Joppa, according to the grant that they had from Cyrus King of Persia. 
 </p><p>
-<sup>8&#160;</sup>Now in the second year of their coming to Elohim’s house at Jerusalem, in the second month, Zerubbabel the son of Shealtiel, Jeshua the son of Jozadak, and the rest of their brothers the priests and the Levites, and all those who had come out of the captivity to Jerusalem, began the work and appointed the Levites, from twenty years old and upward, to have the oversight of the work of Yahweh’s house. 
+<sup>8&#160;</sup>Now in the second year of their coming to Elohim’s house at Jerusalem, in the second month, Zerubbabel the son of Shealtiel, Jeshua the son of Jozadak, and the rest of their brothers the priests and the Levites, and all those who had come out of the captivity to Jerusalem, began the work and appointed the Levites, from twenty years old and upward, to have the oversight of the work of Yahuah’s house. 
 <sup>9&#160;</sup>Then Jeshua stood with his sons and his brothers, Kadmiel and his sons, the sons of Judah, together to have the oversight of the workmen in Elohim’s house: the sons of Henadad, with their sons and their brothers the Levites. 
 </p><p>
-<sup>10&#160;</sup>When the builders laid the foundation of Yahweh’s temple, they set the priests in their vestments with trumpets, with the Levites the sons of Asaph with cymbals, to praise Yahweh, according to the directions of David king of Israel. 
-<sup>11&#160;</sup>They sang to one another in praising and giving thanks to Yahweh, “For he is good, for his loving kindness endures forever toward Israel.” All the people shouted with a great shout, when they praised Yahweh, because the foundation of Yahweh’s house had been laid. 
+<sup>10&#160;</sup>When the builders laid the foundation of Yahuah’s temple, they set the priests in their vestments with trumpets, with the Levites the sons of Asaph with cymbals, to praise Yahuah, according to the directions of David king of Israel. 
+<sup>11&#160;</sup>They sang to one another in praising and giving thanks to Yahuah, “For he is good, for his loving kindness endures forever toward Israel.” All the people shouted with a great shout, when they praised Yahuah, because the foundation of Yahuah’s house had been laid. 
 </p><p>
 <sup>12&#160;</sup>But many of the priests and Levites and heads of fathers’ households, the old men who had seen the first house, when the foundation of this house was laid before their eyes, wept with a loud voice. Many also shouted aloud for joy, 
 <sup>13&#160;</sup>so that the people could not discern the noise of the shout of joy from the noise of the weeping of the people; for the people shouted with a loud shout, and the noise was heard far away. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>Now when the adversaries of Judah and Benjamin heard that the children of the captivity were building a temple to Yahweh, the Elohim of Israel, 
+<sup>1&#160;</sup>Now when the adversaries of Judah and Benjamin heard that the children of the captivity were building a temple to Yahuah, the Elohim of Israel, 
 <sup>2&#160;</sup>they came near to Zerubbabel, and to the heads of fathers’ households, and said to them, “Let us build with you, for we seek your Elohim as you do; and we have been sacrificing to him since the days of Esar Haddon king of Assyria, who brought us up here.” 
 </p><p>
-<sup>3&#160;</sup>But Zerubbabel, Jeshua, and the rest of the heads of fathers’ households of Israel said to them, “You have nothing to do with us in building a house to our Elohim; but we ourselves together will build to Yahweh, the Elohim of Israel, as King Cyrus the king of Persia has commanded us.” 
+<sup>3&#160;</sup>But Zerubbabel, Jeshua, and the rest of the heads of fathers’ households of Israel said to them, “You have nothing to do with us in building a house to our Elohim; but we ourselves together will build to Yahuah, the Elohim of Israel, as King Cyrus the king of Persia has commanded us.” 
 </p><p>
 <sup>4&#160;</sup>Then the people of the land weakened the hands of the people of Judah, and troubled them in building. 
 <sup>5&#160;</sup>They hired counselors against them to frustrate their purpose all the days of Cyrus king of Persia, even until the reign of Darius king of Persia. 
@@ -277,21 +277,21 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>19&#160;</sup>The children of the captivity kept the Passover on the fourteenth day of the first month. 
 <sup>20&#160;</sup>Because the priests and the Levites had purified themselves together, all of them were pure. They killed the Passover for all the children of the captivity, for their brothers the priests, and for themselves. 
-<sup>21&#160;</sup>The children of Israel who had returned out of the captivity, and all who had separated themselves to them from the filthiness of the nations of the land to seek Yahweh, the Elohim of Israel, ate, 
-<sup>22&#160;</sup>and kept the feast of unleavened bread seven days with joy; because Yahweh had made them joyful, and had turned the heart of the king of Assyria to them, to strengthen their hands in the work of Elohim, the Elohim of Israel’s house. 
+<sup>21&#160;</sup>The children of Israel who had returned out of the captivity, and all who had separated themselves to them from the filthiness of the nations of the land to seek Yahuah, the Elohim of Israel, ate, 
+<sup>22&#160;</sup>and kept the feast of unleavened bread seven days with joy; because Yahuah had made them joyful, and had turned the heart of the king of Assyria to them, to strengthen their hands in the work of Elohim, the Elohim of Israel’s house. 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
 <sup>1&#160;</sup>Now after these things, in the reign of Artaxerxes king of Persia, Ezra the son of Seraiah, the son of Azariah, the son of Hilkiah, 
 <sup>2&#160;</sup>the son of Shallum, the son of Zadok, the son of Ahitub, 
 <sup>3&#160;</sup>the son of Amariah, the son of Azariah, the son of Meraioth, 
 <sup>4&#160;</sup>the son of Zerahiah, the son of Uzzi, the son of Bukki, 
-<sup>5&#160;</sup>the son of Abishua, the son of Phinehas, the son of Eleazar, the son of Aaron the chief priest—<sup>6&#160;</sup>this Ezra went up from Babylon. He was a skilled scribe in the law of Moses, which Yahweh, the Elohim of Israel, had given; and the king granted him all his request, according to Yahweh his Elohim’s hand on him. 
+<sup>5&#160;</sup>the son of Abishua, the son of Phinehas, the son of Eleazar, the son of Aaron the chief priest—<sup>6&#160;</sup>this Ezra went up from Babylon. He was a skilled scribe in the law of Moses, which Yahuah, the Elohim of Israel, had given; and the king granted him all his request, according to Yahuah his Elohim’s hand on him. 
 <sup>7&#160;</sup>Some of the children of Israel, including some of the priests, the Levites, the singers, the gatekeepers, and the temple servants went up to Jerusalem in the seventh year of Artaxerxes the king. 
 <sup>8&#160;</sup>He came to Jerusalem in the fifth month, which was in the seventh year of the king. 
 <sup>9&#160;</sup>For on the first day of the first month he began to go up from Babylon; and on the first day of the fifth month he came to Jerusalem, according to the good hand of his Elohim on him. 
-<sup>10&#160;</sup>For Ezra had set his heart to seek Yahweh’s law, and to do it, and to teach statutes and ordinances in Israel. 
+<sup>10&#160;</sup>For Ezra had set his heart to seek Yahuah’s law, and to do it, and to teach statutes and ordinances in Israel. 
 </p><p>
-<sup>11&#160;</sup>Now this is the copy of the letter that King Artaxerxes gave to Ezra the priest, the scribe, even the scribe of the words of Yahweh’s commandments, and of his statutes to Israel: 
+<sup>11&#160;</sup>Now this is the copy of the letter that King Artaxerxes gave to Ezra the priest, the scribe, even the scribe of the words of Yahuah’s commandments, and of his statutes to Israel: 
 </p><p class="b"> &#160; </p>
 <p class="mi">
 <sup>12&#160;</sup>Artaxerxes, king of kings, 
@@ -316,8 +316,8 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>Whoever will not do the law of your Elohim and the law of the king, let judgment be executed on him with all diligence, whether it is to death, or to banishment, or to confiscation of goods, or to imprisonment. 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>27&#160;</sup>Blessed be Yahweh, the Elohim of our fathers, who has put such a thing as this in the king’s heart, to beautify Yahweh’s house which is in Jerusalem; 
-<sup>28&#160;</sup>and has extended loving kindness to me before the king and his counselors, and before all the king’s mighty princes. I was strengthened according to Yahweh my Elohim’s hand on me, and I gathered together chief men out of Israel to go up with me. 
+<sup>27&#160;</sup>Blessed be Yahuah, the Elohim of our fathers, who has put such a thing as this in the king’s heart, to beautify Yahuah’s house which is in Jerusalem; 
+<sup>28&#160;</sup>and has extended loving kindness to me before the king and his counselors, and before all the king’s mighty princes. I was strengthened according to Yahuah my Elohim’s hand on me, and I gathered together chief men out of Israel to go up with me. 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
 <sup>1&#160;</sup>Now these are the heads of their fathers’ households, and this is the genealogy of those who went up with me from Babylon, in the reign of Artaxerxes the king: 
@@ -365,8 +365,8 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>and weighed to them the silver, the gold, and the vessels, even the offering for the house of our Elohim, which the king, his counselors, his princes, and all Israel there present, had offered. 
 <sup>26&#160;</sup>I weighed into their hand six hundred fifty talents of silver, one hundred talents of silver vessels, one hundred talents of gold, 
 <sup>27&#160;</sup>twenty bowls of gold weighing one thousand darics, and two vessels of fine bright bronze, precious as gold. 
-<sup>28&#160;</sup>I said to them, “You are set-apart to Yahweh, and the vessels are set-apart. The silver and the gold are a free will offering to Yahweh, the Elohim of your fathers. 
-<sup>29&#160;</sup>Watch and keep them until you weigh them before the chiefs of the priests, the Levites, and the princes of the fathers’ households of Israel at Jerusalem, in the rooms of Yahweh’s house.” 
+<sup>28&#160;</sup>I said to them, “You are set-apart to Yahuah, and the vessels are set-apart. The silver and the gold are a free will offering to Yahuah, the Elohim of your fathers. 
+<sup>29&#160;</sup>Watch and keep them until you weigh them before the chiefs of the priests, the Levites, and the princes of the fathers’ households of Israel at Jerusalem, in the rooms of Yahuah’s house.” 
 </p><p>
 <sup>30&#160;</sup>So the priests and the Levites received the weight of the silver, the gold, and the vessels, to bring them to Jerusalem to the house of our Elohim. 
 </p><p>
@@ -375,7 +375,7 @@ html[dir=ltr] .q2 {
 <sup>33&#160;</sup>On the fourth day the silver and the gold and the vessels were weighed in the house of our Elohim into the hand of Meremoth the son of Uriah the priest; and with him was Eleazar the son of Phinehas; and with them were Jozabad the son of Jeshua, and Noadiah the son of Binnui, the Levites. 
 <sup>34&#160;</sup>Everything was counted and weighed; and all the weight was written at that time. 
 </p><p>
-<sup>35&#160;</sup>The children of the captivity, who had come out of exile, offered burnt offerings to the Elohim of Israel: twelve bulls for all Israel, ninety-six rams, seventy-seven lambs, and twelve male goats for a sin offering. All this was a burnt offering to Yahweh. 
+<sup>35&#160;</sup>The children of the captivity, who had come out of exile, offered burnt offerings to the Elohim of Israel: twelve bulls for all Israel, ninety-six rams, seventy-seven lambs, and twelve male goats for a sin offering. All this was a burnt offering to Yahuah. 
 <sup>36&#160;</sup>They delivered the king’s commissions to the king’s local governors and to the governors beyond the River. So they supported the people and Elohim’s house. 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
@@ -385,10 +385,10 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>When I heard this thing, I tore my garment and my robe, and pulled the hair out of my head and of my beard, and sat down confounded. 
 <sup>4&#160;</sup>Then everyone who trembled at the words of the Elohim of Israel were assembled to me because of the trespass of the exiles; and I sat confounded until the evening offering. 
 </p><p>
-<sup>5&#160;</sup>At the evening offering I rose up from my humiliation, even with my garment and my robe torn; and I fell on my knees, and spread out my hands to Yahweh my Elohim; 
+<sup>5&#160;</sup>At the evening offering I rose up from my humiliation, even with my garment and my robe torn; and I fell on my knees, and spread out my hands to Yahuah my Elohim; 
 <sup>6&#160;</sup>and I said, “My Elohim, I am ashamed and blush to lift up my face to you, my Elohim, for our iniquities have increased over our head, and our guiltiness has grown up to the heavens. 
 <sup>7&#160;</sup>Since the days of our fathers we have been exceedingly guilty to this day; and for our iniquities we, our kings, and our priests have been delivered into the hand of the kings of the lands, to the sword, to captivity, to plunder, and to confusion of face, as it is this day. 
-<sup>8&#160;</sup>Now for a little moment grace has been shown from Yahweh our Elohim, to leave us a remnant to escape, and to give us a stake in his set-apart place, that our Elohim may lighten our eyes, and revive us a little in our bondage. 
+<sup>8&#160;</sup>Now for a little moment grace has been shown from Yahuah our Elohim, to leave us a remnant to escape, and to give us a stake in his set-apart place, that our Elohim may lighten our eyes, and revive us a little in our bondage. 
 <sup>9&#160;</sup>For we are bondservants; yet our Elohim has not forsaken us in our bondage, but has extended loving kindness to us in the sight of the kings of Persia, to revive us, to set up the house of our Elohim, and to repair its ruins, and to give us a wall in Judah and in Jerusalem. 
 </p><p>
 <sup>10&#160;</sup>“Now, our Elohim, what shall we say after this? For we have forsaken your commandments, 
@@ -397,7 +397,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>13&#160;</sup>“After all that has come on us for our evil deeds and for our great guilt, since you, our Elohim, have punished us less than our iniquities deserve, and have given us such a remnant, 
 <sup>14&#160;</sup>shall we again break your commandments, and join ourselves with the peoples that do these abominations? Wouldn’t you be angry with us until you had consumed us, so that there would be no remnant, nor any to escape? 
-<sup>15&#160;</sup>Yahweh, the Elohim of Israel, you are righteous; for we are left a remnant that has escaped, as it is today. Behold, we are before you in our guiltiness; for no one can stand before you because of this.” 
+<sup>15&#160;</sup>Yahuah, the Elohim of Israel, you are righteous; for we are left a remnant that has escaped, as it is today. Behold, we are before you in our guiltiness; for no one can stand before you because of this.” 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p>
 <sup>1&#160;</sup>Now while Ezra prayed and made confession, weeping and casting himself down before Elohim’s house, there was gathered together to him out of Israel a very great assembly of men and women and children; for the people wept very bitterly. 
@@ -413,7 +413,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Then all the men of Judah and Benjamin gathered themselves together to Jerusalem within the three days. It was the ninth month, on the twentieth day of the month; and all the people sat in the wide place in front of Elohim’s house, trembling because of this matter, and because of the great rain. 
 </p><p>
 <sup>10&#160;</sup>Ezra the priest stood up and said to them, “You have trespassed, and have taken foreign women, increasing the guilt of Israel. 
-<sup>11&#160;</sup>Now therefore make confession to Yahweh, the Elohim of your fathers and do his pleasure. Separate yourselves from the peoples of the land and from the foreign women.” 
+<sup>11&#160;</sup>Now therefore make confession to Yahuah, the Elohim of your fathers and do his pleasure. Separate yourselves from the peoples of the land and from the foreign women.” 
 </p><p>
 <sup>12&#160;</sup>Then all the assembly answered with a loud voice, “We must do as you have said concerning us. 
 <sup>13&#160;</sup>But the people are many, and it is a time of much rain, and we are not able to stand outside. This is not a work of one day or two, for we have greatly transgressed in this matter. 

--- a/book/genesis.html
+++ b/book/genesis.html
@@ -154,32 +154,32 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>On the seventh day Elohim finished his work which he had done; and he rested on the seventh day from all his work which he had done. 
 <sup>3&#160;</sup>Elohim blessed the seventh day, and made it set-apart, because he rested in it from all his work of creation which he had done. 
 </p><p>
-<sup>4&#160;</sup>This is the history of the generations of the heavens and of the earth when they were created, in the day that Yahweh Elohim made the earth and the heavens. 
-<sup>5&#160;</sup>No plant of the field was yet in the earth, and no herb of the field had yet sprung up; for Yahweh Elohim had not caused it to rain on the earth. There was not a man to till the ground, 
+<sup>4&#160;</sup>This is the history of the generations of the heavens and of the earth when they were created, in the day that Yahuah Elohim made the earth and the heavens. 
+<sup>5&#160;</sup>No plant of the field was yet in the earth, and no herb of the field had yet sprung up; for Yahuah Elohim had not caused it to rain on the earth. There was not a man to till the ground, 
 <sup>6&#160;</sup>but a mist went up from the earth, and watered the whole surface of the ground. 
-<sup>7&#160;</sup>Yahweh Elohim formed man from the dust of the ground, and breathed into his nostrils the breath of life; and man became a living soul. 
-<sup>8&#160;</sup>Yahweh Elohim planted a garden eastward, in Eden, and there he put the man whom he had formed. 
-<sup>9&#160;</sup>Out of the ground Yahweh Elohim made every tree to grow that is pleasant to the sight, and good for food, including the tree of life in the middle of the garden and the tree of the knowledge of good and evil. 
+<sup>7&#160;</sup>Yahuah Elohim formed man from the dust of the ground, and breathed into his nostrils the breath of life; and man became a living soul. 
+<sup>8&#160;</sup>Yahuah Elohim planted a garden eastward, in Eden, and there he put the man whom he had formed. 
+<sup>9&#160;</sup>Out of the ground Yahuah Elohim made every tree to grow that is pleasant to the sight, and good for food, including the tree of life in the middle of the garden and the tree of the knowledge of good and evil. 
 <sup>10&#160;</sup>A river went out of Eden to water the garden; and from there it was parted, and became the source of four rivers. 
 <sup>11&#160;</sup>The name of the first is Pishon: it flows through the whole land of Havilah, where there is gold; 
 <sup>12&#160;</sup>and the gold of that land is good. Bdellium and onyx stone are also there. 
 <sup>13&#160;</sup>The name of the second river is Gihon. It is the same river that flows through the whole land of Cush. 
 <sup>14&#160;</sup>The name of the third river is Hiddekel. This is the one which flows in front of Assyria. The fourth river is the Euphrates. 
-<sup>15&#160;</sup>Yahweh Elohim took the man, and put him into the garden of Eden to cultivate and keep it. 
-<sup>16&#160;</sup>Yahweh Elohim commanded the man, saying, “You may freely eat of every tree of the garden; 
+<sup>15&#160;</sup>Yahuah Elohim took the man, and put him into the garden of Eden to cultivate and keep it. 
+<sup>16&#160;</sup>Yahuah Elohim commanded the man, saying, “You may freely eat of every tree of the garden; 
 <sup>17&#160;</sup>but you shall not eat of the tree of the knowledge of good and evil; for in the day that you eat of it, you will surely die.” 
 </p><p>
-<sup>18&#160;</sup>Yahweh Elohim said, “It is not good for the man to be alone. I will make him a helper comparable to him.” 
-<sup>19&#160;</sup>Out of the ground Yahweh Elohim formed every animal of the field, and every bird of the sky, and brought them to the man to see what he would call them. Whatever the man called every living creature became its name. 
+<sup>18&#160;</sup>Yahuah Elohim said, “It is not good for the man to be alone. I will make him a helper comparable to him.” 
+<sup>19&#160;</sup>Out of the ground Yahuah Elohim formed every animal of the field, and every bird of the sky, and brought them to the man to see what he would call them. Whatever the man called every living creature became its name. 
 <sup>20&#160;</sup>The man gave names to all livestock, and to the birds of the sky, and to every animal of the field; but for man there was not found a helper comparable to him. 
-<sup>21&#160;</sup>Yahweh Elohim caused the man to fall into a deep sleep. As the man slept, he took one of his ribs, and closed up the flesh in its place. 
-<sup>22&#160;</sup>Yahweh Elohim made a woman from the rib which he had taken from the man, and brought her to the man. 
+<sup>21&#160;</sup>Yahuah Elohim caused the man to fall into a deep sleep. As the man slept, he took one of his ribs, and closed up the flesh in its place. 
+<sup>22&#160;</sup>Yahuah Elohim made a woman from the rib which he had taken from the man, and brought her to the man. 
 <sup>23&#160;</sup>The man said, “This is now bone of my bones, and flesh of my flesh. She will be called ‘woman,’ because she was taken out of Man.” 
 <sup>24&#160;</sup>Therefore a man will leave his father and his mother, and will join with his woman, and they will be one flesh. 
 <sup>25&#160;</sup>The man and his woman were both naked, and they were not ashamed. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>Now the serpent was more subtle than any animal of the field which Yahweh Elohim had made. He said to the woman, “Has Elohim really said, ‘You shall not eat of any tree of the garden’?” 
+<sup>1&#160;</sup>Now the serpent was more subtle than any animal of the field which Yahuah Elohim had made. He said to the woman, “Has Elohim really said, ‘You shall not eat of any tree of the garden’?” 
 </p><p>
 <sup>2&#160;</sup>The woman said to the serpent, “We may eat fruit from the trees of the garden, 
 <sup>3&#160;</sup>but not the fruit of the tree which is in the middle of the garden. Elohim has said, ‘You shall not eat of it. You shall not touch it, lest you die.’&#160;” 
@@ -189,9 +189,9 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>6&#160;</sup>When the woman saw that the tree was good for food, and that it was a delight to the eyes, and that the tree was to be desired to make one wise, she took some of its fruit, and ate. Then she gave some to her man with her, and he ate it, too. 
 <sup>7&#160;</sup>Their eyes were opened, and they both knew that they were naked. They sewed fig leaves together, and made coverings for themselves. 
-<sup>8&#160;</sup>They heard Yahweh Elohim’s voice walking in the garden in the cool of the day, and the man and his woman hid themselves from the presence of Yahweh Elohim among the trees of the garden. 
+<sup>8&#160;</sup>They heard Yahuah Elohim’s voice walking in the garden in the cool of the day, and the man and his woman hid themselves from the presence of Yahuah Elohim among the trees of the garden. 
 </p><p>
-<sup>9&#160;</sup>Yahweh Elohim called to the man, and said to him, “Where are you?” 
+<sup>9&#160;</sup>Yahuah Elohim called to the man, and said to him, “Where are you?” 
 </p><p>
 <sup>10&#160;</sup>The man said, “I heard your voice in the garden, and I was afraid, because I was naked; so I hid myself.” 
 </p><p>
@@ -199,10 +199,10 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>12&#160;</sup>The man said, “The woman whom you gave to be with me, she gave me fruit from the tree, and I ate it.” 
 </p><p>
-<sup>13&#160;</sup>Yahweh Elohim said to the woman, “What have you done?” 
+<sup>13&#160;</sup>Yahuah Elohim said to the woman, “What have you done?” 
 </p><p>The woman said, “The serpent deceived me, and I ate.” 
 </p><p>
-<sup>14&#160;</sup>Yahweh Elohim said to the serpent, 
+<sup>14&#160;</sup>Yahuah Elohim said to the serpent, 
 </p><p class="q1">“Because you have done this, 
 </p><p class="q2">you are cursed above all livestock, 
 </p><p class="q2">and above every animal of the field. 
@@ -236,35 +236,35 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and you shall return to dust.” 
 </p><p>
 <sup>20&#160;</sup>The man called his woman Eve because she would be the mother of all the living. 
-<sup>21&#160;</sup>Yahweh Elohim made garments of animal skins for Adam and for his woman, and clothed them. 
+<sup>21&#160;</sup>Yahuah Elohim made garments of animal skins for Adam and for his woman, and clothed them. 
 </p><p>
-<sup>22&#160;</sup>Yahweh Elohim said, “Behold, the man has become like one of us, knowing good and evil. Now, lest he reach out his hand, and also take of the tree of life, and eat, and live forever—” 
-<sup>23&#160;</sup>Therefore Yahweh Elohim sent him out from the garden of Eden, to till the ground from which he was taken. 
+<sup>22&#160;</sup>Yahuah Elohim said, “Behold, the man has become like one of us, knowing good and evil. Now, lest he reach out his hand, and also take of the tree of life, and eat, and live forever—” 
+<sup>23&#160;</sup>Therefore Yahuah Elohim sent him out from the garden of Eden, to till the ground from which he was taken. 
 <sup>24&#160;</sup>So he drove out the man; and he placed cherubim at the east of the garden of Eden, and a flaming sword which turned every way, to guard the way to the tree of life. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>The man knew Eve his woman. She conceived, and gave birth to Cain, and said, “I have gotten a man with Yahweh’s help.” 
+<sup>1&#160;</sup>The man knew Eve his woman. She conceived, and gave birth to Cain, and said, “I have gotten a man with Yahuah’s help.” 
 <sup>2&#160;</sup>Again she gave birth, to Cain’s brother Abel. Abel was a keeper of sheep, but Cain was a tiller of the ground. 
-<sup>3&#160;</sup>As time passed, Cain brought an offering to Yahweh from the fruit of the ground. 
-<sup>4&#160;</sup>Abel also brought some of the firstborn of his flock and of its fat. Yahweh respected Abel and his offering, 
+<sup>3&#160;</sup>As time passed, Cain brought an offering to Yahuah from the fruit of the ground. 
+<sup>4&#160;</sup>Abel also brought some of the firstborn of his flock and of its fat. Yahuah respected Abel and his offering, 
 <sup>5&#160;</sup>but he didn’t respect Cain and his offering. Cain was very angry, and the expression on his face fell. 
-<sup>6&#160;</sup>Yahweh said to Cain, “Why are you angry? Why has the expression of your face fallen? 
+<sup>6&#160;</sup>Yahuah said to Cain, “Why are you angry? Why has the expression of your face fallen? 
 <sup>7&#160;</sup>If you do well, won’t it be lifted up? If you don’t do well, sin crouches at the door. Its desire is for you, but you are to rule over it.” 
 <sup>8&#160;</sup>Cain said to Abel, his brother, “Let’s go into the field.” While they were in the field, Cain rose up against Abel, his brother, and killed him. 
 </p><p>
-<sup>9&#160;</sup>Yahweh said to Cain, “Where is Abel, your brother?” 
+<sup>9&#160;</sup>Yahuah said to Cain, “Where is Abel, your brother?” 
 </p><p>He said, “I don’t know. Am I my brother’s keeper?” 
 </p><p>
-<sup>10&#160;</sup>Yahweh said, “What have you done? The voice of your brother’s blood cries to me from the ground. 
+<sup>10&#160;</sup>Yahuah said, “What have you done? The voice of your brother’s blood cries to me from the ground. 
 <sup>11&#160;</sup>Now you are cursed because of the ground, which has opened its mouth to receive your brother’s blood from your hand. 
 <sup>12&#160;</sup>From now on, when you till the ground, it won’t yield its strength to you. You will be a fugitive and a wanderer in the earth.” 
 </p><p>
-<sup>13&#160;</sup>Cain said to Yahweh, “My punishment is greater than I can bear. 
+<sup>13&#160;</sup>Cain said to Yahuah, “My punishment is greater than I can bear. 
 <sup>14&#160;</sup>Behold, you have driven me out today from the surface of the ground. I will be hidden from your face, and I will be a fugitive and a wanderer in the earth. Whoever finds me will kill me.” 
 </p><p>
-<sup>15&#160;</sup>Yahweh said to him, “Therefore whoever slays Cain, vengeance will be taken on him sevenfold.” Yahweh appointed a sign for Cain, so that anyone finding him would not strike him. 
+<sup>15&#160;</sup>Yahuah said to him, “Therefore whoever slays Cain, vengeance will be taken on him sevenfold.” Yahuah appointed a sign for Cain, so that anyone finding him would not strike him. 
 </p><p>
-<sup>16&#160;</sup>Cain left Yahweh’s presence, and lived in the land of Nod, east of Eden. 
+<sup>16&#160;</sup>Cain left Yahuah’s presence, and lived in the land of Nod, east of Eden. 
 <sup>17&#160;</sup>Cain knew his woman. She conceived, and gave birth to Enoch. He built a city, and named the city after the name of his son, Enoch. 
 <sup>18&#160;</sup>Irad was born to Enoch. Irad brought forth Mehujael. Mehujael brought forth Methushael. Methushael brought forth Lamech. 
 <sup>19&#160;</sup>Lamech took two women: the name of the first one was Adah, and the name of the second one was Zillah. 
@@ -281,7 +281,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">truly Lamech seventy-seven times.” 
 </p><p>
 <sup>25&#160;</sup>Adam knew his woman again. She gave birth to a son, and named him Seth, saying, “for Elohim has given me another child instead of Abel, for Cain killed him.” 
-<sup>26&#160;</sup>A son was also born to Seth, and he named him Enosh. At that time men began to call on Yahweh’s name. 
+<sup>26&#160;</sup>A son was also born to Seth, and he named him Enosh. At that time men began to call on Yahuah’s name. 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
 <sup>1&#160;</sup>This is the book of the generations of Adam. In the day that Elohim created man, he made him in Elohim’s likeness. 
@@ -320,7 +320,7 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>All the days of Methuselah were nine hundred sixty-nine years, then he died. 
 </p><p>
 <sup>28&#160;</sup>Lamech lived one hundred eighty-two years, then brought forth a son. 
-<sup>29&#160;</sup>He named him Noah, saying, “This one will comfort us in our work and in the toil of our hands, caused by the ground which Yahweh has cursed.” 
+<sup>29&#160;</sup>He named him Noah, saying, “This one will comfort us in our work and in the toil of our hands, caused by the ground which Yahuah has cursed.” 
 <sup>30&#160;</sup>Lamech lived after he brought forth Noah five hundred ninety-five years, and brought forth other sons and daughters. 
 <sup>31&#160;</sup>All the days of Lamech were seven hundred seventy-seven years, then he died. 
 </p><p>
@@ -329,13 +329,13 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>When men began to multiply on the surface of the ground, and daughters were born to them, 
 <sup>2&#160;</sup>Elohim’s sons saw that men’s daughters were beautiful, and they took any that they wanted for themselves as women. 
-<sup>3&#160;</sup>Yahweh said, “My Spirit will not strive with man forever, because he also is flesh; so his days will be one hundred twenty years.” 
+<sup>3&#160;</sup>Yahuah said, “My Spirit will not strive with man forever, because he also is flesh; so his days will be one hundred twenty years.” 
 <sup>4&#160;</sup>The Nephilim were in the earth in those days, and also after that, when Elohim’s sons came in to men’s daughters and had children with them. Those were the mighty men who were of old, men of renown. 
 </p><p>
-<sup>5&#160;</sup>Yahweh saw that the wickedness of man was great in the earth, and that every imagination of the thoughts of man’s heart was continually only evil. 
-<sup>6&#160;</sup>Yahweh was sorry that he had made man on the earth, and it grieved him in his heart. 
-<sup>7&#160;</sup>Yahweh said, “I will destroy man whom I have created from the surface of the ground—man, along with animals, creeping things, and birds of the sky—for I am sorry that I have made them.” 
-<sup>8&#160;</sup>But Noah found favor in Yahweh’s eyes. 
+<sup>5&#160;</sup>Yahuah saw that the wickedness of man was great in the earth, and that every imagination of the thoughts of man’s heart was continually only evil. 
+<sup>6&#160;</sup>Yahuah was sorry that he had made man on the earth, and it grieved him in his heart. 
+<sup>7&#160;</sup>Yahuah said, “I will destroy man whom I have created from the surface of the ground—man, along with animals, creeping things, and birds of the sky—for I am sorry that I have made them.” 
+<sup>8&#160;</sup>But Noah found favor in Yahuah’s eyes. 
 </p><p>
 <sup>9&#160;</sup>This is the history of the generations of Noah: Noah was a righteous man, blameless among the people of his time. Noah walked with Elohim. 
 <sup>10&#160;</sup>Noah brought forth three sons: Shem, Ham, and Japheth. 
@@ -354,12 +354,12 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>Thus Noah did. He did all that Elohim commanded him. 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Noah, “Come with all of your household into the ship, for I have seen your righteousness before me in this generation. 
+<sup>1&#160;</sup>Yahuah said to Noah, “Come with all of your household into the ship, for I have seen your righteousness before me in this generation. 
 <sup>2&#160;</sup>You shall take seven pairs of every clean animal with you, the male and his female. Of the animals that are not clean, take two, the male and his female. 
 <sup>3&#160;</sup>Also of the birds of the sky, seven and seven, male and female, to keep seed alive on the surface of all the earth. 
 <sup>4&#160;</sup>In seven days, I will cause it to rain on the earth for forty days and forty nights. I will destroy every living thing that I have made from the surface of the ground.” 
 </p><p>
-<sup>5&#160;</sup>Noah did everything that Yahweh commanded him. 
+<sup>5&#160;</sup>Noah did everything that Yahuah commanded him. 
 </p><p>
 <sup>6&#160;</sup>Noah was six hundred years old when the flood of waters came on the earth. 
 <sup>7&#160;</sup>Noah went into the ship with his sons, his woman, and his sons’ women, because of the floodwaters. 
@@ -371,7 +371,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>13&#160;</sup>In the same day Noah, and Shem, Ham, and Japheth—the sons of Noah—and Noah’s woman and the three women of his sons with them, entered into the ship—<sup>14&#160;</sup>they, and every animal after its kind, all the livestock after their kind, every creeping thing that creeps on the earth after its kind, and every bird after its kind, every bird of every sort. 
 <sup>15&#160;</sup>Pairs from all flesh with the breath of life in them went into the ship to Noah. 
-<sup>16&#160;</sup>Those who went in, went in male and female of all flesh, as Elohim commanded him; then Yahweh shut him in. 
+<sup>16&#160;</sup>Those who went in, went in male and female of all flesh, as Elohim commanded him; then Yahuah shut him in. 
 <sup>17&#160;</sup>The flood was forty days on the earth. The waters increased, and lifted up the ship, and it was lifted up above the earth. 
 <sup>18&#160;</sup>The waters rose, and increased greatly on the earth; and the ship floated on the surface of the waters. 
 <sup>19&#160;</sup>The waters rose very high on the earth. All the high mountains that were under the whole sky were covered. 
@@ -406,8 +406,8 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>Noah went out, with his sons, his woman, and his sons’ women with him. 
 <sup>19&#160;</sup>Every animal, every creeping thing, and every bird, whatever moves on the earth, after their families, went out of the ship. 
 </p><p>
-<sup>20&#160;</sup>Noah built an altar to Yahweh, and took of every clean animal, and of every clean bird, and offered burnt offerings on the altar. 
-<sup>21&#160;</sup>Yahweh smelled the pleasant aroma. Yahweh said in his heart, “I will not again curse the ground any more for man’s sake because the imagination of man’s heart is evil from his youth. I will never again strike every living thing, as I have done. 
+<sup>20&#160;</sup>Noah built an altar to Yahuah, and took of every clean animal, and of every clean bird, and offered burnt offerings on the altar. 
+<sup>21&#160;</sup>Yahuah smelled the pleasant aroma. Yahuah said in his heart, “I will not again curse the ground any more for man’s sake because the imagination of man’s heart is evil from his youth. I will never again strike every living thing, as I have done. 
 <sup>22&#160;</sup>While the earth remains, seed time and harvest, and cold and heat, and summer and winter, and day and night will not cease.” 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
@@ -443,7 +443,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He will be a servant of servants to his brothers.” 
 </p><p>
 <sup>26&#160;</sup>He said, 
-</p><p class="q1">“Blessed be Yahweh, the Elohim of Shem. 
+</p><p class="q1">“Blessed be Yahuah, the Elohim of Shem. 
 </p><p class="q2">Let Canaan be his servant. 
 </p><p class="q1">
 <sup>27&#160;</sup>May Elohim enlarge Japheth. 
@@ -464,7 +464,7 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>The sons of Ham were: Cush, Mizraim, Put, and Canaan. 
 <sup>7&#160;</sup>The sons of Cush were: Seba, Havilah, Sabtah, Raamah, and Sabteca. The sons of Raamah were: Sheba and Dedan. 
 <sup>8&#160;</sup>Cush brought forth Nimrod. He began to be a mighty one in the earth. 
-<sup>9&#160;</sup>He was a mighty hunter before Yahweh. Therefore it is said, “like Nimrod, a mighty hunter before Yahweh”. 
+<sup>9&#160;</sup>He was a mighty hunter before Yahuah. Therefore it is said, “like Nimrod, a mighty hunter before Yahuah”. 
 <sup>10&#160;</sup>The beginning of his kingdom was Babel, Erech, Accad, and Calneh, in the land of Shinar. 
 <sup>11&#160;</sup>Out of that land he went into Assyria, and built Nineveh, Rehoboth Ir, Calah, 
 <sup>12&#160;</sup>and Resen between Nineveh and the great city Calah. 
@@ -498,11 +498,11 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>They said to one another, “Come, let’s make bricks, and burn them thoroughly.” They had brick for stone, and they used tar for mortar. 
 <sup>4&#160;</sup>They said, “Come, let’s build ourselves a city, and a tower whose top reaches to the sky, and let’s make a name for ourselves, lest we be scattered abroad on the surface of the whole earth.” 
 </p><p>
-<sup>5&#160;</sup>Yahweh came down to see the city and the tower, which the children of men built. 
-<sup>6&#160;</sup>Yahweh said, “Behold, they are one people, and they all have one language, and this is what they begin to do. Now nothing will be withheld from them, which they intend to do. 
+<sup>5&#160;</sup>Yahuah came down to see the city and the tower, which the children of men built. 
+<sup>6&#160;</sup>Yahuah said, “Behold, they are one people, and they all have one language, and this is what they begin to do. Now nothing will be withheld from them, which they intend to do. 
 <sup>7&#160;</sup>Come, let’s go down, and there confuse their language, that they may not understand one another’s speech.” 
-<sup>8&#160;</sup>So Yahweh scattered them abroad from there on the surface of all the earth. They stopped building the city. 
-<sup>9&#160;</sup>Therefore its name was called Babel, because there Yahweh confused the language of all the earth. From there, Yahweh scattered them abroad on the surface of all the earth. 
+<sup>8&#160;</sup>So Yahuah scattered them abroad from there on the surface of all the earth. They stopped building the city. 
+<sup>9&#160;</sup>Therefore its name was called Babel, because there Yahuah confused the language of all the earth. From there, Yahuah scattered them abroad on the surface of all the earth. 
 </p><p>
 <sup>10&#160;</sup>This is the history of the generations of Shem: Shem was one hundred years old when he brought forth Arpachshad two years after the flood. 
 <sup>11&#160;</sup>Shem lived five hundred years after he brought forth Arpachshad, and brought forth more sons and daughters. 
@@ -538,17 +538,17 @@ html[dir=ltr] .q2 {
 <sup>32&#160;</sup>The days of Terah were two hundred five years. Terah died in Haran. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
-<sup>1&#160;</sup>Now Yahweh said to Abram, “Leave your country, and your relatives, and your father’s house, and go to the land that I will show you. 
+<sup>1&#160;</sup>Now Yahuah said to Abram, “Leave your country, and your relatives, and your father’s house, and go to the land that I will show you. 
 <sup>2&#160;</sup>I will make of you a great nation. I will bless you and make your name great. You will be a blessing. 
 <sup>3&#160;</sup>I will bless those who bless you, and I will curse him who treats you with contempt. All the families of the earth will be blessed through you.” 
 </p><p>
-<sup>4&#160;</sup>So Abram went, as Yahweh had told him. Lot went with him. Abram was seventy-five years old when he departed from Haran. 
+<sup>4&#160;</sup>So Abram went, as Yahuah had told him. Lot went with him. Abram was seventy-five years old when he departed from Haran. 
 <sup>5&#160;</sup>Abram took Sarai his woman, Lot his brother’s son, all their possessions that they had gathered, and the people whom they had acquired in Haran, and they went to go into the land of Canaan. They entered into the land of Canaan. 
 <sup>6&#160;</sup>Abram passed through the land to the place of Shechem, to the oak of Moreh. At that time, Canaanites were in the land. 
 </p><p>
-<sup>7&#160;</sup>Yahweh appeared to Abram and said, “I will give this land to your offspring.” 
-</p><p>He built an altar there to Yahweh, who had appeared to him. 
-<sup>8&#160;</sup>He left from there to go to the mountain on the east of Bethel and pitched his tent, having Bethel on the west, and Ai on the east. There he built an altar to Yahweh and called on Yahweh’s name. 
+<sup>7&#160;</sup>Yahuah appeared to Abram and said, “I will give this land to your offspring.” 
+</p><p>He built an altar there to Yahuah, who had appeared to him. 
+<sup>8&#160;</sup>He left from there to go to the mountain on the east of Bethel and pitched his tent, having Bethel on the west, and Ai on the east. There he built an altar to Yahuah and called on Yahuah’s name. 
 <sup>9&#160;</sup>Abram traveled, still going on toward the South. 
 </p><p>
 <sup>10&#160;</sup>There was a famine in the land. Abram went down into Egypt to live as a foreigner there, for the famine was severe in the land. 
@@ -559,7 +559,7 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>When Abram had come into Egypt, Egyptians saw that the woman was very beautiful. 
 <sup>15&#160;</sup>The princes of Pharaoh saw her, and praised her to Pharaoh; and the woman was taken into Pharaoh’s house. 
 <sup>16&#160;</sup>He dealt well with Abram for her sake. He had sheep, cattle, male donkeys, male servants, female servants, female donkeys, and camels. 
-<sup>17&#160;</sup>Yahweh afflicted Pharaoh and his house with great plagues because of Sarai, Abram’s woman. 
+<sup>17&#160;</sup>Yahuah afflicted Pharaoh and his house with great plagues because of Sarai, Abram’s woman. 
 <sup>18&#160;</sup>Pharaoh called Abram and said, “What is this that you have done to me? Why didn’t you tell me that she was your woman? 
 <sup>19&#160;</sup>Why did you say, ‘She is my sister,’ so that I took her to be my woman? Now therefore, see your woman, take her, and go your way.” 
 </p><p>
@@ -569,24 +569,24 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>Abram went up out of Egypt—he, his woman, all that he had, and Lot with him—into the South. 
 <sup>2&#160;</sup>Abram was very rich in livestock, in silver, and in gold. 
 <sup>3&#160;</sup>He went on his journeys from the South as far as Bethel, to the place where his tent had been at the beginning, between Bethel and Ai, 
-<sup>4&#160;</sup>to the place of the altar, which he had made there at the first. There Abram called on Yahweh’s name. 
+<sup>4&#160;</sup>to the place of the altar, which he had made there at the first. There Abram called on Yahuah’s name. 
 <sup>5&#160;</sup>Lot also, who went with Abram, had flocks, herds, and tents. 
 <sup>6&#160;</sup>The land was not able to bear them, that they might live together; for their possessions were so great that they couldn’t live together. 
 <sup>7&#160;</sup>There was strife between the herdsmen of Abram’s livestock and the herdsmen of Lot’s livestock. The Canaanites and the Perizzites lived in the land at that time. 
 <sup>8&#160;</sup>Abram said to Lot, “Please, let there be no strife between you and me, and between your herdsmen and my herdsmen; for we are relatives. 
 <sup>9&#160;</sup>Isn’t the whole land before you? Please separate yourself from me. If you go to the left hand, then I will go to the right. Or if you go to the right hand, then I will go to the left.” 
 </p><p>
-<sup>10&#160;</sup>Lot lifted up his eyes, and saw all the plain of the Jordan, that it was well-watered everywhere, before Yahweh destroyed Sodom and Gomorrah, like the garden of Yahweh, like the land of Egypt, as you go to Zoar. 
+<sup>10&#160;</sup>Lot lifted up his eyes, and saw all the plain of the Jordan, that it was well-watered everywhere, before Yahuah destroyed Sodom and Gomorrah, like the garden of Yahuah, like the land of Egypt, as you go to Zoar. 
 <sup>11&#160;</sup>So Lot chose the Plain of the Jordan for himself. Lot traveled east, and they separated themselves from one other. 
 <sup>12&#160;</sup>Abram lived in the land of Canaan, and Lot lived in the cities of the plain, and moved his tent as far as Sodom. 
-<sup>13&#160;</sup>Now the men of Sodom were exceedingly wicked and sinners against Yahweh. 
+<sup>13&#160;</sup>Now the men of Sodom were exceedingly wicked and sinners against Yahuah. 
 </p><p>
-<sup>14&#160;</sup>Yahweh said to Abram, after Lot was separated from him, “Now, lift up your eyes, and look from the place where you are, northward and southward and eastward and westward, 
+<sup>14&#160;</sup>Yahuah said to Abram, after Lot was separated from him, “Now, lift up your eyes, and look from the place where you are, northward and southward and eastward and westward, 
 <sup>15&#160;</sup>for I will give all the land which you see to you and to your offspring forever. 
 <sup>16&#160;</sup>I will make your offspring as the dust of the earth, so that if a man can count the dust of the earth, then your offspring may also be counted. 
 <sup>17&#160;</sup>Arise, walk through the land in its length and in its width; for I will give it to you.” 
 </p><p>
-<sup>18&#160;</sup>Abram moved his tent, and came and lived by the oaks of Mamre, which are in Hebron, and built an altar there to Yahweh. 
+<sup>18&#160;</sup>Abram moved his tent, and came and lived by the oaks of Mamre, which are in Hebron, and built an altar there to Yahuah. 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
 <sup>1&#160;</sup>In the days of Amraphel, king of Shinar; Arioch, king of Ellasar; Chedorlaomer, king of Elam; and Tidal, king of Goiim, 
@@ -615,22 +615,22 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>21&#160;</sup>The king of Sodom said to Abram, “Give me the people, and take the goods for yourself.” 
 </p><p>
-<sup>22&#160;</sup>Abram said to the king of Sodom, “I have lifted up my hand to Yahweh, Elohim Most High, possessor of heaven and earth, 
+<sup>22&#160;</sup>Abram said to the king of Sodom, “I have lifted up my hand to Yahuah, Elohim Most High, possessor of heaven and earth, 
 <sup>23&#160;</sup>that I will not take a thread nor a sandal strap nor anything that is yours, lest you should say, ‘I have made Abram rich.’ 
 <sup>24&#160;</sup>I will accept nothing from you except that which the young men have eaten, and the portion of the men who went with me: Aner, Eshcol, and Mamre. Let them take their portion.” 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
-<sup>1&#160;</sup>After these things Yahweh’s word came to Abram in a vision, saying, “Don’t be afraid, Abram. I am your shield, your exceedingly great reward.” 
+<sup>1&#160;</sup>After these things Yahuah’s word came to Abram in a vision, saying, “Don’t be afraid, Abram. I am your shield, your exceedingly great reward.” 
 </p><p>
-<sup>2&#160;</sup>Abram said, “Lord Yahweh, what will you give me, since I go childless, and he who will inherit my estate is Eliezer of Damascus?” 
+<sup>2&#160;</sup>Abram said, “Lord Yahuah, what will you give me, since I go childless, and he who will inherit my estate is Eliezer of Damascus?” 
 <sup>3&#160;</sup>Abram said, “Behold, you have given no children to me: and, behold, one born in my house is my heir.” 
 </p><p>
-<sup>4&#160;</sup>Behold, Yahweh’s word came to him, saying, “This man will not be your heir, but he who will come out of your own body will be your heir.” 
-<sup>5&#160;</sup>Yahweh brought him outside, and said, “Look now toward the sky, and count the stars, if you are able to count them.” He said to Abram, “So your offspring will be.” 
-<sup>6&#160;</sup>He believed in Yahweh, and credited it to him as righteousness. 
-<sup>7&#160;</sup>He said to Abram, “I am Yahweh who brought you out of Ur of the Chaldees, to give you this land to inherit it.” 
+<sup>4&#160;</sup>Behold, Yahuah’s word came to him, saying, “This man will not be your heir, but he who will come out of your own body will be your heir.” 
+<sup>5&#160;</sup>Yahuah brought him outside, and said, “Look now toward the sky, and count the stars, if you are able to count them.” He said to Abram, “So your offspring will be.” 
+<sup>6&#160;</sup>He believed in Yahuah, and credited it to him as righteousness. 
+<sup>7&#160;</sup>He said to Abram, “I am Yahuah who brought you out of Ur of the Chaldees, to give you this land to inherit it.” 
 </p><p>
-<sup>8&#160;</sup>He said, “Lord Yahweh, how will I know that I will inherit it?” 
+<sup>8&#160;</sup>He said, “Lord Yahuah, how will I know that I will inherit it?” 
 </p><p>
 <sup>9&#160;</sup>He said to him, “Bring me a heifer three years old, a female goat three years old, a ram three years old, a turtledove, and a young pigeon.” 
 <sup>10&#160;</sup>He brought him all these, and divided them in the middle, and laid each half opposite the other; but he didn’t divide the birds. 
@@ -642,37 +642,37 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>but you will go to your fathers in peace. You will be buried at a good old age. 
 <sup>16&#160;</sup>In the fourth generation they will come here again, for the iniquity of the Amorite is not yet full.” 
 <sup>17&#160;</sup>It came to pass that, when the sun went down, and it was dark, behold, a smoking furnace and a flaming torch passed between these pieces. 
-<sup>18&#160;</sup>In that day Yahweh made a covenant with Abram, saying, “I have given this land to your offspring, from the river of Egypt to the great river, the river Euphrates: 
+<sup>18&#160;</sup>In that day Yahuah made a covenant with Abram, saying, “I have given this land to your offspring, from the river of Egypt to the great river, the river Euphrates: 
 <sup>19&#160;</sup>the land of the Kenites, the Kenizzites, the Kadmonites, 
 <sup>20&#160;</sup>the Hittites, the Perizzites, the Rephaim, 
 <sup>21&#160;</sup>the Amorites, the Canaanites, the Girgashites, and the Jebusites.” 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
 <sup>1&#160;</sup>Now Sarai, Abram’s woman, bore him no children. She had a servant, an Egyptian, whose name was Hagar. 
-<sup>2&#160;</sup>Sarai said to Abram, “See now, Yahweh has restrained me from bearing. Please go in to my servant. It may be that I will obtain children by her.” Abram listened to the voice of Sarai. 
+<sup>2&#160;</sup>Sarai said to Abram, “See now, Yahuah has restrained me from bearing. Please go in to my servant. It may be that I will obtain children by her.” Abram listened to the voice of Sarai. 
 <sup>3&#160;</sup>Sarai, Abram’s woman, took Hagar the Egyptian, her servant, after Abram had lived ten years in the land of Canaan, and gave her to Abram her man to be his woman. 
 <sup>4&#160;</sup>He went in to Hagar, and she conceived. When she saw that she had conceived, her mistress was despised in her eyes. 
-<sup>5&#160;</sup>Sarai said to Abram, “This wrong is your fault. I gave my servant into your bosom, and when she saw that she had conceived, she despised me. May Yahweh judge between me and you.” 
+<sup>5&#160;</sup>Sarai said to Abram, “This wrong is your fault. I gave my servant into your bosom, and when she saw that she had conceived, she despised me. May Yahuah judge between me and you.” 
 </p><p>
 <sup>6&#160;</sup>But Abram said to Sarai, “Behold, your maid is in your hand. Do to her whatever is good in your eyes.” Sarai dealt harshly with her, and she fled from her face. 
 </p><p>
-<sup>7&#160;</sup>Yahweh’s angel found her by a fountain of water in the wilderness, by the fountain on the way to Shur. 
+<sup>7&#160;</sup>Yahuah’s angel found her by a fountain of water in the wilderness, by the fountain on the way to Shur. 
 <sup>8&#160;</sup>He said, “Hagar, Sarai’s servant, where did you come from? Where are you going?” 
 </p><p>She said, “I am fleeing from the face of my mistress Sarai.” 
 </p><p>
-<sup>9&#160;</sup>Yahweh’s angel said to her, “Return to your mistress, and submit yourself under her hands.” 
-<sup>10&#160;</sup>Yahweh’s angel said to her, “I will greatly multiply your offspring, that they will not be counted for multitude.” 
-<sup>11&#160;</sup>Yahweh’s angel said to her, “Behold, you are with child, and will bear a son. You shall call his name Ishmael, because Yahweh has heard your affliction. 
+<sup>9&#160;</sup>Yahuah’s angel said to her, “Return to your mistress, and submit yourself under her hands.” 
+<sup>10&#160;</sup>Yahuah’s angel said to her, “I will greatly multiply your offspring, that they will not be counted for multitude.” 
+<sup>11&#160;</sup>Yahuah’s angel said to her, “Behold, you are with child, and will bear a son. You shall call his name Ishmael, because Yahuah has heard your affliction. 
 <sup>12&#160;</sup>He will be like a wild donkey among men. His hand will be against every man, and every man’s hand against him. He will live opposed to all of his brothers.” 
 </p><p>
-<sup>13&#160;</sup>She called the name of Yahweh who spoke to her, “You are an Elohim who sees,” for she said, “Have I even stayed alive after seeing him?” 
+<sup>13&#160;</sup>She called the name of Yahuah who spoke to her, “You are an Elohim who sees,” for she said, “Have I even stayed alive after seeing him?” 
 <sup>14&#160;</sup>Therefore the well was called Beer Lahai Roi. Behold, it is between Kadesh and Bered. 
 </p><p>
 <sup>15&#160;</sup>Hagar bore a son for Abram. Abram called the name of his son, whom Hagar bore, Ishmael. 
 <sup>16&#160;</sup>Abram was eighty-six years old when Hagar bore Ishmael to Abram. 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
-<sup>1&#160;</sup>When Abram was ninety-nine years old, Yahweh appeared to Abram and said to him, “I am Elohim Almighty. Walk before me and be blameless. 
+<sup>1&#160;</sup>When Abram was ninety-nine years old, Yahuah appeared to Abram and said to him, “I am Elohim Almighty. Walk before me and be blameless. 
 <sup>2&#160;</sup>I will make my covenant between me and you, and will multiply you exceedingly.” 
 </p><p>
 <sup>3&#160;</sup>Abram fell on his face. Elohim talked with him, saying, 
@@ -707,7 +707,7 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>All the men of his house, those born in the house, and those bought with money from a foreigner, were circumcised with him. 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
-<sup>1&#160;</sup>Yahweh appeared to him by the oaks of Mamre, as he sat in the tent door in the heat of the day. 
+<sup>1&#160;</sup>Yahuah appeared to him by the oaks of Mamre, as he sat in the tent door in the heat of the day. 
 <sup>2&#160;</sup>He lifted up his eyes and looked, and saw that three men stood near him. When he saw them, he ran to meet them from the tent door, and bowed himself to the earth, 
 <sup>3&#160;</sup>and said, “My lord, if now I have found favor in your sight, please don’t go away from your servant. 
 <sup>4&#160;</sup>Now let a little water be fetched, wash your feet, and rest yourselves under the tree. 
@@ -726,25 +726,25 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>Now Abraham and Sarah were old, well advanced in age. Sarah had passed the age of childbearing. 
 <sup>12&#160;</sup>Sarah laughed within herself, saying, “After I have grown old will I have pleasure, my lord being old also?” 
 </p><p>
-<sup>13&#160;</sup>Yahweh said to Abraham, “Why did Sarah laugh, saying, ‘Will I really bear a child when I am old?’ 
-<sup>14&#160;</sup>Is anything too hard for Yahweh? At the set time I will return to you, when the season comes around, and Sarah will have a son.” 
+<sup>13&#160;</sup>Yahuah said to Abraham, “Why did Sarah laugh, saying, ‘Will I really bear a child when I am old?’ 
+<sup>14&#160;</sup>Is anything too hard for Yahuah? At the set time I will return to you, when the season comes around, and Sarah will have a son.” 
 </p><p>
 <sup>15&#160;</sup>Then Sarah denied it, saying, “I didn’t laugh,” for she was afraid. 
 </p><p>He said, “No, but you did laugh.” 
 </p><p>
 <sup>16&#160;</sup>The men rose up from there, and looked toward Sodom. Abraham went with them to see them on their way. 
-<sup>17&#160;</sup>Yahweh said, “Will I hide from Abraham what I do, 
+<sup>17&#160;</sup>Yahuah said, “Will I hide from Abraham what I do, 
 <sup>18&#160;</sup>since Abraham will surely become a great and mighty nation, and all the nations of the earth will be blessed in him? 
-<sup>19&#160;</sup>For I have known him, to the end that he may command his children and his household after him, that they may keep the way of Yahweh, to do righteousness and justice; to the end that Yahweh may bring on Abraham that which he has spoken of him.” 
-<sup>20&#160;</sup>Yahweh said, “Because the cry of Sodom and Gomorrah is great, and because their sin is very grievous, 
+<sup>19&#160;</sup>For I have known him, to the end that he may command his children and his household after him, that they may keep the way of Yahuah, to do righteousness and justice; to the end that Yahuah may bring on Abraham that which he has spoken of him.” 
+<sup>20&#160;</sup>Yahuah said, “Because the cry of Sodom and Gomorrah is great, and because their sin is very grievous, 
 <sup>21&#160;</sup>I will go down now, and see whether their deeds are as bad as the reports which have come to me. If not, I will know.” 
 </p><p>
-<sup>22&#160;</sup>The men turned from there, and went toward Sodom, but Abraham stood yet before Yahweh. 
+<sup>22&#160;</sup>The men turned from there, and went toward Sodom, but Abraham stood yet before Yahuah. 
 <sup>23&#160;</sup>Abraham came near, and said, “Will you consume the righteous with the wicked? 
 <sup>24&#160;</sup>What if there are fifty righteous within the city? Will you consume and not spare the place for the fifty righteous who are in it? 
 <sup>25&#160;</sup>May it be far from you to do things like that, to kill the righteous with the wicked, so that the righteous should be like the wicked. May that be far from you. Shouldn’t the Judge of all the earth do right?” 
 </p><p>
-<sup>26&#160;</sup>Yahweh said, “If I find in Sodom fifty righteous within the city, then I will spare the whole place for their sake.” 
+<sup>26&#160;</sup>Yahuah said, “If I find in Sodom fifty righteous within the city, then I will spare the whole place for their sake.” 
 <sup>27&#160;</sup>Abraham answered, “See now, I have taken it on myself to speak to the Lord, although I am dust and ashes. 
 <sup>28&#160;</sup>What if there will lack five of the fifty righteous? Will you destroy all the city for lack of five?” 
 </p><p>He said, “I will not destroy it if I find forty-five there.” 
@@ -761,7 +761,7 @@ html[dir=ltr] .q2 {
 <sup>32&#160;</sup>He said, “Oh don’t let the Lord be angry, and I will speak just once more. What if ten are found there?” 
 </p><p>He said, “I will not destroy it for the ten’s sake.” 
 </p><p>
-<sup>33&#160;</sup>Yahweh went his way as soon as he had finished communing with Abraham, and Abraham returned to his place. 
+<sup>33&#160;</sup>Yahuah went his way as soon as he had finished communing with Abraham, and Abraham returned to his place. 
 </p><h2 class="chapterlabel" id="19">19</h2>
 <p>
 <sup>1&#160;</sup>The two angels came to Sodom at evening. Lot sat in the gate of Sodom. Lot saw them, and rose up to meet them. He bowed himself with his face to the earth, 
@@ -781,12 +781,12 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>They struck the men who were at the door of the house with blindness, both small and great, so that they wearied themselves to find the door. 
 </p><p>
 <sup>12&#160;</sup>The men said to Lot, “Do you have anybody else here? Sons-in-law, your sons, your daughters, and whomever you have in the city, bring them out of the place: 
-<sup>13&#160;</sup>for we will destroy this place, because the outcry against them has grown so great before Yahweh that Yahweh has sent us to destroy it.” 
+<sup>13&#160;</sup>for we will destroy this place, because the outcry against them has grown so great before Yahuah that Yahuah has sent us to destroy it.” 
 </p><p>
-<sup>14&#160;</sup>Lot went out, and spoke to his sons-in-law, who took his daughters, and said, “Get up! Get out of this place, for Yahweh will destroy the city!” 
+<sup>14&#160;</sup>Lot went out, and spoke to his sons-in-law, who took his daughters, and said, “Get up! Get out of this place, for Yahuah will destroy the city!” 
 </p><p>But he seemed to his sons-in-law to be joking. 
 <sup>15&#160;</sup>When the morning came, then the angels hurried Lot, saying, “Get up! Take your woman and your two daughters who are here, lest you be consumed in the iniquity of the city.” 
-<sup>16&#160;</sup>But he lingered; and the men grabbed his hand, his woman’s hand, and his two daughters’ hands, Yahweh being merciful to him; and they took him out, and set him outside of the city. 
+<sup>16&#160;</sup>But he lingered; and the men grabbed his hand, his woman’s hand, and his two daughters’ hands, Yahuah being merciful to him; and they took him out, and set him outside of the city. 
 <sup>17&#160;</sup>It came to pass, when they had taken them out, that he said, “Escape for your life! Don’t look behind you, and don’t stay anywhere in the plain. Escape to the mountains, lest you be consumed!” 
 </p><p>
 <sup>18&#160;</sup>Lot said to them, “Oh, not so, my lord. 
@@ -797,11 +797,11 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>Hurry, escape there, for I can’t do anything until you get there.” Therefore the name of the city was called Zoar. 
 </p><p>
 <sup>23&#160;</sup>The sun had risen on the earth when Lot came to Zoar. 
-<sup>24&#160;</sup>Then Yahweh rained on Sodom and on Gomorrah sulfur and fire from Yahweh out of the sky. 
+<sup>24&#160;</sup>Then Yahuah rained on Sodom and on Gomorrah sulfur and fire from Yahuah out of the sky. 
 <sup>25&#160;</sup>He overthrew those cities, all the plain, all the inhabitants of the cities, and that which grew on the ground. 
 <sup>26&#160;</sup>But Lot’s woman looked back from behind him, and she became a pillar of salt. 
 </p><p>
-<sup>27&#160;</sup>Abraham went up early in the morning to the place where he had stood before Yahweh. 
+<sup>27&#160;</sup>Abraham went up early in the morning to the place where he had stood before Yahuah. 
 <sup>28&#160;</sup>He looked toward Sodom and Gomorrah, and toward all the land of the plain, and saw that the smoke of the land went up as the smoke of a furnace. 
 </p><p>
 <sup>29&#160;</sup>When Elohim destroyed the cities of the plain, Elohim remembered Abraham, and sent Lot out of the middle of the overthrow, when he overthrew the cities in which Lot lived. 
@@ -840,10 +840,10 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>To Sarah he said, “Behold, I have given your brother a thousand pieces of silver. Behold, it is for you a covering of the eyes to all that are with you. In front of all you are vindicated.” 
 </p><p>
 <sup>17&#160;</sup>Abraham prayed to Elohim. So Elohim healed Abimelech, his woman, and his female servants, and they bore children. 
-<sup>18&#160;</sup>For Yahweh had closed up tight all the wombs of the house of Abimelech, because of Sarah, Abraham’s woman. 
+<sup>18&#160;</sup>For Yahuah had closed up tight all the wombs of the house of Abimelech, because of Sarah, Abraham’s woman. 
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
-<sup>1&#160;</sup>Yahweh visited Sarah as he had said, and Yahweh did to Sarah as he had spoken. 
+<sup>1&#160;</sup>Yahuah visited Sarah as he had said, and Yahuah did to Sarah as he had spoken. 
 <sup>2&#160;</sup>Sarah conceived, and bore Abraham a son in his old age, at the set time of which Elohim had spoken to him. 
 <sup>3&#160;</sup>Abraham called his son who was born to him, whom Sarah bore to him, Isaac. 
 <sup>4&#160;</sup>Abraham circumcised his son, Isaac, when he was eight days old, as Elohim had commanded him. 
@@ -884,7 +884,7 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>He said, “You shall take these seven ewe lambs from my hand, that it may be a witness to me, that I have dug this well.” 
 <sup>31&#160;</sup>Therefore he called that place Beersheba, because they both swore an oath there. 
 <sup>32&#160;</sup>So they made a covenant at Beersheba. Abimelech rose up with Phicol, the captain of his army, and they returned into the land of the Philistines. 
-<sup>33&#160;</sup>Abraham planted a tamarisk tree in Beersheba, and there he called on the name of Yahweh, the Everlasting Elohim. 
+<sup>33&#160;</sup>Abraham planted a tamarisk tree in Beersheba, and there he called on the name of Yahuah, the Everlasting Elohim. 
 <sup>34&#160;</sup>Abraham lived as a foreigner in the land of the Philistines many days. 
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
@@ -905,16 +905,16 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>They came to the place which Elohim had told him of. Abraham built the altar there, and laid the wood in order, bound Isaac his son, and laid him on the altar, on the wood. 
 <sup>10&#160;</sup>Abraham stretched out his hand, and took the knife to kill his son. 
 </p><p>
-<sup>11&#160;</sup>Yahweh’s angel called to him out of the sky, and said, “Abraham, Abraham!” 
+<sup>11&#160;</sup>Yahuah’s angel called to him out of the sky, and said, “Abraham, Abraham!” 
 </p><p>He said, “Here I am.” 
 </p><p>
 <sup>12&#160;</sup>He said, “Don’t lay your hand on the boy or do anything to him. For now I know that you fear Elohim, since you have not withheld your son, your only son, from me.” 
 </p><p>
 <sup>13&#160;</sup>Abraham lifted up his eyes, and looked, and saw that behind him was a ram caught in the thicket by his horns. Abraham went and took the ram, and offered him up for a burnt offering instead of his son. 
-<sup>14&#160;</sup>Abraham called the name of that place “Yahweh Will Provide”. As it is said to this day, “On Yahweh’s mountain, it will be provided.” 
+<sup>14&#160;</sup>Abraham called the name of that place “Yahuah Will Provide”. As it is said to this day, “On Yahuah’s mountain, it will be provided.” 
 </p><p>
-<sup>15&#160;</sup>Yahweh’s angel called to Abraham a second time out of the sky, 
-<sup>16&#160;</sup>and said, “&#160;‘I have sworn by myself,’ says Yahweh, ‘because you have done this thing, and have not withheld your son, your only son, 
+<sup>15&#160;</sup>Yahuah’s angel called to Abraham a second time out of the sky, 
+<sup>16&#160;</sup>and said, “&#160;‘I have sworn by myself,’ says Yahuah, ‘because you have done this thing, and have not withheld your son, your only son, 
 <sup>17&#160;</sup>that I will bless you greatly, and I will multiply your offspring greatly like the stars of the heavens, and like the sand which is on the seashore. Your offspring will possess the gate of his enemies. 
 <sup>18&#160;</sup>All the nations of the earth will be blessed by your offspring, because you have obeyed my voice.’&#160;” 
 </p><p>
@@ -956,21 +956,21 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>The field, and the cave that is in it, were deeded to Abraham by the children of Heth as a possession for a burial place. 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
-<sup>1&#160;</sup>Abraham was old, and well advanced in age. Yahweh had blessed Abraham in all things. 
+<sup>1&#160;</sup>Abraham was old, and well advanced in age. Yahuah had blessed Abraham in all things. 
 <sup>2&#160;</sup>Abraham said to his servant, the elder of his house, who ruled over all that he had, “Please put your hand under my thigh. 
-<sup>3&#160;</sup>I will make you swear by Yahweh, the Elohim of heaven and the Elohim of the earth, that you shall not take a woman for my son of the daughters of the Canaanites, among whom I live. 
+<sup>3&#160;</sup>I will make you swear by Yahuah, the Elohim of heaven and the Elohim of the earth, that you shall not take a woman for my son of the daughters of the Canaanites, among whom I live. 
 <sup>4&#160;</sup>But you shall go to my country, and to my relatives, and take a woman for my son Isaac.” 
 </p><p>
 <sup>5&#160;</sup>The servant said to him, “What if the woman isn’t willing to follow me to this land? Must I bring your son again to the land you came from?” 
 </p><p>
 <sup>6&#160;</sup>Abraham said to him, “Beware that you don’t bring my son there again. 
-<sup>7&#160;</sup>Yahweh, the Elohim of heaven—who took me from my father’s house, and from the land of my birth, who spoke to me, and who swore to me, saying, ‘I will give this land to your offspring—he will send his angel before you, and you shall take a woman for my son from there. 
+<sup>7&#160;</sup>Yahuah, the Elohim of heaven—who took me from my father’s house, and from the land of my birth, who spoke to me, and who swore to me, saying, ‘I will give this land to your offspring—he will send his angel before you, and you shall take a woman for my son from there. 
 <sup>8&#160;</sup>If the woman isn’t willing to follow you, then you shall be clear from this oath to me. Only you shall not bring my son there again.” 
 </p><p>
 <sup>9&#160;</sup>The servant put his hand under the thigh of Abraham his master, and swore to him concerning this matter. 
 <sup>10&#160;</sup>The servant took ten of his master’s camels, and departed, having a variety of good things of his master’s with him. He arose, and went to Mesopotamia, to the city of Nahor. 
 <sup>11&#160;</sup>He made the camels kneel down outside the city by the well of water at the time of evening, the time that women go out to draw water. 
-<sup>12&#160;</sup>He said, “Yahweh, the Elohim of my master Abraham, please give me success today, and show kindness to my master Abraham. 
+<sup>12&#160;</sup>He said, “Yahuah, the Elohim of my master Abraham, please give me success today, and show kindness to my master Abraham. 
 <sup>13&#160;</sup>Behold, I am standing by the spring of water. The daughters of the men of the city are coming out to draw water. 
 <sup>14&#160;</sup>Let it happen, that the young lady to whom I will say, ‘Please let down your pitcher, that I may drink,’ then she says, ‘Drink, and I will also give your camels a drink,’—let her be the one you have appointed for your servant Isaac. By this I will know that you have shown kindness to my master.” 
 </p><p>
@@ -982,51 +982,51 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>When she had finished giving him a drink, she said, “I will also draw for your camels, until they have finished drinking.” 
 <sup>20&#160;</sup>She hurried, and emptied her pitcher into the trough, and ran again to the well to draw, and drew for all his camels. 
 </p><p>
-<sup>21&#160;</sup>The man looked steadfastly at her, remaining silent, to know whether Yahweh had made his journey prosperous or not. 
+<sup>21&#160;</sup>The man looked steadfastly at her, remaining silent, to know whether Yahuah had made his journey prosperous or not. 
 <sup>22&#160;</sup>As the camels had done drinking, the man took a golden ring of half a shekel weight, and two bracelets for her hands of ten shekels weight of gold, 
 <sup>23&#160;</sup>and said, “Whose daughter are you? Please tell me. Is there room in your father’s house for us to stay?” 
 </p><p>
 <sup>24&#160;</sup>She said to him, “I am the daughter of Bethuel the son of Milcah, whom she bore to Nahor.” 
 <sup>25&#160;</sup>She said moreover to him, “We have both straw and feed enough, and room to lodge in.” 
 </p><p>
-<sup>26&#160;</sup>The man bowed his head, and worshiped Yahweh. 
-<sup>27&#160;</sup>He said, “Blessed be Yahweh, the Elohim of my master Abraham, who has not forsaken his loving kindness and his truth toward my master. As for me, Yahweh has led me on the way to the house of my master’s relatives.” 
+<sup>26&#160;</sup>The man bowed his head, and worshiped Yahuah. 
+<sup>27&#160;</sup>He said, “Blessed be Yahuah, the Elohim of my master Abraham, who has not forsaken his loving kindness and his truth toward my master. As for me, Yahuah has led me on the way to the house of my master’s relatives.” 
 </p><p>
 <sup>28&#160;</sup>The young lady ran, and told her mother’s house about these words. 
 <sup>29&#160;</sup>Rebekah had a brother, and his name was Laban. Laban ran out to the man, to the spring. 
 <sup>30&#160;</sup>When he saw the ring, and the bracelets on his sister’s hands, and when he heard the words of Rebekah his sister, saying, “This is what the man said to me,” he came to the man. Behold, he was standing by the camels at the spring. 
-<sup>31&#160;</sup>He said, “Come in, you blessed of Yahweh. Why do you stand outside? For I have prepared the house, and room for the camels.” 
+<sup>31&#160;</sup>He said, “Come in, you blessed of Yahuah. Why do you stand outside? For I have prepared the house, and room for the camels.” 
 </p><p>
 <sup>32&#160;</sup>The man came into the house, and he unloaded the camels. He gave straw and feed for the camels, and water to wash his feet and the feet of the men who were with him. 
 <sup>33&#160;</sup>Food was set before him to eat, but he said, “I will not eat until I have told my message.” 
 </p><p>Laban said, “Speak on.” 
 </p><p>
 <sup>34&#160;</sup>He said, “I am Abraham’s servant. 
-<sup>35&#160;</sup>Yahweh has blessed my master greatly. He has become great. Yahweh has given him flocks and herds, silver and gold, male servants and female servants, and camels and donkeys. 
+<sup>35&#160;</sup>Yahuah has blessed my master greatly. He has become great. Yahuah has given him flocks and herds, silver and gold, male servants and female servants, and camels and donkeys. 
 <sup>36&#160;</sup>Sarah, my master’s woman, bore a son to my master when she was old. He has given all that he has to him. 
 <sup>37&#160;</sup>My master made me swear, saying, ‘You shall not take a woman for my son from the daughters of the Canaanites, in whose land I live, 
 <sup>38&#160;</sup>but you shall go to my father’s house, and to my relatives, and take a woman for my son.’ 
 <sup>39&#160;</sup>I asked my master, ‘What if the woman will not follow me?’ 
-<sup>40&#160;</sup>He said to me, ‘Yahweh, before whom I walk, will send his angel with you, and prosper your way. You shall take a woman for my son from my relatives, and of my father’s house. 
+<sup>40&#160;</sup>He said to me, ‘Yahuah, before whom I walk, will send his angel with you, and prosper your way. You shall take a woman for my son from my relatives, and of my father’s house. 
 <sup>41&#160;</sup>Then you will be clear from my oath, when you come to my relatives. If they don’t give her to you, you shall be clear from my oath.’ 
-<sup>42&#160;</sup>I came today to the spring, and said, ‘Yahweh, the Elohim of my master Abraham, if now you do prosper my way which I go—<sup>43&#160;</sup>behold, I am standing by this spring of water. Let it happen, that the maiden who comes out to draw, to whom I will say, “Please give me a little water from your pitcher to drink,” 
-<sup>44&#160;</sup>then she tells me, “Drink, and I will also draw for your camels,”—let her be the woman whom Yahweh has appointed for my master’s son.’ 
+<sup>42&#160;</sup>I came today to the spring, and said, ‘Yahuah, the Elohim of my master Abraham, if now you do prosper my way which I go—<sup>43&#160;</sup>behold, I am standing by this spring of water. Let it happen, that the maiden who comes out to draw, to whom I will say, “Please give me a little water from your pitcher to drink,” 
+<sup>44&#160;</sup>then she tells me, “Drink, and I will also draw for your camels,”—let her be the woman whom Yahuah has appointed for my master’s son.’ 
 <sup>45&#160;</sup>Before I had finished speaking in my heart, behold, Rebekah came out with her pitcher on her shoulder. She went down to the spring, and drew. I said to her, ‘Please let me drink.’ 
 <sup>46&#160;</sup>She hurried and let down her pitcher from her shoulder, and said, ‘Drink, and I will also give your camels a drink.’ So I drank, and she also gave the camels a drink. 
 <sup>47&#160;</sup>I asked her, and said, ‘Whose daughter are you?’ She said, ‘The daughter of Bethuel, Nahor’s son, whom Milcah bore to him.’ I put the ring on her nose, and the bracelets on her hands. 
-<sup>48&#160;</sup>I bowed my head, and worshiped Yahweh, and blessed Yahweh, the Elohim of my master Abraham, who had led me in the right way to take my master’s brother’s daughter for his son. 
+<sup>48&#160;</sup>I bowed my head, and worshiped Yahuah, and blessed Yahuah, the Elohim of my master Abraham, who had led me in the right way to take my master’s brother’s daughter for his son. 
 <sup>49&#160;</sup>Now if you will deal kindly and truly with my master, tell me. If not, tell me, that I may turn to the right hand, or to the left.” 
 </p><p>
-<sup>50&#160;</sup>Then Laban and Bethuel answered, “The thing proceeds from Yahweh. We can’t speak to you bad or good. 
-<sup>51&#160;</sup>Behold, Rebekah is before you. Take her, and go, and let her be your master’s son’s woman, as Yahweh has spoken.” 
+<sup>50&#160;</sup>Then Laban and Bethuel answered, “The thing proceeds from Yahuah. We can’t speak to you bad or good. 
+<sup>51&#160;</sup>Behold, Rebekah is before you. Take her, and go, and let her be your master’s son’s woman, as Yahuah has spoken.” 
 </p><p>
-<sup>52&#160;</sup>When Abraham’s servant heard their words, he bowed himself down to the earth to Yahweh. 
+<sup>52&#160;</sup>When Abraham’s servant heard their words, he bowed himself down to the earth to Yahuah. 
 <sup>53&#160;</sup>The servant brought out jewels of silver, and jewels of gold, and clothing, and gave them to Rebekah. He also gave precious things to her brother and her mother. 
 <sup>54&#160;</sup>They ate and drank, he and the men who were with him, and stayed all night. They rose up in the morning, and he said, “Send me away to my master.” 
 </p><p>
 <sup>55&#160;</sup>Her brother and her mother said, “Let the young lady stay with us a few days, at least ten. After that she will go.” 
 </p><p>
-<sup>56&#160;</sup>He said to them, “Don’t hinder me, since Yahweh has prospered my way. Send me away that I may go to my master.” 
+<sup>56&#160;</sup>He said to them, “Don’t hinder me, since Yahuah has prospered my way. Send me away that I may go to my master.” 
 </p><p>
 <sup>57&#160;</sup>They said, “We will call the young lady, and ask her.” 
 <sup>58&#160;</sup>They called Rebekah, and said to her, “Will you go with this man?” 
@@ -1068,9 +1068,9 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>19&#160;</sup>This is the history of the generations of Isaac, Abraham’s son. Abraham brought forth Isaac. 
 <sup>20&#160;</sup>Isaac was forty years old when he took Rebekah, the daughter of Bethuel the Syrian of Paddan Aram, the sister of Laban the Syrian, to be his woman. 
-<sup>21&#160;</sup>Isaac entreated Yahweh for his woman, because she was barren. Yahweh was entreated by him, and Rebekah his woman conceived. 
-<sup>22&#160;</sup>The children struggled together within her. She said, “If it is like this, why do I live?” She went to inquire of Yahweh. 
-<sup>23&#160;</sup>Yahweh said to her, 
+<sup>21&#160;</sup>Isaac entreated Yahuah for his woman, because she was barren. Yahuah was entreated by him, and Rebekah his woman conceived. 
+<sup>22&#160;</sup>The children struggled together within her. She said, “If it is like this, why do I live?” She went to inquire of Yahuah. 
+<sup>23&#160;</sup>Yahuah said to her, 
 </p><p class="q1">“Two nations are in your womb. 
 </p><p class="q1">Two peoples will be separated from your body. 
 </p><p class="q1">The one people will be stronger than the other people. 
@@ -1095,7 +1095,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="26">26</h2>
 <p>
 <sup>1&#160;</sup>There was a famine in the land, in addition to the first famine that was in the days of Abraham. Isaac went to Abimelech king of the Philistines, to Gerar. 
-<sup>2&#160;</sup>Yahweh appeared to him, and said, “Don’t go down into Egypt. Live in the land I will tell you about. 
+<sup>2&#160;</sup>Yahuah appeared to him, and said, “Don’t go down into Egypt. Live in the land I will tell you about. 
 <sup>3&#160;</sup>Live in this land, and I will be with you, and will bless you. For I will give to you, and to your offspring, all these lands, and I will establish the oath which I swore to Abraham your father. 
 <sup>4&#160;</sup>I will multiply your offspring as the stars of the sky, and will give all these lands to your offspring. In your offspring all the nations of the earth will be blessed, 
 <sup>5&#160;</sup>because Abraham obeyed my voice, and kept my requirements, my commandments, my statutes, and my laws.” 
@@ -1110,7 +1110,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>11&#160;</sup>Abimelech commanded all the people, saying, “He who touches this man or his woman will surely be put to death.” 
 </p><p>
-<sup>12&#160;</sup>Isaac sowed in that land, and reaped in the same year one hundred times what he planted. Yahweh blessed him. 
+<sup>12&#160;</sup>Isaac sowed in that land, and reaped in the same year one hundred times what he planted. Yahuah blessed him. 
 <sup>13&#160;</sup>The man grew great, and grew more and more until he became very great. 
 <sup>14&#160;</sup>He had possessions of flocks, possessions of herds, and a great household. The Philistines envied him. 
 <sup>15&#160;</sup>Now all the wells which his father’s servants had dug in the days of Abraham his father, the Philistines had stopped, and filled with earth. 
@@ -1122,18 +1122,18 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>Isaac’s servants dug in the valley, and found there a well of flowing water. 
 <sup>20&#160;</sup>The herdsmen of Gerar argued with Isaac’s herdsmen, saying, “The water is ours.” So he called the name of the well Esek, because they contended with him. 
 <sup>21&#160;</sup>They dug another well, and they argued over that, also. So he called its name Sitnah. 
-<sup>22&#160;</sup>He left that place, and dug another well. They didn’t argue over that one. So he called it Rehoboth. He said, “For now Yahweh has made room for us, and we will be fruitful in the land.” 
+<sup>22&#160;</sup>He left that place, and dug another well. They didn’t argue over that one. So he called it Rehoboth. He said, “For now Yahuah has made room for us, and we will be fruitful in the land.” 
 </p><p>
 <sup>23&#160;</sup>He went up from there to Beersheba. 
-<sup>24&#160;</sup>Yahweh appeared to him the same night, and said, “I am the Elohim of Abraham your father. Don’t be afraid, for I am with you, and will bless you, and multiply your offspring for my servant Abraham’s sake.” 
+<sup>24&#160;</sup>Yahuah appeared to him the same night, and said, “I am the Elohim of Abraham your father. Don’t be afraid, for I am with you, and will bless you, and multiply your offspring for my servant Abraham’s sake.” 
 </p><p>
-<sup>25&#160;</sup>He built an altar there, and called on Yahweh’s name, and pitched his tent there. There Isaac’s servants dug a well. 
+<sup>25&#160;</sup>He built an altar there, and called on Yahuah’s name, and pitched his tent there. There Isaac’s servants dug a well. 
 </p><p>
 <sup>26&#160;</sup>Then Abimelech went to him from Gerar with Ahuzzath his friend, and Phicol the captain of his army. 
 <sup>27&#160;</sup>Isaac said to them, “Why have you come to me, since you hate me, and have sent me away from you?” 
 </p><p>
-<sup>28&#160;</sup>They said, “We saw plainly that Yahweh was with you. We said, ‘Let there now be an oath between us, even between us and you, and let’s make a covenant with you, 
-<sup>29&#160;</sup>that you will do us no harm, as we have not touched you, and as we have done to you nothing but good, and have sent you away in peace.’ You are now the blessed of Yahweh.” 
+<sup>28&#160;</sup>They said, “We saw plainly that Yahuah was with you. We said, ‘Let there now be an oath between us, even between us and you, and let’s make a covenant with you, 
+<sup>29&#160;</sup>that you will do us no harm, as we have not touched you, and as we have done to you nothing but good, and have sent you away in peace.’ You are now the blessed of Yahuah.” 
 </p><p>
 <sup>30&#160;</sup>He made them a feast, and they ate and drank. 
 <sup>31&#160;</sup>They rose up some time in the morning, and swore an oath to one another. Isaac sent them away, and they departed from him in peace. 
@@ -1153,7 +1153,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>5&#160;</sup>Rebekah heard when Isaac spoke to Esau his son. Esau went to the field to hunt for venison, and to bring it. 
 <sup>6&#160;</sup>Rebekah spoke to Jacob her son, saying, “Behold, I heard your father speak to Esau your brother, saying, 
-<sup>7&#160;</sup>‘Bring me venison, and make me savory food, that I may eat, and bless you before Yahweh before my death.’ 
+<sup>7&#160;</sup>‘Bring me venison, and make me savory food, that I may eat, and bless you before Yahuah before my death.’ 
 <sup>8&#160;</sup>Now therefore, my son, obey my voice according to that which I command you. 
 <sup>9&#160;</sup>Go now to the flock and get me two good young goats from there. I will make them savory food for your father, such as he loves. 
 <sup>10&#160;</sup>You shall bring it to your father, that he may eat, so that he may bless you before his death.” 
@@ -1174,7 +1174,7 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>Jacob said to his father, “I am Esau your firstborn. I have done what you asked me to do. Please arise, sit and eat of my venison, that your soul may bless me.” 
 </p><p>
 <sup>20&#160;</sup>Isaac said to his son, “How is it that you have found it so quickly, my son?” 
-</p><p>He said, “Because Yahweh your Elohim gave me success.” 
+</p><p>He said, “Because Yahuah your Elohim gave me success.” 
 </p><p>
 <sup>21&#160;</sup>Isaac said to Jacob, “Please come near, that I may feel you, my son, whether you are really my son Esau or not.” 
 </p><p>
@@ -1188,7 +1188,7 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>His father Isaac said to him, “Come near now, and kiss me, my son.” 
 <sup>27&#160;</sup>He came near, and kissed him. He smelled the smell of his clothing, and blessed him, and said, 
 </p><p class="q1">“Behold, the smell of my son 
-</p><p class="q2">is as the smell of a field which Yahweh has blessed. 
+</p><p class="q2">is as the smell of a field which Yahuah has blessed. 
 </p><p class="q1">
 <sup>28&#160;</sup>Elohim give you of the dew of the sky, 
 </p><p class="q2">of the fatness of the earth, 
@@ -1251,17 +1251,17 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>Jacob went out from Beersheba, and went toward Haran. 
 <sup>11&#160;</sup>He came to a certain place, and stayed there all night, because the sun had set. He took one of the stones of the place, and put it under his head, and lay down in that place to sleep. 
 <sup>12&#160;</sup>He dreamed and saw a stairway set upon the earth, and its top reached to heaven. Behold, the angels of Elohim were ascending and descending on it. 
-<sup>13&#160;</sup>Behold, Yahweh stood above it, and said, “I am Yahweh, the Elohim of Abraham your father, and the Elohim of Isaac. I will give the land you lie on to you and to your offspring. 
+<sup>13&#160;</sup>Behold, Yahuah stood above it, and said, “I am Yahuah, the Elohim of Abraham your father, and the Elohim of Isaac. I will give the land you lie on to you and to your offspring. 
 <sup>14&#160;</sup>Your offspring will be as the dust of the earth, and you will spread abroad to the west, and to the east, and to the north, and to the south. In you and in your offspring, all the families of the earth will be blessed. 
 <sup>15&#160;</sup>Behold, I am with you, and will keep you, wherever you go, and will bring you again into this land. For I will not leave you until I have done that which I have spoken of to you.” 
 </p><p>
-<sup>16&#160;</sup>Jacob awakened out of his sleep, and he said, “Surely Yahweh is in this place, and I didn’t know it.” 
+<sup>16&#160;</sup>Jacob awakened out of his sleep, and he said, “Surely Yahuah is in this place, and I didn’t know it.” 
 <sup>17&#160;</sup>He was afraid, and said, “How awesome this place is! This is none other than Elohim’s house, and this is the gate of heaven.” 
 </p><p>
 <sup>18&#160;</sup>Jacob rose up early in the morning, and took the stone that he had put under his head, and set it up for a pillar, and poured oil on its top. 
 <sup>19&#160;</sup>He called the name of that place Bethel, but the name of the city was Luz at the first. 
 <sup>20&#160;</sup>Jacob vowed a vow, saying, “If Elohim will be with me, and will keep me in this way that I go, and will give me bread to eat, and clothing to put on, 
-<sup>21&#160;</sup>so that I come again to my father’s house in peace, and Yahweh will be my Elohim, 
+<sup>21&#160;</sup>so that I come again to my father’s house in peace, and Yahuah will be my Elohim, 
 <sup>22&#160;</sup>then this stone, which I have set up for a pillar, will be Elohim’s house. Of all that you will give me I will surely give a tenth to you.” 
 </p><h2 class="chapterlabel" id="29">29</h2>
 <p>
@@ -1312,11 +1312,11 @@ html[dir=ltr] .q2 {
 <sup>29&#160;</sup>Laban gave Bilhah, his servant, to his daughter Rachel to be her servant. 
 <sup>30&#160;</sup>He went in also to Rachel, and he loved also Rachel more than Leah, and served with him seven more years. 
 </p><p>
-<sup>31&#160;</sup>Yahweh saw that Leah was hated, and he opened her womb, but Rachel was barren. 
-<sup>32&#160;</sup>Leah conceived, and bore a son, and she named him Reuben. For she said, “Because Yahweh has looked at my affliction; for now my man will love me.” 
-<sup>33&#160;</sup>She conceived again, and bore a son, and said, “Because Yahweh has heard that I am hated, he has therefore given me this son also.” She named him Simeon. 
+<sup>31&#160;</sup>Yahuah saw that Leah was hated, and he opened her womb, but Rachel was barren. 
+<sup>32&#160;</sup>Leah conceived, and bore a son, and she named him Reuben. For she said, “Because Yahuah has looked at my affliction; for now my man will love me.” 
+<sup>33&#160;</sup>She conceived again, and bore a son, and said, “Because Yahuah has heard that I am hated, he has therefore given me this son also.” She named him Simeon. 
 <sup>34&#160;</sup>She conceived again, and bore a son. She said, “Now this time my man will be joined to me, because I have borne him three sons.” Therefore his name was called Levi. 
-<sup>35&#160;</sup>She conceived again, and bore a son. She said, “This time I will praise Yahweh.” Therefore she named him Judah. Then she stopped bearing. 
+<sup>35&#160;</sup>She conceived again, and bore a son. She said, “This time I will praise Yahuah.” Therefore she named him Judah. Then she stopped bearing. 
 </p><h2 class="chapterlabel" id="30">30</h2>
 <p>
 <sup>1&#160;</sup>When Rachel saw that she bore Jacob no children, Rachel envied her sister. She said to Jacob, “Give me children, or else I will die.” 
@@ -1351,16 +1351,16 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>22&#160;</sup>Elohim remembered Rachel, and Elohim listened to her, and opened her womb. 
 <sup>23&#160;</sup>She conceived, bore a son, and said, “Elohim has taken away my reproach.” 
-<sup>24&#160;</sup>She named him Joseph, saying, “May Yahweh add another son to me.” 
+<sup>24&#160;</sup>She named him Joseph, saying, “May Yahuah add another son to me.” 
 </p><p>
 <sup>25&#160;</sup>When Rachel had borne Joseph, Jacob said to Laban, “Send me away, that I may go to my own place, and to my country. 
 <sup>26&#160;</sup>Give me my women and my children for whom I have served you, and let me go; for you know my service with which I have served you.” 
 </p><p>
-<sup>27&#160;</sup>Laban said to him, “If now I have found favor in your eyes, stay here, for I have divined that Yahweh has blessed me for your sake.” 
+<sup>27&#160;</sup>Laban said to him, “If now I have found favor in your eyes, stay here, for I have divined that Yahuah has blessed me for your sake.” 
 <sup>28&#160;</sup>He said, “Appoint me your wages, and I will give it.” 
 </p><p>
 <sup>29&#160;</sup>Jacob said to him, “You know how I have served you, and how your livestock have fared with me. 
-<sup>30&#160;</sup>For it was little which you had before I came, and it has increased to a multitude. Yahweh has blessed you wherever I turned. Now when will I provide for my own house also?” 
+<sup>30&#160;</sup>For it was little which you had before I came, and it has increased to a multitude. Yahuah has blessed you wherever I turned. Now when will I provide for my own house also?” 
 </p><p>
 <sup>31&#160;</sup>Laban said, “What shall I give you?” 
 </p><p>Jacob said, “You shall not give me anything. If you will do this thing for me, I will again feed your flock and keep it. 
@@ -1383,7 +1383,7 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Jacob heard Laban’s sons’ words, saying, “Jacob has taken away all that was our father’s. He has obtained all this wealth from that which was our father’s.” 
 <sup>2&#160;</sup>Jacob saw the expression on Laban’s face, and, behold, it was not toward him as before. 
-<sup>3&#160;</sup>Yahweh said to Jacob, “Return to the land of your fathers, and to your relatives, and I will be with you.” 
+<sup>3&#160;</sup>Yahuah said to Jacob, “Return to the land of your fathers, and to your relatives, and I will be with you.” 
 </p><p>
 <sup>4&#160;</sup>Jacob sent and called Rachel and Leah to the field to his flock, 
 <sup>5&#160;</sup>and said to them, “I see the expression on your father’s face, that it is not toward me as before; but the Elohim of my father has been with me. 
@@ -1441,7 +1441,7 @@ html[dir=ltr] .q2 {
 <sup>46&#160;</sup>Jacob said to his relatives, “Gather stones.” They took stones, and made a heap. They ate there by the heap. 
 <sup>47&#160;</sup>Laban called it Jegar Sahadutha, but Jacob called it Galeed. 
 <sup>48&#160;</sup>Laban said, “This heap is witness between me and you today.” Therefore it was named Galeed 
-<sup>49&#160;</sup>and Mizpah, for he said, “Yahweh watch between me and you, when we are absent one from another. 
+<sup>49&#160;</sup>and Mizpah, for he said, “Yahuah watch between me and you, when we are absent one from another. 
 <sup>50&#160;</sup>If you afflict my daughters, or if you take women in addition to my daughters, no man is with us; behold, Elohim is witness between me and you.” 
 <sup>51&#160;</sup>Laban said to Jacob, “See this heap, and see the pillar, which I have set between me and you. 
 <sup>52&#160;</sup>May this heap be a witness, and the pillar be a witness, that I will not pass over this heap to you, and that you will not pass over this heap and this pillar to me, for harm. 
@@ -1459,7 +1459,7 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>The messengers returned to Jacob, saying, “We came to your brother Esau. He is coming to meet you, and four hundred men are with him.” 
 <sup>7&#160;</sup>Then Jacob was greatly afraid and was distressed. He divided the people who were with him, along with the flocks, the herds, and the camels, into two companies. 
 <sup>8&#160;</sup>He said, “If Esau comes to the one company, and strikes it, then the company which is left will escape.” 
-<sup>9&#160;</sup>Jacob said, “Elohim of my father Abraham, and Elohim of my father Isaac, Yahweh, who said to me, ‘Return to your country, and to your relatives, and I will do you good,’ 
+<sup>9&#160;</sup>Jacob said, “Elohim of my father Abraham, and Elohim of my father Isaac, Yahuah, who said to me, ‘Return to your country, and to your relatives, and I will do you good,’ 
 <sup>10&#160;</sup>I am not worthy of the least of all the loving kindnesses, and of all the truth, which you have shown to your servant; for with just my staff I crossed over this Jordan; and now I have become two companies. 
 <sup>11&#160;</sup>Please deliver me from the hand of my brother, from the hand of Esau; for I fear him, lest he come and strike me and the mothers with the children. 
 <sup>12&#160;</sup>You said, ‘I will surely do you good, and make your offspring as the sand of the sea, which can’t be counted because there are so many.’&#160;” 
@@ -1712,10 +1712,10 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>She conceived again, and bore a son; and she named him Onan. 
 <sup>5&#160;</sup>She yet again bore a son, and named him Shelah. He was at Chezib when she bore him. 
 <sup>6&#160;</sup>Judah took a woman for Er, his firstborn, and her name was Tamar. 
-<sup>7&#160;</sup>Er, Judah’s firstborn, was wicked in Yahweh’s sight. So Yahweh killed him. 
+<sup>7&#160;</sup>Er, Judah’s firstborn, was wicked in Yahuah’s sight. So Yahuah killed him. 
 <sup>8&#160;</sup>Judah said to Onan, “Go in to your brother’s woman, and perform the duty of a brother-in-law to her, and raise up offspring for your brother.” 
 <sup>9&#160;</sup>Onan knew that the offspring wouldn’t be his; and when he went in to his brother’s woman, he spilled his semen on the ground, lest he should give offspring to his brother. 
-<sup>10&#160;</sup>The thing which he did was evil in Yahweh’s sight, and he killed him also. 
+<sup>10&#160;</sup>The thing which he did was evil in Yahuah’s sight, and he killed him also. 
 <sup>11&#160;</sup>Then Judah said to Tamar, his daughter-in-law, “Remain a widow in your father’s house, until Shelah, my son, is grown up;” for he said, “Lest he also die, like his brothers.” Tamar went and lived in her father’s house. 
 </p><p>
 <sup>12&#160;</sup>After many days, Shua’s daughter, the woman of Judah, died. Judah was comforted, and went up to his sheep shearers to Timnah, he and his friend Hirah, the Adullamite. 
@@ -1752,10 +1752,10 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="39">39</h2>
 <p>
 <sup>1&#160;</sup>Joseph was brought down to Egypt. Potiphar, an officer of Pharaoh’s, the captain of the guard, an Egyptian, bought him from the hand of the Ishmaelites that had brought him down there. 
-<sup>2&#160;</sup>Yahweh was with Joseph, and he was a prosperous man. He was in the house of his master the Egyptian. 
-<sup>3&#160;</sup>His master saw that Yahweh was with him, and that Yahweh made all that he did prosper in his hand. 
+<sup>2&#160;</sup>Yahuah was with Joseph, and he was a prosperous man. He was in the house of his master the Egyptian. 
+<sup>3&#160;</sup>His master saw that Yahuah was with him, and that Yahuah made all that he did prosper in his hand. 
 <sup>4&#160;</sup>Joseph found favor in his sight. He ministered to him, and Potiphar made him overseer over his house, and all that he had he put into his hand. 
-<sup>5&#160;</sup>From the time that he made him overseer in his house, and over all that he had, Yahweh blessed the Egyptian’s house for Joseph’s sake. Yahweh’s blessing was on all that he had, in the house and in the field. 
+<sup>5&#160;</sup>From the time that he made him overseer in his house, and over all that he had, Yahuah blessed the Egyptian’s house for Joseph’s sake. Yahuah’s blessing was on all that he had, in the house and in the field. 
 <sup>6&#160;</sup>He left all that he had in Joseph’s hand. He didn’t concern himself with anything, except for the food which he ate. 
 </p><p>Joseph was well-built and handsome. 
 <sup>7&#160;</sup>After these things, his master’s woman set her eyes on Joseph; and she said, “Lie with me.” 
@@ -1776,9 +1776,9 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>19&#160;</sup>When his master heard the words of his woman, which she spoke to him, saying, “This is what your servant did to me,” his wrath was kindled. 
 <sup>20&#160;</sup>Joseph’s master took him, and put him into the prison, the place where the king’s prisoners were bound, and he was there in custody. 
-<sup>21&#160;</sup>But Yahweh was with Joseph, and showed kindness to him, and gave him favor in the sight of the keeper of the prison. 
+<sup>21&#160;</sup>But Yahuah was with Joseph, and showed kindness to him, and gave him favor in the sight of the keeper of the prison. 
 <sup>22&#160;</sup>The keeper of the prison committed to Joseph’s hand all the prisoners who were in the prison. Whatever they did there, he was responsible for it. 
-<sup>23&#160;</sup>The keeper of the prison didn’t look after anything that was under his hand, because Yahweh was with him; and that which he did, Yahweh made it prosper. 
+<sup>23&#160;</sup>The keeper of the prison didn’t look after anything that was under his hand, because Yahuah was with him; and that which he did, Yahuah made it prosper. 
 </p><h2 class="chapterlabel" id="40">40</h2>
 <p>
 <sup>1&#160;</sup>After these things, the butler of the king of Egypt and his baker offended their lord, the king of Egypt. 
@@ -2255,7 +2255,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">that bites the horse’s heels, 
 </p><p class="q2">so that his rider falls backward. 
 </p><p class="q1">
-<sup>18&#160;</sup>I have waited for your salvation, Yahweh. 
+<sup>18&#160;</sup>I have waited for your salvation, Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>19&#160;</sup>“A troop will press on Gad, 

--- a/book/habakkuk.html
+++ b/book/habakkuk.html
@@ -63,7 +63,7 @@ html[dir=ltr] .q2 {
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
 <sup>1&#160;</sup>The revelation which Habakkuk the prophet saw. 
-<sup>2&#160;</sup>Yahweh, how long will I cry, and you will not hear? I cry out to you “Violence!” and will you not save? 
+<sup>2&#160;</sup>Yahuah, how long will I cry, and you will not hear? I cry out to you “Violence!” and will you not save? 
 <sup>3&#160;</sup>Why do you show me iniquity, and look at perversity? For destruction and violence are before me. There is strife, and contention rises up. 
 <sup>4&#160;</sup>Therefore the law is paralyzed, and justice never prevails; for the wicked surround the righteous; therefore justice comes out perverted. 
 </p><p>
@@ -75,7 +75,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>Yes, they scoff at kings, and princes are a derision to them. They laugh at every stronghold, for they build up an earthen ramp and take it. 
 <sup>11&#160;</sup>Then they sweep by like the wind and go on. They are indeed guilty, whose strength is their elohim.” 
 </p><p>
-<sup>12&#160;</sup>Aren’t you from everlasting, Yahweh my Elohim, my Set-Apart One? We will not die. Yahweh, you have appointed them for judgment. You, Rock, have established him to punish. 
+<sup>12&#160;</sup>Aren’t you from everlasting, Yahuah my Elohim, my Set-Apart One? We will not die. Yahuah, you have appointed them for judgment. You, Rock, have established him to punish. 
 <sup>13&#160;</sup>You who have purer eyes than to see evil, and who cannot look on perversity, why do you tolerate those who deal treacherously and keep silent when the wicked swallows up the man who is more righteous than he, 
 <sup>14&#160;</sup>and make men like the fish of the sea, like the creeping things that have no ruler over them? 
 <sup>15&#160;</sup>He takes up all of them with the hook. He catches them in his net and gathers them in his dragnet. Therefore he rejoices and is glad. 
@@ -85,7 +85,7 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>I will stand at my watch and set myself on the ramparts, and will look out to see what he will say to me, and what I will answer concerning my complaint. 
 </p><p>
-<sup>2&#160;</sup>Yahweh answered me, “Write the vision, and make it plain on tablets, that he who runs may read it. 
+<sup>2&#160;</sup>Yahuah answered me, “Write the vision, and make it plain on tablets, that he who runs may read it. 
 <sup>3&#160;</sup>For the vision is yet for the appointed time, and it hurries toward the end, and won’t prove false. Though it takes time, wait for it, because it will surely come. It won’t delay. 
 <sup>4&#160;</sup>Behold, his soul is puffed up. It is not upright in him, but the righteous will live by his faith. 
 <sup>5&#160;</sup>Yes, moreover, wine is treacherous: an arrogant man who doesn’t stay at home, who enlarges his desire as Sheol; he is like death and can’t be satisfied, but gathers to himself all nations and heaps to himself all peoples. 
@@ -99,22 +99,22 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>For the stone will cry out of the wall, and the beam out of the woodwork will answer it. 
 </p><p>
 <sup>12&#160;</sup>Woe to him who builds a town with blood, and establishes a city by iniquity! 
-<sup>13&#160;</sup>Behold, isn’t it from Yahweh of Armies that the peoples labor for the fire, and the nations weary themselves for vanity? 
-<sup>14&#160;</sup>For the earth will be filled with the knowledge of Yahweh’s glory, as the waters cover the sea. 
+<sup>13&#160;</sup>Behold, isn’t it from Yahuah of Armies that the peoples labor for the fire, and the nations weary themselves for vanity? 
+<sup>14&#160;</sup>For the earth will be filled with the knowledge of Yahuah’s glory, as the waters cover the sea. 
 </p><p>
 <sup>15&#160;</sup>“Woe to him who gives his neighbor drink, pouring your inflaming wine until they are drunk, so that you may gaze at their naked bodies! 
-<sup>16&#160;</sup>You are filled with shame, and not glory. You will also drink and be exposed! The cup of Yahweh’s right hand will come around to you, and disgrace will cover your glory. 
+<sup>16&#160;</sup>You are filled with shame, and not glory. You will also drink and be exposed! The cup of Yahuah’s right hand will come around to you, and disgrace will cover your glory. 
 <sup>17&#160;</sup>For the violence done to Lebanon will overwhelm you, and the destruction of the animals will terrify you, because of men’s blood and for the violence done to the land, to every city and to those who dwell in them. 
 </p><p>
 <sup>18&#160;</sup>“What value does the engraved image have, that its maker has engraved it; the molten image, even the teacher of lies, that he who fashions its form trusts in it, to make mute idols? 
 <sup>19&#160;</sup>Woe to him who says to the wood, ‘Awake!’ or to the mute stone, ‘Arise!’ Shall this teach? Behold, it is overlaid with gold and silver, and there is no breath at all within it. 
-<sup>20&#160;</sup>But Yahweh is in his set-apart temple. Let all the earth be silent before him!” 
+<sup>20&#160;</sup>But Yahuah is in his set-apart temple. Let all the earth be silent before him!” 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
 <sup>1&#160;</sup>A prayer of Habakkuk, the prophet, set to victorious music. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh, I have heard of your fame. 
-</p><p class="q2">I stand in awe of your deeds, Yahweh. 
+<sup>2&#160;</sup>Yahuah, I have heard of your fame. 
+</p><p class="q2">I stand in awe of your deeds, Yahuah. 
 </p><p class="q1">Renew your work in the middle of the years. 
 </p><p class="q2">In the middle of the years make it known. 
 </p><p class="q2">In wrath, you remember mercy. 
@@ -140,7 +140,7 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>I saw the tents of Cushan in affliction. 
 </p><p class="q2">The dwellings of the land of Midian trembled. 
 </p><p class="q1">
-<sup>8&#160;</sup>Was Yahweh displeased with the rivers? 
+<sup>8&#160;</sup>Was Yahuah displeased with the rivers? 
 </p><p class="q2">Was your anger against the rivers, 
 </p><p class="q2">or your wrath against the sea, 
 </p><p class="q2">that you rode on your horses, 
@@ -187,10 +187,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the flocks are cut off from the fold, 
 </p><p class="q2">and there is no herd in the stalls, 
 </p><p class="q1">
-<sup>18&#160;</sup>yet I will rejoice in Yahweh. 
+<sup>18&#160;</sup>yet I will rejoice in Yahuah. 
 </p><p class="q2">I will be joyful in the Elohim of my salvation! 
 </p><p class="q1">
-<sup>19&#160;</sup>Yahweh, the Lord, is my strength. 
+<sup>19&#160;</sup>Yahuah, the Lord, is my strength. 
 </p><p class="q2">He makes my feet like deer’s feet, 
 </p><p class="q2">and enables me to go in high places. 
 </p><p>For the music director, on my stringed instruments. </p></div><script src="../main.js"></script></body></html>

--- a/book/haggai.html
+++ b/book/haggai.html
@@ -61,54 +61,54 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>In the second year of Darius the king, in the sixth month, in the first day of the month, Yahweh’s word came by Haggai the prophet, to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Jehozadak, the high priest, saying, 
-<sup>2&#160;</sup>“This is what Yahweh of Armies says: These people say, ‘The time hasn’t yet come, the time for Yahweh’s house to be built.’&#160;” 
+<sup>1&#160;</sup>In the second year of Darius the king, in the sixth month, in the first day of the month, Yahuah’s word came by Haggai the prophet, to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Jehozadak, the high priest, saying, 
+<sup>2&#160;</sup>“This is what Yahuah of Armies says: These people say, ‘The time hasn’t yet come, the time for Yahuah’s house to be built.’&#160;” 
 </p><p>
-<sup>3&#160;</sup>Then Yahweh’s word came by Haggai the prophet, saying, 
+<sup>3&#160;</sup>Then Yahuah’s word came by Haggai the prophet, saying, 
 <sup>4&#160;</sup>“Is it a time for you yourselves to dwell in your paneled houses, while this house lies waste? 
-<sup>5&#160;</sup>Now therefore this is what Yahweh of Armies says: ‘Consider your ways. 
+<sup>5&#160;</sup>Now therefore this is what Yahuah of Armies says: ‘Consider your ways. 
 <sup>6&#160;</sup>You have sown much, and bring in little. You eat, but you don’t have enough. You drink, but you aren’t filled with drink. You clothe yourselves, but no one is warm; and he who earns wages earns wages to put them into a bag with holes in it.’ 
 </p><p>
-<sup>7&#160;</sup>“This is what Yahweh of Armies says: ‘Consider your ways. 
-<sup>8&#160;</sup>Go up to the mountain, bring wood, and build the house. I will take pleasure in it, and I will be glorified,” says Yahweh. 
-<sup>9&#160;</sup>“You looked for much, and, behold, it came to little; and when you brought it home, I blew it away. Why?” says Yahweh of Armies, “Because of my house that lies waste, while each of you is busy with his own house. 
+<sup>7&#160;</sup>“This is what Yahuah of Armies says: ‘Consider your ways. 
+<sup>8&#160;</sup>Go up to the mountain, bring wood, and build the house. I will take pleasure in it, and I will be glorified,” says Yahuah. 
+<sup>9&#160;</sup>“You looked for much, and, behold, it came to little; and when you brought it home, I blew it away. Why?” says Yahuah of Armies, “Because of my house that lies waste, while each of you is busy with his own house. 
 <sup>10&#160;</sup>Therefore for your sake the heavens withhold the dew, and the earth withholds its fruit. 
 <sup>11&#160;</sup>I called for a drought on the land, on the mountains, on the grain, on the new wine, on the oil, on that which the ground produces, on men, on livestock, and on all the labor of the hands.” 
 </p><p>
-<sup>12&#160;</sup>Then Zerubbabel the son of Shealtiel and Joshua the son of Jehozadak, the high priest, with all the remnant of the people, obeyed Yahweh their Elohim’s voice, and the words of Haggai the prophet, as Yahweh their Elohim had sent him; and the people feared Yahweh. 
+<sup>12&#160;</sup>Then Zerubbabel the son of Shealtiel and Joshua the son of Jehozadak, the high priest, with all the remnant of the people, obeyed Yahuah their Elohim’s voice, and the words of Haggai the prophet, as Yahuah their Elohim had sent him; and the people feared Yahuah. 
 </p><p>
-<sup>13&#160;</sup>Then Haggai, Yahweh’s messenger, spoke Yahweh’s message to the people, saying, “I am with you,” says Yahweh. 
+<sup>13&#160;</sup>Then Haggai, Yahuah’s messenger, spoke Yahuah’s message to the people, saying, “I am with you,” says Yahuah. 
 </p><p>
-<sup>14&#160;</sup>Yahweh stirred up the spirit of Zerubbabel the son of Shealtiel, governor of Judah, and the spirit of Joshua the son of Jehozadak, the high priest, and the spirit of all the remnant of the people; and they came and worked on the house of Yahweh of Armies, their Elohim, 
+<sup>14&#160;</sup>Yahuah stirred up the spirit of Zerubbabel the son of Shealtiel, governor of Judah, and the spirit of Joshua the son of Jehozadak, the high priest, and the spirit of all the remnant of the people; and they came and worked on the house of Yahuah of Armies, their Elohim, 
 <sup>15&#160;</sup>in the twenty-fourth day of the month, in the sixth month, in the second year of Darius the king. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>In the seventh month, in the twenty-first day of the month, Yahweh’s word came by Haggai the prophet, saying, 
+<sup>1&#160;</sup>In the seventh month, in the twenty-first day of the month, Yahuah’s word came by Haggai the prophet, saying, 
 <sup>2&#160;</sup>“Speak now to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Jehozadak, the high priest, and to the remnant of the people, saying, 
 <sup>3&#160;</sup>‘Who is left among you who saw this house in its former glory? How do you see it now? Isn’t it in your eyes as nothing? 
-<sup>4&#160;</sup>Yet now be strong, Zerubbabel,’ says Yahweh. ‘Be strong, Joshua son of Jehozadak, the high priest. Be strong, all you people of the land,’ says Yahweh, ‘and work, for I am with you,’ says Yahweh of Armies. 
+<sup>4&#160;</sup>Yet now be strong, Zerubbabel,’ says Yahuah. ‘Be strong, Joshua son of Jehozadak, the high priest. Be strong, all you people of the land,’ says Yahuah, ‘and work, for I am with you,’ says Yahuah of Armies. 
 <sup>5&#160;</sup>This is the word that I covenanted with you when you came out of Egypt, and my Spirit lived among you. ‘Don’t be afraid.’ 
-<sup>6&#160;</sup>For this is what Yahweh of Armies says: ‘Yet once more, it is a little while, and I will shake the heavens, the earth, the sea, and the dry land; 
-<sup>7&#160;</sup>and I will shake all nations. The treasure of all nations will come, and I will fill this house with glory, says Yahweh of Armies. 
-<sup>8&#160;</sup>The silver is mine, and the gold is mine,’ says Yahweh of Armies. 
-<sup>9&#160;</sup>‘The latter glory of this house will be greater than the former,’ says Yahweh of Armies; ‘and in this place I will give peace,’ says Yahweh of Armies.” 
+<sup>6&#160;</sup>For this is what Yahuah of Armies says: ‘Yet once more, it is a little while, and I will shake the heavens, the earth, the sea, and the dry land; 
+<sup>7&#160;</sup>and I will shake all nations. The treasure of all nations will come, and I will fill this house with glory, says Yahuah of Armies. 
+<sup>8&#160;</sup>The silver is mine, and the gold is mine,’ says Yahuah of Armies. 
+<sup>9&#160;</sup>‘The latter glory of this house will be greater than the former,’ says Yahuah of Armies; ‘and in this place I will give peace,’ says Yahuah of Armies.” 
 </p><p>
-<sup>10&#160;</sup>In the twenty-fourth day of the ninth month, in the second year of Darius, Yahweh’s word came by Haggai the prophet, saying, 
-<sup>11&#160;</sup>“Yahweh of Armies says: Ask now the priests concerning the law, saying, 
+<sup>10&#160;</sup>In the twenty-fourth day of the ninth month, in the second year of Darius, Yahuah’s word came by Haggai the prophet, saying, 
+<sup>11&#160;</sup>“Yahuah of Armies says: Ask now the priests concerning the law, saying, 
 <sup>12&#160;</sup>‘If someone carries set-apart meat in the fold of his garment, and with his fold touches bread, stew, wine, oil, or any food, will it become set-apart?’&#160;” 
 </p><p>The priests answered, “No.” 
 </p><p>
 <sup>13&#160;</sup>Then Haggai said, “If one who is unclean by reason of a dead body touch any of these, will it be unclean?” 
 </p><p>The priests answered, “It will be unclean.” 
 </p><p>
-<sup>14&#160;</sup>Then Haggai answered, “&#160;‘So is this people, and so is this nation before me,’ says Yahweh; ‘and so is every work of their hands. That which they offer there is unclean. 
-<sup>15&#160;</sup>Now, please consider from this day and backward, before a stone was laid on a stone in Yahweh’s temple. 
+<sup>14&#160;</sup>Then Haggai answered, “&#160;‘So is this people, and so is this nation before me,’ says Yahuah; ‘and so is every work of their hands. That which they offer there is unclean. 
+<sup>15&#160;</sup>Now, please consider from this day and backward, before a stone was laid on a stone in Yahuah’s temple. 
 <sup>16&#160;</sup>Through all that time, when one came to a heap of twenty measures, there were only ten. When one came to the wine vat to draw out fifty, there were only twenty. 
-<sup>17&#160;</sup>I struck you with blight, mildew, and hail in all the work of your hands; yet you didn’t turn to me,’ says Yahweh. 
-<sup>18&#160;</sup>‘Consider, please, from this day and backward, from the twenty-fourth day of the ninth month, since the day that the foundation of Yahweh’s temple was laid, consider it. 
+<sup>17&#160;</sup>I struck you with blight, mildew, and hail in all the work of your hands; yet you didn’t turn to me,’ says Yahuah. 
+<sup>18&#160;</sup>‘Consider, please, from this day and backward, from the twenty-fourth day of the ninth month, since the day that the foundation of Yahuah’s temple was laid, consider it. 
 <sup>19&#160;</sup>Is the seed yet in the barn? Yes, the vine, the fig tree, the pomegranate, and the olive tree haven’t produced. From today I will bless you.’&#160;” 
 </p><p>
-<sup>20&#160;</sup>Yahweh’s word came the second time to Haggai in the twenty-fourth day of the month, saying, 
+<sup>20&#160;</sup>Yahuah’s word came the second time to Haggai in the twenty-fourth day of the month, saying, 
 <sup>21&#160;</sup>“Speak to Zerubbabel, governor of Judah, saying, ‘I will shake the heavens and the earth. 
 <sup>22&#160;</sup>I will overthrow the throne of kingdoms. I will destroy the strength of the kingdoms of the nations. I will overthrow the chariots and those who ride in them. The horses and their riders will come down, everyone by the sword of his brother. 
-<sup>23&#160;</sup>In that day, says Yahweh of Armies, I will take you, Zerubbabel my servant, the son of Shealtiel,’ says Yahweh, ‘and will make you like a signet ring, for I have chosen you,’ says Yahweh of Armies.” </p></div><script src="../main.js"></script></body></html>
+<sup>23&#160;</sup>In that day, says Yahuah of Armies, I will take you, Zerubbabel my servant, the son of Shealtiel,’ says Yahuah, ‘and will make you like a signet ring, for I have chosen you,’ says Yahuah of Armies.” </p></div><script src="../main.js"></script></body></html>

--- a/book/hosea.html
+++ b/book/hosea.html
@@ -73,18 +73,18 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>Yahweh’s word that came to Hosea the son of Beeri, in the days of Uzziah, Jotham, Ahaz, and Hezekiah, kings of Judah, and in the days of Jeroboam the son of Joash, king of Israel. 
+<sup>1&#160;</sup>Yahuah’s word that came to Hosea the son of Beeri, in the days of Uzziah, Jotham, Ahaz, and Hezekiah, kings of Judah, and in the days of Jeroboam the son of Joash, king of Israel. 
 </p><p>
-<sup>2&#160;</sup>When Yahweh spoke at first by Hosea, Yahweh said to Hosea, “Go, take for yourself a woman of prostitution and children of unfaithfulness; for the land commits great adultery, forsaking Yahweh.” 
+<sup>2&#160;</sup>When Yahuah spoke at first by Hosea, Yahuah said to Hosea, “Go, take for yourself a woman of prostitution and children of unfaithfulness; for the land commits great adultery, forsaking Yahuah.” 
 </p><p>
 <sup>3&#160;</sup>So he went and took Gomer the daughter of Diblaim; and she conceived, and bore him a son. 
 </p><p>
-<sup>4&#160;</sup>Yahweh said to him, “Call his name Jezreel, for yet a little while, and I will avenge the blood of Jezreel on the house of Jehu, and will cause the kingdom of the house of Israel to cease. 
+<sup>4&#160;</sup>Yahuah said to him, “Call his name Jezreel, for yet a little while, and I will avenge the blood of Jezreel on the house of Jehu, and will cause the kingdom of the house of Israel to cease. 
 <sup>5&#160;</sup>It will happen in that day that I will break the bow of Israel in the valley of Jezreel.” 
 </p><p>
 <sup>6&#160;</sup>She conceived again, and bore a daughter. 
 </p><p>Then he said to him, “Call her name Lo-Ruhamah, for I will no longer have mercy on the house of Israel, that I should in any way pardon them. 
-<sup>7&#160;</sup>But I will have mercy on the house of Judah, and will save them by Yahweh their Elohim, and will not save them by bow, sword, battle, horses, or horsemen.” 
+<sup>7&#160;</sup>But I will have mercy on the house of Judah, and will save them by Yahuah their Elohim, and will not save them by bow, sword, battle, horses, or horsemen.” 
 </p><p>
 <sup>8&#160;</sup>Now when she had weaned Lo-Ruhamah, she conceived, and bore a son. 
 </p><p>
@@ -151,7 +151,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">to which she burned incense 
 </p><p class="q1">when she decked herself with her earrings and her jewels, 
 </p><p class="q2">and went after her lovers 
-</p><p class="q2">and forgot me,” says Yahweh. 
+</p><p class="q2">and forgot me,” says Yahuah. 
 </p><p class="q1">
 <sup>14&#160;</sup>“Therefore behold, I will allure her, 
 </p><p class="q2">and bring her into the wilderness, 
@@ -163,7 +163,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">as in the days of her youth, 
 </p><p class="q2">and as in the day when she came up out of the land of Egypt. 
 </p><p class="q1">
-<sup>16&#160;</sup>It will be in that day,” says Yahweh, 
+<sup>16&#160;</sup>It will be in that day,” says Yahuah, 
 </p><p class="q2">“that you will call me ‘my man,’ 
 </p><p class="q2">and no longer call me ‘my owner.’ 
 </p><p class="q1">
@@ -180,9 +180,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Yes, I will betroth you to me in righteousness, in justice, in loving kindness, and in compassion. 
 </p><p class="q1">
 <sup>20&#160;</sup>I will even betroth you to me in faithfulness; 
-</p><p class="q2">and you shall know Yahweh. 
+</p><p class="q2">and you shall know Yahuah. 
 </p><p class="q1">
-<sup>21&#160;</sup>It will happen in that day, that I will respond,” says Yahweh. 
+<sup>21&#160;</sup>It will happen in that day, that I will respond,” says Yahuah. 
 </p><p class="q2">“I will respond to the heavens, 
 </p><p class="q2">and they will respond to the earth; 
 </p><p class="q2">
@@ -195,17 +195,17 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and they will say, ‘You are My Elohim!’&#160;” 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to me, “Go again, love a woman loved by another, and an adulteress, even as Yahweh loves the children of Israel, though they turn to other elohims, and love cakes of raisins.” 
+<sup>1&#160;</sup>Yahuah said to me, “Go again, love a woman loved by another, and an adulteress, even as Yahuah loves the children of Israel, though they turn to other elohims, and love cakes of raisins.” 
 </p><p>
 <sup>2&#160;</sup>So I bought her for myself for fifteen pieces of silver and a homer and a half of barley. 
 <sup>3&#160;</sup>I said to her, “You shall stay with me many days. You shall not play the prostitute, and you shall not be with any other man. I will also be so toward you.” 
 </p><p>
 <sup>4&#160;</sup>For the children of Israel shall live many days without king, without prince, without sacrifice, without sacred stone, and without ephod or idols. 
-<sup>5&#160;</sup>Afterward the children of Israel shall return and seek Yahweh their Elohim, and David their king, and shall come with trembling to Yahweh and to his blessings in the last days. 
+<sup>5&#160;</sup>Afterward the children of Israel shall return and seek Yahuah their Elohim, and David their king, and shall come with trembling to Yahuah and to his blessings in the last days. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>Hear Yahweh’s word, you children of Israel, 
-</p><p class="q2">for Yahweh has a charge against the inhabitants of the land: 
+<sup>1&#160;</sup>Hear Yahuah’s word, you children of Israel, 
+</p><p class="q2">for Yahuah has a charge against the inhabitants of the land: 
 </p><p class="q1">“Indeed there is no truth, nor goodness, 
 </p><p class="q2">nor knowledge of Elohim in the land. 
 </p><p class="q1">
@@ -244,7 +244,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>10&#160;</sup>They will eat, and not have enough. 
 </p><p class="q2">They will play the prostitute, and will not increase; 
-</p><p class="q2">because they have abandoned listening to Yahweh. 
+</p><p class="q2">because they have abandoned listening to Yahuah. 
 </p><p class="q1">
 <sup>11&#160;</sup>Prostitution, wine, and new wine take away understanding. 
 </p><p class="q2">
@@ -270,10 +270,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">yet don’t let Judah offend; 
 </p><p class="q2">and don’t come to Gilgal, 
 </p><p class="q2">neither go up to Beth Aven, 
-</p><p class="q2">nor swear, ‘As Yahweh lives.’ 
+</p><p class="q2">nor swear, ‘As Yahuah lives.’ 
 </p><p class="q1">
 <sup>16&#160;</sup>For Israel has behaved extremely stubbornly, like a stubborn heifer. 
-</p><p class="q2">Then how will Yahweh feed them like a lamb in a meadow? 
+</p><p class="q2">Then how will Yahuah feed them like a lamb in a meadow? 
 </p><p class="q1">
 <sup>17&#160;</sup>Ephraim is joined to idols. 
 </p><p class="q2">Leave him alone! 
@@ -304,17 +304,17 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>4&#160;</sup>Their deeds won’t allow them to turn to their Elohim, 
 </p><p class="q2">for the spirit of prostitution is within them, 
-</p><p class="q2">and they don’t know Yahweh. 
+</p><p class="q2">and they don’t know Yahuah. 
 </p><p class="q1">
 <sup>5&#160;</sup>The pride of Israel testifies to his face. 
 </p><p class="q2">Therefore Israel and Ephraim will stumble in their iniquity. 
 </p><p class="q2">Judah also will stumble with them. 
 </p><p class="q1">
-<sup>6&#160;</sup>They will go with their flocks and with their herds to seek Yahweh, 
+<sup>6&#160;</sup>They will go with their flocks and with their herds to seek Yahuah, 
 </p><p class="q2">but they won’t find him. 
 </p><p class="q2">He has withdrawn himself from them. 
 </p><p class="q1">
-<sup>7&#160;</sup>They are unfaithful to Yahweh; 
+<sup>7&#160;</sup>They are unfaithful to Yahuah; 
 </p><p class="q2">for they have borne illegitimate children. 
 </p><p class="q2">Now the new moon will devour them with their fields. 
 </p><p class="b"> &#160; </p>
@@ -356,7 +356,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>“Come! Let’s return to Yahweh; 
+<sup>1&#160;</sup>“Come! Let’s return to Yahuah; 
 </p><p class="q2">for he has torn us to pieces, 
 </p><p class="q2">and he will heal us; 
 </p><p class="q1">he has injured us, 
@@ -366,10 +366,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">On the third day he will raise us up, 
 </p><p class="q2">and we will live before him. 
 </p><p class="q1">
-<sup>3&#160;</sup>Let’s acknowledge Yahweh. 
-</p><p class="q2">Let’s press on to know Yahweh. 
+<sup>3&#160;</sup>Let’s acknowledge Yahuah. 
+</p><p class="q2">Let’s press on to know Yahuah. 
 </p><p class="q1">As surely as the sun rises, 
-</p><p class="q2">Yahweh will appear. 
+</p><p class="q2">Yahuah will appear. 
 </p><p class="q1">He will come to us like the rain, 
 </p><p class="q2">like the spring rain that waters the earth.” 
 </p><p class="b"> &#160; </p>
@@ -445,7 +445,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and he doesn’t realize it. 
 </p><p class="q1">
 <sup>10&#160;</sup>The pride of Israel testifies to his face; 
-</p><p class="q2">yet they haven’t returned to Yahweh their Elohim, 
+</p><p class="q2">yet they haven’t returned to Yahuah their Elohim, 
 </p><p class="q2">nor sought him, for all this. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -480,7 +480,7 @@ html[dir=ltr] .q2 {
 <h2 class="chapterlabel" id="8">8</h2>
 <p>
 <sup>1&#160;</sup>“Put the trumpet to your lips! 
-</p><p class="q2">Something like an eagle is over Yahweh’s house, 
+</p><p class="q2">Something like an eagle is over Yahuah’s house, 
 </p><p class="q2">because they have broken my covenant 
 </p><p class="q2">and rebelled against my law. 
 </p><p class="q1">
@@ -527,7 +527,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>13&#160;</sup>As for the sacrifices of my offerings, 
 </p><p class="q2">they sacrifice meat and eat it, 
-</p><p class="q2">but Yahweh doesn’t accept them. 
+</p><p class="q2">but Yahuah doesn’t accept them. 
 </p><p class="q1">Now he will remember their iniquity, 
 </p><p class="q2">and punish their sins. 
 </p><p class="q2">They will return to Egypt. 
@@ -546,19 +546,19 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>The threshing floor and the wine press won’t feed them, 
 </p><p class="q2">and the new wine will fail her. 
 </p><p class="q1">
-<sup>3&#160;</sup>They won’t dwell in Yahweh’s land; 
+<sup>3&#160;</sup>They won’t dwell in Yahuah’s land; 
 </p><p class="q2">but Ephraim will return to Egypt, 
 </p><p class="q2">and they will eat unclean food in Assyria. 
 </p><p class="q1">
-<sup>4&#160;</sup>They won’t pour out wine offerings to Yahweh, 
+<sup>4&#160;</sup>They won’t pour out wine offerings to Yahuah, 
 </p><p class="q2">neither will they be pleasing to him. 
 </p><p class="q2">Their sacrifices will be to them like the bread of mourners; 
 </p><p class="q2">all who eat of it will be polluted; 
 </p><p class="q2">for their bread will be for their appetite. 
-</p><p class="q2">It will not come into Yahweh’s house. 
+</p><p class="q2">It will not come into Yahuah’s house. 
 </p><p class="q1">
 <sup>5&#160;</sup>What will you do in the day of solemn assembly, 
-</p><p class="q2">and in the day of the feast of Yahweh? 
+</p><p class="q2">and in the day of the feast of Yahuah? 
 </p><p class="q1">
 <sup>6&#160;</sup>For, behold, when they flee destruction, 
 </p><p class="q2">Egypt will gather them up. 
@@ -597,7 +597,7 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>I have seen Ephraim, like Tyre, planted in a pleasant place; 
 </p><p class="q2">but Ephraim will bring out his children to the murderer. 
 </p><p class="q1">
-<sup>14&#160;</sup>Give them—Yahweh what will you give? 
+<sup>14&#160;</sup>Give them—Yahuah what will you give? 
 </p><p class="q2">Give them a miscarrying womb and dry breasts. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -626,7 +626,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He will demolish their altars. 
 </p><p class="q2">He will destroy their sacred stones. 
 </p><p class="q1">
-<sup>3&#160;</sup>Surely now they will say, “We have no king; for we don’t fear Yahweh; 
+<sup>3&#160;</sup>Surely now they will say, “We have no king; for we don’t fear Yahuah; 
 </p><p class="q2">and the king, what can he do for us?” 
 </p><p class="q1">
 <sup>4&#160;</sup>They make promises, swearing falsely in making covenants. 
@@ -666,7 +666,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Sow to yourselves in righteousness, 
 </p><p class="q2">reap according to kindness. 
 </p><p class="q1">Break up your fallow ground, 
-</p><p class="q2">for it is time to seek Yahweh, 
+</p><p class="q2">for it is time to seek Yahuah, 
 </p><p class="q2">until he comes and rains righteousness on you. 
 </p><p class="q1">
 <sup>13&#160;</sup>You have plowed wickedness. 
@@ -725,13 +725,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for I am Elohim, and not man—the Set-Apart One among you. 
 </p><p class="q2">I will not come in wrath. 
 </p><p class="q1">
-<sup>10&#160;</sup>They will walk after Yahweh, 
+<sup>10&#160;</sup>They will walk after Yahuah, 
 </p><p class="q2">who will roar like a lion; 
 </p><p class="q2">for he will roar, and the children will come trembling from the west. 
 </p><p class="q1">
 <sup>11&#160;</sup>They will come trembling like a bird out of Egypt, 
 </p><p class="q2">and like a dove out of the land of Assyria; 
-</p><p class="q1">and I will settle them in their houses,” says Yahweh. 
+</p><p class="q1">and I will settle them in their houses,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>12&#160;</sup>Ephraim surrounds me with falsehood, 
@@ -746,7 +746,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They make a covenant with Assyria, 
 </p><p class="q2">and oil is carried into Egypt. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh also has a controversy with Judah, 
+<sup>2&#160;</sup>Yahuah also has a controversy with Judah, 
 </p><p class="q2">and will punish Jacob according to his ways; 
 </p><p class="q2">according to his deeds he will repay him. 
 </p><p class="q1">
@@ -756,8 +756,8 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>Indeed, he struggled with the angel, and prevailed; 
 </p><p class="q2">he wept, and made supplication to him. 
 </p><p class="q2">He found him at Bethel, and there he spoke with us—</p><p class="q2">
-<sup>5&#160;</sup>even Yahweh, the Elohim of Armies. 
-</p><p class="q2">Yahweh is his name of renown! 
+<sup>5&#160;</sup>even Yahuah, the Elohim of Armies. 
+</p><p class="q2">Yahuah is his name of renown! 
 </p><p class="q1">
 <sup>6&#160;</sup>Therefore turn to your Elohim. 
 </p><p class="q2">Keep kindness and justice, 
@@ -772,7 +772,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">In all my wealth they won’t find in me any iniquity that is sin.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>9&#160;</sup>“But I am Yahweh your Elohim from the land of Egypt. 
+<sup>9&#160;</sup>“But I am Yahuah your Elohim from the land of Egypt. 
 </p><p class="q2">I will yet again make you dwell in tents, 
 </p><p class="q2">as in the days of the solemn feast. 
 </p><p class="q1">
@@ -789,7 +789,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Israel served to get a woman. 
 </p><p class="q2">For a woman he tended flocks and herds. 
 </p><p class="q1">
-<sup>13&#160;</sup>By a prophet Yahweh brought Israel up out of Egypt, 
+<sup>13&#160;</sup>By a prophet Yahuah brought Israel up out of Egypt, 
 </p><p class="q2">and by a prophet he was preserved. 
 </p><p class="q1">
 <sup>14&#160;</sup>Ephraim has bitterly provoked anger. 
@@ -813,7 +813,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and like the smoke out of the chimney. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>4&#160;</sup>“Yet I am Yahweh your Elohim from the land of Egypt; 
+<sup>4&#160;</sup>“Yet I am Yahuah your Elohim from the land of Egypt; 
 </p><p class="q2">and you shall acknowledge no elohim but me, 
 </p><p class="q2">and besides me there is no savior. 
 </p><p class="q1">
@@ -856,7 +856,7 @@ html[dir=ltr] .q2 {
 <p class="q1">“Compassion will be hidden from my eyes. 
 </p><p class="q2">
 <sup>15&#160;</sup>Though he is fruitful among his brothers, an east wind will come, 
-</p><p class="q2">the breath of Yahweh coming up from the wilderness; 
+</p><p class="q2">the breath of Yahuah coming up from the wilderness; 
 </p><p class="q2">and his spring will become dry, 
 </p><p class="q2">and his fountain will be dried up. 
 </p><p class="q2">He will plunder the storehouse of treasure. 
@@ -869,10 +869,10 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <h2 class="chapterlabel" id="14">14</h2>
 <p class="q1">
-<sup>1&#160;</sup>Israel, return to Yahweh your Elohim; 
+<sup>1&#160;</sup>Israel, return to Yahuah your Elohim; 
 </p><p class="q2">for you have fallen because of your sin. 
 </p><p class="q1">
-<sup>2&#160;</sup>Take words with you, and return to Yahweh. 
+<sup>2&#160;</sup>Take words with you, and return to Yahuah. 
 </p><p class="q2">Tell him, “Forgive all our sins, 
 </p><p class="q2">and accept that which is good; 
 </p><p class="q2">so we offer bulls as we vowed of our lips. 
@@ -908,6 +908,6 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>9&#160;</sup>Who is wise, that he may understand these things? 
 </p><p class="q2">Who is prudent, that he may know them? 
-</p><p class="q2">For the ways of Yahweh are right, 
+</p><p class="q2">For the ways of Yahuah are right, 
 </p><p class="q2">and the righteous walk in them, 
 </p><p class="q2">but the rebellious stumble in them. </p></div><script src="../main.js"></script></body></html>

--- a/book/isaiah.html
+++ b/book/isaiah.html
@@ -128,7 +128,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>The vision of Isaiah the son of Amoz, which he saw concerning Judah and Jerusalem, in the days of Uzziah, Jotham, Ahaz, and Hezekiah, kings of Judah. 
 </p><p class="q1">
 <sup>2&#160;</sup>Hear, heavens, 
-</p><p class="q2">and listen, earth; for Yahweh has spoken: 
+</p><p class="q2">and listen, earth; for Yahuah has spoken: 
 </p><p class="q1">“I have nourished and brought up children 
 </p><p class="q2">and they have rebelled against me. 
 </p><p class="q1">
@@ -141,7 +141,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">a people loaded with iniquity, 
 </p><p class="q2">offspring of evildoers, 
 </p><p class="q2">children who deal corruptly! 
-</p><p class="q1">They have forsaken Yahweh. 
+</p><p class="q1">They have forsaken Yahuah. 
 </p><p class="q2">They have despised the Set-Apart One of Israel. 
 </p><p class="q2">They are estranged and backward. 
 </p><p class="q1">
@@ -164,15 +164,15 @@ html[dir=ltr] .q2 {
 </p><p class="q2">like a hut in a field of melons, 
 </p><p class="q2">like a besieged city. 
 </p><p class="q1">
-<sup>9&#160;</sup>Unless Yahweh of Armies had left to us a very small remnant, 
+<sup>9&#160;</sup>Unless Yahuah of Armies had left to us a very small remnant, 
 </p><p class="q2">we would have been as Sodom. 
 </p><p class="q2">We would have been like Gomorrah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>Hear Yahweh’s word, you rulers of Sodom! 
+<sup>10&#160;</sup>Hear Yahuah’s word, you rulers of Sodom! 
 </p><p class="q2">Listen to the law of our Elohim, you people of Gomorrah! 
 </p><p class="q1">
-<sup>11&#160;</sup>“What are the multitude of your sacrifices to me?”, says Yahweh. 
+<sup>11&#160;</sup>“What are the multitude of your sacrifices to me?”, says Yahuah. 
 </p><p class="q2">“I have had enough of the burnt offerings of rams 
 </p><p class="q2">and the fat of fed animals. 
 </p><p class="q2">I don’t delight in the blood of bulls, 
@@ -205,7 +205,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Plead for the widow.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>18&#160;</sup>“Come now, and let’s reason together,” says Yahweh: 
+<sup>18&#160;</sup>“Come now, and let’s reason together,” says Yahuah: 
 </p><p class="q2">“Though your sins are as scarlet, they shall be as white as snow. 
 </p><p class="q2">Though they are red like crimson, they shall be as wool. 
 </p><p class="q1">
@@ -213,7 +213,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">you will eat the good of the land; 
 </p><p class="q2">
 <sup>20&#160;</sup>but if you refuse and rebel, you will be devoured with the sword; 
-</p><p class="q2">for Yahweh’s mouth has spoken it.” 
+</p><p class="q2">for Yahuah’s mouth has spoken it.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>21&#160;</sup>How the faithful city has become a prostitute! 
@@ -230,7 +230,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">neither does the cause of the widow come to them. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>24&#160;</sup>Therefore the Lord, Yahweh of Armies, 
+<sup>24&#160;</sup>Therefore the Lord, Yahuah of Armies, 
 </p><p class="q2">the Mighty One of Israel, says: 
 </p><p class="q1">“Ah, I will get relief from my adversaries, 
 </p><p class="q2">and avenge myself on my enemies. 
@@ -248,7 +248,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and her converts with righteousness. 
 </p><p class="q1">
 <sup>28&#160;</sup>But the destruction of transgressors and sinners shall be together, 
-</p><p class="q2">and those who forsake Yahweh shall be consumed. 
+</p><p class="q2">and those who forsake Yahuah shall be consumed. 
 </p><p class="q1">
 <sup>29&#160;</sup>For they shall be ashamed of the oaks which you have desired, 
 </p><p class="q2">and you shall be confounded for the gardens that you have chosen. 
@@ -264,17 +264,17 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>This is what Isaiah the son of Amoz saw concerning Judah and Jerusalem. 
 </p><p class="q1">
-<sup>2&#160;</sup>It shall happen in the latter days, that the mountain of Yahweh’s house shall be established on the top of the mountains, 
+<sup>2&#160;</sup>It shall happen in the latter days, that the mountain of Yahuah’s house shall be established on the top of the mountains, 
 </p><p class="q2">and shall be raised above the hills; 
 </p><p class="q2">and all nations shall flow to it. 
 </p><p class="q1">
 <sup>3&#160;</sup>Many peoples shall go and say, 
-</p><p class="q2">“Come, let’s go up to the mountain of Yahweh, 
+</p><p class="q2">“Come, let’s go up to the mountain of Yahuah, 
 </p><p class="q2">to the house of the Elohim of Jacob; 
 </p><p class="q2">and he will teach us of his ways, 
 </p><p class="q2">and we will walk in his paths.” 
 </p><p class="q1">For the law shall go out of Zion, 
-</p><p class="q2">and Yahweh’s word from Jerusalem. 
+</p><p class="q2">and Yahuah’s word from Jerusalem. 
 </p><p class="q1">
 <sup>4&#160;</sup>He will judge between the nations, 
 </p><p class="q2">and will decide concerning many peoples. 
@@ -284,7 +284,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">neither shall they learn war any more. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>5&#160;</sup>House of Jacob, come, and let’s walk in the light of Yahweh. 
+<sup>5&#160;</sup>House of Jacob, come, and let’s walk in the light of Yahuah. 
 </p><p class="q1">
 <sup>6&#160;</sup>For you have forsaken your people, the house of Jacob, 
 </p><p class="q2">because they are filled from the east, 
@@ -306,15 +306,15 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>10&#160;</sup>Enter into the rock, 
 </p><p class="q2">and hide in the dust, 
-</p><p class="q1">from before the terror of Yahweh, 
+</p><p class="q1">from before the terror of Yahuah, 
 </p><p class="q2">and from the glory of his majesty. 
 </p><p class="q1">
 <sup>11&#160;</sup>The lofty looks of man will be brought low, 
 </p><p class="q2">the arrogance of men will be bowed down, 
-</p><p class="q2">and Yahweh alone will be exalted in that day. 
+</p><p class="q2">and Yahuah alone will be exalted in that day. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>12&#160;</sup>For there will be a day of Yahweh of Armies for all that is proud and arrogant, 
+<sup>12&#160;</sup>For there will be a day of Yahuah of Armies for all that is proud and arrogant, 
 </p><p class="q2">and for all that is lifted up, 
 </p><p class="q2">and it shall be brought low—</p><p class="q2">
 <sup>13&#160;</sup>for all the cedars of Lebanon, that are high and lifted up, 
@@ -331,13 +331,13 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>17&#160;</sup>The loftiness of man shall be bowed down, 
 </p><p class="q2">and the arrogance of men shall be brought low; 
-</p><p class="q2">and Yahweh alone shall be exalted in that day. 
+</p><p class="q2">and Yahuah alone shall be exalted in that day. 
 </p><p class="q1">
 <sup>18&#160;</sup>The idols shall utterly pass away. 
 </p><p class="q1">
 <sup>19&#160;</sup>Men shall go into the caves of the rocks, 
 </p><p class="q2">and into the holes of the earth, 
-</p><p class="q2">from before the terror of Yahweh, 
+</p><p class="q2">from before the terror of Yahuah, 
 </p><p class="q2">and from the glory of his majesty, 
 </p><p class="q2">when he arises to shake the earth mightily. 
 </p><p class="q1">
@@ -348,7 +348,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">
 <sup>21&#160;</sup>to go into the caverns of the rocks, 
 </p><p class="q2">and into the clefts of the ragged rocks, 
-</p><p class="q2">from before the terror of Yahweh, 
+</p><p class="q2">from before the terror of Yahuah, 
 </p><p class="q2">and from the glory of his majesty, 
 </p><p class="q2">when he arises to shake the earth mightily. 
 </p><p class="q1">
@@ -356,7 +356,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for of what account is he? 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p class="q1">
-<sup>1&#160;</sup>For, behold, the Lord, Yahweh of Armies, takes away from Jerusalem and from Judah supply and support, 
+<sup>1&#160;</sup>For, behold, the Lord, Yahuah of Armies, takes away from Jerusalem and from Judah supply and support, 
 </p><p class="q2">the whole supply of bread, 
 </p><p class="q2">and the whole supply of water; 
 </p><p class="q2">
@@ -391,7 +391,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">You shall not make me ruler of the people.” 
 </p><p class="q1">
 <sup>8&#160;</sup>For Jerusalem is ruined, and Judah is fallen; 
-</p><p class="q2">because their tongue and their doings are against Yahweh, 
+</p><p class="q2">because their tongue and their doings are against Yahuah, 
 </p><p class="q1">to provoke the eyes of his glory. 
 </p><p class="q1">
 <sup>9&#160;</sup>The look of their faces testify against them. 
@@ -413,25 +413,25 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and destroy the way of your paths. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>13&#160;</sup>Yahweh stands up to contend, 
+<sup>13&#160;</sup>Yahuah stands up to contend, 
 </p><p class="q2">and stands to judge the peoples. 
 </p><p class="q1">
-<sup>14&#160;</sup>Yahweh will enter into judgment with the elders of his people 
+<sup>14&#160;</sup>Yahuah will enter into judgment with the elders of his people 
 </p><p class="q2">and their leaders: 
 </p><p class="q2">“It is you who have eaten up the vineyard. 
 </p><p class="q2">The plunder of the poor is in your houses. 
 </p><p class="q2">
 <sup>15&#160;</sup>What do you mean that you crush my people, 
-</p><p class="q2">and grind the face of the poor?” says the Lord, Yahweh of Armies. 
+</p><p class="q2">and grind the face of the poor?” says the Lord, Yahuah of Armies. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>16&#160;</sup>Moreover Yahweh said, “Because the daughters of Zion are arrogant, 
+<sup>16&#160;</sup>Moreover Yahuah said, “Because the daughters of Zion are arrogant, 
 </p><p class="q2">and walk with outstretched necks and flirting eyes, 
 </p><p class="q2">walking daintily as they go, 
 </p><p class="q2">jingling ornaments on their feet; 
 </p><p class="q1">
 <sup>17&#160;</sup>therefore the Lord brings sores on the crown of the head of the women of Zion, 
-</p><p class="q2">and Yahweh will make their scalps bald.” 
+</p><p class="q2">and Yahuah will make their scalps bald.” 
 </p><p>
 <sup>18&#160;</sup>In that day the Lord will take away the beauty of their anklets, the headbands, the crescent necklaces, 
 <sup>19&#160;</sup>the earrings, the bracelets, the veils, 
@@ -455,10 +455,10 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Seven women shall take hold of one man in that day, saying, “We will eat our own bread, and wear our own clothing. Just let us be called by your name. Take away our reproach.” 
 </p><p>
-<sup>2&#160;</sup>In that day, Yahweh’s branch will be beautiful and glorious, and the fruit of the land will be the beauty and glory of the survivors of Israel. 
+<sup>2&#160;</sup>In that day, Yahuah’s branch will be beautiful and glorious, and the fruit of the land will be the beauty and glory of the survivors of Israel. 
 <sup>3&#160;</sup>It will happen that he who is left in Zion and he who remains in Jerusalem shall be called set-apart, even everyone who is written among the living in Jerusalem, 
 <sup>4&#160;</sup>when the Lord shall have washed away the filth of the daughters of Zion, and shall have purged the blood of Jerusalem from within it, by the spirit of justice and by the spirit of burning. 
-<sup>5&#160;</sup>Yahweh will create over the whole habitation of Mount Zion and over her assemblies, a cloud and smoke by day, and the shining of a flaming fire by night, for over all the glory will be a canopy. 
+<sup>5&#160;</sup>Yahuah will create over the whole habitation of Mount Zion and over her assemblies, a cloud and smoke by day, and the shining of a flaming fire by night, for over all the glory will be a canopy. 
 <sup>6&#160;</sup>There will be a pavilion for a shade in the daytime from the heat, and for a refuge and for a shelter from storm and from rain. 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p class="q1">
@@ -489,7 +489,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">but it will grow briers and thorns. 
 </p><p class="q2">I will also command the clouds that they rain no rain on it.” 
 </p><p class="q1">
-<sup>7&#160;</sup>For the vineyard of Yahweh of Armies is the house of Israel, 
+<sup>7&#160;</sup>For the vineyard of Yahuah of Armies is the house of Israel, 
 </p><p class="q2">and the men of Judah his pleasant plant. 
 </p><p class="q2">He looked for justice, but behold, oppression, 
 </p><p class="q2">for righteousness, but behold, a cry of distress. 
@@ -499,7 +499,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">who lay field to field, until there is no room, 
 </p><p class="q2">and you are made to dwell alone in the middle of the land! 
 </p><p class="q1">
-<sup>9&#160;</sup>In my ears, Yahweh of Armies says: “Surely many houses will be desolate, 
+<sup>9&#160;</sup>In my ears, Yahuah of Armies says: “Surely many houses will be desolate, 
 </p><p class="q2">even great and beautiful, unoccupied. 
 </p><p class="q1">
 <sup>10&#160;</sup>For ten acres of vineyard shall yield one bath, 
@@ -509,7 +509,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">who stay late into the night, until wine inflames them! 
 </p><p class="q1">
 <sup>12&#160;</sup>The harp, lyre, tambourine, and flute, with wine, are at their feasts; 
-</p><p class="q2">but they don’t respect the work of Yahweh, 
+</p><p class="q2">but they don’t respect the work of Yahuah, 
 </p><p class="q2">neither have they considered the operation of his hands. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -525,7 +525,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">mankind is humbled, 
 </p><p class="q2">and the eyes of the arrogant ones are humbled; 
 </p><p class="q1">
-<sup>16&#160;</sup>but Yahweh of Armies is exalted in justice, 
+<sup>16&#160;</sup>but Yahuah of Armies is exalted in justice, 
 </p><p class="q2">and Elohim the Set-Apart One is sanctified in righteousness. 
 </p><p class="q1">
 <sup>17&#160;</sup>Then the lambs will graze as in their pasture, 
@@ -559,10 +559,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and as the dry grass sinks down in the flame, 
 </p><p class="q2">so their root shall be as rottenness, 
 </p><p class="q2">and their blossom shall go up as dust, 
-</p><p class="q1">because they have rejected the law of Yahweh of Armies, 
+</p><p class="q1">because they have rejected the law of Yahuah of Armies, 
 </p><p class="q2">and despised the word of the Set-Apart One of Israel. 
 </p><p class="q1">
-<sup>25&#160;</sup>Therefore Yahweh’s anger burns against his people, 
+<sup>25&#160;</sup>Therefore Yahuah’s anger burns against his people, 
 </p><p class="q2">and he has stretched out his hand against them and has struck them. 
 </p><p class="q1">The mountains tremble, 
 </p><p class="q2">and their dead bodies are as refuse in the middle of the streets. 
@@ -598,11 +598,11 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>In the year that King Uzziah died, I saw the Lord sitting on a throne, high and lifted up; and his train filled the temple. 
 <sup>2&#160;</sup>Above him stood the seraphim. Each one had six wings. With two he covered his face. With two he covered his feet. With two he flew. 
 <sup>3&#160;</sup>One called to another, and said, 
-</p><p class="q1">“Set-Apart, set-apart, set-apart, is Yahweh of Armies! 
+</p><p class="q1">“Set-Apart, set-apart, set-apart, is Yahuah of Armies! 
 </p><p class="q2">The whole earth is full of his glory!” 
 </p><p>
 <sup>4&#160;</sup>The foundations of the thresholds shook at the voice of him who called, and the house was filled with smoke. 
-<sup>5&#160;</sup>Then I said, “Woe is me! For I am undone, because I am a man of unclean lips and I live among a people of unclean lips, for my eyes have seen the King, Yahweh of Armies!” 
+<sup>5&#160;</sup>Then I said, “Woe is me! For I am undone, because I am a man of unclean lips and I live among a people of unclean lips, for my eyes have seen the King, Yahuah of Armies!” 
 </p><p>
 <sup>6&#160;</sup>Then one of the seraphim flew to me, having a live coal in his hand, which he had taken with the tongs from off the altar. 
 <sup>7&#160;</sup>He touched my mouth with it, and said, “Behold, this has touched your lips; and your iniquity is taken away, and your sin forgiven.” 
@@ -629,7 +629,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">houses without man, 
 </p><p class="q2">the land becomes utterly waste, 
 </p><p class="q2">
-<sup>12&#160;</sup>and Yahweh has removed men far away, 
+<sup>12&#160;</sup>and Yahuah has removed men far away, 
 </p><p class="q2">and the forsaken places are many within the land. 
 </p><p class="q1">
 <sup>13&#160;</sup>If there is a tenth left in it, 
@@ -641,26 +641,26 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>In the days of Ahaz the son of Jotham, the son of Uzziah, king of Judah, Rezin the king of Syria and Pekah the son of Remaliah, king of Israel, went up to Jerusalem to war against it, but could not prevail against it. 
 <sup>2&#160;</sup>David’s house was told, “Syria is allied with Ephraim.” His heart trembled, and the heart of his people, as the trees of the forest tremble with the wind. 
 </p><p>
-<sup>3&#160;</sup>Then Yahweh said to Isaiah, “Go out now to meet Ahaz, you, and Shearjashub your son, at the end of the conduit of the upper pool, on the highway of the fuller’s field. 
+<sup>3&#160;</sup>Then Yahuah said to Isaiah, “Go out now to meet Ahaz, you, and Shearjashub your son, at the end of the conduit of the upper pool, on the highway of the fuller’s field. 
 <sup>4&#160;</sup>Tell him, ‘Be careful, and keep calm. Don’t be afraid, neither let your heart be faint because of these two tails of smoking torches, for the fierce anger of Rezin and Syria, and of the son of Remaliah. 
 <sup>5&#160;</sup>Because Syria, Ephraim, and the son of Remaliah, have plotted evil against you, saying, 
 <sup>6&#160;</sup>“Let’s go up against Judah, and tear it apart, and let’s divide it among ourselves, and set up a king within it, even the son of Tabeel.” 
-<sup>7&#160;</sup>This is what the Lord Yahweh says: “It shall not stand, neither shall it happen.” 
+<sup>7&#160;</sup>This is what the Lord Yahuah says: “It shall not stand, neither shall it happen.” 
 <sup>8&#160;</sup>For the head of Syria is Damascus, and the head of Damascus is Rezin. Within sixty-five years Ephraim shall be broken in pieces, so that it shall not be a people. 
 <sup>9&#160;</sup>The head of Ephraim is Samaria, and the head of Samaria is Remaliah’s son. If you will not believe, surely you shall not be established.’&#160;” 
 </p><p>
-<sup>10&#160;</sup>Yahweh spoke again to Ahaz, saying, 
-<sup>11&#160;</sup>“Ask a sign of Yahweh your Elohim; ask it either in the depth, or in the height above.” 
+<sup>10&#160;</sup>Yahuah spoke again to Ahaz, saying, 
+<sup>11&#160;</sup>“Ask a sign of Yahuah your Elohim; ask it either in the depth, or in the height above.” 
 </p><p>
-<sup>12&#160;</sup>But Ahaz said, “I won’t ask. I won’t tempt Yahweh.” 
+<sup>12&#160;</sup>But Ahaz said, “I won’t ask. I won’t tempt Yahuah.” 
 </p><p>
 <sup>13&#160;</sup>He said, “Listen now, house of David. Is it not enough for you to try the patience of men, that you will try the patience of my Elohim also? 
 <sup>14&#160;</sup>Therefore the Lord himself will give you a sign. Behold, the young woman will conceive, and bear a son, and shall call his name Immanuel. 
 <sup>15&#160;</sup>He shall eat butter and honey when he knows to refuse the evil and choose the good. 
 <sup>16&#160;</sup>For before the child knows to refuse the evil and choose the good, the land whose two kings you abhor shall be forsaken. 
-<sup>17&#160;</sup>Yahweh will bring on you, on your people, and on your father’s house days that have not come, from the day that Ephraim departed from Judah, even the king of Assyria. 
+<sup>17&#160;</sup>Yahuah will bring on you, on your people, and on your father’s house days that have not come, from the day that Ephraim departed from Judah, even the king of Assyria. 
 </p><p>
-<sup>18&#160;</sup>It will happen in that day that Yahweh will whistle for the fly that is in the uttermost part of the rivers of Egypt, and for the bee that is in the land of Assyria. 
+<sup>18&#160;</sup>It will happen in that day that Yahuah will whistle for the fly that is in the uttermost part of the rivers of Egypt, and for the bee that is in the land of Assyria. 
 <sup>19&#160;</sup>They shall come, and shall all rest in the desolate valleys, in the clefts of the rocks, on all thorn hedges, and on all pastures. 
 </p><p>
 <sup>20&#160;</sup>In that day the Lord will shave with a razor that is hired in the parts beyond the River, even with the king of Assyria, the head and the hair of the feet; and it shall also consume the beard. 
@@ -673,13 +673,13 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>All the hills that were cultivated with the hoe, you shall not come there for fear of briers and thorns; but it shall be for the sending out of oxen, and for sheep to tread on.” 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to me, “Take a large tablet, and write on it with a man’s pen, ‘For Maher Shalal Hash Baz’; 
+<sup>1&#160;</sup>Yahuah said to me, “Take a large tablet, and write on it with a man’s pen, ‘For Maher Shalal Hash Baz’; 
 <sup>2&#160;</sup>and I will take for myself faithful witnesses to testify: Uriah the priest, and Zechariah the son of Jeberechiah.” 
 </p><p>
-<sup>3&#160;</sup>I went to the prophetess, and she conceived, and bore a son. Then Yahweh said to me, “Call his name ‘Maher Shalal Hash Baz.’ 
+<sup>3&#160;</sup>I went to the prophetess, and she conceived, and bore a son. Then Yahuah said to me, “Call his name ‘Maher Shalal Hash Baz.’ 
 <sup>4&#160;</sup>For before the child knows how to say, ‘My father’ and ‘My mother,’ the riches of Damascus and the plunder of Samaria will be carried away by the king of Assyria.” 
 </p><p>
-<sup>5&#160;</sup>Yahweh spoke to me yet again, saying, 
+<sup>5&#160;</sup>Yahuah spoke to me yet again, saying, 
 <sup>6&#160;</sup>“Because this people has refused the waters of Shiloah that go softly, and rejoice in Rezin and Remaliah’s son; 
 <sup>7&#160;</sup>now therefore, behold, the Lord brings upon them the mighty flood waters of the River: the king of Assyria and all his glory. It will come up over all its channels, and go over all its banks. 
 <sup>8&#160;</sup>It will sweep onward into Judah. It will overflow and pass through. It will reach even to the neck. The stretching out of its wings will fill the width of your land, O Immanuel. 
@@ -687,15 +687,15 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Make an uproar, you peoples, and be broken in pieces! Listen, all you from far countries: dress for battle, and be shattered! Dress for battle, and be shattered! 
 <sup>10&#160;</sup>Take counsel together, and it will be brought to nothing; speak the word, and it will not stand, for Elohim is with us.” 
 </p><p>
-<sup>11&#160;</sup>For Yahweh spoke this to me with a strong hand, and instructed me not to walk in the way of this people, saying, 
+<sup>11&#160;</sup>For Yahuah spoke this to me with a strong hand, and instructed me not to walk in the way of this people, saying, 
 <sup>12&#160;</sup>“Don’t call a conspiracy all that this people call a conspiracy. Don’t fear their threats or be terrorized. 
-<sup>13&#160;</sup>Yahweh of Armies is who you must respect as set-apart. He is the one you must fear. He is the one you must dread. 
+<sup>13&#160;</sup>Yahuah of Armies is who you must respect as set-apart. He is the one you must fear. He is the one you must dread. 
 <sup>14&#160;</sup>He will be a sanctuary, but for both houses of Israel, he will be a stumbling stone and a rock that makes them fall. For the people of Jerusalem, he will be a trap and a snare. 
 <sup>15&#160;</sup>Many will stumble over it, fall, be broken, be snared, and be captured.” 
 </p><p>
 <sup>16&#160;</sup>Wrap up the covenant. Seal the law among my disciples. 
-<sup>17&#160;</sup>I will wait for Yahweh, who hides his face from the house of Jacob, and I will look for him. 
-<sup>18&#160;</sup>Behold, I and the children whom Yahweh has given me are for signs and for wonders in Israel from Yahweh of Armies, who dwells in Mount Zion. 
+<sup>17&#160;</sup>I will wait for Yahuah, who hides his face from the house of Jacob, and I will look for him. 
+<sup>18&#160;</sup>Behold, I and the children whom Yahuah has given me are for signs and for wonders in Israel from Yahuah of Armies, who dwells in Mount Zion. 
 </p><p>
 <sup>19&#160;</sup>When they tell you, “Consult with those who have familiar spirits and with the wizards, who chirp and who mutter,” shouldn’t a people consult with their Elohim? Should they consult the dead on behalf of the living? 
 <sup>20&#160;</sup>Turn to the law and to the covenant! If they don’t speak according to this word, surely there is no morning for them. 
@@ -714,7 +714,7 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>For the yoke of his burden, and the staff of his shoulder, the rod of his oppressor, you have broken as in the day of Midian. 
 <sup>5&#160;</sup>For all the armor of the armed man in the noisy battle, and the garments rolled in blood, will be for burning, fuel for the fire. 
 <sup>6&#160;</sup>For a child is born to us. A son is given to us; and the government will be on his shoulders. His name will be called Wonderful Counselor, Mighty Elohim, Everlasting Father, Prince of Peace. 
-<sup>7&#160;</sup>Of the increase of his government and of peace there shall be no end, on David’s throne, and on his kingdom, to establish it, and to uphold it with justice and with righteousness from that time on, even forever. The zeal of Yahweh of Armies will perform this. 
+<sup>7&#160;</sup>Of the increase of his government and of peace there shall be no end, on David’s throne, and on his kingdom, to establish it, and to uphold it with justice and with righteousness from that time on, even forever. The zeal of Yahuah of Armies will perform this. 
 </p><p>
 <sup>8&#160;</sup>The Lord sent a word into Jacob, 
 </p><p class="q2">and it falls on Israel. 
@@ -727,7 +727,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">The sycamore fig trees have been cut down, 
 </p><p class="q2">but we will put cedars in their place.” 
 </p><p class="q1">
-<sup>11&#160;</sup>Therefore Yahweh will set up on high against him the adversaries of Rezin, 
+<sup>11&#160;</sup>Therefore Yahuah will set up on high against him the adversaries of Rezin, 
 </p><p class="q2">and will stir up his enemies, 
 </p><p class="q2">
 <sup>12&#160;</sup>The Syrians in front, 
@@ -738,9 +738,9 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>13&#160;</sup>Yet the people have not turned to him who struck them, 
-</p><p class="q2">neither have they sought Yahweh of Armies. 
+</p><p class="q2">neither have they sought Yahuah of Armies. 
 </p><p class="q1">
-<sup>14&#160;</sup>Therefore Yahweh will cut off from Israel head and tail, 
+<sup>14&#160;</sup>Therefore Yahuah will cut off from Israel head and tail, 
 </p><p class="q2">palm branch and reed, in one day. 
 </p><p class="q1">
 <sup>15&#160;</sup>The elder and the honorable man is the head, 
@@ -762,7 +762,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">yes, it kindles in the thickets of the forest, 
 </p><p class="q2">and they roll upward in a column of smoke. 
 </p><p class="q1">
-<sup>19&#160;</sup>Through Yahweh of Armies’ wrath, the land is burned up; 
+<sup>19&#160;</sup>Through Yahuah of Armies’ wrath, the land is burned up; 
 </p><p class="q2">and the people are the fuel for the fire. 
 </p><p class="q2">No one spares his brother. 
 </p><p class="q1">
@@ -798,19 +798,19 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>My hand has found the riches of the peoples like a nest, and like one gathers eggs that are abandoned, I have gathered all the earth. There was no one who moved their wing, or that opened their mouth, or chirped.” 
 </p><p>
 <sup>15&#160;</sup>Should an ax brag against him who chops with it? Should a saw exalt itself above him who saws with it? As if a rod should lift those who lift it up, or as if a staff should lift up someone who is not wood. 
-<sup>16&#160;</sup>Therefore the Lord, Yahweh of Armies, will send among his fat ones leanness; and under his glory a burning will be kindled like the burning of fire. 
+<sup>16&#160;</sup>Therefore the Lord, Yahuah of Armies, will send among his fat ones leanness; and under his glory a burning will be kindled like the burning of fire. 
 <sup>17&#160;</sup>The light of Israel will be for a fire, and his Set-Apart One for a flame; and it will burn and devour his thorns and his briers in one day. 
 <sup>18&#160;</sup>He will consume the glory of his forest and of his fruitful field, both soul and body. It will be as when a standard bearer faints. 
 <sup>19&#160;</sup>The remnant of the trees of his forest shall be few, so that a child could write their number. 
 </p><p>
-<sup>20&#160;</sup>It will come to pass in that day that the remnant of Israel, and those who have escaped from the house of Jacob will no more again lean on him who struck them, but shall lean on Yahweh, the Set-Apart One of Israel, in truth. 
+<sup>20&#160;</sup>It will come to pass in that day that the remnant of Israel, and those who have escaped from the house of Jacob will no more again lean on him who struck them, but shall lean on Yahuah, the Set-Apart One of Israel, in truth. 
 <sup>21&#160;</sup>A remnant will return, even the remnant of Jacob, to the mighty Elohim. 
 <sup>22&#160;</sup>For though your people, Israel, are like the sand of the sea, only a remnant of them will return. A destruction is determined, overflowing with righteousness. 
-<sup>23&#160;</sup>For the Lord, Yahweh of Armies, will make a full end, and that determined, throughout all the earth. 
+<sup>23&#160;</sup>For the Lord, Yahuah of Armies, will make a full end, and that determined, throughout all the earth. 
 </p><p>
-<sup>24&#160;</sup>Therefore the Lord, Yahweh of Armies, says, “My people who dwell in Zion, don’t be afraid of the Assyrian, though he strike you with the rod, and lift up his staff against you, as Egypt did. 
+<sup>24&#160;</sup>Therefore the Lord, Yahuah of Armies, says, “My people who dwell in Zion, don’t be afraid of the Assyrian, though he strike you with the rod, and lift up his staff against you, as Egypt did. 
 <sup>25&#160;</sup>For yet a very little while, and the indignation against you will be accomplished, and my anger will be directed to his destruction.” 
-<sup>26&#160;</sup>Yahweh of Armies will stir up a scourge against him, as in the slaughter of Midian at the rock of Oreb. His rod will be over the sea, and he will lift it up like he did against Egypt. 
+<sup>26&#160;</sup>Yahuah of Armies will stir up a scourge against him, as in the slaughter of Midian at the rock of Oreb. His rod will be over the sea, and he will lift it up like he did against Egypt. 
 <sup>27&#160;</sup>It will happen in that day that his burden will depart from off your shoulder, and his yoke from off your neck, and the yoke shall be destroyed because of the anointing oil. 
 </p><p>
 <sup>28&#160;</sup>He has come to Aiath. He has passed through Migron. At Michmash he stores his baggage. 
@@ -819,19 +819,19 @@ html[dir=ltr] .q2 {
 <sup>31&#160;</sup>Madmenah is a fugitive. The inhabitants of Gebim flee for safety. 
 <sup>32&#160;</sup>This very day he will halt at Nob. He shakes his hand at the mountain of the daughter of Zion, the hill of Jerusalem. 
 </p><p>
-<sup>33&#160;</sup>Behold, the Lord, Yahweh of Armies, will lop the boughs with terror. The tall will be cut down, and the lofty will be brought low. 
+<sup>33&#160;</sup>Behold, the Lord, Yahuah of Armies, will lop the boughs with terror. The tall will be cut down, and the lofty will be brought low. 
 <sup>34&#160;</sup>He will cut down the thickets of the forest with iron, and Lebanon will fall by the Mighty One. 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p class="q1">
 <sup>1&#160;</sup>A shoot will come out of the stock of Jesse, 
 </p><p class="q2">and a branch out of his roots will bear fruit. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh’s Spirit will rest on him: 
+<sup>2&#160;</sup>Yahuah’s Spirit will rest on him: 
 </p><p class="q2">the spirit of wisdom and understanding, 
 </p><p class="q2">the spirit of counsel and might, 
-</p><p class="q2">the spirit of knowledge and of the fear of Yahweh. 
+</p><p class="q2">the spirit of knowledge and of the fear of Yahuah. 
 </p><p class="q1">
-<sup>3&#160;</sup>His delight will be in the fear of Yahweh. 
+<sup>3&#160;</sup>His delight will be in the fear of Yahuah. 
 </p><p class="q1">He will not judge by the sight of his eyes, 
 </p><p class="q2">neither decide by the hearing of his ears; 
 </p><p class="q1">
@@ -857,7 +857,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and the weaned child will put his hand on the viper’s den. 
 </p><p class="q1">
 <sup>9&#160;</sup>They will not hurt nor destroy in all my set-apart mountain; 
-</p><p class="q2">for the earth will be full of the knowledge of Yahweh, 
+</p><p class="q2">for the earth will be full of the knowledge of Yahuah, 
 </p><p class="q2">as the waters cover the sea. 
 </p><p class="b"> &#160; </p>
 <p>
@@ -867,15 +867,15 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>He will set up a banner for the nations, and will assemble the outcasts of Israel, and gather together the dispersed of Judah from the four corners of the earth. 
 <sup>13&#160;</sup>The envy also of Ephraim will depart, and those who persecute Judah will be cut off. Ephraim won’t envy Judah, and Judah won’t persecute Ephraim. 
 <sup>14&#160;</sup>They will fly down on the shoulders of the Philistines on the west. Together they will plunder the children of the east. They will extend their power over Edom and Moab, and the children of Ammon will obey them. 
-<sup>15&#160;</sup>Yahweh will utterly destroy the tongue of the Egyptian sea; and with his scorching wind he will wave his hand over the River, and will split it into seven streams, and cause men to march over in sandals. 
+<sup>15&#160;</sup>Yahuah will utterly destroy the tongue of the Egyptian sea; and with his scorching wind he will wave his hand over the River, and will split it into seven streams, and cause men to march over in sandals. 
 <sup>16&#160;</sup>There will be a highway for the remnant that is left of his people from Assyria, like there was for Israel in the day that he came up out of the land of Egypt. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
-<sup>1&#160;</sup>In that day you will say, “I will give thanks to you, Yahweh; for though you were angry with me, your anger has turned away and you comfort me. 
-<sup>2&#160;</sup>Behold, Elohim is my salvation. I will trust, and will not be afraid; for Yah, Yahweh, is my strength and song; and he has become my salvation.” 
+<sup>1&#160;</sup>In that day you will say, “I will give thanks to you, Yahuah; for though you were angry with me, your anger has turned away and you comfort me. 
+<sup>2&#160;</sup>Behold, Elohim is my salvation. I will trust, and will not be afraid; for Yah, Yahuah, is my strength and song; and he has become my salvation.” 
 <sup>3&#160;</sup>Therefore with joy you will draw water out of the wells of salvation. 
-<sup>4&#160;</sup>In that day you will say, “Give thanks to Yahweh! Call on his name! Declare his doings among the peoples! Proclaim that his name is exalted! 
-<sup>5&#160;</sup>Sing to Yahweh, for he has done excellent things! Let this be known in all the earth! 
+<sup>4&#160;</sup>In that day you will say, “Give thanks to Yahuah! Call on his name! Declare his doings among the peoples! Proclaim that his name is exalted! 
+<sup>5&#160;</sup>Sing to Yahuah, for he has done excellent things! Let this be known in all the earth! 
 <sup>6&#160;</sup>Cry aloud and shout, you inhabitant of Zion, for the Set-Apart One of Israel is great among you!” 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
@@ -883,17 +883,17 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>2&#160;</sup>Set up a banner on the bare mountain! Lift up your voice to them! Wave your hand, that they may go into the gates of the nobles. 
 <sup>3&#160;</sup>I have commanded my consecrated ones; yes, I have called my mighty men for my anger, even my proudly exulting ones. 
-<sup>4&#160;</sup>The noise of a multitude is in the mountains, as of a great people; the noise of an uproar of the kingdoms of the nations gathered together! Yahweh of Armies is mustering the army for the battle. 
-<sup>5&#160;</sup>They come from a far country, from the uttermost part of heaven, even Yahweh, and the weapons of his indignation, to destroy the whole land. 
+<sup>4&#160;</sup>The noise of a multitude is in the mountains, as of a great people; the noise of an uproar of the kingdoms of the nations gathered together! Yahuah of Armies is mustering the army for the battle. 
+<sup>5&#160;</sup>They come from a far country, from the uttermost part of heaven, even Yahuah, and the weapons of his indignation, to destroy the whole land. 
 </p><p>
-<sup>6&#160;</sup>Wail, for Yahweh’s day is at hand! It will come as destruction from the Almighty. 
+<sup>6&#160;</sup>Wail, for Yahuah’s day is at hand! It will come as destruction from the Almighty. 
 <sup>7&#160;</sup>Therefore all hands will be feeble, and everyone’s heart will melt. 
 <sup>8&#160;</sup>They will be dismayed. Pangs and sorrows will seize them. They will be in pain like a woman in labor. They will look in amazement one at another. Their faces will be faces of flame. 
-<sup>9&#160;</sup>Behold, the day of Yahweh comes, cruel, with wrath and fierce anger; to make the land a desolation, and to destroy its sinners out of it. 
+<sup>9&#160;</sup>Behold, the day of Yahuah comes, cruel, with wrath and fierce anger; to make the land a desolation, and to destroy its sinners out of it. 
 <sup>10&#160;</sup>For the stars of the sky and its constellations will not give their light. The sun will be darkened in its going out, and the moon will not cause its light to shine. 
 <sup>11&#160;</sup>I will punish the world for their evil, and the wicked for their iniquity. I will cause the arrogance of the proud to cease, and will humble the arrogance of the terrible. 
 <sup>12&#160;</sup>I will make people more rare than fine gold, even a person than the pure gold of Ophir. 
-<sup>13&#160;</sup>Therefore I will make the heavens tremble, and the earth will be shaken out of its place in Yahweh of Armies’ wrath, and in the day of his fierce anger. 
+<sup>13&#160;</sup>Therefore I will make the heavens tremble, and the earth will be shaken out of its place in Yahuah of Armies’ wrath, and in the day of his fierce anger. 
 <sup>14&#160;</sup>It will happen that like a hunted gazelle and like sheep that no one gathers, they will each turn to their own people, and will each flee to their own land. 
 <sup>15&#160;</sup>Everyone who is found will be thrust through. Everyone who is captured will fall by the sword. 
 <sup>16&#160;</sup>Their infants also will be dashed in pieces before their eyes. Their houses will be ransacked, and their women raped. 
@@ -906,12 +906,12 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>Hyenas will cry in their fortresses, and jackals in the pleasant palaces. Her time is near to come, and her days will not be prolonged. 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
-<sup>1&#160;</sup>For Yahweh will have compassion on Jacob, and will yet choose Israel, and set them in their own land. The foreigner will join himself with them, and they will unite with the house of Jacob. 
-<sup>2&#160;</sup>The peoples will take them, and bring them to their place. The house of Israel will possess them in Yahweh’s land for servants and for handmaids. They will take as captives those whose captives they were; and they shall rule over their oppressors. 
+<sup>1&#160;</sup>For Yahuah will have compassion on Jacob, and will yet choose Israel, and set them in their own land. The foreigner will join himself with them, and they will unite with the house of Jacob. 
+<sup>2&#160;</sup>The peoples will take them, and bring them to their place. The house of Israel will possess them in Yahuah’s land for servants and for handmaids. They will take as captives those whose captives they were; and they shall rule over their oppressors. 
 </p><p>
-<sup>3&#160;</sup>It will happen in the day that Yahweh will give you rest from your sorrow, from your trouble, and from the hard service in which you were made to serve, 
+<sup>3&#160;</sup>It will happen in the day that Yahuah will give you rest from your sorrow, from your trouble, and from the hard service in which you were made to serve, 
 <sup>4&#160;</sup>that you will take up this parable against the king of Babylon, and say, “How the oppressor has ceased! The golden city has ceased!” 
-<sup>5&#160;</sup>Yahweh has broken the staff of the wicked, the scepter of the rulers, 
+<sup>5&#160;</sup>Yahuah has broken the staff of the wicked, the scepter of the rulers, 
 <sup>6&#160;</sup>who struck the peoples in wrath with a continual stroke, who ruled the nations in anger, with a persecution that no one restrained. 
 <sup>7&#160;</sup>The whole earth is at rest, and is quiet. They break out in song. 
 <sup>8&#160;</sup>Yes, the cypress trees rejoice with you, with the cedars of Lebanon, saying, “Since you are humbled, no lumberjack has come up against us.” 
@@ -931,13 +931,13 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>You will not join them in burial, because you have destroyed your land. You have killed your people. The offspring of evildoers will not be named forever. 
 </p><p>
 <sup>21&#160;</sup>Prepare for slaughter of his children because of the iniquity of their fathers, that they not rise up and possess the earth, and fill the surface of the world with cities. 
-<sup>22&#160;</sup>“I will rise up against them,” says Yahweh of Armies, “and cut off from Babylon name and remnant, and son and son’s son,” says Yahweh. 
-<sup>23&#160;</sup>“I will also make it a possession for the porcupine, and pools of water. I will sweep it with the broom of destruction,” says Yahweh of Armies. 
+<sup>22&#160;</sup>“I will rise up against them,” says Yahuah of Armies, “and cut off from Babylon name and remnant, and son and son’s son,” says Yahuah. 
+<sup>23&#160;</sup>“I will also make it a possession for the porcupine, and pools of water. I will sweep it with the broom of destruction,” says Yahuah of Armies. 
 </p><p>
-<sup>24&#160;</sup>Yahweh of Armies has sworn, saying, “Surely, as I have thought, so shall it happen; and as I have purposed, so shall it stand: 
+<sup>24&#160;</sup>Yahuah of Armies has sworn, saying, “Surely, as I have thought, so shall it happen; and as I have purposed, so shall it stand: 
 <sup>25&#160;</sup>that I will break the Assyrian in my land, and tread him under foot on my mountains. Then his yoke will leave them, and his burden leave their shoulders. 
 <sup>26&#160;</sup>This is the plan that is determined for the whole earth. This is the hand that is stretched out over all the nations. 
-<sup>27&#160;</sup>For Yahweh of Armies has planned, and who can stop it? His hand is stretched out, and who can turn it back?” 
+<sup>27&#160;</sup>For Yahuah of Armies has planned, and who can stop it? His hand is stretched out, and who can turn it back?” 
 </p><p>
 <sup>28&#160;</sup>This burden was in the year that King Ahaz died. 
 </p><p>
@@ -946,7 +946,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>31&#160;</sup>Howl, gate! Cry, city! You are melted away, Philistia, all of you; for smoke comes out of the north, and there is no straggler in his ranks. 
 </p><p>
-<sup>32&#160;</sup>What will they answer the messengers of the nation? That Yahweh has founded Zion, and in her the afflicted of his people will take refuge. 
+<sup>32&#160;</sup>What will they answer the messengers of the nation? That Yahuah has founded Zion, and in her the afflicted of his people will take refuge. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
 <sup>1&#160;</sup>The burden of Moab. 
@@ -975,18 +975,18 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>Therefore my heart sounds like a harp for Moab, and my inward parts for Kir Heres. 
 <sup>12&#160;</sup>It will happen that when Moab presents himself, when he wearies himself on the high place, and comes to his sanctuary to pray, that he will not prevail. 
 </p><p>
-<sup>13&#160;</sup>This is the word that Yahweh spoke concerning Moab in time past. 
-<sup>14&#160;</sup>But now Yahweh has spoken, saying, “Within three years, as a worker bound by contract would count them, the glory of Moab shall be brought into contempt, with all his great multitude; and the remnant will be very small and feeble.” 
+<sup>13&#160;</sup>This is the word that Yahuah spoke concerning Moab in time past. 
+<sup>14&#160;</sup>But now Yahuah has spoken, saying, “Within three years, as a worker bound by contract would count them, the glory of Moab shall be brought into contempt, with all his great multitude; and the remnant will be very small and feeble.” 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
 <sup>1&#160;</sup>The burden of Damascus. 
 </p><p>“Behold, Damascus is taken away from being a city, and it will be a ruinous heap. 
 <sup>2&#160;</sup>The cities of Aroer are forsaken. They will be for flocks, which shall lie down, and no one shall make them afraid. 
-<sup>3&#160;</sup>The fortress shall cease from Ephraim, and the kingdom from Damascus, and the remnant of Syria. They will be as the glory of the children of Israel,” says Yahweh of Armies. 
+<sup>3&#160;</sup>The fortress shall cease from Ephraim, and the kingdom from Damascus, and the remnant of Syria. They will be as the glory of the children of Israel,” says Yahuah of Armies. 
 </p><p>
 <sup>4&#160;</sup>“It will happen in that day that the glory of Jacob will be made thin, and the fatness of his flesh will become lean. 
 <sup>5&#160;</sup>It will be like when the harvester gathers the wheat, and his arm reaps the grain. Yes, it will be like when one gleans grain in the valley of Rephaim. 
-<sup>6&#160;</sup>Yet gleanings will be left there, like the shaking of an olive tree, two or three olives in the top of the uppermost bough, four or five in the outermost branches of a fruitful tree,” says Yahweh, the Elohim of Israel. 
+<sup>6&#160;</sup>Yet gleanings will be left there, like the shaking of an olive tree, two or three olives in the top of the uppermost bough, four or five in the outermost branches of a fruitful tree,” says Yahuah, the Elohim of Israel. 
 <sup>7&#160;</sup>In that day, people will look to their Maker, and their eyes will have respect for the Set-Apart One of Israel. 
 <sup>8&#160;</sup>They will not look to the altars, the work of their hands; neither shall they respect that which their fingers have made, either the Asherah poles or the incense altars. 
 <sup>9&#160;</sup>In that day, their strong cities will be like the forsaken places in the woods and on the mountain top, which were forsaken from before the children of Israel; and it will be a desolation. 
@@ -1002,17 +1002,17 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>that sends ambassadors by the sea, even in vessels of papyrus on the waters, saying, “Go, you swift messengers, to a nation tall and smooth, to a people awesome from their beginning onward, a nation that measures out and treads down, whose land the rivers divide!” 
 <sup>3&#160;</sup>All you inhabitants of the world, and you dwellers on the earth, when a banner is lifted up on the mountains, look! When the trumpet is blown, listen! 
 </p><p>
-<sup>4&#160;</sup>For Yahweh said to me, “I will be still, and I will see in my dwelling place, like clear heat in sunshine, like a cloud of dew in the heat of harvest.” 
+<sup>4&#160;</sup>For Yahuah said to me, “I will be still, and I will see in my dwelling place, like clear heat in sunshine, like a cloud of dew in the heat of harvest.” 
 <sup>5&#160;</sup>For before the harvest, when the blossom is over, and the flower becomes a ripening grape, he will cut off the sprigs with pruning hooks, and he will cut down and take away the spreading branches. 
 <sup>6&#160;</sup>They will be left together for the ravenous birds of the mountains, and for the animals of the earth. The ravenous birds will eat them in the summer, and all the animals of the earth will eat them in the winter. 
-<sup>7&#160;</sup>In that time, a present will be brought to Yahweh of Armies from a people tall and smooth, even from a people awesome from their beginning onward, a nation that measures out and treads down, whose land the rivers divide, to the place of the name of Yahweh of Armies, Mount Zion. 
+<sup>7&#160;</sup>In that time, a present will be brought to Yahuah of Armies from a people tall and smooth, even from a people awesome from their beginning onward, a nation that measures out and treads down, whose land the rivers divide, to the place of the name of Yahuah of Armies, Mount Zion. 
 </p><h2 class="chapterlabel" id="19">19</h2>
 <p>
 <sup>1&#160;</sup>The burden of Egypt. 
-</p><p>“Behold, Yahweh rides on a swift cloud, and comes to Egypt. The idols of Egypt will tremble at his presence; and the heart of Egypt will melt within it. 
+</p><p>“Behold, Yahuah rides on a swift cloud, and comes to Egypt. The idols of Egypt will tremble at his presence; and the heart of Egypt will melt within it. 
 <sup>2&#160;</sup>I will stir up the Egyptians against the Egyptians, and they will fight everyone against his brother, and everyone against his neighbor; city against city, and kingdom against kingdom. 
 <sup>3&#160;</sup>The spirit of the Egyptians will fail within them. I will destroy their counsel. They will seek the idols, the charmers, those who have familiar spirits, and the wizards. 
-<sup>4&#160;</sup>I will give over the Egyptians into the hand of a cruel lord. A fierce king will rule over them,” says the Lord, Yahweh of Armies. 
+<sup>4&#160;</sup>I will give over the Egyptians into the hand of a cruel lord. A fierce king will rule over them,” says the Lord, Yahuah of Armies. 
 </p><p>
 <sup>5&#160;</sup>The waters will fail from the sea, and the river will be wasted and become dry. 
 <sup>6&#160;</sup>The rivers will become foul. The streams of Egypt will be diminished and dried up. The reeds and flags will wither away. 
@@ -1022,28 +1022,28 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>The pillars will be broken in pieces. All those who work for hire will be grieved in soul. 
 </p><p>
 <sup>11&#160;</sup>The princes of Zoan are utterly foolish. The counsel of the wisest counselors of Pharaoh has become stupid. How do you say to Pharaoh, “I am the son of the wise, the son of ancient kings”? 
-<sup>12&#160;</sup>Where then are your wise men? Let them tell you now; and let them know what Yahweh of Armies has purposed concerning Egypt. 
+<sup>12&#160;</sup>Where then are your wise men? Let them tell you now; and let them know what Yahuah of Armies has purposed concerning Egypt. 
 <sup>13&#160;</sup>The princes of Zoan have become fools. The princes of Memphis are deceived. They have caused Egypt to go astray, those who are the cornerstone of her tribes. 
-<sup>14&#160;</sup>Yahweh has mixed a spirit of perverseness in the middle of her; and they have caused Egypt to go astray in all of its works, like a drunken man staggers in his vomit. 
+<sup>14&#160;</sup>Yahuah has mixed a spirit of perverseness in the middle of her; and they have caused Egypt to go astray in all of its works, like a drunken man staggers in his vomit. 
 <sup>15&#160;</sup>Neither shall there be any work for Egypt, which head or tail, palm branch or rush, may do. 
-<sup>16&#160;</sup>In that day the Egyptians will be like women. They will tremble and fear because of the shaking of Yahweh of Armies’s hand, which he shakes over them. 
-<sup>17&#160;</sup>The land of Judah will become a terror to Egypt. Everyone to whom mention is made of it will be afraid, because of the plans of Yahweh of Armies, which he determines against it. 
-<sup>18&#160;</sup>In that day, there will be five cities in the land of Egypt that speak the language of Canaan, and swear to Yahweh of Armies. One will be called “The city of destruction.” 
+<sup>16&#160;</sup>In that day the Egyptians will be like women. They will tremble and fear because of the shaking of Yahuah of Armies’s hand, which he shakes over them. 
+<sup>17&#160;</sup>The land of Judah will become a terror to Egypt. Everyone to whom mention is made of it will be afraid, because of the plans of Yahuah of Armies, which he determines against it. 
+<sup>18&#160;</sup>In that day, there will be five cities in the land of Egypt that speak the language of Canaan, and swear to Yahuah of Armies. One will be called “The city of destruction.” 
 </p><p>
-<sup>19&#160;</sup>In that day, there will be an altar to Yahweh in the middle of the land of Egypt, and a pillar to Yahweh at its border. 
-<sup>20&#160;</sup>It will be for a sign and for a witness to Yahweh of Armies in the land of Egypt; for they will cry to Yahweh because of oppressors, and he will send them a savior and a defender, and he will deliver them. 
-<sup>21&#160;</sup>Yahweh will be known to Egypt, and the Egyptians will know Yahweh in that day. Yes, they will worship with sacrifice and offering, and will vow a vow to Yahweh, and will perform it. 
-<sup>22&#160;</sup>Yahweh will strike Egypt, striking and healing. They will return to Yahweh, and he will be entreated by them, and will heal them. 
+<sup>19&#160;</sup>In that day, there will be an altar to Yahuah in the middle of the land of Egypt, and a pillar to Yahuah at its border. 
+<sup>20&#160;</sup>It will be for a sign and for a witness to Yahuah of Armies in the land of Egypt; for they will cry to Yahuah because of oppressors, and he will send them a savior and a defender, and he will deliver them. 
+<sup>21&#160;</sup>Yahuah will be known to Egypt, and the Egyptians will know Yahuah in that day. Yes, they will worship with sacrifice and offering, and will vow a vow to Yahuah, and will perform it. 
+<sup>22&#160;</sup>Yahuah will strike Egypt, striking and healing. They will return to Yahuah, and he will be entreated by them, and will heal them. 
 </p><p>
 <sup>23&#160;</sup>In that day there will be a highway out of Egypt to Assyria, and the Assyrian shall come into Egypt, and the Egyptian into Assyria; and the Egyptians will worship with the Assyrians. 
 </p><p>
 <sup>24&#160;</sup>In that day, Israel will be the third with Egypt and with Assyria, a blessing within the earth; 
-<sup>25&#160;</sup>because Yahweh of Armies has blessed them, saying, “Blessed be Egypt my people, Assyria the work of my hands, and Israel my inheritance.” 
+<sup>25&#160;</sup>because Yahuah of Armies has blessed them, saying, “Blessed be Egypt my people, Assyria the work of my hands, and Israel my inheritance.” 
 </p><h2 class="chapterlabel" id="20">20</h2>
 <p>
 <sup>1&#160;</sup>In the year that Tartan came to Ashdod, when Sargon the king of Assyria sent him, and he fought against Ashdod and took it; 
-<sup>2&#160;</sup>at that time Yahweh spoke by Isaiah the son of Amoz, saying, “Go, and loosen the sackcloth from off your waist, and take your sandals from off your feet.” He did so, walking naked and barefoot. 
-<sup>3&#160;</sup>Yahweh said, “As my servant Isaiah has walked naked and barefoot three years for a sign and a wonder concerning Egypt and concerning Ethiopia, 
+<sup>2&#160;</sup>at that time Yahuah spoke by Isaiah the son of Amoz, saying, “Go, and loosen the sackcloth from off your waist, and take your sandals from off your feet.” He did so, walking naked and barefoot. 
+<sup>3&#160;</sup>Yahuah said, “As my servant Isaiah has walked naked and barefoot three years for a sign and a wonder concerning Egypt and concerning Ethiopia, 
 <sup>4&#160;</sup>so the king of Assyria will lead away the captives of Egypt and the exiles of Ethiopia, young and old, naked and barefoot, and with buttocks uncovered, to the shame of Egypt. 
 <sup>5&#160;</sup>They will be dismayed and confounded, because of Ethiopia their expectation, and of Egypt their glory. 
 <sup>6&#160;</sup>The inhabitants of this coast land will say in that day, ‘Behold, this is our expectation, where we fled for help to be delivered from the king of Assyria. And we, how will we escape?’&#160;” 
@@ -1060,7 +1060,7 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>He cried like a lion: “Lord, I stand continually on the watchtower in the daytime, and every night I stay at my post. 
 <sup>9&#160;</sup>Behold, here comes a troop of men, horsemen in pairs.” He answered, “Fallen, fallen is Babylon; and all the engraved images of her elohims are broken to the ground. 
 </p><p>
-<sup>10&#160;</sup>You are my threshing, and the grain of my floor!” That which I have heard from Yahweh of Armies, the Elohim of Israel, I have declared to you. 
+<sup>10&#160;</sup>You are my threshing, and the grain of my floor!” That which I have heard from Yahuah of Armies, the Elohim of Israel, I have declared to you. 
 </p><p>
 <sup>11&#160;</sup>The burden of Dumah. 
 </p><p>One calls to me out of Seir, “Watchman, what of the night? Watchman, what of the night?” 
@@ -1071,7 +1071,7 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>They brought water to him who was thirsty. The inhabitants of the land of Tema met the fugitives with their bread. 
 <sup>15&#160;</sup>For they fled away from the swords, from the drawn sword, from the bent bow, and from the heat of battle. 
 <sup>16&#160;</sup>For the Lord said to me, “Within a year, as a worker bound by contract would count it, all the glory of Kedar will fail, 
-<sup>17&#160;</sup>and the residue of the number of the archers, the mighty men of the children of Kedar, will be few; for Yahweh, the Elohim of Israel, has spoken it.” 
+<sup>17&#160;</sup>and the residue of the number of the archers, the mighty men of the children of Kedar, will be few; for Yahuah, the Elohim of Israel, has spoken it.” 
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
 <sup>1&#160;</sup>The burden of the valley of vision. 
@@ -1080,7 +1080,7 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>All your rulers fled away together. They were bound by the archers. All who were found by you were bound together. They fled far away. 
 <sup>4&#160;</sup>Therefore I said, “Look away from me. I will weep bitterly. Don’t labor to comfort me for the destruction of the daughter of my people. 
 </p><p>
-<sup>5&#160;</sup>For it is a day of confusion, and of treading down, and of perplexity from the Lord, Yahweh of Armies, in the valley of vision, a breaking down of the walls, and a crying to the mountains.” 
+<sup>5&#160;</sup>For it is a day of confusion, and of treading down, and of perplexity from the Lord, Yahuah of Armies, in the valley of vision, a breaking down of the walls, and a crying to the mountains.” 
 <sup>6&#160;</sup>Elam carried his quiver, with chariots of men and horsemen; and Kir uncovered the shield. 
 <sup>7&#160;</sup>Your choicest valleys were full of chariots, and the horsemen set themselves in array at the gate. 
 <sup>8&#160;</sup>He took away the covering of Judah; and you looked in that day to the armor in the house of the forest. 
@@ -1088,13 +1088,13 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>You counted the houses of Jerusalem, and you broke down the houses to fortify the wall. 
 <sup>11&#160;</sup>You also made a reservoir between the two walls for the water of the old pool. But you didn’t look to him who had done this, neither did you have respect for him who planned it long ago. 
 </p><p>
-<sup>12&#160;</sup>In that day, the Lord, Yahweh of Armies, called to weeping, to mourning, to baldness, and to dressing in sackcloth; 
+<sup>12&#160;</sup>In that day, the Lord, Yahuah of Armies, called to weeping, to mourning, to baldness, and to dressing in sackcloth; 
 <sup>13&#160;</sup>and behold, there is joy and gladness, killing cattle and killing sheep, eating meat and drinking wine: “Let’s eat and drink, for tomorrow we will die.” 
-<sup>14&#160;</sup>Yahweh of Armies revealed himself in my ears, “Surely this iniquity will not be forgiven you until you die,” says the Lord, Yahweh of Armies. 
+<sup>14&#160;</sup>Yahuah of Armies revealed himself in my ears, “Surely this iniquity will not be forgiven you until you die,” says the Lord, Yahuah of Armies. 
 </p><p>
-<sup>15&#160;</sup>The Lord, Yahweh of Armies says, “Go, get yourself to this treasurer, even to Shebna, who is over the house, and say, 
+<sup>15&#160;</sup>The Lord, Yahuah of Armies says, “Go, get yourself to this treasurer, even to Shebna, who is over the house, and say, 
 <sup>16&#160;</sup>‘What are you doing here? Who has you here, that you have dug out a tomb here?’ Cutting himself out a tomb on high, chiseling a habitation for himself in the rock!” 
-<sup>17&#160;</sup>Behold, Yahweh will overcome you and hurl you away violently. Yes, he will grasp you firmly. 
+<sup>17&#160;</sup>Behold, Yahuah will overcome you and hurl you away violently. Yes, he will grasp you firmly. 
 <sup>18&#160;</sup>He will surely wind you around and around, and throw you like a ball into a large country. There you will die, and there the chariots of your glory will be, you disgrace of your lord’s house. 
 <sup>19&#160;</sup>I will thrust you from your office. You will be pulled down from your station. 
 </p><p>
@@ -1103,7 +1103,7 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>I will lay the key of David’s house on his shoulder. He will open, and no one will shut. He will shut, and no one will open. 
 <sup>23&#160;</sup>I will fasten him like a nail in a sure place. He will be for a throne of glory to his father’s house. 
 <sup>24&#160;</sup>They will hang on him all the glory of his father’s house, the offspring and the issue, every small vessel, from the cups even to all the pitchers. 
-<sup>25&#160;</sup>“In that day,” says Yahweh of Armies, “the nail that was fastened in a sure place will give way. It will be cut down and fall. The burden that was on it will be cut off, for Yahweh has spoken it.” 
+<sup>25&#160;</sup>“In that day,” says Yahuah of Armies, “the nail that was fastened in a sure place will give way. It will be cut down and fall. The burden that was on it will be cut off, for Yahuah has spoken it.” 
 </p><h2 class="chapterlabel" id="23">23</h2>
 <p>
 <sup>1&#160;</sup>The burden of Tyre. 
@@ -1116,22 +1116,22 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>Is this your joyous city, whose antiquity is of ancient days, whose feet carried her far away to travel? 
 </p><p>
 <sup>8&#160;</sup>Who has planned this against Tyre, the giver of crowns, whose merchants are princes, whose traders are the honorable of the earth? 
-<sup>9&#160;</sup>Yahweh of Armies has planned it, to stain the pride of all glory, to bring into contempt all the honorable of the earth. 
+<sup>9&#160;</sup>Yahuah of Armies has planned it, to stain the pride of all glory, to bring into contempt all the honorable of the earth. 
 <sup>10&#160;</sup>Pass through your land like the Nile, daughter of Tarshish. There is no restraint any more. 
-<sup>11&#160;</sup>He has stretched out his hand over the sea. He has shaken the kingdoms. Yahweh has ordered the destruction of Canaan’s strongholds. 
+<sup>11&#160;</sup>He has stretched out his hand over the sea. He has shaken the kingdoms. Yahuah has ordered the destruction of Canaan’s strongholds. 
 <sup>12&#160;</sup>He said, “You shall rejoice no more, you oppressed virgin daughter of Sidon. Arise, pass over to Kittim. Even there you will have no rest.” 
 </p><p>
 <sup>13&#160;</sup>Behold, the land of the Chaldeans. This people didn’t exist. The Assyrians founded it for those who dwell in the wilderness. They set up their towers. They overthrew its palaces. They made it a ruin. 
 <sup>14&#160;</sup>Howl, you ships of Tarshish, for your stronghold is laid waste! 
 <sup>15&#160;</sup>It will come to pass in that day that Tyre will be forgotten seventy years, according to the days of one king. After the end of seventy years it will be to Tyre like in the song of the prostitute. 
 <sup>16&#160;</sup>Take a harp; go about the city, you prostitute that has been forgotten. Make sweet melody. Sing many songs, that you may be remembered. 
-<sup>17&#160;</sup>It will happen after the end of seventy years that Yahweh will visit Tyre. She will return to her wages, and will play the prostitute with all the kingdoms of the world on the surface of the earth. 
-<sup>18&#160;</sup>Her merchandise and her wages will be set-apartness to Yahweh. It will not be treasured nor laid up; for her merchandise will be for those who dwell before Yahweh, to eat sufficiently, and for durable clothing. 
+<sup>17&#160;</sup>It will happen after the end of seventy years that Yahuah will visit Tyre. She will return to her wages, and will play the prostitute with all the kingdoms of the world on the surface of the earth. 
+<sup>18&#160;</sup>Her merchandise and her wages will be set-apartness to Yahuah. It will not be treasured nor laid up; for her merchandise will be for those who dwell before Yahuah, to eat sufficiently, and for durable clothing. 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
-<sup>1&#160;</sup>Behold, Yahweh makes the earth empty, makes it waste, turns it upside down, and scatters its inhabitants. 
+<sup>1&#160;</sup>Behold, Yahuah makes the earth empty, makes it waste, turns it upside down, and scatters its inhabitants. 
 <sup>2&#160;</sup>It will be as with the people, so with the priest; as with the servant, so with his master; as with the maid, so with her mistress; as with the buyer, so with the seller; as with the creditor, so with the debtor; as with the taker of interest, so with the giver of interest. 
-<sup>3&#160;</sup>The earth will be utterly emptied and utterly laid waste; for Yahweh has spoken this word. 
+<sup>3&#160;</sup>The earth will be utterly emptied and utterly laid waste; for Yahuah has spoken this word. 
 <sup>4&#160;</sup>The earth mourns and fades away. The world languishes and fades away. The lofty people of the earth languish. 
 <sup>5&#160;</sup>The earth also is polluted under its inhabitants, because they have transgressed the laws, violated the statutes, and broken the everlasting covenant. 
 <sup>6&#160;</sup>Therefore the curse has devoured the earth, and those who dwell therein are found guilty. Therefore the inhabitants of the earth are burned, and few men are left. 
@@ -1143,8 +1143,8 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>The city is left in desolation, and the gate is struck with destruction. 
 <sup>13&#160;</sup>For it will be so within the earth among the peoples, as the shaking of an olive tree, as the gleanings when the vintage is done. 
 </p><p>
-<sup>14&#160;</sup>These shall lift up their voice. They will shout for the majesty of Yahweh. They cry aloud from the sea. 
-<sup>15&#160;</sup>Therefore glorify Yahweh in the east, even the name of Yahweh, the Elohim of Israel, in the islands of the sea! 
+<sup>14&#160;</sup>These shall lift up their voice. They will shout for the majesty of Yahuah. They cry aloud from the sea. 
+<sup>15&#160;</sup>Therefore glorify Yahuah in the east, even the name of Yahuah, the Elohim of Israel, in the islands of the sea! 
 <sup>16&#160;</sup>From the uttermost part of the earth have we heard songs. Glory to the righteous! 
 </p><p>But I said, “I pine away! I pine away! woe is me!” The treacherous have dealt treacherously. Yes, the treacherous have dealt very treacherously. 
 <sup>17&#160;</sup>Fear, the pit, and the snare are on you who inhabit the earth. 
@@ -1152,23 +1152,23 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>The earth is utterly broken. The earth is torn apart. The earth is shaken violently. 
 <sup>20&#160;</sup>The earth will stagger like a drunken man, and will sway back and forth like a hammock. Its disobedience will be heavy on it, and it will fall and not rise again. 
 </p><p>
-<sup>21&#160;</sup>It will happen in that day that Yahweh will punish the army of the high ones on high, and the kings of the earth on the earth. 
+<sup>21&#160;</sup>It will happen in that day that Yahuah will punish the army of the high ones on high, and the kings of the earth on the earth. 
 <sup>22&#160;</sup>They will be gathered together, as prisoners are gathered in the pit, and will be shut up in the prison; and after many days they will be visited. 
-<sup>23&#160;</sup>Then the moon will be confounded, and the sun ashamed; for Yahweh of Armies will reign on Mount Zion and in Jerusalem; and glory will be before his elders. 
+<sup>23&#160;</sup>Then the moon will be confounded, and the sun ashamed; for Yahuah of Armies will reign on Mount Zion and in Jerusalem; and glory will be before his elders. 
 </p><h2 class="chapterlabel" id="25">25</h2>
 <p>
-<sup>1&#160;</sup>Yahweh, you are my Elohim. I will exalt you! I will praise your name, for you have done wonderful things, things planned long ago, in complete faithfulness and truth. 
+<sup>1&#160;</sup>Yahuah, you are my Elohim. I will exalt you! I will praise your name, for you have done wonderful things, things planned long ago, in complete faithfulness and truth. 
 <sup>2&#160;</sup>For you have made a city into a heap, a fortified city into a ruin, a palace of strangers to be no city. It will never be built. 
 <sup>3&#160;</sup>Therefore a strong people will glorify you. A city of awesome nations will fear you. 
 <sup>4&#160;</sup>For you have been a stronghold to the poor, a stronghold to the needy in his distress, a refuge from the storm, a shade from the heat, when the blast of the dreaded ones is like a storm against the wall. 
 <sup>5&#160;</sup>As the heat in a dry place you will bring down the noise of strangers; as the heat by the shade of a cloud, the song of the dreaded ones will be brought low. 
 </p><p>
-<sup>6&#160;</sup>In this mountain, Yahweh of Armies will make all peoples a feast of choice meat, a feast of choice wines, of choice meat full of marrow, of well refined choice wines. 
+<sup>6&#160;</sup>In this mountain, Yahuah of Armies will make all peoples a feast of choice meat, a feast of choice wines, of choice meat full of marrow, of well refined choice wines. 
 <sup>7&#160;</sup>He will destroy in this mountain the surface of the covering that covers all peoples, and the veil that is spread over all nations. 
-<sup>8&#160;</sup>He has swallowed up death forever! The Lord Yahweh will wipe away tears from off all faces. He will take the reproach of his people away from off all the earth, for Yahweh has spoken it. 
+<sup>8&#160;</sup>He has swallowed up death forever! The Lord Yahuah will wipe away tears from off all faces. He will take the reproach of his people away from off all the earth, for Yahuah has spoken it. 
 </p><p>
-<sup>9&#160;</sup>It shall be said in that day, “Behold, this is our Elohim! We have waited for him, and he will save us! This is Yahweh! We have waited for him. We will be glad and rejoice in his salvation!” 
-<sup>10&#160;</sup>For Yahweh’s hand will rest in this mountain. 
+<sup>9&#160;</sup>It shall be said in that day, “Behold, this is our Elohim! We have waited for him, and he will save us! This is Yahuah! We have waited for him. We will be glad and rejoice in his salvation!” 
+<sup>10&#160;</sup>For Yahuah’s hand will rest in this mountain. 
 </p><p>Moab will be trodden down in his place, even like straw is trodden down in the water of the dunghill. 
 <sup>11&#160;</sup>He will spread out his hands in the middle of it, like one who swims spreads out hands to swim, but his pride will be humbled together with the craft of his hands. 
 <sup>12&#160;</sup>He has brought the high fortress of your walls down, laid low, and brought to the ground, even to the dust. 
@@ -1184,8 +1184,8 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>You will keep whoever’s mind is steadfast in perfect peace, 
 </p><p class="q2">because he trusts in you. 
 </p><p class="q1">
-<sup>4&#160;</sup>Trust in Yahweh forever; 
-</p><p class="q2">for in Yah, Yahweh, is an everlasting Rock. 
+<sup>4&#160;</sup>Trust in Yahuah forever; 
+</p><p class="q2">for in Yah, Yahuah, is an everlasting Rock. 
 </p><p class="q1">
 <sup>5&#160;</sup>For he has brought down those who dwell on high, the lofty city. 
 </p><p class="q2">He lays it low. 
@@ -1200,7 +1200,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">You who are upright make the path of the righteous level. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>8&#160;</sup>Yes, in the way of your judgments, Yahweh, we have waited for you. 
+<sup>8&#160;</sup>Yes, in the way of your judgments, Yahuah, we have waited for you. 
 </p><p class="q2">Your name and your renown are the desire of our soul. 
 </p><p class="q1">
 <sup>9&#160;</sup>With my soul I have desired you in the night. 
@@ -1210,17 +1210,17 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>Let favor be shown to the wicked, 
 </p><p class="q2">yet he will not learn righteousness. 
 </p><p class="q1">In the land of uprightness he will deal wrongfully, 
-</p><p class="q2">and will not see Yahweh’s majesty. 
+</p><p class="q2">and will not see Yahuah’s majesty. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>11&#160;</sup>Yahweh, your hand is lifted up, yet they don’t see; 
+<sup>11&#160;</sup>Yahuah, your hand is lifted up, yet they don’t see; 
 </p><p class="q2">but they will see your zeal for the people and be disappointed. 
 </p><p class="q2">Yes, fire will consume your adversaries. 
 </p><p class="q1">
-<sup>12&#160;</sup>Yahweh, you will ordain peace for us, 
+<sup>12&#160;</sup>Yahuah, you will ordain peace for us, 
 </p><p class="q2">for you have also done all our work for us. 
 </p><p class="q1">
-<sup>13&#160;</sup>Yahweh our Elohim, other lords besides you have had dominion over us, 
+<sup>13&#160;</sup>Yahuah our Elohim, other lords besides you have had dominion over us, 
 </p><p class="q2">but we will only acknowledge your name. 
 </p><p class="q1">
 <sup>14&#160;</sup>The dead shall not live. 
@@ -1228,18 +1228,18 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Therefore you have visited and destroyed them, 
 </p><p class="q2">and caused all memory of them to perish. 
 </p><p class="q1">
-<sup>15&#160;</sup>You have increased the nation, O Yahweh. 
+<sup>15&#160;</sup>You have increased the nation, O Yahuah. 
 </p><p class="q2">You have increased the nation! 
 </p><p class="q1">You are glorified! 
 </p><p class="q2">You have enlarged all the borders of the land. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>16&#160;</sup>Yahweh, in trouble they have visited you. 
+<sup>16&#160;</sup>Yahuah, in trouble they have visited you. 
 </p><p class="q2">They poured out a prayer when your chastening was on them. 
 </p><p class="q1">
 <sup>17&#160;</sup>Just as a woman with child, who draws near the time of her delivery, 
 </p><p class="q2">is in pain and cries out in her pangs, 
-</p><p class="q2">so we have been before you, Yahweh. 
+</p><p class="q2">so we have been before you, Yahuah. 
 </p><p class="q1">
 <sup>18&#160;</sup>We have been with child. 
 </p><p class="q2">We have been in pain. 
@@ -1259,14 +1259,14 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Hide yourself for a little moment, 
 </p><p class="q2">until the indignation is past. 
 </p><p class="q1">
-<sup>21&#160;</sup>For, behold, Yahweh comes out of his place to punish the inhabitants of the earth for their iniquity. 
+<sup>21&#160;</sup>For, behold, Yahuah comes out of his place to punish the inhabitants of the earth for their iniquity. 
 </p><p class="q2">The earth also will disclose her blood, and will no longer cover her slain. 
 </p><h2 class="chapterlabel" id="27">27</h2>
 <p>
-<sup>1&#160;</sup>In that day, Yahweh with his hard and great and strong sword will punish leviathan, the fleeing serpent, and leviathan, the twisted serpent; and he will kill the dragon that is in the sea. 
+<sup>1&#160;</sup>In that day, Yahuah with his hard and great and strong sword will punish leviathan, the fleeing serpent, and leviathan, the twisted serpent; and he will kill the dragon that is in the sea. 
 </p><p>
 <sup>2&#160;</sup>In that day, sing to her, “A pleasant vineyard! 
-<sup>3&#160;</sup>I, Yahweh, am its keeper. I will water it every moment. Lest anyone damage it, I will keep it night and day. 
+<sup>3&#160;</sup>I, Yahuah, am its keeper. I will water it every moment. Lest anyone damage it, I will keep it night and day. 
 <sup>4&#160;</sup>Wrath is not in me, but if I should find briers and thorns, I would do battle! I would march on them and I would burn them together. 
 <sup>5&#160;</sup>Or else let him take hold of my strength, that he may make peace with me. Let him make peace with me.” 
 </p><p>
@@ -1277,16 +1277,16 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>For the fortified city is solitary, a habitation deserted and forsaken, like the wilderness. The calf will feed there, and there he will lie down, and consume its branches. 
 <sup>11&#160;</sup>When its boughs are withered, they will be broken off. The women will come and set them on fire, for they are a people of no understanding. Therefore he who made them will not have compassion on them, and he who formed them will show them no favor. 
 </p><p>
-<sup>12&#160;</sup>It will happen in that day that Yahweh will thresh from the flowing stream of the Euphrates to the brook of Egypt; and you will be gathered one by one, children of Israel. 
+<sup>12&#160;</sup>It will happen in that day that Yahuah will thresh from the flowing stream of the Euphrates to the brook of Egypt; and you will be gathered one by one, children of Israel. 
 </p><p>
-<sup>13&#160;</sup>It will happen in that day that a great trumpet will be blown; and those who were ready to perish in the land of Assyria, and those who were outcasts in the land of Egypt, shall come; and they will worship Yahweh in the set-apart mountain at Jerusalem. 
+<sup>13&#160;</sup>It will happen in that day that a great trumpet will be blown; and those who were ready to perish in the land of Assyria, and those who were outcasts in the land of Egypt, shall come; and they will worship Yahuah in the set-apart mountain at Jerusalem. 
 </p><h2 class="chapterlabel" id="28">28</h2>
 <p>
 <sup>1&#160;</sup>Woe to the crown of pride of the drunkards of Ephraim, and to the fading flower of his glorious beauty, which is on the head of the fertile valley of those who are overcome with wine! 
 <sup>2&#160;</sup>Behold, the Lord has one who is mighty and strong. Like a storm of hail, a destroying storm, and like a storm of mighty waters overflowing, he will cast them down to the earth with his hand. 
 <sup>3&#160;</sup>The crown of pride of the drunkards of Ephraim will be trodden under foot. 
 <sup>4&#160;</sup>The fading flower of his glorious beauty, which is on the head of the fertile valley, shall be like the first-ripe fig before the summer, which someone picks and eats as soon as he sees it. 
-<sup>5&#160;</sup>In that day, Yahweh of Armies will become a crown of glory and a diadem of beauty to the residue of his people, 
+<sup>5&#160;</sup>In that day, Yahuah of Armies will become a crown of glory and a diadem of beauty to the residue of his people, 
 <sup>6&#160;</sup>and a spirit of justice to him who sits in judgment, and strength to those who turn back the battle at the gate. 
 </p><p>
 <sup>7&#160;</sup>They also reel with wine, and stagger with strong drink. The priest and the prophet reel with strong drink. They are swallowed up by wine. They stagger with strong drink. They err in vision. They stumble in judgment. 
@@ -1297,17 +1297,17 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>11&#160;</sup>But he will speak to this nation with stammering lips and in another language, 
 <sup>12&#160;</sup>to whom he said, “This is the resting place. Give rest to the weary,” and “This is the refreshing;” yet they would not hear. 
-<sup>13&#160;</sup>Therefore Yahweh’s word will be to them precept on precept, precept on precept; line on line, line on line; here a little, there a little; that they may go, fall backward, be broken, be snared, and be taken. 
+<sup>13&#160;</sup>Therefore Yahuah’s word will be to them precept on precept, precept on precept; line on line, line on line; here a little, there a little; that they may go, fall backward, be broken, be snared, and be taken. 
 </p><p>
-<sup>14&#160;</sup>Therefore hear Yahweh’s word, you scoffers, that rule this people in Jerusalem: 
+<sup>14&#160;</sup>Therefore hear Yahuah’s word, you scoffers, that rule this people in Jerusalem: 
 <sup>15&#160;</sup>“Because you have said, ‘We have made a covenant with death, and we are in agreement with Sheol. When the overflowing scourge passes through, it won’t come to us; for we have made lies our refuge, and we have hidden ourselves under falsehood.’&#160;” 
-<sup>16&#160;</sup>Therefore the Lord Yahweh says, “Behold, I lay in Zion for a foundation a stone, a tried stone, a precious cornerstone of a sure foundation. He who believes shall not act hastily. 
+<sup>16&#160;</sup>Therefore the Lord Yahuah says, “Behold, I lay in Zion for a foundation a stone, a tried stone, a precious cornerstone of a sure foundation. He who believes shall not act hastily. 
 <sup>17&#160;</sup>I will make justice the measuring line, and righteousness the plumb line. The hail will sweep away the refuge of lies, and the waters will overflow the hiding place. 
 <sup>18&#160;</sup>Your covenant with death shall be annulled, and your agreement with Sheol shall not stand. When the overflowing scourge passes through, then you will be trampled down by it. 
 <sup>19&#160;</sup>As often as it passes through, it will seize you; for morning by morning it will pass through, by day and by night; and it will be nothing but terror to understand the message.” 
 <sup>20&#160;</sup>For the bed is too short to stretch out on, and the blanket is too narrow to wrap oneself in. 
-<sup>21&#160;</sup>For Yahweh will rise up as on Mount Perazim. He will be angry as in the valley of Gibeon; that he may do his work, his unusual work, and bring to pass his act, his extraordinary act. 
-<sup>22&#160;</sup>Now therefore don’t be scoffers, lest your bonds be made strong; for I have heard a decree of destruction from the Lord, Yahweh of Armies, on the whole earth. 
+<sup>21&#160;</sup>For Yahuah will rise up as on Mount Perazim. He will be angry as in the valley of Gibeon; that he may do his work, his unusual work, and bring to pass his act, his extraordinary act. 
+<sup>22&#160;</sup>Now therefore don’t be scoffers, lest your bonds be made strong; for I have heard a decree of destruction from the Lord, Yahuah of Armies, on the whole earth. 
 </p><p>
 <sup>23&#160;</sup>Give ear, and hear my voice! Listen, and hear my speech! 
 <sup>24&#160;</sup>Does he who plows to sow plow continually? Does he keep turning the soil and breaking the clods? 
@@ -1315,7 +1315,7 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>For his Elohim instructs him in right judgment and teaches him. 
 <sup>27&#160;</sup>For the dill isn’t threshed with a sharp instrument, neither is a cart wheel turned over the cumin; but the dill is beaten out with a stick, and the cumin with a rod. 
 <sup>28&#160;</sup>Bread flour must be ground; so he will not always be threshing it. Although he drives the wheel of his threshing cart over it, his horses don’t grind it. 
-<sup>29&#160;</sup>This also comes out from Yahweh of Armies, who is wonderful in counsel, and excellent in wisdom. 
+<sup>29&#160;</sup>This also comes out from Yahuah of Armies, who is wonderful in counsel, and excellent in wisdom. 
 </p><h2 class="chapterlabel" id="29">29</h2>
 <p>
 <sup>1&#160;</sup>Woe to Ariel! Ariel, the city where David encamped! Add year to year; let the feasts come around; 
@@ -1324,32 +1324,32 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>You will be brought down, and will speak out of the ground. Your speech will mumble out of the dust. Your voice will be as of one who has a familiar spirit, out of the ground, and your speech will whisper out of the dust. 
 </p><p>
 <sup>5&#160;</sup>But the multitude of your foes will be like fine dust, and the multitude of the ruthless ones like chaff that blows away. Yes, it will be in an instant, suddenly. 
-<sup>6&#160;</sup>She will be visited by Yahweh of Armies with thunder, with earthquake, with great noise, with whirlwind and storm, and with the flame of a devouring fire. 
+<sup>6&#160;</sup>She will be visited by Yahuah of Armies with thunder, with earthquake, with great noise, with whirlwind and storm, and with the flame of a devouring fire. 
 <sup>7&#160;</sup>The multitude of all the nations that fight against Ariel, even all who fight against her and her stronghold, and who distress her, will be like a dream, a vision of the night. 
 <sup>8&#160;</sup>It will be like when a hungry man dreams, and behold, he eats; but he awakes, and his hunger isn’t satisfied; or like when a thirsty man dreams, and behold, he drinks; but he awakes, and behold, he is faint, and he is still thirsty. The multitude of all the nations that fight against Mount Zion will be like that. 
 </p><p>
 <sup>9&#160;</sup>Pause and wonder! Blind yourselves and be blind! They are drunken, but not with wine; they stagger, but not with strong drink. 
-<sup>10&#160;</sup>For Yahweh has poured out on you a spirit of deep sleep, and has closed your eyes, the prophets; and he has covered your heads, the seers. 
+<sup>10&#160;</sup>For Yahuah has poured out on you a spirit of deep sleep, and has closed your eyes, the prophets; and he has covered your heads, the seers. 
 <sup>11&#160;</sup>All vision has become to you like the words of a book that is sealed, which men deliver to one who is educated, saying, “Read this, please;” and he says, “I can’t, for it is sealed;” 
 <sup>12&#160;</sup>and the book is delivered to one who is not educated, saying, “Read this, please;” and he says, “I can’t read.” 
 </p><p>
 <sup>13&#160;</sup>The Lord said, “Because this people draws near with their mouth and honors me with their lips, but they have removed their heart far from me, and their fear of me is a commandment of men which has been taught; 
 <sup>14&#160;</sup>therefore, behold, I will proceed to do a marvelous work among this people, even a marvelous work and a wonder; and the wisdom of their wise men will perish, and the understanding of their prudent men will be hidden.” 
 </p><p>
-<sup>15&#160;</sup>Woe to those who deeply hide their counsel from Yahweh, and whose deeds are in the dark, and who say, “Who sees us?” and “Who knows us?” 
+<sup>15&#160;</sup>Woe to those who deeply hide their counsel from Yahuah, and whose deeds are in the dark, and who say, “Who sees us?” and “Who knows us?” 
 <sup>16&#160;</sup>You turn things upside down! Should the potter be thought to be like clay, that the thing made should say about him who made it, “He didn’t make me;” or the thing formed say of him who formed it, “He has no understanding”? 
 </p><p>
 <sup>17&#160;</sup>Isn’t it yet a very little while, and Lebanon will be turned into a fruitful field, and the fruitful field will be regarded as a forest? 
 <sup>18&#160;</sup>In that day, the deaf will hear the words of the book, and the eyes of the blind will see out of obscurity and out of darkness. 
-<sup>19&#160;</sup>The humble also will increase their joy in Yahweh, and the poor among men will rejoice in the Set-Apart One of Israel. 
+<sup>19&#160;</sup>The humble also will increase their joy in Yahuah, and the poor among men will rejoice in the Set-Apart One of Israel. 
 <sup>20&#160;</sup>For the ruthless is brought to nothing, and the scoffer ceases, and all those who are alert to do evil are cut off—<sup>21&#160;</sup>who cause a person to be indicted by a word, and lay a snare for one who reproves in the gate, and who deprive the innocent of justice with false testimony. 
 </p><p>
-<sup>22&#160;</sup>Therefore Yahweh, who redeemed Abraham, says concerning the house of Jacob: “Jacob shall no longer be ashamed, neither shall his face grow pale. 
+<sup>22&#160;</sup>Therefore Yahuah, who redeemed Abraham, says concerning the house of Jacob: “Jacob shall no longer be ashamed, neither shall his face grow pale. 
 <sup>23&#160;</sup>But when he sees his children, the work of my hands, in the middle of him, they will sanctify my name. Yes, they will sanctify the Set-Apart One of Jacob, and will stand in awe of the Elohim of Israel. 
 <sup>24&#160;</sup>They also who err in spirit will come to understanding, and those who grumble will receive instruction.” 
 </p><h2 class="chapterlabel" id="30">30</h2>
 <p>
-<sup>1&#160;</sup>“Woe to the rebellious children”, says Yahweh, “who take counsel, but not from me; and who make an alliance, but not with my Spirit, that they may add sin to sin; 
+<sup>1&#160;</sup>“Woe to the rebellious children”, says Yahuah, “who take counsel, but not from me; and who make an alliance, but not with my Spirit, that they may add sin to sin; 
 <sup>2&#160;</sup>who set out to go down into Egypt without asking for my advice, to strengthen themselves in the strength of Pharaoh, and to take refuge in the shadow of Egypt! 
 <sup>3&#160;</sup>Therefore the strength of Pharaoh will be your shame, and the refuge in the shadow of Egypt your confusion. 
 <sup>4&#160;</sup>For their princes are at Zoan, and their ambassadors have come to Hanes. 
@@ -1359,18 +1359,18 @@ html[dir=ltr] .q2 {
 </p><p>Through the land of trouble and anguish, of the lioness and the lion, the viper and fiery flying serpent, they carry their riches on the shoulders of young donkeys, and their treasures on the humps of camels, to an unprofitable people. 
 <sup>7&#160;</sup>For Egypt helps in vain, and to no purpose; therefore I have called her Rahab who sits still. 
 <sup>8&#160;</sup>Now go, write it before them on a tablet, and inscribe it in a book, that it may be for the time to come forever and ever. 
-<sup>9&#160;</sup>For it is a rebellious people, lying children, children who will not hear Yahweh’s law; 
+<sup>9&#160;</sup>For it is a rebellious people, lying children, children who will not hear Yahuah’s law; 
 <sup>10&#160;</sup>who tell the seers, “Don’t see!” and the prophets, “Don’t prophesy to us right things. Tell us pleasant things. Prophesy deceits. 
 <sup>11&#160;</sup>Get out of the way. Turn away from the path. Cause the Set-Apart One of Israel to cease from before us.” 
 <sup>12&#160;</sup>Therefore the Set-Apart One of Israel says, “Because you despise this word, and trust in oppression and perverseness, and rely on it, 
 <sup>13&#160;</sup>therefore this iniquity shall be to you like a breach ready to fall, swelling out in a high wall, whose breaking comes suddenly in an instant. 
 <sup>14&#160;</sup>He will break it as a potter’s vessel is broken, breaking it in pieces without sparing, so that there won’t be found among the broken pieces a piece good enough to take fire from the hearth, or to dip up water out of the cistern.” 
 </p><p>
-<sup>15&#160;</sup>For thus said the Lord Yahweh, the Set-Apart One of Israel, “You will be saved in returning and rest. Your strength will be in quietness and in confidence.” You refused, 
+<sup>15&#160;</sup>For thus said the Lord Yahuah, the Set-Apart One of Israel, “You will be saved in returning and rest. Your strength will be in quietness and in confidence.” You refused, 
 <sup>16&#160;</sup>but you said, “No, for we will flee on horses;” therefore you will flee; and, “We will ride on the swift;” therefore those who pursue you will be swift. 
 <sup>17&#160;</sup>One thousand will flee at the threat of one. At the threat of five, you will flee until you are left like a beacon on the top of a mountain, and like a banner on a hill. 
 </p><p>
-<sup>18&#160;</sup>Therefore Yahweh will wait, that he may be gracious to you; and therefore he will be exalted, that he may have mercy on you, for Yahweh is an Elohim of justice. Blessed are all those who wait for him. 
+<sup>18&#160;</sup>Therefore Yahuah will wait, that he may be gracious to you; and therefore he will be exalted, that he may have mercy on you, for Yahuah is an Elohim of justice. Blessed are all those who wait for him. 
 <sup>19&#160;</sup>For the people will dwell in Zion at Jerusalem. You will weep no more. He will surely be gracious to you at the voice of your cry. When he hears you, he will answer you. 
 <sup>20&#160;</sup>Though the Lord may give you the bread of adversity and the water of affliction, yet your teachers won’t be hidden any more, but your eyes will see your teachers; 
 <sup>21&#160;</sup>and when you turn to the right hand, and when you turn to the left, your ears will hear a voice behind you, saying, “This is the way. Walk in it.” 
@@ -1379,15 +1379,15 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>He will give the rain for your seed, with which you will sow the ground; and bread of the increase of the ground will be rich and plentiful. In that day, your livestock will feed in large pastures. 
 <sup>24&#160;</sup>The oxen likewise and the young donkeys that till the ground will eat savory feed, which has been winnowed with the shovel and with the fork. 
 <sup>25&#160;</sup>There will be brooks and streams of water on every lofty mountain and on every high hill in the day of the great slaughter, when the towers fall. 
-<sup>26&#160;</sup>Moreover the light of the moon will be like the light of the sun, and the light of the sun will be seven times brighter, like the light of seven days, in the day that Yahweh binds up the fracture of his people, and heals the wound they were struck with. 
+<sup>26&#160;</sup>Moreover the light of the moon will be like the light of the sun, and the light of the sun will be seven times brighter, like the light of seven days, in the day that Yahuah binds up the fracture of his people, and heals the wound they were struck with. 
 </p><p>
-<sup>27&#160;</sup>Behold, Yahweh’s name comes from far away, burning with his anger, and in thick rising smoke. His lips are full of indignation. His tongue is as a devouring fire. 
+<sup>27&#160;</sup>Behold, Yahuah’s name comes from far away, burning with his anger, and in thick rising smoke. His lips are full of indignation. His tongue is as a devouring fire. 
 <sup>28&#160;</sup>His breath is as an overflowing stream that reaches even to the neck, to sift the nations with the sieve of destruction. A bridle that leads to ruin will be in the jaws of the peoples. 
-<sup>29&#160;</sup>You will have a song, as in the night when a set-apart feast is kept, and gladness of heart, as when one goes with a flute to come to Yahweh’s mountain, to Israel’s Rock. 
-<sup>30&#160;</sup>Yahweh will cause his glorious voice to be heard, and will show the descent of his arm, with the indignation of his anger and the flame of a devouring fire, with a blast, storm, and hailstones. 
-<sup>31&#160;</sup>For through Yahweh’s voice the Assyrian will be dismayed. He will strike him with his rod. 
-<sup>32&#160;</sup>Every stroke of the rod of punishment, which Yahweh will lay on him, will be with the sound of tambourines and harps. He will fight with them in battles, brandishing weapons. 
-<sup>33&#160;</sup>For his burning place has long been ready. Yes, it is prepared for the king. He has made its pyre deep and large with fire and much wood. Yahweh’s breath, like a stream of sulfur, kindles it. 
+<sup>29&#160;</sup>You will have a song, as in the night when a set-apart feast is kept, and gladness of heart, as when one goes with a flute to come to Yahuah’s mountain, to Israel’s Rock. 
+<sup>30&#160;</sup>Yahuah will cause his glorious voice to be heard, and will show the descent of his arm, with the indignation of his anger and the flame of a devouring fire, with a blast, storm, and hailstones. 
+<sup>31&#160;</sup>For through Yahuah’s voice the Assyrian will be dismayed. He will strike him with his rod. 
+<sup>32&#160;</sup>Every stroke of the rod of punishment, which Yahuah will lay on him, will be with the sound of tambourines and harps. He will fight with them in battles, brandishing weapons. 
+<sup>33&#160;</sup>For his burning place has long been ready. Yes, it is prepared for the king. He has made its pyre deep and large with fire and much wood. Yahuah’s breath, like a stream of sulfur, kindles it. 
 </p><h2 class="chapterlabel" id="31">31</h2>
 <p class="q1">
 <sup>1&#160;</sup>Woe to those who go down to Egypt for help, 
@@ -1395,7 +1395,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and trust in chariots because they are many, 
 </p><p class="q2">and in horsemen because they are very strong, 
 </p><p class="q2">but they don’t look to the Set-Apart One of Israel, 
-</p><p class="q2">and they don’t seek Yahweh! 
+</p><p class="q2">and they don’t seek Yahuah! 
 </p><p class="q1">
 <sup>2&#160;</sup>Yet he also is wise, and will bring disaster, 
 </p><p class="q2">and will not call back his words, but will arise against the house of the evildoers, 
@@ -1403,19 +1403,19 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>3&#160;</sup>Now the Egyptians are men, and not Elohim; 
 </p><p class="q2">and their horses flesh, and not spirit. 
-</p><p class="q1">When Yahweh stretches out his hand, both he who helps shall stumble, 
+</p><p class="q1">When Yahuah stretches out his hand, both he who helps shall stumble, 
 </p><p class="q2">and he who is helped shall fall, 
 </p><p class="q2">and they all shall be consumed together. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>4&#160;</sup>For Yahweh says to me, 
+<sup>4&#160;</sup>For Yahuah says to me, 
 </p><p class="q1">“As the lion and the young lion growling over his prey, 
 </p><p class="q2">if a multitude of shepherds is called together against him, 
 </p><p class="q2">will not be dismayed at their voice, 
 </p><p class="q2">nor abase himself for their noise, 
-</p><p class="q2">so Yahweh of Armies will come down to fight on Mount Zion and on its heights. 
+</p><p class="q2">so Yahuah of Armies will come down to fight on Mount Zion and on its heights. 
 </p><p class="q1">
-<sup>5&#160;</sup>As birds hovering, so Yahweh of Armies will protect Jerusalem. 
+<sup>5&#160;</sup>As birds hovering, so Yahuah of Armies will protect Jerusalem. 
 </p><p class="q2">He will protect and deliver it. 
 </p><p class="q2">He will pass over and preserve it.” 
 </p><p class="q1">
@@ -1429,7 +1429,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>9&#160;</sup>His rock will pass away by reason of terror, 
 </p><p class="q2">and his princes will be afraid of the banner,” 
-</p><p class="q1">says Yahweh, whose fire is in Zion, 
+</p><p class="q1">says Yahuah, whose fire is in Zion, 
 </p><p class="q2">and his furnace in Jerusalem. 
 </p><h2 class="chapterlabel" id="32">32</h2>
 <p class="q1">
@@ -1453,7 +1453,7 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>For the fool will speak folly, 
 </p><p class="q2">and his heart will work iniquity, 
 </p><p class="q2">to practice profanity, 
-</p><p class="q2">and to utter error against Yahweh, 
+</p><p class="q2">and to utter error against Yahuah, 
 </p><p class="q2">to make empty the soul of the hungry, 
 </p><p class="q2">and to cause the drink of the thirsty to fail. 
 </p><p class="q1">
@@ -1517,7 +1517,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and when you have finished betrayal, you will be betrayed. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>2&#160;</sup>Yahweh, be gracious to us. We have waited for you. 
+<sup>2&#160;</sup>Yahuah, be gracious to us. We have waited for you. 
 </p><p class="q2">Be our strength every morning, 
 </p><p class="q2">our salvation also in the time of trouble. 
 </p><p class="q1">
@@ -1527,11 +1527,11 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>Your plunder will be gathered as the caterpillar gathers. 
 </p><p class="q2">Men will leap on it as locusts leap. 
 </p><p class="q1">
-<sup>5&#160;</sup>Yahweh is exalted, for he dwells on high. 
+<sup>5&#160;</sup>Yahuah is exalted, for he dwells on high. 
 </p><p class="q2">He has filled Zion with justice and righteousness. 
 </p><p class="q1">
 <sup>6&#160;</sup>There will be stability in your times, abundance of salvation, wisdom, and knowledge. 
-</p><p class="q2">The fear of Yahweh is your treasure. 
+</p><p class="q2">The fear of Yahuah is your treasure. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>7&#160;</sup>Behold, their valiant ones cry outside; 
@@ -1547,7 +1547,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Lebanon is confounded and withers away. 
 </p><p class="q2">Sharon is like a desert, and Bashan and Carmel are stripped bare. 
 </p><p class="q1">
-<sup>10&#160;</sup>“Now I will arise,” says Yahweh. 
+<sup>10&#160;</sup>“Now I will arise,” says Yahuah. 
 </p><p class="q2">“Now I will lift myself up. 
 </p><p class="q2">Now I will be exalted. 
 </p><p class="q1">
@@ -1597,14 +1597,14 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Its stakes will never be plucked up, 
 </p><p class="q2">nor will any of its cords be broken. 
 </p><p class="q1">
-<sup>21&#160;</sup>But there Yahweh will be with us in majesty, 
+<sup>21&#160;</sup>But there Yahuah will be with us in majesty, 
 </p><p class="q2">a place of wide rivers and streams, 
 </p><p class="q2">in which no galley with oars will go, 
 </p><p class="q2">neither will any gallant ship pass by there. 
 </p><p class="q1">
-<sup>22&#160;</sup>For Yahweh is our judge. 
-</p><p class="q2">Yahweh is our lawgiver. 
-</p><p class="q2">Yahweh is our king. 
+<sup>22&#160;</sup>For Yahuah is our judge. 
+</p><p class="q2">Yahuah is our lawgiver. 
+</p><p class="q2">Yahuah is our king. 
 </p><p class="q2">He will save us. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -1624,7 +1624,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Let the earth and all it contains hear, 
 </p><p class="q2">the world, and everything that comes from it. 
 </p><p class="q1">
-<sup>2&#160;</sup>For Yahweh is enraged against all the nations, 
+<sup>2&#160;</sup>For Yahuah is enraged against all the nations, 
 </p><p class="q2">and angry with all their armies. 
 </p><p class="q1">He has utterly destroyed them. 
 </p><p class="q2">He has given them over for slaughter. 
@@ -1642,10 +1642,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Behold, it will come down on Edom, 
 </p><p class="q2">and on the people of my curse, for judgment. 
 </p><p class="q1">
-<sup>6&#160;</sup>Yahweh’s sword is filled with blood. 
+<sup>6&#160;</sup>Yahuah’s sword is filled with blood. 
 </p><p class="q2">It is covered with fat, with the blood of lambs and goats, 
 </p><p class="q2">with the fat of the kidneys of rams; 
-</p><p class="q2">for Yahweh has a sacrifice in Bozrah, 
+</p><p class="q2">for Yahuah has a sacrifice in Bozrah, 
 </p><p class="q2">and a great slaughter in the land of Edom. 
 </p><p class="q1">
 <sup>7&#160;</sup>The wild oxen will come down with them, 
@@ -1654,7 +1654,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and their dust made greasy with fat. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>8&#160;</sup>For Yahweh has a day of vengeance, 
+<sup>8&#160;</sup>For Yahuah has a day of vengeance, 
 </p><p class="q2">a year of recompense for the cause of Zion. 
 </p><p class="q1">
 <sup>9&#160;</sup>Its streams will be turned into pitch, 
@@ -1689,7 +1689,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Yes, the kites will be gathered there, every one with her mate. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>16&#160;</sup>Search in the book of Yahweh, and read: 
+<sup>16&#160;</sup>Search in the book of Yahuah, and read: 
 </p><p class="q2">not one of these will be missing. 
 </p><p class="q2">None will lack her mate. 
 </p><p class="q2">For my mouth has commanded, 
@@ -1709,7 +1709,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and rejoice even with joy and singing. 
 </p><p class="q2">Lebanon’s glory will be given to it, 
 </p><p class="q2">the excellence of Carmel and Sharon. 
-</p><p class="q2">They will see Yahweh’s glory, 
+</p><p class="q2">They will see Yahuah’s glory, 
 </p><p class="q2">the excellence of our Elohim. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -1745,7 +1745,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They will not be found there; 
 </p><p class="q2">but the redeemed will walk there. 
 </p><p class="q1">
-<sup>10&#160;</sup>Then Yahweh’s ransomed ones will return, 
+<sup>10&#160;</sup>Then Yahuah’s ransomed ones will return, 
 </p><p class="q2">and come with singing to Zion; 
 </p><p class="q2">and everlasting joy will be on their heads. 
 </p><p class="q1">They will obtain gladness and joy, 
@@ -1759,36 +1759,36 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>Rabshakeh said to them, “Now tell Hezekiah, ‘The great king, the king of Assyria, says, “What confidence is this in which you trust? 
 <sup>5&#160;</sup>I say that your counsel and strength for the war are only vain words. Now in whom do you trust, that you have rebelled against me? 
 <sup>6&#160;</sup>Behold, you trust in the staff of this bruised reed, even in Egypt, which if a man leans on it, it will go into his hand and pierce it. So is Pharaoh king of Egypt to all who trust in him. 
-<sup>7&#160;</sup>But if you tell me, ‘We trust in Yahweh our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar’?” 
+<sup>7&#160;</sup>But if you tell me, ‘We trust in Yahuah our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar’?” 
 <sup>8&#160;</sup>Now therefore, please make a pledge to my master the king of Assyria, and I will give you two thousand horses, if you are able on your part to set riders on them. 
 <sup>9&#160;</sup>How then can you turn away the face of one captain of the least of my master’s servants, and put your trust in Egypt for chariots and for horsemen? 
-<sup>10&#160;</sup>Have I come up now without Yahweh against this land to destroy it? Yahweh said to me, “Go up against this land, and destroy it.”&#160;’&#160;” 
+<sup>10&#160;</sup>Have I come up now without Yahuah against this land to destroy it? Yahuah said to me, “Go up against this land, and destroy it.”&#160;’&#160;” 
 </p><p>
 <sup>11&#160;</sup>Then Eliakim, Shebna and Joah said to Rabshakeh, “Please speak to your servants in Aramaic, for we understand it. Don’t speak to us in the Jews’ language in the hearing of the people who are on the wall.” 
 </p><p>
 <sup>12&#160;</sup>But Rabshakeh said, “Has my master sent me only to your master and to you, to speak these words, and not to the men who sit on the wall, who will eat their own dung and drink their own urine with you?” 
 <sup>13&#160;</sup>Then Rabshakeh stood, and called out with a loud voice in the Jews’ language, and said, “Hear the words of the great king, the king of Assyria! 
 <sup>14&#160;</sup>The king says, ‘Don’t let Hezekiah deceive you; for he will not be able to deliver you. 
-<sup>15&#160;</sup>Don’t let Hezekiah make you trust in Yahweh, saying, “Yahweh will surely deliver us. This city won’t be given into the hand of the king of Assyria.”&#160;’ 
+<sup>15&#160;</sup>Don’t let Hezekiah make you trust in Yahuah, saying, “Yahuah will surely deliver us. This city won’t be given into the hand of the king of Assyria.”&#160;’ 
 <sup>16&#160;</sup>Don’t listen to Hezekiah, for the king of Assyria says, ‘Make your peace with me, and come out to me; and each of you eat from his vine, and each one from his fig tree, and each one of you drink the waters of his own cistern; 
 <sup>17&#160;</sup>until I come and take you away to a land like your own land, a land of grain and new wine, a land of bread and vineyards. 
-<sup>18&#160;</sup>Beware lest Hezekiah persuade you, saying, “Yahweh will deliver us.” Have any of the elohims of the nations delivered their lands from the hand of the king of Assyria? 
+<sup>18&#160;</sup>Beware lest Hezekiah persuade you, saying, “Yahuah will deliver us.” Have any of the elohims of the nations delivered their lands from the hand of the king of Assyria? 
 <sup>19&#160;</sup>Where are the elohims of Hamath and Arpad? Where are the elohims of Sepharvaim? Have they delivered Samaria from my hand? 
-<sup>20&#160;</sup>Who are they among all the elohims of these countries that have delivered their country out of my hand, that Yahweh should deliver Jerusalem out of my hand?’&#160;” 
+<sup>20&#160;</sup>Who are they among all the elohims of these countries that have delivered their country out of my hand, that Yahuah should deliver Jerusalem out of my hand?’&#160;” 
 </p><p>
 <sup>21&#160;</sup>But they remained silent, and said nothing in reply, for the king’s commandment was, “Don’t answer him.” 
 </p><p>
 <sup>22&#160;</sup>Then Eliakim the son of Hilkiah, who was over the household, and Shebna the scribe, and Joah, the son of Asaph the recorder, came to Hezekiah with their clothes torn, and told him the words of Rabshakeh. 
 </p><h2 class="chapterlabel" id="37">37</h2>
 <p>
-<sup>1&#160;</sup>When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahweh’s house. 
+<sup>1&#160;</sup>When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahuah’s house. 
 <sup>2&#160;</sup>He sent Eliakim, who was over the household, and Shebna the scribe, and the elders of the priests, covered with sackcloth, to Isaiah the prophet, the son of Amoz. 
 <sup>3&#160;</sup>They said to him, “Hezekiah says, ‘Today is a day of trouble, and of rebuke, and of rejection; for the children have come to the birth, and there is no strength to give birth. 
-<sup>4&#160;</sup>It may be Yahweh your Elohim will hear the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahweh your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’&#160;” 
+<sup>4&#160;</sup>It may be Yahuah your Elohim will hear the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahuah your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’&#160;” 
 </p><p>
 <sup>5&#160;</sup>So the servants of King Hezekiah came to Isaiah. 
 </p><p>
-<sup>6&#160;</sup>Isaiah said to them, “Tell your master, ‘Yahweh says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
+<sup>6&#160;</sup>Isaiah said to them, “Tell your master, ‘Yahuah says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
 <sup>7&#160;</sup>Behold, I will put a spirit in him and he will hear news, and will return to his own land. I will cause him to fall by the sword in his own land.”&#160;’&#160;” 
 </p><p>
 <sup>8&#160;</sup>So Rabshakeh returned, and found the king of Assyria warring against Libnah, for he heard that he had departed from Lachish. 
@@ -1798,16 +1798,16 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Have the elohims of the nations delivered them, which my fathers have destroyed, Gozan, Haran, Rezeph, and the children of Eden who were in Telassar? 
 <sup>13&#160;</sup>Where is the king of Hamath, and the king of Arpad, and the king of the city of Sepharvaim, of Hena, and Ivvah?’&#160;” 
 </p><p>
-<sup>14&#160;</sup>Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahweh’s house, and spread it before Yahweh. 
-<sup>15&#160;</sup>Hezekiah prayed to Yahweh, saying, 
-<sup>16&#160;</sup>“Yahweh of Armies, the Elohim of Israel, who is enthroned among the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
-<sup>17&#160;</sup>Turn your ear, Yahweh, and hear. Open your eyes, Yahweh, and behold. Hear all of the words of Sennacherib, who has sent to defy the living Elohim. 
-<sup>18&#160;</sup>Truly, Yahweh, the kings of Assyria have destroyed all the countries and their land, 
+<sup>14&#160;</sup>Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahuah’s house, and spread it before Yahuah. 
+<sup>15&#160;</sup>Hezekiah prayed to Yahuah, saying, 
+<sup>16&#160;</sup>“Yahuah of Armies, the Elohim of Israel, who is enthroned among the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
+<sup>17&#160;</sup>Turn your ear, Yahuah, and hear. Open your eyes, Yahuah, and behold. Hear all of the words of Sennacherib, who has sent to defy the living Elohim. 
+<sup>18&#160;</sup>Truly, Yahuah, the kings of Assyria have destroyed all the countries and their land, 
 <sup>19&#160;</sup>and have cast their elohims into the fire; for they were no elohims, but the work of men’s hands, wood and stone; therefore they have destroyed them. 
-<sup>20&#160;</sup>Now therefore, Yahweh our Elohim, save us from his hand, that all the kingdoms of the earth may know that you are Yahweh, even you only.” 
+<sup>20&#160;</sup>Now therefore, Yahuah our Elohim, save us from his hand, that all the kingdoms of the earth may know that you are Yahuah, even you only.” 
 </p><p>
-<sup>21&#160;</sup>Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahweh, the Elohim of Israel says, ‘Because you have prayed to me against Sennacherib king of Assyria, 
-<sup>22&#160;</sup>this is the word which Yahweh has spoken concerning him: The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
+<sup>21&#160;</sup>Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahuah, the Elohim of Israel says, ‘Because you have prayed to me against Sennacherib king of Assyria, 
+<sup>22&#160;</sup>this is the word which Yahuah has spoken concerning him: The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
 <sup>23&#160;</sup>Whom have you defied and blasphemed? Against whom have you exalted your voice and lifted up your eyes on high? Against the Set-Apart One of Israel. 
 <sup>24&#160;</sup>By your servants, you have defied the Lord, and have said, “With the multitude of my chariots I have come up to the height of the mountains, to the innermost parts of Lebanon. I will cut down its tall cedars and its choice cypress trees. I will enter into its farthest height, the forest of its fruitful field. 
 <sup>25&#160;</sup>I have dug and drunk water, and with the sole of my feet I will dry up all the rivers of Egypt.” 
@@ -1819,26 +1819,26 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>30&#160;</sup>“&#160;‘This shall be the sign to you: You will eat this year that which grows of itself, and in the second year that which springs from it; and in the third year sow and reap and plant vineyards, and eat their fruit. 
 <sup>31&#160;</sup>The remnant that is escaped of the house of Judah will again take root downward, and bear fruit upward. 
-<sup>32&#160;</sup>For out of Jerusalem a remnant will go out, and survivors will escape from Mount Zion. The zeal of Yahweh of Armies will perform this.’ 
+<sup>32&#160;</sup>For out of Jerusalem a remnant will go out, and survivors will escape from Mount Zion. The zeal of Yahuah of Armies will perform this.’ 
 </p><p>
-<sup>33&#160;</sup>“Therefore Yahweh says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there, neither will he come before it with shield, nor cast up a mound against it. 
-<sup>34&#160;</sup>He will return the way that he came, and he won’t come to this city,’ says Yahweh. 
+<sup>33&#160;</sup>“Therefore Yahuah says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there, neither will he come before it with shield, nor cast up a mound against it. 
+<sup>34&#160;</sup>He will return the way that he came, and he won’t come to this city,’ says Yahuah. 
 <sup>35&#160;</sup>‘For I will defend this city to save it, for my own sake, and for my servant David’s sake.’&#160;” 
 </p><p>
-<sup>36&#160;</sup>Then Yahweh’s angel went out and struck one hundred and eighty-five thousand men in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
+<sup>36&#160;</sup>Then Yahuah’s angel went out and struck one hundred and eighty-five thousand men in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
 <sup>37&#160;</sup>So Sennacherib king of Assyria departed, went away, returned to Nineveh, and stayed there. 
 <sup>38&#160;</sup>As he was worshiping in the house of Nisroch his elohim, Adrammelech and Sharezer his sons struck him with the sword; and they escaped into the land of Ararat. Esar Haddon his son reigned in his place. 
 </p><h2 class="chapterlabel" id="38">38</h2>
 <p>
-<sup>1&#160;</sup>In those days Hezekiah was sick and near death. Isaiah the prophet, the son of Amoz, came to him, and said to him, “Yahweh says, ‘Set your house in order, for you will die, and not live.’&#160;” 
+<sup>1&#160;</sup>In those days Hezekiah was sick and near death. Isaiah the prophet, the son of Amoz, came to him, and said to him, “Yahuah says, ‘Set your house in order, for you will die, and not live.’&#160;” 
 </p><p>
-<sup>2&#160;</sup>Then Hezekiah turned his face to the wall and prayed to Yahweh, 
-<sup>3&#160;</sup>and said, “Remember now, Yahweh, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” Then Hezekiah wept bitterly. 
+<sup>2&#160;</sup>Then Hezekiah turned his face to the wall and prayed to Yahuah, 
+<sup>3&#160;</sup>and said, “Remember now, Yahuah, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” Then Hezekiah wept bitterly. 
 </p><p>
-<sup>4&#160;</sup>Then Yahweh’s word came to Isaiah, saying, 
-<sup>5&#160;</sup>“Go, and tell Hezekiah, ‘Yahweh, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will add fifteen years to your life. 
+<sup>4&#160;</sup>Then Yahuah’s word came to Isaiah, saying, 
+<sup>5&#160;</sup>“Go, and tell Hezekiah, ‘Yahuah, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will add fifteen years to your life. 
 <sup>6&#160;</sup>I will deliver you and this city out of the hand of the king of Assyria, and I will defend this city. 
-<sup>7&#160;</sup>This shall be the sign to you from Yahweh, that Yahweh will do this thing that he has spoken. 
+<sup>7&#160;</sup>This shall be the sign to you from Yahuah, that Yahuah will do this thing that he has spoken. 
 <sup>8&#160;</sup>Behold, I will cause the shadow on the sundial, which has gone down on the sundial of Ahaz with the sun, to return backward ten steps.”&#160;’&#160;” So the sun returned ten steps on the sundial on which it had gone down. 
 </p><p>
 <sup>9&#160;</sup>The writing of Hezekiah king of Judah, when he had been sick, and had recovered of his sickness: 
@@ -1885,11 +1885,11 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>The living, the living, he shall praise you, as I do today. 
 </p><p class="q2">The father shall make known your truth to the children. 
 </p><p class="q1">
-<sup>20&#160;</sup>Yahweh will save me. 
-</p><p class="q2">Therefore we will sing my songs with stringed instruments all the days of our life in Yahweh’s house. 
+<sup>20&#160;</sup>Yahuah will save me. 
+</p><p class="q2">Therefore we will sing my songs with stringed instruments all the days of our life in Yahuah’s house. 
 </p><p>
 <sup>21&#160;</sup>Now Isaiah had said, “Let them take a cake of figs, and lay it for a poultice on the boil, and he shall recover.” 
-<sup>22&#160;</sup>Hezekiah also had said, “What is the sign that I will go up to Yahweh’s house?” 
+<sup>22&#160;</sup>Hezekiah also had said, “What is the sign that I will go up to Yahuah’s house?” 
 </p><h2 class="chapterlabel" id="39">39</h2>
 <p>
 <sup>1&#160;</sup>At that time, Merodach-baladan the son of Baladan, king of Babylon, sent letters and a present to Hezekiah, for he heard that he had been sick, and had recovered. 
@@ -1900,18 +1900,18 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>Then he asked, “What have they seen in your house?” 
 </p><p>Hezekiah answered, “They have seen all that is in my house. There is nothing among my treasures that I have not shown them.” 
 </p><p>
-<sup>5&#160;</sup>Then Isaiah said to Hezekiah, “Hear the word of Yahweh of Armies: 
-<sup>6&#160;</sup>‘Behold, the days are coming when all that is in your house, and that which your fathers have stored up until today, will be carried to Babylon. Nothing will be left,’ says Yahweh. 
+<sup>5&#160;</sup>Then Isaiah said to Hezekiah, “Hear the word of Yahuah of Armies: 
+<sup>6&#160;</sup>‘Behold, the days are coming when all that is in your house, and that which your fathers have stored up until today, will be carried to Babylon. Nothing will be left,’ says Yahuah. 
 <sup>7&#160;</sup>‘They will take away your sons who will issue from you, whom you shall father, and they will be eunuchs in the king of Babylon’s palace.’&#160;” 
 </p><p>
-<sup>8&#160;</sup>Then Hezekiah said to Isaiah, “Yahweh’s word which you have spoken is good.” He said moreover, “For there will be peace and truth in my days.” 
+<sup>8&#160;</sup>Then Hezekiah said to Isaiah, “Yahuah’s word which you have spoken is good.” He said moreover, “For there will be peace and truth in my days.” 
 </p><h2 class="chapterlabel" id="40">40</h2>
 <p>
 <sup>1&#160;</sup>“Comfort, comfort my people,” says your Elohim. 
-<sup>2&#160;</sup>“Speak comfortably to Jerusalem, and call out to her that her warfare is accomplished, that her iniquity is pardoned, that she has received of Yahweh’s hand double for all her sins.” 
+<sup>2&#160;</sup>“Speak comfortably to Jerusalem, and call out to her that her warfare is accomplished, that her iniquity is pardoned, that she has received of Yahuah’s hand double for all her sins.” 
 </p><p class="q1">
 <sup>3&#160;</sup>The voice of one who calls out, 
-</p><p class="q2">“Prepare the way of Yahweh in the wilderness! 
+</p><p class="q2">“Prepare the way of Yahuah in the wilderness! 
 </p><p class="q2">Make a level highway in the desert for our Elohim. 
 </p><p class="q1">
 <sup>4&#160;</sup>Every valley shall be exalted, 
@@ -1919,9 +1919,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">The uneven shall be made level, 
 </p><p class="q2">and the rough places a plain. 
 </p><p class="q1">
-<sup>5&#160;</sup>Yahweh’s glory shall be revealed, 
+<sup>5&#160;</sup>Yahuah’s glory shall be revealed, 
 </p><p class="q2">and all flesh shall see it together; 
-</p><p class="q2">for the mouth of Yahweh has spoken it.” 
+</p><p class="q2">for the mouth of Yahuah has spoken it.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>6&#160;</sup>The voice of one saying, “Cry out!” 
@@ -1931,7 +1931,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>7&#160;</sup>The grass withers, 
 </p><p class="q2">the flower fades, 
-</p><p class="q2">because Yahweh’s breath blows on it. 
+</p><p class="q2">because Yahuah’s breath blows on it. 
 </p><p class="q2">Surely the people are like grass. 
 </p><p class="q1">
 <sup>8&#160;</sup>The grass withers, 
@@ -1944,7 +1944,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Lift it up! Don’t be afraid! 
 </p><p class="q2">Say to the cities of Judah, “Behold, your Elohim!” 
 </p><p class="q1">
-<sup>10&#160;</sup>Behold, the Lord Yahweh will come as a mighty one, 
+<sup>10&#160;</sup>Behold, the Lord Yahuah will come as a mighty one, 
 </p><p class="q2">and his arm will rule for him. 
 </p><p class="q2">Behold, his reward is with him, 
 </p><p class="q2">and his recompense before him. 
@@ -1961,7 +1961,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and weighed the mountains in scales, 
 </p><p class="q2">and the hills in a balance? 
 </p><p class="q1">
-<sup>13&#160;</sup>Who has directed Yahweh’s Spirit, 
+<sup>13&#160;</sup>Who has directed Yahuah’s Spirit, 
 </p><p class="q2">or has taught him as his counselor? 
 </p><p class="q1">
 <sup>14&#160;</sup>Who did he take counsel with, 
@@ -2026,12 +2026,12 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>27&#160;</sup>Why do you say, Jacob, 
 </p><p class="q2">and speak, Israel, 
-</p><p class="q2">“My way is hidden from Yahweh, 
+</p><p class="q2">“My way is hidden from Yahuah, 
 </p><p class="q2">and the justice due me is disregarded by my Elohim”? 
 </p><p class="q1">
 <sup>28&#160;</sup>Haven’t you known? 
 </p><p class="q2">Haven’t you heard? 
-</p><p class="q2">The everlasting Elohim, Yahweh, 
+</p><p class="q2">The everlasting Elohim, Yahuah, 
 </p><p class="q2">the Creator of the ends of the earth, doesn’t faint. 
 </p><p class="q2">He isn’t weary. 
 </p><p class="q2">His understanding is unsearchable. 
@@ -2042,7 +2042,7 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>Even the youths faint and get weary, 
 </p><p class="q2">and the young men utterly fall; 
 </p><p class="q2">
-<sup>31&#160;</sup>but those who wait for Yahweh will renew their strength. 
+<sup>31&#160;</sup>but those who wait for Yahuah will renew their strength. 
 </p><p class="q2">They will mount up with wings like eagles. 
 </p><p class="q2">They will run, and not be weary. 
 </p><p class="q2">They will walk, and not faint. 
@@ -2067,7 +2067,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>4&#160;</sup>Who has worked and done it, 
 </p><p class="q2">calling the generations from the beginning? 
-</p><p class="q2">I, Yahweh, the first, and with the last, I am he.” 
+</p><p class="q2">I, Yahuah, the first, and with the last, I am he.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>5&#160;</sup>The islands have seen, and fear. 
@@ -2105,13 +2105,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Those who war against you will be as nothing, 
 </p><p class="q2">as a nonexistent thing. 
 </p><p class="q1">
-<sup>13&#160;</sup>For I, Yahweh your Elohim, will hold your right hand, 
+<sup>13&#160;</sup>For I, Yahuah your Elohim, will hold your right hand, 
 </p><p class="q2">saying to you, ‘Don’t be afraid. 
 </p><p class="q2">I will help you.’ 
 </p><p class="q1">
 <sup>14&#160;</sup>Don’t be afraid, you worm Jacob, 
 </p><p class="q2">and you men of Israel. 
-</p><p class="q2">I will help you,” says Yahweh. 
+</p><p class="q2">I will help you,” says Yahuah. 
 </p><p class="q2">“Your Redeemer is the Set-Apart One of Israel. 
 </p><p class="q1">
 <sup>15&#160;</sup>Behold, I have made you into a new sharp threshing instrument with teeth. 
@@ -2122,13 +2122,13 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>You will winnow them, 
 </p><p class="q2">and the wind will carry them away, 
 </p><p class="q2">and the whirlwind will scatter them. 
-</p><p class="q1">You will rejoice in Yahweh. 
+</p><p class="q1">You will rejoice in Yahuah. 
 </p><p class="q2">You will glory in the Set-Apart One of Israel. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>17&#160;</sup>The poor and needy seek water, and there is none. 
 </p><p class="q2">Their tongue fails for thirst. 
-</p><p class="q1">I, Yahweh, will answer them. 
+</p><p class="q1">I, Yahuah, will answer them. 
 </p><p class="q2">I, the Elohim of Israel, will not forsake them. 
 </p><p class="q1">
 <sup>18&#160;</sup>I will open rivers on the bare heights, 
@@ -2140,11 +2140,11 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I will set cypress trees, pine, and box trees together in the desert; 
 </p><p class="q2">
 <sup>20&#160;</sup>that they may see, know, consider, and understand together, 
-</p><p class="q2">that Yahweh’s hand has done this, 
+</p><p class="q2">that Yahuah’s hand has done this, 
 </p><p class="q2">and the Set-Apart One of Israel has created it. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>21&#160;</sup>Produce your cause,” says Yahweh. 
+<sup>21&#160;</sup>Produce your cause,” says Yahuah. 
 </p><p class="q2">“Bring out your strong reasons!” says the King of Jacob. 
 </p><p class="q1">
 <sup>22&#160;</sup>“Let them announce and declare to us what will happen! 
@@ -2202,12 +2202,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and the islands wait for his law.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>5&#160;</sup>Elohim Yahweh, 
+<sup>5&#160;</sup>Elohim Yahuah, 
 </p><p class="q2">he who created the heavens and stretched them out, 
 </p><p class="q2">he who spread out the earth and that which comes out of it, 
 </p><p class="q2">he who gives breath to its people and spirit to those who walk in it, says: 
 </p><p class="q1">
-<sup>6&#160;</sup>“I, Yahweh, have called you in righteousness. 
+<sup>6&#160;</sup>“I, Yahuah, have called you in righteousness. 
 </p><p class="q2">I will hold your hand. 
 </p><p class="q2">I will keep you, 
 </p><p class="q2">and make you a covenant for the people, 
@@ -2218,7 +2218,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and those who sit in darkness out of the prison. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>8&#160;</sup>“I am Yahweh. 
+<sup>8&#160;</sup>“I am Yahuah. 
 </p><p class="q2">That is my name. 
 </p><p class="q2">I will not give my glory to another, 
 </p><p class="q2">nor my praise to engraved images. 
@@ -2228,7 +2228,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I tell you about them before they come up.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>Sing to Yahweh a new song, 
+<sup>10&#160;</sup>Sing to Yahuah a new song, 
 </p><p class="q2">and his praise from the end of the earth, 
 </p><p class="q2">you who go down to the sea, 
 </p><p class="q2">and all that is therein, 
@@ -2239,10 +2239,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Let the inhabitants of Sela sing. 
 </p><p class="q2">Let them shout from the top of the mountains! 
 </p><p class="q1">
-<sup>12&#160;</sup>Let them give glory to Yahweh, 
+<sup>12&#160;</sup>Let them give glory to Yahuah, 
 </p><p class="q2">and declare his praise in the islands. 
 </p><p class="q1">
-<sup>13&#160;</sup>Yahweh will go out like a mighty man. 
+<sup>13&#160;</sup>Yahuah will go out like a mighty man. 
 </p><p class="q2">He will stir up zeal like a man of war. 
 </p><p class="q2">He will raise a war cry. 
 </p><p class="q2">Yes, he will shout aloud. 
@@ -2280,12 +2280,12 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>Who is blind, but my servant? 
 </p><p class="q2">Or who is as deaf as my messenger whom I send? 
 </p><p class="q1">Who is as blind as he who is at peace, 
-</p><p class="q2">and as blind as Yahweh’s servant? 
+</p><p class="q2">and as blind as Yahuah’s servant? 
 </p><p class="q1">
 <sup>20&#160;</sup>You see many things, but don’t observe. 
 </p><p class="q2">His ears are open, but he doesn’t listen. 
 </p><p class="q1">
-<sup>21&#160;</sup>It pleased Yahweh, for his righteousness’ sake, to magnify the law 
+<sup>21&#160;</sup>It pleased Yahuah, for his righteousness’ sake, to magnify the law 
 </p><p class="q2">and make it honorable. 
 </p><p class="q1">
 <sup>22&#160;</sup>But this is a robbed and plundered people. 
@@ -2300,7 +2300,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>24&#160;</sup>Who gave Jacob as plunder, 
 </p><p class="q2">and Israel to the robbers? 
-</p><p class="q2">Didn’t Yahweh, he against whom we have sinned? 
+</p><p class="q2">Didn’t Yahuah, he against whom we have sinned? 
 </p><p class="q2">For they would not walk in his ways, 
 </p><p class="q2">and they disobeyed his law. 
 </p><p class="q1">
@@ -2310,7 +2310,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">It burned him, but he didn’t take it to heart.” 
 </p><h2 class="chapterlabel" id="43">43</h2>
 <p class="q1">
-<sup>1&#160;</sup>But now Yahweh who created you, Jacob, 
+<sup>1&#160;</sup>But now Yahuah who created you, Jacob, 
 </p><p class="q2">and he who formed you, Israel, says: 
 </p><p class="q1">“Don’t be afraid, for I have redeemed you. 
 </p><p class="q2">I have called you by your name. 
@@ -2321,7 +2321,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">When you walk through the fire, you will not be burned, 
 </p><p class="q2">and flame will not scorch you. 
 </p><p class="q1">
-<sup>3&#160;</sup>For I am Yahweh your Elohim, 
+<sup>3&#160;</sup>For I am Yahuah your Elohim, 
 </p><p class="q2">the Set-Apart One of Israel, 
 </p><p class="q2">your Savior. 
 </p><p class="q1">I have given Egypt as your ransom, 
@@ -2357,29 +2357,29 @@ html[dir=ltr] .q2 {
 </p><p class="q2">or let them hear, and say, “That is true.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>“You are my witnesses,” says Yahweh, 
+<sup>10&#160;</sup>“You are my witnesses,” says Yahuah, 
 </p><p class="q2">“With my servant whom I have chosen; 
 </p><p class="q2">that you may know and believe me, 
 </p><p class="q2">and understand that I am he. 
 </p><p class="q1">Before me there was no Elohim formed, 
 </p><p class="q2">neither will there be after me. 
 </p><p class="q1">
-<sup>11&#160;</sup>I myself am Yahweh. 
+<sup>11&#160;</sup>I myself am Yahuah. 
 </p><p class="q2">Besides me, there is no savior. 
 </p><p class="q1">
 <sup>12&#160;</sup>I have declared, I have saved, and I have shown, 
 </p><p class="q2">and there was no strange elohim among you. 
 </p><p class="q1">Therefore you are my witnesses”, 
-</p><p class="q2">says Yahweh, “and I am Elohim. 
+</p><p class="q2">says Yahuah, “and I am Elohim. 
 </p><p class="q1">
 <sup>13&#160;</sup>Yes, since the day was, I am he. 
 </p><p class="q2">There is no one who can deliver out of my hand. 
 </p><p class="q2">I will work, and who can hinder it?” 
 </p><p>
-<sup>14&#160;</sup>Yahweh, your Redeemer, the Set-Apart One of Israel says: “For your sake, I have sent to Babylon, and I will bring all of them down as fugitives, even the Chaldeans, in the ships of their rejoicing. 
-<sup>15&#160;</sup>I am Yahweh, your Set-Apart One, the Creator of Israel, your King.” 
+<sup>14&#160;</sup>Yahuah, your Redeemer, the Set-Apart One of Israel says: “For your sake, I have sent to Babylon, and I will bring all of them down as fugitives, even the Chaldeans, in the ships of their rejoicing. 
+<sup>15&#160;</sup>I am Yahuah, your Set-Apart One, the Creator of Israel, your King.” 
 </p><p>
-<sup>16&#160;</sup>Yahweh, who makes a way in the sea, 
+<sup>16&#160;</sup>Yahuah, who makes a way in the sea, 
 </p><p class="q2">and a path in the mighty waters, 
 </p><p class="q1">
 <sup>17&#160;</sup>who brings out the chariot and horse, 
@@ -2437,7 +2437,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>Yet listen now, Jacob my servant, 
 </p><p class="q2">and Israel, whom I have chosen. 
 </p><p class="q1">
-<sup>2&#160;</sup>This is what Yahweh who made you, 
+<sup>2&#160;</sup>This is what Yahuah who made you, 
 </p><p class="q2">and formed you from the womb, 
 </p><p class="q2">who will help you says: 
 </p><p class="q1">“Don’t be afraid, Jacob my servant; 
@@ -2451,14 +2451,14 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>and they will spring up among the grass, 
 </p><p class="q2">as willows by the watercourses. 
 </p><p class="q1">
-<sup>5&#160;</sup>One will say, ‘I am Yahweh’s.’ 
+<sup>5&#160;</sup>One will say, ‘I am Yahuah’s.’ 
 </p><p class="q2">Another will be called by the name of Jacob; 
-</p><p class="q2">and another will write with his hand ‘to Yahweh,’ 
+</p><p class="q2">and another will write with his hand ‘to Yahuah,’ 
 </p><p class="q2">and honor the name of Israel.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>6&#160;</sup>This is what Yahweh, the King of Israel, 
-</p><p class="q2">and his Redeemer, Yahweh of Armies, says: 
+<sup>6&#160;</sup>This is what Yahuah, the King of Israel, 
+</p><p class="q2">and his Redeemer, Yahuah of Armies, says: 
 </p><p class="q1">“I am the first, and I am the last; 
 </p><p class="q2">and besides me there is no Elohim. 
 </p><p class="q1">
@@ -2565,16 +2565,16 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Return to me, for I have redeemed you. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>23&#160;</sup>Sing, you heavens, for Yahweh has done it! 
+<sup>23&#160;</sup>Sing, you heavens, for Yahuah has done it! 
 </p><p class="q2">Shout, you lower parts of the earth! 
 </p><p class="q2">Break out into singing, you mountains, O forest, all of your trees, 
-</p><p class="q2">for Yahweh has redeemed Jacob, 
+</p><p class="q2">for Yahuah has redeemed Jacob, 
 </p><p class="q2">and will glorify himself in Israel. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>24&#160;</sup>Yahweh, your Redeemer, 
+<sup>24&#160;</sup>Yahuah, your Redeemer, 
 </p><p class="q2">and he who formed you from the womb says: 
-</p><p class="q1">“I am Yahweh, who makes all things; 
+</p><p class="q1">“I am Yahuah, who makes all things; 
 </p><p class="q2">who alone stretches out the heavens; 
 </p><p class="q2">who spreads out the earth by myself; 
 </p><p class="q1">
@@ -2597,7 +2597,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and of the temple, ‘Your foundation will be laid.’&#160;” 
 </p><h2 class="chapterlabel" id="45">45</h2>
 <p>
-<sup>1&#160;</sup>Yahweh says to his anointed, to Cyrus, whose right hand I have held to subdue nations before him and strip kings of their armor, to open the doors before him, and the gates shall not be shut: 
+<sup>1&#160;</sup>Yahuah says to his anointed, to Cyrus, whose right hand I have held to subdue nations before him and strip kings of their armor, to open the doors before him, and the gates shall not be shut: 
 </p><p class="q1">
 <sup>2&#160;</sup>“I will go before you 
 </p><p class="q2">and make the rough places smooth. 
@@ -2606,7 +2606,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>3&#160;</sup>I will give you the treasures of darkness 
 </p><p class="q2">and hidden riches of secret places, 
-</p><p class="q1">that you may know that it is I, Yahweh, who calls you by your name, 
+</p><p class="q1">that you may know that it is I, Yahuah, who calls you by your name, 
 </p><p class="q2">even the Elohim of Israel. 
 </p><p class="q1">
 <sup>4&#160;</sup>For Jacob my servant’s sake, 
@@ -2615,7 +2615,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I have given you a title, 
 </p><p class="q2">though you have not known me. 
 </p><p class="q1">
-<sup>5&#160;</sup>I am Yahweh, and there is no one else. 
+<sup>5&#160;</sup>I am Yahuah, and there is no one else. 
 </p><p class="q2">Besides me, there is no Elohim. 
 </p><p class="q1">I will strengthen you, 
 </p><p class="q2">though you have not known me, 
@@ -2623,13 +2623,13 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>that they may know from the rising of the sun, 
 </p><p class="q2">and from the west, 
 </p><p class="q1">that there is no one besides me. 
-</p><p class="q2">I am Yahweh, and there is no one else. 
+</p><p class="q2">I am Yahuah, and there is no one else. 
 </p><p class="q1">
 <sup>7&#160;</sup>I form the light 
 </p><p class="q2">and create darkness. 
 </p><p class="q1">I make peace 
 </p><p class="q2">and create calamity. 
-</p><p class="q1">I am Yahweh, 
+</p><p class="q1">I am Yahuah, 
 </p><p class="q2">who does all these things. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -2637,7 +2637,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and let the skies pour down righteousness. 
 </p><p class="q1">Let the earth open, that it may produce salvation, 
 </p><p class="q2">and let it cause righteousness to spring up with it. 
-</p><p class="q1">I, Yahweh, have created it. 
+</p><p class="q1">I, Yahuah, have created it. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>9&#160;</sup>Woe to him who strives with his Maker—</p><p class="q2">a clay pot among the clay pots of the earth! 
@@ -2648,7 +2648,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">or to a mother, ‘What have you given birth to?’&#160;” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>11&#160;</sup>Yahweh, the Set-Apart One of Israel 
+<sup>11&#160;</sup>Yahuah, the Set-Apart One of Israel 
 </p><p class="q2">and his Maker says: 
 </p><p class="q1">“You ask me about the things that are to come, concerning my sons, 
 </p><p class="q2">and you command me concerning the work of my hands! 
@@ -2661,10 +2661,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and I will make all his ways straight. 
 </p><p class="q1">He shall build my city, 
 </p><p class="q2">and he shall let my exiles go free, 
-</p><p class="q2">not for price nor reward,” says Yahweh of Armies. 
+</p><p class="q2">not for price nor reward,” says Yahuah of Armies. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>14&#160;</sup>Yahweh says: “The labor of Egypt, 
+<sup>14&#160;</sup>Yahuah says: “The labor of Egypt, 
 </p><p class="q2">and the merchandise of Ethiopia, 
 </p><p class="q2">and the Sabeans, men of stature, will come over to you, 
 </p><p class="q2">and they will be yours. 
@@ -2682,21 +2682,21 @@ html[dir=ltr] .q2 {
 </p><p class="q2">yes, confounded, all of them. 
 </p><p class="q2">Those who are makers of idols will go into confusion together. 
 </p><p class="q1">
-<sup>17&#160;</sup>Israel will be saved by Yahweh with an everlasting salvation. 
+<sup>17&#160;</sup>Israel will be saved by Yahuah with an everlasting salvation. 
 </p><p class="q2">You will not be disappointed nor confounded to ages everlasting. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>18&#160;</sup>For Yahweh who created the heavens, 
+<sup>18&#160;</sup>For Yahuah who created the heavens, 
 </p><p class="q2">the Elohim who formed the earth and made it, 
 </p><p class="q2">who established it and didn’t create it a waste, 
 </p><p class="q2">who formed it to be inhabited says: 
-</p><p class="q1">“I am Yahweh. 
+</p><p class="q1">“I am Yahuah. 
 </p><p class="q2">There is no other. 
 </p><p class="q1">
 <sup>19&#160;</sup>I have not spoken in secret, 
 </p><p class="q2">in a place of the land of darkness. 
 </p><p class="q1">I didn’t say to the offspring of Jacob, ‘Seek me in vain.’ 
-</p><p class="q2">I, Yahweh, speak righteousness. 
+</p><p class="q2">I, Yahuah, speak righteousness. 
 </p><p class="q2">I declare things that are right. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -2709,7 +2709,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Yes, let them take counsel together. 
 </p><p class="q1">Who has shown this from ancient time? 
 </p><p class="q2">Who has declared it of old? 
-</p><p class="q2">Haven’t I, Yahweh? 
+</p><p class="q2">Haven’t I, Yahuah? 
 </p><p class="q1">There is no other Elohim besides me, a just Elohim and a Savior. 
 </p><p class="q2">There is no one besides me. 
 </p><p class="b"> &#160; </p>
@@ -2723,11 +2723,11 @@ html[dir=ltr] .q2 {
 </p><p class="q2">every tongue shall take an oath. 
 </p><p class="q1">
 <sup>24&#160;</sup>They will say of me, 
-</p><p class="q2">‘There is righteousness and strength only in Yahweh.’&#160;” 
+</p><p class="q2">‘There is righteousness and strength only in Yahuah.’&#160;” 
 </p><p class="q1">Even to him will men come. 
 </p><p class="q2">All those who raged against him will be disappointed. 
 </p><p class="q1">
-<sup>25&#160;</sup>All the offspring of Israel will be justified in Yahweh, 
+<sup>25&#160;</sup>All the offspring of Israel will be justified in Yahuah, 
 </p><p class="q2">and will rejoice! 
 </p><h2 class="chapterlabel" id="46">46</h2>
 <p class="q1">
@@ -2815,7 +2815,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will spare no one.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>4&#160;</sup>Our Redeemer, Yahweh of Armies is his name, 
+<sup>4&#160;</sup>Our Redeemer, Yahuah of Armies is his name, 
 </p><p class="q2">is the Set-Apart One of Israel. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -2885,12 +2885,12 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>“Hear this, house of Jacob, 
 </p><p class="q2">you who are called by the name of Israel, 
 </p><p class="q2">and have come out of the waters of Judah. 
-</p><p class="q1">You swear by Yahweh’s name, 
+</p><p class="q1">You swear by Yahuah’s name, 
 </p><p class="q2">and make mention of the Elohim of Israel, 
 </p><p class="q2">but not in truth, nor in righteousness—</p><p class="q1">
 <sup>2&#160;</sup>for they call themselves citizens of the set-apart city, 
 </p><p class="q2">and rely on the Elohim of Israel; 
-</p><p class="q2">Yahweh of Armies is his name. 
+</p><p class="q2">Yahuah of Armies is his name. 
 </p><p class="q1">
 <sup>3&#160;</sup>I have declared the former things from of old. 
 </p><p class="q2">Yes, they went out of my mouth, and I revealed them. 
@@ -2949,7 +2949,7 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>14&#160;</sup>“Assemble yourselves, all of you, and hear! 
 </p><p class="q2">Who among them has declared these things? 
-</p><p class="q1">He whom Yahweh loves will do what he likes to Babylon, 
+</p><p class="q1">He whom Yahuah loves will do what he likes to Babylon, 
 </p><p class="q2">and his arm will be against the Chaldeans. 
 </p><p class="q1">
 <sup>15&#160;</sup>I, even I, have spoken. 
@@ -2962,14 +2962,14 @@ html[dir=ltr] .q2 {
 <p class="q1">“From the beginning I have not spoken in secret; 
 </p><p class="q2">from the time that it happened, I was there.” 
 </p><p class="b"> &#160; </p>
-<p class="q1">Now the Lord Yahweh has sent me 
+<p class="q1">Now the Lord Yahuah has sent me 
 </p><p class="q2">with his Spirit. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>17&#160;</sup>Yahweh, 
+<sup>17&#160;</sup>Yahuah, 
 </p><p class="q2">your Redeemer, 
 </p><p class="q2">the Set-Apart One of Israel, says: 
-</p><p class="q1">“I am Yahweh your Elohim, 
+</p><p class="q1">“I am Yahuah your Elohim, 
 </p><p class="q2">who teaches you to profit, 
 </p><p class="q2">who leads you by the way that you should go. 
 </p><p class="q1">
@@ -2986,19 +2986,19 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Flee from the Chaldeans! 
 </p><p class="q1">With the sound of joyful shouting announce this, 
 </p><p class="q2">tell it even to the end of the earth; 
-</p><p class="q2">say, “Yahweh has redeemed his servant Jacob!” 
+</p><p class="q2">say, “Yahuah has redeemed his servant Jacob!” 
 </p><p class="q1">
 <sup>21&#160;</sup>They didn’t thirst when he led them through the deserts. 
 </p><p class="q2">He caused the waters to flow out of the rock for them. 
 </p><p class="q2">He also split the rock and the waters gushed out. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>22&#160;</sup>“There is no peace”, says Yahweh, “for the wicked.” 
+<sup>22&#160;</sup>“There is no peace”, says Yahuah, “for the wicked.” 
 </p><h2 class="chapterlabel" id="49">49</h2>
 <p class="q1">
 <sup>1&#160;</sup>Listen, islands, to me. 
 </p><p class="q2">Listen, you peoples, from afar: 
-</p><p class="q1">Yahweh has called me from the womb; 
+</p><p class="q1">Yahuah has called me from the womb; 
 </p><p class="q2">from the inside of my mother, he has mentioned my name. 
 </p><p class="q1">
 <sup>2&#160;</sup>He has made my mouth like a sharp sword. 
@@ -3011,14 +3011,14 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>4&#160;</sup>But I said, “I have labored in vain. 
 </p><p class="q2">I have spent my strength in vain for nothing; 
-</p><p class="q1">yet surely the justice due to me is with Yahweh, 
+</p><p class="q1">yet surely the justice due to me is with Yahuah, 
 </p><p class="q2">and my reward with my Elohim.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>5&#160;</sup>Now Yahweh, he who formed me from the womb to be his servant, 
+<sup>5&#160;</sup>Now Yahuah, he who formed me from the womb to be his servant, 
 </p><p class="q2">says to bring Jacob again to him, 
 </p><p class="q2">and to gather Israel to him, 
-</p><p class="q2">for I am honorable in Yahweh’s eyes, 
+</p><p class="q2">for I am honorable in Yahuah’s eyes, 
 </p><p class="q2">and my Elohim has become my strength. 
 </p><p class="q1">
 <sup>6&#160;</sup>Indeed, he says, “It is too light a thing that you should be my servant to raise up the tribes of Jacob, 
@@ -3026,14 +3026,14 @@ html[dir=ltr] .q2 {
 </p><p class="q1">I will also give you as a light to the nations, 
 </p><p class="q2">that you may be my salvation to the end of the earth.” 
 </p><p class="q1">
-<sup>7&#160;</sup>Yahweh, the Redeemer of Israel, and his Set-Apart One, 
+<sup>7&#160;</sup>Yahuah, the Redeemer of Israel, and his Set-Apart One, 
 </p><p class="q2">says to him whom man despises, to him whom the nation abhors, to a servant of rulers: 
 </p><p class="q1">“Kings shall see and rise up, 
 </p><p class="q2">princes, and they shall worship, 
-</p><p class="q2">because of Yahweh who is faithful, even the Set-Apart One of Israel, who has chosen you.” 
+</p><p class="q2">because of Yahuah who is faithful, even the Set-Apart One of Israel, who has chosen you.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>8&#160;</sup>Yahweh says, “I have answered you in an acceptable time. 
+<sup>8&#160;</sup>Yahuah says, “I have answered you in an acceptable time. 
 </p><p class="q2">I have helped you in a day of salvation. 
 </p><p class="q1">I will preserve you and give you for a covenant of the people, 
 </p><p class="q2">to raise up the land, to make them inherit the desolate heritage, 
@@ -3057,11 +3057,11 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>13&#160;</sup>Sing, heavens, and be joyful, earth! 
 </p><p class="q2">Break out into singing, mountains! 
-</p><p class="q1">For Yahweh has comforted his people, 
+</p><p class="q1">For Yahuah has comforted his people, 
 </p><p class="q2">and will have compassion on his afflicted. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>14&#160;</sup>But Zion said, “Yahweh has forsaken me, 
+<sup>14&#160;</sup>But Zion said, “Yahuah has forsaken me, 
 </p><p class="q2">and the Lord has forgotten me.” 
 </p><p class="q1">
 <sup>15&#160;</sup>“Can a woman forget her nursing child, 
@@ -3077,7 +3077,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>18&#160;</sup>Lift up your eyes all around, and see: 
 </p><p class="q2">all these gather themselves together, and come to you. 
-</p><p class="q1">As I live,” says Yahweh, “you shall surely clothe yourself with them all as with an ornament, 
+</p><p class="q1">As I live,” says Yahuah, “you shall surely clothe yourself with them all as with an ornament, 
 </p><p class="q2">and dress yourself with them, like a bride. 
 </p><p class="q1">
 <sup>19&#160;</sup>“For, as for your waste and your desolate places, 
@@ -3095,7 +3095,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Behold, I was left alone. Where were these?’&#160;” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>22&#160;</sup>The Lord Yahweh says, “Behold, I will lift up my hand to the nations, 
+<sup>22&#160;</sup>The Lord Yahuah says, “Behold, I will lift up my hand to the nations, 
 </p><p class="q2">and lift up my banner to the peoples. 
 </p><p class="q1">They shall bring your sons in their bosom, 
 </p><p class="q2">and your daughters shall be carried on their shoulders. 
@@ -3104,25 +3104,25 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and their queens your nursing mothers. 
 </p><p class="q1">They will bow down to you with their faces to the earth, 
 </p><p class="q2">and lick the dust of your feet. 
-</p><p class="q1">Then you will know that I am Yahweh; 
+</p><p class="q1">Then you will know that I am Yahuah; 
 </p><p class="q2">and those who wait for me won’t be disappointed.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>24&#160;</sup>Shall the plunder be taken from the mighty, 
 </p><p class="q2">or the lawful captives be delivered? 
 </p><p class="q1">
-<sup>25&#160;</sup>But Yahweh says, “Even the captives of the mighty shall be taken away, 
+<sup>25&#160;</sup>But Yahuah says, “Even the captives of the mighty shall be taken away, 
 </p><p class="q2">and the plunder retrieved from the fierce, 
 </p><p class="q1">for I will contend with him who contends with you 
 </p><p class="q2">and I will save your children. 
 </p><p class="q1">
 <sup>26&#160;</sup>I will feed those who oppress you with their own flesh; 
 </p><p class="q2">and they will be drunk on their own blood, as with sweet wine. 
-</p><p class="q1">Then all flesh shall know that I, Yahweh, am your Savior 
+</p><p class="q1">Then all flesh shall know that I, Yahuah, am your Savior 
 </p><p class="q2">and your Redeemer, the Mighty One of Jacob.” 
 </p><h2 class="chapterlabel" id="50">50</h2>
 <p class="q1">
-<sup>1&#160;</sup>Yahweh says, “Where is the bill of your mother’s divorce, with which I have put her away? 
+<sup>1&#160;</sup>Yahuah says, “Where is the bill of your mother’s divorce, with which I have put her away? 
 </p><p class="q2">Or to which of my creditors have I sold you? 
 </p><p class="q1">Behold, you were sold for your iniquities, 
 </p><p class="q2">and your mother was put away for your transgressions. 
@@ -3139,12 +3139,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I make sackcloth their covering.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>4&#160;</sup>The Lord Yahweh has given me the tongue of those who are taught, 
+<sup>4&#160;</sup>The Lord Yahuah has given me the tongue of those who are taught, 
 </p><p class="q2">that I may know how to sustain with words him who is weary. 
 </p><p class="q1">He awakens morning by morning, 
 </p><p class="q2">he awakens my ear to hear as those who are taught. 
 </p><p class="q1">
-<sup>5&#160;</sup>The Lord Yahweh has opened my ear. 
+<sup>5&#160;</sup>The Lord Yahuah has opened my ear. 
 </p><p class="q2">I was not rebellious. 
 </p><p class="q2">I have not turned back. 
 </p><p class="q1">
@@ -3152,7 +3152,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and my cheeks to those who plucked off the hair. 
 </p><p class="q2">I didn’t hide my face from shame and spitting. 
 </p><p class="q1">
-<sup>7&#160;</sup>For the Lord Yahweh will help me. 
+<sup>7&#160;</sup>For the Lord Yahuah will help me. 
 </p><p class="q2">Therefore I have not been confounded. 
 </p><p class="q1">Therefore I have set my face like a flint, 
 </p><p class="q2">and I know that I won’t be disappointed. 
@@ -3163,17 +3163,17 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Who is my adversary? 
 </p><p class="q2">Let him come near to me. 
 </p><p class="q1">
-<sup>9&#160;</sup>Behold, the Lord Yahweh will help me! 
+<sup>9&#160;</sup>Behold, the Lord Yahuah will help me! 
 </p><p class="q2">Who is he who will condemn me? 
 </p><p class="q1">Behold, they will all grow old like a garment. 
 </p><p class="q2">The moths will eat them up. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>Who among you fears Yahweh 
+<sup>10&#160;</sup>Who among you fears Yahuah 
 </p><p class="q2">and obeys the voice of his servant? 
 </p><p class="q1">He who walks in darkness 
 </p><p class="q2">and has no light, 
-</p><p class="q1">let him trust in Yahweh’s name, 
+</p><p class="q1">let him trust in Yahuah’s name, 
 </p><p class="q2">and rely on his Elohim. 
 </p><p class="q1">
 <sup>11&#160;</sup>Behold, all you who kindle a fire, 
@@ -3185,7 +3185,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="51">51</h2>
 <p class="q1">
 <sup>1&#160;</sup>“Listen to me, you who follow after righteousness, 
-</p><p class="q2">you who seek Yahweh. 
+</p><p class="q2">you who seek Yahuah. 
 </p><p class="q1">Look to the rock you were cut from, 
 </p><p class="q2">and to the quarry you were dug from. 
 </p><p class="q1">
@@ -3195,10 +3195,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I blessed him, 
 </p><p class="q2">and made him many. 
 </p><p class="q1">
-<sup>3&#160;</sup>For Yahweh has comforted Zion. 
+<sup>3&#160;</sup>For Yahuah has comforted Zion. 
 </p><p class="q2">He has comforted all her waste places, 
 </p><p class="q2">and has made her wilderness like Eden, 
-</p><p class="q2">and her desert like the garden of Yahweh. 
+</p><p class="q2">and her desert like the garden of Yahuah. 
 </p><p class="q1">Joy and gladness will be found in them, 
 </p><p class="q2">thanksgiving, and the voice of melody. 
 </p><p class="b"> &#160; </p>
@@ -3234,7 +3234,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and my salvation to all generations.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>9&#160;</sup>Awake, awake, put on strength, arm of Yahweh! 
+<sup>9&#160;</sup>Awake, awake, put on strength, arm of Yahuah! 
 </p><p class="q2">Awake, as in the days of old, 
 </p><p class="q2">the generations of ancient times. 
 </p><p class="q1">Isn’t it you who cut Rahab in pieces, 
@@ -3244,7 +3244,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the waters of the great deep; 
 </p><p class="q2">who made the depths of the sea a way for the redeemed to pass over? 
 </p><p class="q1">
-<sup>11&#160;</sup>Those ransomed by Yahweh will return, 
+<sup>11&#160;</sup>Those ransomed by Yahuah will return, 
 </p><p class="q2">and come with singing to Zion. 
 </p><p class="q2">Everlasting joy shall be on their heads. 
 </p><p class="q1">They will obtain gladness and joy. 
@@ -3255,7 +3255,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Who are you, that you are afraid of man who shall die, 
 </p><p class="q2">and of the son of man who will be made as grass? 
 </p><p class="q1">
-<sup>13&#160;</sup>Have you forgotten Yahweh your Maker, 
+<sup>13&#160;</sup>Have you forgotten Yahuah your Maker, 
 </p><p class="q2">who stretched out the heavens, 
 </p><p class="q2">and laid the foundations of the earth? 
 </p><p class="q1">Do you live in fear continually all day because of the fury of the oppressor, 
@@ -3266,9 +3266,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He will not die and go down into the pit. 
 </p><p class="q2">His bread won’t fail. 
 </p><p class="q1">
-<sup>15&#160;</sup>For I am Yahweh your Elohim, who stirs up the sea 
+<sup>15&#160;</sup>For I am Yahuah your Elohim, who stirs up the sea 
 </p><p class="q2">so that its waves roar. 
-</p><p class="q2">Yahweh of Armies is his name. 
+</p><p class="q2">Yahuah of Armies is his name. 
 </p><p class="q1">
 <sup>16&#160;</sup>I have put my words in your mouth 
 </p><p class="q2">and have covered you in the shadow of my hand, 
@@ -3279,7 +3279,7 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>17&#160;</sup>Awake, awake! 
 </p><p class="q2">Stand up, Jerusalem, 
-</p><p class="q2">you who have drunk from Yahweh’s hand the cup of his wrath. 
+</p><p class="q2">you who have drunk from Yahuah’s hand the cup of his wrath. 
 </p><p class="q1">You have drunken the bowl of the cup of staggering, 
 </p><p class="q2">and drained it. 
 </p><p class="q1">
@@ -3293,14 +3293,14 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>Your sons have fainted. 
 </p><p class="q2">They lie at the head of all the streets, 
 </p><p class="q2">like an antelope in a net. 
-</p><p class="q1">They are full of Yahweh’s wrath, 
+</p><p class="q1">They are full of Yahuah’s wrath, 
 </p><p class="q2">the rebuke of your Elohim. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>21&#160;</sup>Therefore now hear this, you afflicted, 
 </p><p class="q2">and drunken, but not with wine: 
 </p><p class="q1">
-<sup>22&#160;</sup>Your Lord Yahweh, 
+<sup>22&#160;</sup>Your Lord Yahuah, 
 </p><p class="q2">your Elohim who pleads the cause of his people, says, 
 </p><p class="q1">“Behold, I have taken out of your hand the cup of staggering, 
 </p><p class="q2">even the bowl of the cup of my wrath. 
@@ -3321,18 +3321,18 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Release yourself from the bonds of your neck, captive daughter of Zion! 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>3&#160;</sup>For Yahweh says, “You were sold for nothing; 
+<sup>3&#160;</sup>For Yahuah says, “You were sold for nothing; 
 </p><p class="q2">and you will be redeemed without money.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>4&#160;</sup>For the Lord Yahweh says: 
+<sup>4&#160;</sup>For the Lord Yahuah says: 
 </p><p class="q1">“My people went down at the first into Egypt to live there; 
 </p><p class="q2">and the Assyrian has oppressed them without cause. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>5&#160;</sup>“Now therefore, what do I do here,” says Yahweh, 
+<sup>5&#160;</sup>“Now therefore, what do I do here,” says Yahuah, 
 </p><p class="q2">“seeing that my people are taken away for nothing? 
-</p><p class="q1">Those who rule over them mock,” says Yahweh, 
+</p><p class="q1">Those who rule over them mock,” says Yahuah, 
 </p><p class="q2">“and my name is blasphemed continually all day long. 
 </p><p class="q1">
 <sup>6&#160;</sup>Therefore my people shall know my name. 
@@ -3348,24 +3348,24 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>8&#160;</sup>Your watchmen lift up their voice. 
 </p><p class="q2">Together they sing; 
-</p><p class="q2">for they shall see eye to eye when Yahweh returns to Zion. 
+</p><p class="q2">for they shall see eye to eye when Yahuah returns to Zion. 
 </p><p class="q1">
 <sup>9&#160;</sup>Break out into joy! 
 </p><p class="q2">Sing together, you waste places of Jerusalem; 
-</p><p class="q2">for Yahweh has comforted his people. 
+</p><p class="q2">for Yahuah has comforted his people. 
 </p><p class="q2">He has redeemed Jerusalem. 
 </p><p class="q1">
-<sup>10&#160;</sup>Yahweh has made his set-apart arm bare in the eyes of all the nations. 
+<sup>10&#160;</sup>Yahuah has made his set-apart arm bare in the eyes of all the nations. 
 </p><p class="q2">All the ends of the earth have seen the salvation of our Elohim. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>11&#160;</sup>Depart! Depart! Go out from there! Touch no unclean thing! 
 </p><p class="q2">Go out from among her! 
-</p><p class="q2">Cleanse yourselves, you who carry Yahweh’s vessels. 
+</p><p class="q2">Cleanse yourselves, you who carry Yahuah’s vessels. 
 </p><p class="q1">
 <sup>12&#160;</sup>For you shall not go out in haste, 
 </p><p class="q2">neither shall you go by flight; 
-</p><p class="q1">for Yahweh will go before you, 
+</p><p class="q1">for Yahuah will go before you, 
 </p><p class="q2">and the Elohim of Israel will be your rear guard. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -3381,7 +3381,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="53">53</h2>
 <p class="q1">
 <sup>1&#160;</sup>Who has believed our message? 
-</p><p class="q2">To whom has Yahweh’s arm been revealed? 
+</p><p class="q2">To whom has Yahuah’s arm been revealed? 
 </p><p class="q1">
 <sup>2&#160;</sup>For he grew up before him as a tender plant, 
 </p><p class="q2">and as a root out of dry ground. 
@@ -3408,7 +3408,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>6&#160;</sup>All we like sheep have gone astray. 
 </p><p class="q2">Everyone has turned to his own way; 
-</p><p class="q2">and Yahweh has laid on him the iniquity of us all. 
+</p><p class="q2">and Yahuah has laid on him the iniquity of us all. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>7&#160;</sup>He was oppressed, 
@@ -3428,12 +3428,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">nor was any deceit in his mouth. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>Yet it pleased Yahweh to bruise him. 
+<sup>10&#160;</sup>Yet it pleased Yahuah to bruise him. 
 </p><p class="q2">He has caused him to suffer. 
 </p><p class="q1">When you make his soul an offering for sin, 
 </p><p class="q2">he will see his offspring. 
 </p><p class="q1">He will prolong his days 
-</p><p class="q2">and Yahweh’s pleasure will prosper in his hand. 
+</p><p class="q2">and Yahuah’s pleasure will prosper in his hand. 
 </p><p class="q1">
 <sup>11&#160;</sup>After the suffering of his soul, 
 </p><p class="q2">he will see the light and be satisfied. 
@@ -3450,7 +3450,7 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>1&#160;</sup>“Sing, barren, you who didn’t give birth! 
 </p><p class="q2">Break out into singing, and cry aloud, you who didn’t travail with child! 
-</p><p class="q2">For more are the children of the desolate than the children of the owned woman,” says Yahweh. 
+</p><p class="q2">For more are the children of the desolate than the children of the owned woman,” says Yahuah. 
 </p><p class="q1">
 <sup>2&#160;</sup>“Enlarge the place of your tent, 
 </p><p class="q2">and let them stretch out the curtains of your habitations; 
@@ -3466,11 +3466,11 @@ html[dir=ltr] .q2 {
 </p><p class="q1">For you will forget the shame of your youth. 
 </p><p class="q2">You will remember the reproach of your widowhood no more. 
 </p><p class="q1">
-<sup>5&#160;</sup>For your Maker is your owner; Yahweh of Armies is his name. 
+<sup>5&#160;</sup>For your Maker is your owner; Yahuah of Armies is his name. 
 </p><p class="q2">The Set-Apart One of Israel is your Redeemer. 
 </p><p class="q2">He will be called the Elohim of the whole earth. 
 </p><p class="q1">
-<sup>6&#160;</sup>For Yahweh has called you as a woman forsaken and grieved in spirit, 
+<sup>6&#160;</sup>For Yahuah has called you as a woman forsaken and grieved in spirit, 
 </p><p class="q2">even a woman of youth, when she is cast off,” says your Elohim. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -3478,7 +3478,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">but I will gather you with great mercies. 
 </p><p class="q1">
 <sup>8&#160;</sup>In overflowing wrath I hid my face from you for a moment, 
-</p><p class="q2">but with everlasting loving kindness I will have mercy on you,” says Yahweh your Redeemer. 
+</p><p class="q2">but with everlasting loving kindness I will have mercy on you,” says Yahuah your Redeemer. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>9&#160;</sup>“For this is like the waters of Noah to me; 
@@ -3489,7 +3489,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and the hills be removed, 
 </p><p class="q1">but my loving kindness will not depart from you, 
 </p><p class="q2">and my covenant of peace will not be removed,” 
-</p><p class="q2">says Yahweh who has mercy on you. 
+</p><p class="q2">says Yahuah who has mercy on you. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>11&#160;</sup>“You afflicted, tossed with storms, and not comforted, 
@@ -3500,7 +3500,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">your gates of sparkling jewels, 
 </p><p class="q2">and all your walls of precious stones. 
 </p><p class="q1">
-<sup>13&#160;</sup>All your children will be taught by Yahweh, 
+<sup>13&#160;</sup>All your children will be taught by Yahuah, 
 </p><p class="q2">and your children’s peace will be great. 
 </p><p class="q1">
 <sup>14&#160;</sup>You will be established in righteousness. 
@@ -3519,8 +3519,8 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>17&#160;</sup>No weapon that is formed against you will prevail; 
 </p><p class="q2">and you will condemn every tongue that rises against you in judgment. 
-</p><p class="q1">This is the heritage of Yahweh’s servants, 
-</p><p class="q2">and their righteousness is of me,” says Yahweh. 
+</p><p class="q1">This is the heritage of Yahuah’s servants, 
+</p><p class="q2">and their righteousness is of me,” says Yahuah. 
 </p><h2 class="chapterlabel" id="55">55</h2>
 <p class="q1">
 <sup>1&#160;</sup>“Hey! Come, everyone who thirsts, to the waters! 
@@ -3541,22 +3541,22 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>5&#160;</sup>Behold, you shall call a nation that you don’t know; 
 </p><p class="q2">and a nation that didn’t know you shall run to you, 
-</p><p class="q2">because of Yahweh your Elohim, 
+</p><p class="q2">because of Yahuah your Elohim, 
 </p><p class="q2">and for the Set-Apart One of Israel; 
 </p><p class="q2">for he has glorified you.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>6&#160;</sup>Seek Yahweh while he may be found. 
+<sup>6&#160;</sup>Seek Yahuah while he may be found. 
 </p><p class="q2">Call on him while he is near. 
 </p><p class="q1">
 <sup>7&#160;</sup>Let the wicked forsake his way, 
 </p><p class="q2">and the unrighteous man his thoughts. 
-</p><p class="q1">Let him return to Yahweh, and he will have mercy on him, 
+</p><p class="q1">Let him return to Yahuah, and he will have mercy on him, 
 </p><p class="q2">to our Elohim, for he will freely pardon. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>8&#160;</sup>“For my thoughts are not your thoughts, 
-</p><p class="q2">and your ways are not my ways,” says Yahweh. 
+</p><p class="q2">and your ways are not my ways,” says Yahuah. 
 </p><p class="q1">
 <sup>9&#160;</sup>“For as the heavens are higher than the earth, 
 </p><p class="q2">so are my ways higher than your ways, 
@@ -3579,11 +3579,11 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>13&#160;</sup>Instead of the thorn the cypress tree will come up; 
 </p><p class="q2">and instead of the brier the myrtle tree will come up. 
-</p><p class="q1">It will make a name for Yahweh, 
+</p><p class="q1">It will make a name for Yahuah, 
 </p><p class="q2">for an everlasting sign that will not be cut off.” 
 </p><h2 class="chapterlabel" id="56">56</h2>
 <p>
-<sup>1&#160;</sup>Yahweh says: 
+<sup>1&#160;</sup>Yahuah says: 
 </p><p class="q1">“Maintain justice 
 </p><p class="q2">and do what is right, 
 </p><p class="q1">for my salvation is near 
@@ -3595,12 +3595,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and keeps his hand from doing any evil.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>3&#160;</sup>Let no foreigner who has joined himself to Yahweh speak, saying, 
-</p><p class="q2">“Yahweh will surely separate me from his people.” 
+<sup>3&#160;</sup>Let no foreigner who has joined himself to Yahuah speak, saying, 
+</p><p class="q2">“Yahuah will surely separate me from his people.” 
 </p><p class="q2">Do not let the eunuch say, “Behold, I am a dry tree.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>4&#160;</sup>For Yahweh says, “To the eunuchs who keep my Sabbaths, 
+<sup>4&#160;</sup>For Yahuah says, “To the eunuchs who keep my Sabbaths, 
 </p><p class="q2">choose the things that please me, 
 </p><p class="q2">and hold fast to my covenant, 
 </p><p class="q1">
@@ -3608,9 +3608,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I will give them an everlasting name that will not be cut off. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>6&#160;</sup>Also the foreigners who join themselves to Yahweh 
+<sup>6&#160;</sup>Also the foreigners who join themselves to Yahuah 
 </p><p class="q2">to serve him, 
-</p><p class="q1">and to love Yahweh’s name, 
+</p><p class="q1">and to love Yahuah’s name, 
 </p><p class="q2">to be his servants, 
 </p><p class="q1">everyone who keeps the Sabbath from profaning it, 
 </p><p class="q2">and holds fast my covenant, 
@@ -3620,7 +3620,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Their burnt offerings and their sacrifices will be accepted on my altar; 
 </p><p class="q2">for my house will be called a house of prayer for all peoples.” 
 </p><p class="q1">
-<sup>8&#160;</sup>The Lord Yahweh, who gathers the outcasts of Israel, says, 
+<sup>8&#160;</sup>The Lord Yahuah, who gathers the outcasts of Israel, says, 
 </p><p class="q2">“I will yet gather others to him, 
 </p><p class="q2">in addition to his own who are gathered.” 
 </p><p class="b"> &#160; </p>
@@ -3737,7 +3737,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>19&#160;</sup>I create the fruit of the lips: 
 </p><p class="q2">Peace, peace, to him who is far off and to him who is near,” 
-</p><p class="q2">says Yahweh; “and I will heal them.” 
+</p><p class="q2">says Yahuah; “and I will heal them.” 
 </p><p class="q1">
 <sup>20&#160;</sup>But the wicked are like the troubled sea; 
 </p><p class="q2">for it can’t rest and its waters cast up mire and mud. 
@@ -3773,7 +3773,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Is it to bow down his head like a reed, 
 </p><p class="q2">and to spread sackcloth and ashes under himself? 
 </p><p class="q1">Will you call this a fast, 
-</p><p class="q2">and an acceptable day to Yahweh? 
+</p><p class="q2">and an acceptable day to Yahuah? 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>6&#160;</sup>“Isn’t this the fast that I have chosen: 
@@ -3791,9 +3791,9 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>Then your light will break out as the morning, 
 </p><p class="q2">and your healing will appear quickly; 
 </p><p class="q1">then your righteousness shall go before you, 
-</p><p class="q2">and Yahweh’s glory will be your rear guard. 
+</p><p class="q2">and Yahuah’s glory will be your rear guard. 
 </p><p class="q1">
-<sup>9&#160;</sup>Then you will call, and Yahweh will answer. 
+<sup>9&#160;</sup>Then you will call, and Yahuah will answer. 
 </p><p class="q2">You will cry for help, and he will say, ‘Here I am.’ 
 </p><p class="b"> &#160; </p>
 <p class="q1">“If you take away from among you the yoke, 
@@ -3805,7 +3805,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">then your light will rise in darkness, 
 </p><p class="q2">and your obscurity will be as the noonday; 
 </p><p class="q1">
-<sup>11&#160;</sup>and Yahweh will guide you continually, 
+<sup>11&#160;</sup>and Yahuah will guide you continually, 
 </p><p class="q2">satisfy your soul in dry places, 
 </p><p class="q2">and make your bones strong. 
 </p><p class="q1">You will be like a watered garden, 
@@ -3821,19 +3821,19 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>“If you turn away your foot from the Sabbath, 
 </p><p class="q2">from doing your pleasure on my set-apart day, 
 </p><p class="q1">and call the Sabbath a delight, 
-</p><p class="q2">and the set-apart of Yahweh honorable, 
+</p><p class="q2">and the set-apart of Yahuah honorable, 
 </p><p class="q2">and honor it, 
 </p><p class="q2">not doing your own ways, 
 </p><p class="q2">nor finding your own pleasure, 
 </p><p class="q2">nor speaking your own words, 
 </p><p class="q1">
-<sup>14&#160;</sup>then you will delight yourself in Yahweh, 
+<sup>14&#160;</sup>then you will delight yourself in Yahuah, 
 </p><p class="q2">and I will make you to ride on the high places of the earth, 
 </p><p class="q2">and I will feed you with the heritage of Jacob your father;” 
-</p><p class="q2">for Yahweh’s mouth has spoken it. 
+</p><p class="q2">for Yahuah’s mouth has spoken it. 
 </p><h2 class="chapterlabel" id="59">59</h2>
 <p class="q1">
-<sup>1&#160;</sup>Behold, Yahweh’s hand is not shortened, that it can’t save; 
+<sup>1&#160;</sup>Behold, Yahuah’s hand is not shortened, that it can’t save; 
 </p><p class="q2">nor his ear dull, that it can’t hear. 
 </p><p class="q1">
 <sup>2&#160;</sup>But your iniquities have separated you and your Elohim, 
@@ -3894,7 +3894,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">for our transgressions are with us, 
 </p><p class="q2">and as for our iniquities, we know them: 
 </p><p class="q1">
-<sup>13&#160;</sup>transgressing and denying Yahweh, 
+<sup>13&#160;</sup>transgressing and denying Yahuah, 
 </p><p class="q2">and turning away from following our Elohim, 
 </p><p class="q2">speaking oppression and revolt, 
 </p><p class="q2">conceiving and uttering from the heart words of falsehood. 
@@ -3907,7 +3907,7 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Yes, truth is lacking; 
 </p><p class="q2">and he who departs from evil makes himself a prey. 
 </p><p class="b"> &#160; </p>
-<p class="q1">Yahweh saw it, 
+<p class="q1">Yahuah saw it, 
 </p><p class="q2">and it displeased him that there was no justice. 
 </p><p class="q1">
 <sup>16&#160;</sup>He saw that there was no man, 
@@ -3926,24 +3926,24 @@ html[dir=ltr] .q2 {
 </p><p class="q2">recompense to his enemies. 
 </p><p class="q2">He will repay the islands their due. 
 </p><p class="q1">
-<sup>19&#160;</sup>So they will fear Yahweh’s name from the west, 
+<sup>19&#160;</sup>So they will fear Yahuah’s name from the west, 
 </p><p class="q2">and his glory from the rising of the sun; 
 </p><p class="q1">for he will come as a rushing stream, 
-</p><p class="q2">which Yahweh’s breath drives. 
+</p><p class="q2">which Yahuah’s breath drives. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>20&#160;</sup>“A Redeemer will come to Zion, 
-</p><p class="q2">and to those who turn from disobedience in Jacob,” says Yahweh. 
+</p><p class="q2">and to those who turn from disobedience in Jacob,” says Yahuah. 
 </p><p>
-<sup>21&#160;</sup>“As for me, this is my covenant with them,” says Yahweh. “My Spirit who is on you, and my words which I have put in your mouth shall not depart out of your mouth, nor out of the mouth of your offspring, nor out of the mouth of your offspring’s offspring,” says Yahweh, “from now on and forever.” 
+<sup>21&#160;</sup>“As for me, this is my covenant with them,” says Yahuah. “My Spirit who is on you, and my words which I have put in your mouth shall not depart out of your mouth, nor out of the mouth of your offspring, nor out of the mouth of your offspring’s offspring,” says Yahuah, “from now on and forever.” 
 </p><h2 class="chapterlabel" id="60">60</h2>
 <p class="q1">
 <sup>1&#160;</sup>“Arise, shine; for your light has come, 
-</p><p class="q2">and Yahweh’s glory has risen on you! 
+</p><p class="q2">and Yahuah’s glory has risen on you! 
 </p><p class="q1">
 <sup>2&#160;</sup>For behold, darkness will cover the earth, 
 </p><p class="q2">and thick darkness the peoples; 
-</p><p class="q1">but Yahweh will arise on you, 
+</p><p class="q1">but Yahuah will arise on you, 
 </p><p class="q2">and his glory shall be seen on you. 
 </p><p class="q1">
 <sup>3&#160;</sup>Nations will come to your light, 
@@ -3965,7 +3965,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the dromedaries of Midian and Ephah. 
 </p><p class="q1">All from Sheba will come. 
 </p><p class="q2">They will bring gold and frankincense, 
-</p><p class="q2">and will proclaim the praises of Yahweh. 
+</p><p class="q2">and will proclaim the praises of Yahuah. 
 </p><p class="q1">
 <sup>7&#160;</sup>All the flocks of Kedar will be gathered together to you. 
 </p><p class="q2">The rams of Nebaioth will serve you. 
@@ -3980,7 +3980,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and the ships of Tarshish first, 
 </p><p class="q1">to bring your sons from far away, 
 </p><p class="q2">their silver and their gold with them, 
-</p><p class="q1">for the name of Yahweh your Elohim, 
+</p><p class="q1">for the name of Yahuah your Elohim, 
 </p><p class="q2">and for the Set-Apart One of Israel, 
 </p><p class="q2">because he has glorified you. 
 </p><p class="b"> &#160; </p>
@@ -3999,7 +3999,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>14&#160;</sup>The sons of those who afflicted you will come bowing to you; 
 </p><p class="q2">and all those who despised you will bow themselves down at the soles of your feet. 
-</p><p class="q1">They will call you Yahweh’s City, 
+</p><p class="q1">They will call you Yahuah’s City, 
 </p><p class="q2">the Zion of the Set-Apart One of Israel. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -4010,7 +4010,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>16&#160;</sup>You will also drink the milk of the nations, 
 </p><p class="q2">and will nurse from royal breasts. 
-</p><p class="q1">Then you will know that I, Yahweh, am your Savior, 
+</p><p class="q1">Then you will know that I, Yahuah, am your Savior, 
 </p><p class="q2">your Redeemer, 
 </p><p class="q2">the Mighty One of Jacob. 
 </p><p class="q1">
@@ -4028,12 +4028,12 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>19&#160;</sup>The sun will be no more your light by day, 
 </p><p class="q2">nor will the brightness of the moon give light to you, 
-</p><p class="q1">but Yahweh will be your everlasting light, 
+</p><p class="q1">but Yahuah will be your everlasting light, 
 </p><p class="q2">and your Elohim will be your glory. 
 </p><p class="q1">
 <sup>20&#160;</sup>Your sun will not go down any more, 
 </p><p class="q2">nor will your moon withdraw itself; 
-</p><p class="q1">for Yahweh will be your everlasting light, 
+</p><p class="q1">for Yahuah will be your everlasting light, 
 </p><p class="q2">and the days of your mourning will end. 
 </p><p class="q1">
 <sup>21&#160;</sup>Then your people will all be righteous. 
@@ -4044,16 +4044,16 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>22&#160;</sup>The little one will become a thousand, 
 </p><p class="q2">and the small one a strong nation. 
-</p><p class="q2">I, Yahweh, will do this quickly in its time.” 
+</p><p class="q2">I, Yahuah, will do this quickly in its time.” 
 </p><h2 class="chapterlabel" id="61">61</h2>
 <p class="q1">
-<sup>1&#160;</sup>The Lord Yahweh’s Spirit is on me, 
-</p><p class="q2">because Yahweh has anointed me to preach good news to the humble. 
+<sup>1&#160;</sup>The Lord Yahuah’s Spirit is on me, 
+</p><p class="q2">because Yahuah has anointed me to preach good news to the humble. 
 </p><p class="q1">He has sent me to bind up the broken hearted, 
 </p><p class="q2">to proclaim liberty to the captives 
 </p><p class="q2">and release to those who are bound, 
 </p><p class="q1">
-<sup>2&#160;</sup>to proclaim the year of Yahweh’s favor 
+<sup>2&#160;</sup>to proclaim the year of Yahuah’s favor 
 </p><p class="q2">and the day of vengeance of our Elohim, 
 </p><p class="q2">to comfort all who mourn, 
 </p><p class="q1">
@@ -4062,7 +4062,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the oil of joy for mourning, 
 </p><p class="q2">the garment of praise for the spirit of heaviness, 
 </p><p class="q1">that they may be called trees of righteousness, 
-</p><p class="q2">the planting of Yahweh, 
+</p><p class="q2">the planting of Yahuah, 
 </p><p class="q2">that he may be glorified. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -4074,7 +4074,7 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>Strangers will stand and feed your flocks. 
 </p><p class="q2">Foreigners will work your fields and your vineyards. 
 </p><p class="q1">
-<sup>6&#160;</sup>But you will be called Yahweh’s priests. 
+<sup>6&#160;</sup>But you will be called Yahuah’s priests. 
 </p><p class="q2">Men will call you the servants of our Elohim. 
 </p><p class="q1">You will eat the wealth of the nations. 
 </p><p class="q2">You will boast in their glory. 
@@ -4084,7 +4084,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Therefore in their land they will possess double. 
 </p><p class="q2">Everlasting joy will be to them. 
 </p><p class="q1">
-<sup>8&#160;</sup>“For I, Yahweh, love justice. 
+<sup>8&#160;</sup>“For I, Yahuah, love justice. 
 </p><p class="q2">I hate robbery and iniquity. 
 </p><p class="q1">I will give them their reward in truth 
 </p><p class="q2">and I will make an everlasting covenant with them. 
@@ -4092,10 +4092,10 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Their offspring will be known among the nations, 
 </p><p class="q2">and their offspring among the peoples. 
 </p><p class="q1">All who see them will acknowledge them, 
-</p><p class="q2">that they are the offspring which Yahweh has blessed.” 
+</p><p class="q2">that they are the offspring which Yahuah has blessed.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>I will greatly rejoice in Yahweh! 
+<sup>10&#160;</sup>I will greatly rejoice in Yahuah! 
 </p><p class="q2">My soul will be joyful in my Elohim, 
 </p><p class="q1">for he has clothed me with the garments of salvation. 
 </p><p class="q2">He has covered me with the robe of righteousness, 
@@ -4104,7 +4104,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>11&#160;</sup>For as the earth produces its bud, 
 </p><p class="q2">and as the garden causes the things that are sown in it to spring up, 
-</p><p class="q2">so the Lord Yahweh will cause righteousness and praise to spring up before all the nations. 
+</p><p class="q2">so the Lord Yahuah will cause righteousness and praise to spring up before all the nations. 
 </p><h2 class="chapterlabel" id="62">62</h2>
 <p class="q1">
 <sup>1&#160;</sup>For Zion’s sake I will not hold my peace, 
@@ -4115,16 +4115,16 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>The nations will see your righteousness, 
 </p><p class="q2">and all kings your glory. 
 </p><p class="q1">You will be called by a new name, 
-</p><p class="q2">which Yahweh’s mouth will name. 
+</p><p class="q2">which Yahuah’s mouth will name. 
 </p><p class="q1">
-<sup>3&#160;</sup>You will also be a crown of beauty in Yahweh’s hand, 
+<sup>3&#160;</sup>You will also be a crown of beauty in Yahuah’s hand, 
 </p><p class="q2">and a royal diadem in your Elohim’s hand. 
 </p><p class="q1">
 <sup>4&#160;</sup>You will not be called Forsaken any more, 
 </p><p class="q2">nor will your land be called Desolate any more; 
 </p><p class="q1">but you will be called Hephzibah, 
 </p><p class="q2">and your land Beulah; 
-</p><p class="q1">for Yahweh delights in you, 
+</p><p class="q1">for Yahuah delights in you, 
 </p><p class="q2">and your land will be owned. 
 </p><p class="q1">
 <sup>5&#160;</sup>For as a young man owns a virgin, 
@@ -4135,18 +4135,18 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>6&#160;</sup>I have set watchmen on your walls, Jerusalem. 
 </p><p class="q2">They will never be silent day nor night. 
-</p><p class="q1">You who call on Yahweh, take no rest, 
+</p><p class="q1">You who call on Yahuah, take no rest, 
 </p><p class="q2">
 <sup>7&#160;</sup>and give him no rest until he establishes, 
 </p><p class="q2">and until he makes Jerusalem a praise in the earth. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>8&#160;</sup>Yahweh has sworn by his right hand, 
+<sup>8&#160;</sup>Yahuah has sworn by his right hand, 
 </p><p class="q2">and by the arm of his strength, 
 </p><p class="q1">“Surely I will no more give your grain to be food for your enemies, 
 </p><p class="q2">and foreigners will not drink your new wine, for which you have labored, 
 </p><p class="q1">
-<sup>9&#160;</sup>but those who have harvested it will eat it, and praise Yahweh. 
+<sup>9&#160;</sup>but those who have harvested it will eat it, and praise Yahuah. 
 </p><p class="q2">Those who have gathered it will drink it in the courts of my sanctuary.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -4156,14 +4156,14 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Gather out the stones! 
 </p><p class="q2">Lift up a banner for the peoples. 
 </p><p class="q1">
-<sup>11&#160;</sup>Behold, Yahweh has proclaimed to the end of the earth: 
+<sup>11&#160;</sup>Behold, Yahuah has proclaimed to the end of the earth: 
 </p><p class="q2">“Say to the daughter of Zion, 
 </p><p class="q2">‘Behold, your salvation comes! 
 </p><p class="q1">Behold, his reward is with him, 
 </p><p class="q2">and his recompense before him!’&#160;” 
 </p><p class="q1">
 <sup>12&#160;</sup>They will call them “The Set-Apart People, 
-</p><p class="q2">Yahweh’s Redeemed”. 
+</p><p class="q2">Yahuah’s Redeemed”. 
 </p><p class="q1">You will be called “Sought Out, 
 </p><p class="q2">A City Not Forsaken”. 
 </p><h2 class="chapterlabel" id="63">63</h2>
@@ -4199,9 +4199,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I poured their lifeblood out on the earth.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>7&#160;</sup>I will tell of the loving kindnesses of Yahweh 
-</p><p class="q2">and the praises of Yahweh, 
-</p><p class="q2">according to all that Yahweh has given to us, 
+<sup>7&#160;</sup>I will tell of the loving kindnesses of Yahuah 
+</p><p class="q2">and the praises of Yahuah, 
+</p><p class="q2">according to all that Yahuah has given to us, 
 </p><p class="q1">and the great goodness toward the house of Israel, 
 </p><p class="q2">which he has given to them according to his mercies, 
 </p><p class="q2">and according to the multitude of his loving kindnesses. 
@@ -4236,7 +4236,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">so that they didn’t stumble? 
 </p><p class="q1">
 <sup>14&#160;</sup>As the livestock that go down into the valley, 
-</p><p class="q2">Yahweh’s Spirit caused them to rest. 
+</p><p class="q2">Yahuah’s Spirit caused them to rest. 
 </p><p class="q2">So you led your people to make yourself a glorious name. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -4248,10 +4248,10 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>For you are our Father, 
 </p><p class="q2">though Abraham doesn’t know us, 
 </p><p class="q2">and Israel does not acknowledge us. 
-</p><p class="q1">You, Yahweh, are our Father. 
+</p><p class="q1">You, Yahuah, are our Father. 
 </p><p class="q2">Our Redeemer from everlasting is your name. 
 </p><p class="q1">
-<sup>17&#160;</sup>O Yahweh, why do you make us wander from your ways, 
+<sup>17&#160;</sup>O Yahuah, why do you make us wander from your ways, 
 </p><p class="q2">and harden our heart from your fear? 
 </p><p class="q1">Return for your servants’ sake, 
 </p><p class="q2">the tribes of your inheritance. 
@@ -4296,11 +4296,11 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and have consumed us by means of our iniquities. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>8&#160;</sup>But now, Yahweh, you are our Father. 
+<sup>8&#160;</sup>But now, Yahuah, you are our Father. 
 </p><p class="q2">We are the clay and you our potter. 
 </p><p class="q2">We all are the work of your hand. 
 </p><p class="q1">
-<sup>9&#160;</sup>Don’t be furious, Yahweh. 
+<sup>9&#160;</sup>Don’t be furious, Yahuah. 
 </p><p class="q2">Don’t remember iniquity forever. 
 </p><p class="q1">Look and see, we beg you, 
 </p><p class="q2">we are all your people. 
@@ -4313,7 +4313,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">is burned with fire. 
 </p><p class="q2">All our pleasant places are laid waste. 
 </p><p class="q1">
-<sup>12&#160;</sup>Will you hold yourself back for these things, Yahweh? 
+<sup>12&#160;</sup>Will you hold yourself back for these things, Yahuah? 
 </p><p class="q2">Will you keep silent and punish us very severely? 
 </p><h2 class="chapterlabel" id="65">65</h2>
 <p class="q1">
@@ -4346,13 +4346,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">but will repay, 
 </p><p class="q2">yes, I will repay into their bosom 
 </p><p class="q1">
-<sup>7&#160;</sup>your own iniquities and the iniquities of your fathers together”, says Yahweh, 
+<sup>7&#160;</sup>your own iniquities and the iniquities of your fathers together”, says Yahuah, 
 </p><p class="q2">“who have burned incense on the mountains, 
 </p><p class="q2">and blasphemed me on the hills. 
 </p><p class="q2">Therefore I will first measure their work into their bosom.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>8&#160;</sup>Yahweh says, 
+<sup>8&#160;</sup>Yahuah says, 
 </p><p class="q1">“As the new wine is found in the cluster, 
 </p><p class="q2">and one says, ‘Don’t destroy it, for a blessing is in it:’ 
 </p><p class="q1">so I will do for my servants’ sake, 
@@ -4368,7 +4368,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for my people who have sought me. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>11&#160;</sup>“But you who forsake Yahweh, 
+<sup>11&#160;</sup>“But you who forsake Yahuah, 
 </p><p class="q2">who forget my set-apart mountain, 
 </p><p class="q2">who prepare a table for Fortune, 
 </p><p class="q2">and who fill up mixed wine to Destiny; 
@@ -4381,7 +4381,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and chose that in which I didn’t delight.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>13&#160;</sup>Therefore the Lord Yahweh says, 
+<sup>13&#160;</sup>Therefore the Lord Yahuah says, 
 </p><p class="q1">“Behold, my servants will eat, 
 </p><p class="q2">but you will be hungry; 
 </p><p class="q1">behold, my servants will drink, 
@@ -4394,7 +4394,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will wail for anguish of spirit. 
 </p><p class="q1">
 <sup>15&#160;</sup>You will leave your name for a curse to my chosen, 
-</p><p class="q2">and the Lord Yahweh will kill you. 
+</p><p class="q2">and the Lord Yahuah will kill you. 
 </p><p class="q1">He will call his servants by another name, 
 </p><p class="q2">
 <sup>16&#160;</sup>so that he who blesses himself in the earth will bless himself in the Elohim of truth; 
@@ -4432,7 +4432,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>23&#160;</sup>They will not labor in vain 
 </p><p class="q2">nor give birth for calamity; 
-</p><p class="q1">for they are the offspring of Yahweh’s blessed 
+</p><p class="q1">for they are the offspring of Yahuah’s blessed 
 </p><p class="q2">and their descendants with them. 
 </p><p class="q1">
 <sup>24&#160;</sup>It will happen that before they call, I will answer; 
@@ -4442,16 +4442,16 @@ html[dir=ltr] .q2 {
 </p><p class="q2">The lion will eat straw like the ox. 
 </p><p class="q2">Dust will be the serpent’s food. 
 </p><p class="q1">They will not hurt nor destroy in all my set-apart mountain,” 
-</p><p class="q2">says Yahweh. 
+</p><p class="q2">says Yahuah. 
 </p><h2 class="chapterlabel" id="66">66</h2>
 <p>
-<sup>1&#160;</sup>Yahweh says: 
+<sup>1&#160;</sup>Yahuah says: 
 </p><p class="q1">“Heaven is my throne, and the earth is my footstool. 
 </p><p class="q2">What kind of house will you build to me? 
 </p><p class="q2">Where will I rest? 
 </p><p class="q1">
 <sup>2&#160;</sup>For my hand has made all these things, 
-</p><p class="q2">and so all these things came to be,” says Yahweh: 
+</p><p class="q2">and so all these things came to be,” says Yahuah: 
 </p><p class="q1">“but I will look to this man, 
 </p><p class="q2">even to he who is poor and of a contrite spirit, 
 </p><p class="q2">and who trembles at my word. 
@@ -4471,17 +4471,17 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and chose that in which I didn’t delight.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>5&#160;</sup>Hear Yahweh’s word, 
+<sup>5&#160;</sup>Hear Yahuah’s word, 
 </p><p class="q2">you who tremble at his word: 
 </p><p class="q1">“Your brothers who hate you, 
 </p><p class="q2">who cast you out for my name’s sake, have said, 
-</p><p class="q1">‘Let Yahweh be glorified, 
+</p><p class="q1">‘Let Yahuah be glorified, 
 </p><p class="q2">that we may see your joy;’ 
 </p><p class="q2">but it is those who shall be disappointed. 
 </p><p class="q1">
 <sup>6&#160;</sup>A voice of tumult from the city, 
 </p><p class="q2">a voice from the temple, 
-</p><p class="q2">a voice of Yahweh that repays his enemies what they deserve. 
+</p><p class="q2">a voice of Yahuah that repays his enemies what they deserve. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>7&#160;</sup>“Before she travailed, she gave birth. 
@@ -4494,7 +4494,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">For as soon as Zion travailed, 
 </p><p class="q2">she gave birth to her children. 
 </p><p class="q1">
-<sup>9&#160;</sup>Shall I bring to the birth, and not cause to be delivered?” says Yahweh. 
+<sup>9&#160;</sup>Shall I bring to the birth, and not cause to be delivered?” says Yahuah. 
 </p><p class="q2">“Shall I who cause to give birth shut the womb?” says your Elohim. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -4506,7 +4506,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and be delighted with the abundance of her glory.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>12&#160;</sup>For Yahweh says, “Behold, I will extend peace to her like a river, 
+<sup>12&#160;</sup>For Yahuah says, “Behold, I will extend peace to her like a river, 
 </p><p class="q2">and the glory of the nations like an overflowing stream, 
 </p><p class="q2">and you will nurse. 
 </p><p class="q1">You will be carried on her side, 
@@ -4519,26 +4519,26 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>14&#160;</sup>You will see it, and your heart shall rejoice, 
 </p><p class="q2">and your bones will flourish like the tender grass. 
-</p><p class="q1">Yahweh’s hand will be known among his servants; 
+</p><p class="q1">Yahuah’s hand will be known among his servants; 
 </p><p class="q2">and he will have indignation against his enemies. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>15&#160;</sup>For, behold, Yahweh will come with fire, 
+<sup>15&#160;</sup>For, behold, Yahuah will come with fire, 
 </p><p class="q2">and his chariots will be like the whirlwind; 
 </p><p class="q1">to render his anger with fierceness, 
 </p><p class="q2">and his rebuke with flames of fire. 
 </p><p class="q1">
-<sup>16&#160;</sup>For Yahweh will execute judgment by fire and by his sword on all flesh; 
-</p><p class="q2">and those slain by Yahweh will be many. 
+<sup>16&#160;</sup>For Yahuah will execute judgment by fire and by his sword on all flesh; 
+</p><p class="q2">and those slain by Yahuah will be many. 
 </p><p>
-<sup>17&#160;</sup>“Those who sanctify themselves and purify themselves to go to the gardens, following one in the middle, eating pig’s meat, abominable things, and the mouse, they shall come to an end together,” says Yahweh. 
+<sup>17&#160;</sup>“Those who sanctify themselves and purify themselves to go to the gardens, following one in the middle, eating pig’s meat, abominable things, and the mouse, they shall come to an end together,” says Yahuah. 
 </p><p>
 <sup>18&#160;</sup>“For I know their works and their thoughts. The time comes that I will gather all nations and languages, and they will come, and will see my glory. 
 </p><p>
 <sup>19&#160;</sup>“I will set a sign among them, and I will send those who escape of them to the nations, to Tarshish, Pul, and Lud, who draw the bow, to Tubal and Javan, to far-away islands, who have not heard my fame, nor have seen my glory; and they shall declare my glory among the nations. 
-<sup>20&#160;</sup>They shall bring all your brothers out of all the nations for an offering to Yahweh, on horses, in chariots, in litters, on mules, and on camels, to my set-apart mountain Jerusalem, says Yahweh, as the children of Israel bring their offering in a clean vessel into Yahweh’s house. 
-<sup>21&#160;</sup>Of them I will also select priests and Levites,” says Yahweh. 
+<sup>20&#160;</sup>They shall bring all your brothers out of all the nations for an offering to Yahuah, on horses, in chariots, in litters, on mules, and on camels, to my set-apart mountain Jerusalem, says Yahuah, as the children of Israel bring their offering in a clean vessel into Yahuah’s house. 
+<sup>21&#160;</sup>Of them I will also select priests and Levites,” says Yahuah. 
 </p><p>
-<sup>22&#160;</sup>“For as the new heavens and the new earth, which I will make, shall remain before me,” says Yahweh, “so your offspring and your name shall remain. 
-<sup>23&#160;</sup>It shall happen that from one new moon to another, and from one Sabbath to another, all flesh will come to worship before me,” says Yahweh. 
+<sup>22&#160;</sup>“For as the new heavens and the new earth, which I will make, shall remain before me,” says Yahuah, “so your offspring and your name shall remain. 
+<sup>23&#160;</sup>It shall happen that from one new moon to another, and from one Sabbath to another, all flesh will come to worship before me,” says Yahuah. 
 <sup>24&#160;</sup>“They will go out, and look at the dead bodies of the men who have transgressed against me; for their worm will not die, nor will their fire be quenched, and they will be loathsome to all mankind.” </p></div><script src="../main.js"></script></body></html>

--- a/book/jeremiah.html
+++ b/book/jeremiah.html
@@ -112,32 +112,32 @@ html[dir=ltr] .q2 {
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
 <sup>1&#160;</sup>The words of Jeremiah the son of Hilkiah, one of the priests who were in Anathoth in the land of Benjamin. 
-<sup>2&#160;</sup>Yahweh’s word came to him in the days of Josiah the son of Amon, king of Judah, in the thirteenth year of his reign. 
+<sup>2&#160;</sup>Yahuah’s word came to him in the days of Josiah the son of Amon, king of Judah, in the thirteenth year of his reign. 
 <sup>3&#160;</sup>It came also in the days of Jehoiakim the son of Josiah, king of Judah, to the end of the eleventh year of Zedekiah, the son of Josiah, king of Judah, to the carrying away of Jerusalem captive in the fifth month. 
-<sup>4&#160;</sup>Now Yahweh’s word came to me, saying, 
+<sup>4&#160;</sup>Now Yahuah’s word came to me, saying, 
 </p><p class="q1">
 <sup>5&#160;</sup>“Before I formed you in the womb, I knew you. 
 </p><p class="q2">Before you were born, I sanctified you. 
 </p><p class="q2">I have appointed you a prophet to the nations.” 
 </p><p>
-<sup>6&#160;</sup>Then I said, “Ah, Lord Yahweh! Behold, I don’t know how to speak; for I am a child.” 
+<sup>6&#160;</sup>Then I said, “Ah, Lord Yahuah! Behold, I don’t know how to speak; for I am a child.” 
 </p><p>
-<sup>7&#160;</sup>But Yahweh said to me, “Don’t say, ‘I am a child;’ for you must go to whomever I send you, and you must say whatever I command you. 
-<sup>8&#160;</sup>Don’t be afraid because of them, for I am with you to rescue you,” says Yahweh. 
+<sup>7&#160;</sup>But Yahuah said to me, “Don’t say, ‘I am a child;’ for you must go to whomever I send you, and you must say whatever I command you. 
+<sup>8&#160;</sup>Don’t be afraid because of them, for I am with you to rescue you,” says Yahuah. 
 </p><p>
-<sup>9&#160;</sup>Then Yahweh stretched out his hand and touched my mouth. Then Yahweh said to me, “Behold, I have put my words in your mouth. 
+<sup>9&#160;</sup>Then Yahuah stretched out his hand and touched my mouth. Then Yahuah said to me, “Behold, I have put my words in your mouth. 
 <sup>10&#160;</sup>Behold, I have today set you over the nations and over the kingdoms, to uproot and to tear down, to destroy and to overthrow, to build and to plant.” 
 </p><p>
-<sup>11&#160;</sup>Moreover Yahweh’s word came to me, saying, “Jeremiah, what do you see?” 
+<sup>11&#160;</sup>Moreover Yahuah’s word came to me, saying, “Jeremiah, what do you see?” 
 </p><p>I said, “I see a branch of an almond tree.” 
 </p><p>
-<sup>12&#160;</sup>Then Yahweh said to me, “You have seen well; for I watch over my word to perform it.” 
+<sup>12&#160;</sup>Then Yahuah said to me, “You have seen well; for I watch over my word to perform it.” 
 </p><p>
-<sup>13&#160;</sup>Yahweh’s word came to me the second time, saying, “What do you see?” 
+<sup>13&#160;</sup>Yahuah’s word came to me the second time, saying, “What do you see?” 
 </p><p>I said, “I see a boiling cauldron; and it is tipping away from the north.” 
 </p><p>
-<sup>14&#160;</sup>Then Yahweh said to me, “Out of the north, evil will break out on all the inhabitants of the land. 
-<sup>15&#160;</sup>For behold, I will call all the families of the kingdoms of the north,” says Yahweh. 
+<sup>14&#160;</sup>Then Yahuah said to me, “Out of the north, evil will break out on all the inhabitants of the land. 
+<sup>15&#160;</sup>For behold, I will call all the families of the kingdoms of the north,” says Yahuah. 
 </p><p class="q1">“They will come, and they will each set his throne at the entrance of the gates of Jerusalem, 
 </p><p class="q2">and against all its walls all around, and against all the cities of Judah. 
 </p><p class="q1">
@@ -148,29 +148,29 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>17&#160;</sup>“You therefore put your belt on your waist, arise, and say to them all that I command you. Don’t be dismayed at them, lest I dismay you before them. 
 <sup>18&#160;</sup>For behold, I have made you today a fortified city, an iron pillar, and bronze walls against the whole land—against the kings of Judah, against its princes, against its priests, and against the people of the land. 
-<sup>19&#160;</sup>They will fight against you, but they will not prevail against you; for I am with you”, says Yahweh, “to rescue you.” 
+<sup>19&#160;</sup>They will fight against you, but they will not prevail against you; for I am with you”, says Yahuah, “to rescue you.” 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
-<sup>2&#160;</sup>“Go and proclaim in the ears of Jerusalem, saying, ‘Yahweh says, 
+<sup>1&#160;</sup>Yahuah’s word came to me, saying, 
+<sup>2&#160;</sup>“Go and proclaim in the ears of Jerusalem, saying, ‘Yahuah says, 
 </p><p class="q1">“I remember for you the kindness of your youth, 
 </p><p class="q2">your love as a bride, 
 </p><p class="q1">how you went after me in the wilderness, 
 </p><p class="q2">in a land that was not sown. 
 </p><p class="q1">
-<sup>3&#160;</sup>Israel was set-apartness to Yahweh, 
+<sup>3&#160;</sup>Israel was set-apartness to Yahuah, 
 </p><p class="q2">the first fruits of his increase. 
 </p><p class="q1">All who devour him will be held guilty. 
-</p><p class="q2">Evil will come on them,”&#160;’ says Yahweh.” 
+</p><p class="q2">Evil will come on them,”&#160;’ says Yahuah.” 
 </p><p>
-<sup>4&#160;</sup>Hear Yahweh’s word, O house of Jacob, and all the families of the house of Israel! 
-<sup>5&#160;</sup>Yahweh says, 
+<sup>4&#160;</sup>Hear Yahuah’s word, O house of Jacob, and all the families of the house of Israel! 
+<sup>5&#160;</sup>Yahuah says, 
 </p><p class="q1">“What unrighteousness have your fathers found in me, 
 </p><p class="q2">that they have gone far from me, 
 </p><p class="q1">and have walked after worthless vanity, 
 </p><p class="q2">and have become worthless? 
 </p><p class="q1">
-<sup>6&#160;</sup>They didn’t say, ‘Where is Yahweh who brought us up out of the land of Egypt, 
+<sup>6&#160;</sup>They didn’t say, ‘Where is Yahuah who brought us up out of the land of Egypt, 
 </p><p class="q2">who led us through the wilderness, 
 </p><p class="q2">through a land of deserts and of pits, 
 </p><p class="q2">through a land of drought and of the shadow of death, 
@@ -182,13 +182,13 @@ html[dir=ltr] .q2 {
 </p><p class="q1">but when you entered, you defiled my land, 
 </p><p class="q2">and made my heritage an abomination. 
 </p><p class="q1">
-<sup>8&#160;</sup>The priests didn’t say, ‘Where is Yahweh?’ 
+<sup>8&#160;</sup>The priests didn’t say, ‘Where is Yahuah?’ 
 </p><p class="q2">and those who handle the law didn’t know me. 
 </p><p class="q1">The rulers also transgressed against me, 
 </p><p class="q2">and the prophets prophesied by Baal 
 </p><p class="q2">and followed things that do not profit. 
 </p><p class="q1">
-<sup>9&#160;</sup>“Therefore I will yet contend with you,” says Yahweh, 
+<sup>9&#160;</sup>“Therefore I will yet contend with you,” says Yahuah, 
 </p><p class="q2">“and I will contend with your children’s children. 
 </p><p class="q1">
 <sup>10&#160;</sup>For pass over to the islands of Kittim, and see. 
@@ -201,7 +201,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>12&#160;</sup>“Be astonished, you heavens, at this 
 </p><p class="q2">and be horribly afraid. 
-</p><p class="q2">Be very desolate,” says Yahweh. 
+</p><p class="q2">Be very desolate,” says Yahuah. 
 </p><p class="q1">
 <sup>13&#160;</sup>“For my people have committed two evils: 
 </p><p class="q2">they have forsaken me, the spring of living waters, 
@@ -218,7 +218,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>The children also of Memphis and Tahpanhes have broken the crown of your head. 
 </p><p class="q1">
 <sup>17&#160;</sup>“Haven’t you brought this on yourself, 
-</p><p class="q2">in that you have forsaken Yahweh your Elohim, when he led you by the way? 
+</p><p class="q2">in that you have forsaken Yahuah your Elohim, when he led you by the way? 
 </p><p class="q1">
 <sup>18&#160;</sup>Now what do you gain by going to Egypt, to drink the waters of the Shihor? 
 </p><p class="q2">Or why do you go on the way to Assyria, to drink the waters of the River? 
@@ -226,8 +226,8 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>“Your own wickedness will correct you, 
 </p><p class="q2">and your backsliding will rebuke you. 
 </p><p class="q1">Know therefore and see that it is an evil and bitter thing, 
-</p><p class="q2">that you have forsaken Yahweh your Elohim, 
-</p><p class="q2">and that my fear is not in you,” says the Lord, Yahweh of Armies. 
+</p><p class="q2">that you have forsaken Yahuah your Elohim, 
+</p><p class="q2">and that my fear is not in you,” says the Lord, Yahuah of Armies. 
 </p><p class="q1">
 <sup>20&#160;</sup>“For long ago I broke off your yoke, 
 </p><p class="q2">and burst your bonds. 
@@ -241,7 +241,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>22&#160;</sup>For though you wash yourself with lye, 
 </p><p class="q2">and use much soap, 
-</p><p class="q2">yet your iniquity is marked before me,” says the Lord Yahweh. 
+</p><p class="q2">yet your iniquity is marked before me,” says the Lord Yahuah. 
 </p><p class="q1">
 <sup>23&#160;</sup>“How can you say, ‘I am not defiled. 
 </p><p class="q2">I have not gone after the Baals’? 
@@ -272,14 +272,14 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for you have as many elohims as you have towns, O Judah. 
 </p><p class="q1">
 <sup>29&#160;</sup>“Why will you contend with me? 
-</p><p class="q2">You all have transgressed against me,” says Yahweh. 
+</p><p class="q2">You all have transgressed against me,” says Yahuah. 
 </p><p class="q1">
 <sup>30&#160;</sup>“I have struck your children in vain. 
 </p><p class="q2">They received no correction. 
 </p><p class="q1">Your own sword has devoured your prophets, 
 </p><p class="q2">like a destroying lion. 
 </p><p class="q1">
-<sup>31&#160;</sup>Generation, consider Yahweh’s word. 
+<sup>31&#160;</sup>Generation, consider Yahuah’s word. 
 </p><p class="q2">Have I been a wilderness to Israel? 
 </p><p class="q2">Or a land of thick darkness? 
 </p><p class="q1">Why do my people say, ‘We have broken loose. 
@@ -306,11 +306,11 @@ html[dir=ltr] .q2 {
 </p><p class="q2">as you were ashamed of Assyria. 
 </p><p class="q1">
 <sup>37&#160;</sup>You will also leave that place with your hands on your head; 
-</p><p class="q2">for Yahweh has rejected those in whom you trust, 
+</p><p class="q2">for Yahuah has rejected those in whom you trust, 
 </p><p class="q2">and you won’t prosper with them. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>“They say, ‘If a man puts away his woman, and she goes from him, and becomes another man’s, should he return to her again?’ Wouldn’t that land be greatly polluted? But you have played the prostitute with many lovers; yet return again to me,” says Yahweh. 
+<sup>1&#160;</sup>“They say, ‘If a man puts away his woman, and she goes from him, and becomes another man’s, should he return to her again?’ Wouldn’t that land be greatly polluted? But you have played the prostitute with many lovers; yet return again to me,” says Yahuah. 
 </p><p>
 <sup>2&#160;</sup>“Lift up your eyes to the bare heights, and see! Where have you not been lain with? You have sat waiting for them by the road, as an Arabian in the wilderness. You have polluted the land with your prostitution and with your wickedness. 
 <sup>3&#160;</sup>Therefore the showers have been withheld and there has been no latter rain; yet you have had a prostitute’s forehead and you refused to be ashamed. 
@@ -318,45 +318,45 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>5&#160;</sup>“&#160;‘Will he retain his anger forever? Will he keep it to the end?’ Behold, you have spoken and have done evil things, and have had your way.” 
 </p><p>
-<sup>6&#160;</sup>Moreover, Yahweh said to me in the days of Josiah the king, “Have you seen that which backsliding Israel has done? She has gone up on every high mountain and under every green tree, and has played the prostitute there. 
+<sup>6&#160;</sup>Moreover, Yahuah said to me in the days of Josiah the king, “Have you seen that which backsliding Israel has done? She has gone up on every high mountain and under every green tree, and has played the prostitute there. 
 <sup>7&#160;</sup>I said after she had done all these things, ‘She will return to me;’ but she didn’t return, and her treacherous sister Judah saw it. 
 <sup>8&#160;</sup>I saw when, for this very cause, that backsliding Israel had committed adultery, I had put her away and given her a certificate of divorce, yet treacherous Judah, her sister, had no fear, but she also went and played the prostitute. 
 <sup>9&#160;</sup>Because she took her prostitution lightly, the land was polluted, and she committed adultery with stones and with wood. 
-<sup>10&#160;</sup>Yet for all this her treacherous sister, Judah, has not returned to me with her whole heart, but only in pretense,” says Yahweh. 
+<sup>10&#160;</sup>Yet for all this her treacherous sister, Judah, has not returned to me with her whole heart, but only in pretense,” says Yahuah. 
 </p><p>
-<sup>11&#160;</sup>Yahweh said to me, “Backsliding Israel has shown herself more righteous than treacherous Judah. 
-<sup>12&#160;</sup>Go, and proclaim these words toward the north, and say, ‘Return, you backsliding Israel,’ says Yahweh; ‘I will not look in anger on you, for I am merciful,’ says Yahweh. ‘I will not keep anger forever. 
-<sup>13&#160;</sup>Only acknowledge your iniquity, that you have transgressed against Yahweh your Elohim, and have scattered your ways to the strangers under every green tree, and you have not obeyed my voice,’&#160;” says Yahweh. 
-<sup>14&#160;</sup>“Return, backsliding children,” says Yahweh, “for I am an owner to you. I will take one of you from a city, and two from a family, and I will bring you to Zion. 
+<sup>11&#160;</sup>Yahuah said to me, “Backsliding Israel has shown herself more righteous than treacherous Judah. 
+<sup>12&#160;</sup>Go, and proclaim these words toward the north, and say, ‘Return, you backsliding Israel,’ says Yahuah; ‘I will not look in anger on you, for I am merciful,’ says Yahuah. ‘I will not keep anger forever. 
+<sup>13&#160;</sup>Only acknowledge your iniquity, that you have transgressed against Yahuah your Elohim, and have scattered your ways to the strangers under every green tree, and you have not obeyed my voice,’&#160;” says Yahuah. 
+<sup>14&#160;</sup>“Return, backsliding children,” says Yahuah, “for I am an owner to you. I will take one of you from a city, and two from a family, and I will bring you to Zion. 
 <sup>15&#160;</sup>I will give you shepherds according to my heart, who will feed you with knowledge and understanding. 
-<sup>16&#160;</sup>It will come to pass, when you are multiplied and increased in the land in those days,” says Yahweh, “they will no longer say, ‘the ark of Yahweh’s covenant!’ It will not come to mind. They won’t remember it. They won’t miss it, nor will another be made. 
-<sup>17&#160;</sup>At that time they will call Jerusalem ‘Yahweh’s Throne;’ and all the nations will be gathered to it, to Yahweh’s name, to Jerusalem. They will no longer walk after the stubbornness of their evil heart. 
+<sup>16&#160;</sup>It will come to pass, when you are multiplied and increased in the land in those days,” says Yahuah, “they will no longer say, ‘the ark of Yahuah’s covenant!’ It will not come to mind. They won’t remember it. They won’t miss it, nor will another be made. 
+<sup>17&#160;</sup>At that time they will call Jerusalem ‘Yahuah’s Throne;’ and all the nations will be gathered to it, to Yahuah’s name, to Jerusalem. They will no longer walk after the stubbornness of their evil heart. 
 <sup>18&#160;</sup>In those days the house of Judah will walk with the house of Israel, and they will come together out of the land of the north to the land that I gave for an inheritance to your fathers. 
 </p><p>
 <sup>19&#160;</sup>“But I said, ‘How I desire to put you among the children, and give you a pleasant land, a goodly heritage of the armies of the nations!’ and I said, ‘You shall call me “My Father”, and shall not turn away from following me.’ 
 </p><p>
-<sup>20&#160;</sup>“Surely as a woman treacherously departs from her friend, so you have dealt treacherously with me, house of Israel,” says Yahweh. 
-<sup>21&#160;</sup>A voice is heard on the bare heights, the weeping and the petitions of the children of Israel; because they have perverted their way, they have forgotten Yahweh their Elohim. 
+<sup>20&#160;</sup>“Surely as a woman treacherously departs from her friend, so you have dealt treacherously with me, house of Israel,” says Yahuah. 
+<sup>21&#160;</sup>A voice is heard on the bare heights, the weeping and the petitions of the children of Israel; because they have perverted their way, they have forgotten Yahuah their Elohim. 
 <sup>22&#160;</sup>Return, you backsliding children, and I will heal your backsliding. 
-</p><p>“Behold, we have come to you; for you are Yahweh our Elohim. 
-<sup>23&#160;</sup>Truly help from the hills, the tumult on the mountains, is in vain. Truly the salvation of Israel is in Yahweh our Elohim. 
+</p><p>“Behold, we have come to you; for you are Yahuah our Elohim. 
+<sup>23&#160;</sup>Truly help from the hills, the tumult on the mountains, is in vain. Truly the salvation of Israel is in Yahuah our Elohim. 
 <sup>24&#160;</sup>But the shameful thing has devoured the labor of our fathers from our youth, their flocks and their herds, their sons and their daughters. 
-<sup>25&#160;</sup>Let us lie down in our shame, and let our confusion cover us; for we have sinned against Yahweh our Elohim, we and our fathers, from our youth even to this day. We have not obeyed Yahweh our Elohim’s voice.” 
+<sup>25&#160;</sup>Let us lie down in our shame, and let our confusion cover us; for we have sinned against Yahuah our Elohim, we and our fathers, from our youth even to this day. We have not obeyed Yahuah our Elohim’s voice.” 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>“If you will return, Israel,” says Yahweh, “if you will return to me, and if you will put away your abominations out of my sight; then you will not be removed; 
-<sup>2&#160;</sup>and you will swear, ‘As Yahweh lives,’ in truth, in justice, and in righteousness. The nations will bless themselves in him, and they will glory in him.” 
+<sup>1&#160;</sup>“If you will return, Israel,” says Yahuah, “if you will return to me, and if you will put away your abominations out of my sight; then you will not be removed; 
+<sup>2&#160;</sup>and you will swear, ‘As Yahuah lives,’ in truth, in justice, and in righteousness. The nations will bless themselves in him, and they will glory in him.” 
 </p><p>
-<sup>3&#160;</sup>For Yahweh says to the men of Judah and to Jerusalem, “Break up your fallow ground, and don’t sow among thorns. 
-<sup>4&#160;</sup>Circumcise yourselves to Yahweh, and take away the foreskins of your heart, you men of Judah and inhabitants of Jerusalem; lest my wrath go out like fire, and burn so that no one can quench it, because of the evil of your doings. 
+<sup>3&#160;</sup>For Yahuah says to the men of Judah and to Jerusalem, “Break up your fallow ground, and don’t sow among thorns. 
+<sup>4&#160;</sup>Circumcise yourselves to Yahuah, and take away the foreskins of your heart, you men of Judah and inhabitants of Jerusalem; lest my wrath go out like fire, and burn so that no one can quench it, because of the evil of your doings. 
 <sup>5&#160;</sup>Declare in Judah, and publish in Jerusalem; and say, ‘Blow the trumpet in the land!’ Cry aloud and say, ‘Assemble yourselves! Let’s go into the fortified cities!’ 
 <sup>6&#160;</sup>Set up a standard toward Zion. Flee for safety! Don’t wait; for I will bring evil from the north, and a great destruction.” 
 </p><p>
 <sup>7&#160;</sup>A lion has gone up from his thicket, and a destroyer of nations. He is on his way. He has gone out from his place, to make your land desolate, that your cities be laid waste, without inhabitant. 
-<sup>8&#160;</sup>For this, clothe yourself with sackcloth, lament and wail; for the fierce anger of Yahweh hasn’t turned back from us. 
-<sup>9&#160;</sup>“It will happen at that day,” says Yahweh, “that the heart of the king will perish, along with the heart of the princes. The priests will be astonished, and the prophets will wonder.” 
+<sup>8&#160;</sup>For this, clothe yourself with sackcloth, lament and wail; for the fierce anger of Yahuah hasn’t turned back from us. 
+<sup>9&#160;</sup>“It will happen at that day,” says Yahuah, “that the heart of the king will perish, along with the heart of the princes. The priests will be astonished, and the prophets will wonder.” 
 </p><p>
-<sup>10&#160;</sup>Then I said, “Ah, Lord Yahweh! Surely you have greatly deceived this people and Jerusalem, saying, ‘You will have peace;’ whereas the sword reaches to the heart.” 
+<sup>10&#160;</sup>Then I said, “Ah, Lord Yahuah! Surely you have greatly deceived this people and Jerusalem, saying, ‘You will have peace;’ whereas the sword reaches to the heart.” 
 </p><p>
 <sup>11&#160;</sup>At that time it will be said to this people and to Jerusalem, “A hot wind blows from the bare heights in the wilderness toward the daughter of my people, not to winnow, nor to cleanse. 
 <sup>12&#160;</sup>A full wind from these will come for me. Now I will also utter judgments against them.” 
@@ -365,7 +365,7 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>Jerusalem, wash your heart from wickedness, that you may be saved. How long will your evil thoughts lodge within you? 
 <sup>15&#160;</sup>For a voice declares from Dan, and publishes evil from the hills of Ephraim: 
 <sup>16&#160;</sup>“Tell the nations, behold, publish against Jerusalem, ‘Watchers come from a far country, and raise their voice against the cities of Judah. 
-<sup>17&#160;</sup>As keepers of a field, they are against her all around, because she has been rebellious against me,’&#160;” says Yahweh. 
+<sup>17&#160;</sup>As keepers of a field, they are against her all around, because she has been rebellious against me,’&#160;” says Yahuah. 
 <sup>18&#160;</sup>“Your way and your doings have brought these things to you. This is your wickedness, for it is bitter, for it reaches to your heart.” 
 </p><p>
 <sup>19&#160;</sup>My anguish, my anguish! I am pained at my very heart! My heart trembles within me. I can’t hold my peace, because you have heard, O my soul, the sound of the trumpet, the alarm of war. 
@@ -376,8 +376,8 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>I saw the earth and, behold, it was waste and void, and the heavens, and they had no light. 
 <sup>24&#160;</sup>I saw the mountains, and behold, they trembled, and all the hills moved back and forth. 
 <sup>25&#160;</sup>I saw, and behold, there was no man, and all the birds of the sky had fled. 
-<sup>26&#160;</sup>I saw, and behold, the fruitful field was a wilderness, and all its cities were broken down at the presence of Yahweh, before his fierce anger. 
-<sup>27&#160;</sup>For Yahweh says, “The whole land will be a desolation; yet I will not make a full end. 
+<sup>26&#160;</sup>I saw, and behold, the fruitful field was a wilderness, and all its cities were broken down at the presence of Yahuah, before his fierce anger. 
+<sup>27&#160;</sup>For Yahuah says, “The whole land will be a desolation; yet I will not make a full end. 
 <sup>28&#160;</sup>For this the earth will mourn, and the heavens above be black, because I have spoken it. I have planned it, and I have not repented, neither will I turn back from it.” 
 </p><p>
 <sup>29&#160;</sup>Every city flees for the noise of the horsemen and archers. They go into the thickets and climb up on the rocks. Every city is forsaken, and not a man dwells therein. 
@@ -386,45 +386,45 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
 <sup>1&#160;</sup>“Run back and forth through the streets of Jerusalem, and see now, and know, and seek in its wide places, if you can find a man, if there is anyone who does justly, who seeks truth, then I will pardon her. 
-<sup>2&#160;</sup>Though they say, ‘As Yahweh lives,’ surely they swear falsely.” 
+<sup>2&#160;</sup>Though they say, ‘As Yahuah lives,’ surely they swear falsely.” 
 </p><p>
-<sup>3&#160;</sup>O Yahweh, don’t your eyes look on truth? You have stricken them, but they were not grieved. You have consumed them, but they have refused to receive correction. They have made their faces harder than a rock. They have refused to return. 
+<sup>3&#160;</sup>O Yahuah, don’t your eyes look on truth? You have stricken them, but they were not grieved. You have consumed them, but they have refused to receive correction. They have made their faces harder than a rock. They have refused to return. 
 </p><p>
-<sup>4&#160;</sup>Then I said, “Surely these are poor. They are foolish; for they don’t know Yahweh’s way, nor the law of their Elohim. 
-<sup>5&#160;</sup>I will go to the great men and will speak to them, for they know the way of Yahweh, and the law of their Elohim.” But these with one accord have broken the yoke, and burst the bonds. 
+<sup>4&#160;</sup>Then I said, “Surely these are poor. They are foolish; for they don’t know Yahuah’s way, nor the law of their Elohim. 
+<sup>5&#160;</sup>I will go to the great men and will speak to them, for they know the way of Yahuah, and the law of their Elohim.” But these with one accord have broken the yoke, and burst the bonds. 
 <sup>6&#160;</sup>Therefore a lion out of the forest will kill them. A wolf of the evenings will destroy them. A leopard will watch against their cities. Everyone who goes out there will be torn in pieces, because their transgressions are many and their backsliding has increased. 
 </p><p>
 <sup>7&#160;</sup>“How can I pardon you? Your children have forsaken me, and sworn by what are no elohims. When I had fed them to the full, they committed adultery, and assembled themselves in troops at the prostitutes’ houses. 
 <sup>8&#160;</sup>They were as fed horses roaming at large. Everyone neighed after his neighbor’s woman. 
-<sup>9&#160;</sup>Shouldn’t I punish them for these things?” says Yahweh. “Shouldn’t my soul be avenged on such a nation as this? 
+<sup>9&#160;</sup>Shouldn’t I punish them for these things?” says Yahuah. “Shouldn’t my soul be avenged on such a nation as this? 
 </p><p>
-<sup>10&#160;</sup>“Go up on her walls, and destroy, but don’t make a full end. Take away her branches, for they are not Yahweh’s. 
-<sup>11&#160;</sup>For the house of Israel and the house of Judah have dealt very treacherously against me,” says Yahweh. 
+<sup>10&#160;</sup>“Go up on her walls, and destroy, but don’t make a full end. Take away her branches, for they are not Yahuah’s. 
+<sup>11&#160;</sup>For the house of Israel and the house of Judah have dealt very treacherously against me,” says Yahuah. 
 </p><p>
-<sup>12&#160;</sup>They have denied Yahweh, and said, “It is not he. Evil won’t come on us. We won’t see sword or famine. 
+<sup>12&#160;</sup>They have denied Yahuah, and said, “It is not he. Evil won’t come on us. We won’t see sword or famine. 
 <sup>13&#160;</sup>The prophets will become wind, and the word is not in them. Thus it will be done to them.” 
 </p><p>
-<sup>14&#160;</sup>Therefore Yahweh, the Elohim of Armies says, “Because you speak this word, behold, I will make my words in your mouth fire, and this people wood, and it will devour them. 
-<sup>15&#160;</sup>Behold, I will bring a nation on you from far away, house of Israel,” says Yahweh. “It is a mighty nation. It is an ancient nation, a nation whose language you don’t know and don’t understand what they say. 
+<sup>14&#160;</sup>Therefore Yahuah, the Elohim of Armies says, “Because you speak this word, behold, I will make my words in your mouth fire, and this people wood, and it will devour them. 
+<sup>15&#160;</sup>Behold, I will bring a nation on you from far away, house of Israel,” says Yahuah. “It is a mighty nation. It is an ancient nation, a nation whose language you don’t know and don’t understand what they say. 
 <sup>16&#160;</sup>Their quiver is an open tomb. They are all mighty men. 
 <sup>17&#160;</sup>They will eat up your harvest and your bread, which your sons and your daughters should eat. They will eat up your flocks and your herds. They will eat up your vines and your fig trees. They will beat down your fortified cities in which you trust with the sword. 
 </p><p>
-<sup>18&#160;</sup>“But even in those days,” says Yahweh, “I will not make a full end of you. 
-<sup>19&#160;</sup>It will happen when you say, ‘Why has Yahweh our Elohim done all these things to us?’ Then you shall say to them, ‘Just as you have forsaken me and served foreign elohims in your land, so you will serve strangers in a land that is not yours.’ 
+<sup>18&#160;</sup>“But even in those days,” says Yahuah, “I will not make a full end of you. 
+<sup>19&#160;</sup>It will happen when you say, ‘Why has Yahuah our Elohim done all these things to us?’ Then you shall say to them, ‘Just as you have forsaken me and served foreign elohims in your land, so you will serve strangers in a land that is not yours.’ 
 </p><p>
 <sup>20&#160;</sup>“Declare this in the house of Jacob, and publish it in Judah, saying, 
 <sup>21&#160;</sup>‘Hear this now, foolish people without understanding, who have eyes, and don’t see, who have ears, and don’t hear: 
-<sup>22&#160;</sup>Don’t you fear me?’ says Yahweh; ‘Won’t you tremble at my presence, who have placed the sand for the bound of the sea by a perpetual decree, that it can’t pass it? Though its waves toss themselves, yet they can’t prevail. Though they roar, they still can’t pass over it.’ 
+<sup>22&#160;</sup>Don’t you fear me?’ says Yahuah; ‘Won’t you tremble at my presence, who have placed the sand for the bound of the sea by a perpetual decree, that it can’t pass it? Though its waves toss themselves, yet they can’t prevail. Though they roar, they still can’t pass over it.’ 
 </p><p>
 <sup>23&#160;</sup>“But this people has a revolting and a rebellious heart. They have revolted and gone. 
-<sup>24&#160;</sup>They don’t say in their heart, ‘Let’s now fear Yahweh our Elohim, who gives rain, both the former and the latter, in its season, who preserves to us the appointed weeks of the harvest.’ 
+<sup>24&#160;</sup>They don’t say in their heart, ‘Let’s now fear Yahuah our Elohim, who gives rain, both the former and the latter, in its season, who preserves to us the appointed weeks of the harvest.’ 
 </p><p>
 <sup>25&#160;</sup>“Your iniquities have turned away these things, and your sins have withheld good from you. 
 <sup>26&#160;</sup>For wicked men are found among my people. They watch, as fowlers lie in wait. They set a trap. They catch men. 
 <sup>27&#160;</sup>As a cage is full of birds, so are their houses full of deceit. Therefore they have become great, and grew rich. 
 <sup>28&#160;</sup>They have grown fat. They shine; yes, they excel in deeds of wickedness. They don’t plead the cause, the cause of the fatherless, that they may prosper; and they don’t defend the rights of the needy. 
 </p><p>
-<sup>29&#160;</sup>“Shouldn’t I punish for these things?” says Yahweh. “Shouldn’t my soul be avenged on such a nation as this? 
+<sup>29&#160;</sup>“Shouldn’t I punish for these things?” says Yahuah. “Shouldn’t my soul be avenged on such a nation as this? 
 </p><p>
 <sup>30&#160;</sup>“An astonishing and horrible thing has happened in the land. 
 <sup>31&#160;</sup>The prophets prophesy falsely, and the priests rule by their own authority; and my people love to have it so. What will you do in the end of it? 
@@ -436,14 +436,14 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>4&#160;</sup>“Prepare war against her! Arise! Let’s go up at noon. Woe to us! For the day declines, for the shadows of the evening are stretched out. 
 <sup>5&#160;</sup>Arise! Let’s go up by night, and let’s destroy her palaces.” 
-<sup>6&#160;</sup>For Yahweh of Armies said, “Cut down trees, and cast up a mound against Jerusalem. This is the city to be visited. She is filled with oppression within herself. 
+<sup>6&#160;</sup>For Yahuah of Armies said, “Cut down trees, and cast up a mound against Jerusalem. This is the city to be visited. She is filled with oppression within herself. 
 <sup>7&#160;</sup>As a well produces its waters, so she produces her wickedness. Violence and destruction is heard in her. Sickness and wounds are continually before me. 
 <sup>8&#160;</sup>Be instructed, Jerusalem, lest my soul be alienated from you, lest I make you a desolation, an uninhabited land.” 
 </p><p>
-<sup>9&#160;</sup>Yahweh of Armies says, “They will thoroughly glean the remnant of Israel like a vine. Turn again your hand as a grape gatherer into the baskets.” 
+<sup>9&#160;</sup>Yahuah of Armies says, “They will thoroughly glean the remnant of Israel like a vine. Turn again your hand as a grape gatherer into the baskets.” 
 </p><p>
-<sup>10&#160;</sup>To whom should I speak and testify, that they may hear? Behold, their ear is uncircumcised, and they can’t listen. Behold, Yahweh’s word has become a reproach to them. They have no delight in it. 
-<sup>11&#160;</sup>Therefore I am full of Yahweh’s wrath. I am weary with holding it in. 
+<sup>10&#160;</sup>To whom should I speak and testify, that they may hear? Behold, their ear is uncircumcised, and they can’t listen. Behold, Yahuah’s word has become a reproach to them. They have no delight in it. 
+<sup>11&#160;</sup>Therefore I am full of Yahuah’s wrath. I am weary with holding it in. 
 </p><p class="q1">“Pour it out on the children in the street, 
 </p><p class="q2">and on the assembly of young men together; 
 </p><p class="q1">for even the man with the woman will be taken, 
@@ -451,7 +451,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>12&#160;</sup>Their houses will be turned to others, 
 </p><p class="q2">their fields and their women together; 
-</p><p class="q1">for I will stretch out my hand on the inhabitants of the land, says Yahweh.” 
+</p><p class="q1">for I will stretch out my hand on the inhabitants of the land, says Yahuah.” 
 </p><p class="q1">
 <sup>13&#160;</sup>“For from their least even to their greatest, everyone is given to desire. 
 </p><p class="q2">From the prophet even to the priest, everyone deals falsely. 
@@ -462,16 +462,16 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Were they ashamed when they had committed abomination? 
 </p><p class="q2">No, they were not at all ashamed, neither could they blush. 
 </p><p class="q1">Therefore they will fall among those who fall. 
-</p><p class="q2">When I visit them, they will be cast down,” says Yahweh. 
+</p><p class="q2">When I visit them, they will be cast down,” says Yahuah. 
 </p><p>
-<sup>16&#160;</sup>Yahweh says, “Stand in the ways and see, and ask for the old paths, ‘Where is the good way?’ and walk in it, and you will find rest for your souls. But they said, ‘We will not walk in it.’ 
+<sup>16&#160;</sup>Yahuah says, “Stand in the ways and see, and ask for the old paths, ‘Where is the good way?’ and walk in it, and you will find rest for your souls. But they said, ‘We will not walk in it.’ 
 <sup>17&#160;</sup>I set watchmen over you, saying, ‘Listen to the sound of the trumpet!’ But they said, ‘We will not listen!’ 
 <sup>18&#160;</sup>Therefore hear, you nations, and know, congregation, what is among them. 
 <sup>19&#160;</sup>Hear, earth! Behold, I will bring evil on this people, even the fruit of their thoughts, because they have not listened to my words; and as for my law, they have rejected it. 
 <sup>20&#160;</sup>To what purpose does frankincense from Sheba come to me, and the sweet cane from a far country? Your burnt offerings are not acceptable, and your sacrifices are not pleasing to me.” 
 </p><p>
-<sup>21&#160;</sup>Therefore Yahweh says, “Behold, I will lay stumbling blocks before this people. The fathers and the sons together will stumble against them. The neighbor and his friend will perish.” 
-<sup>22&#160;</sup>Yahweh says, “Behold, a people comes from the north country. A great nation will be stirred up from the uttermost parts of the earth. 
+<sup>21&#160;</sup>Therefore Yahuah says, “Behold, I will lay stumbling blocks before this people. The fathers and the sons together will stumble against them. The neighbor and his friend will perish.” 
+<sup>22&#160;</sup>Yahuah says, “Behold, a people comes from the north country. A great nation will be stirred up from the uttermost parts of the earth. 
 <sup>23&#160;</sup>They take hold of bow and spear. They are cruel, and have no mercy. Their voice roars like the sea, and they ride on horses, everyone set in array, as a man to the battle, against you, daughter of Zion.” 
 </p><p>
 <sup>24&#160;</sup>We have heard its report. Our hands become feeble. Anguish has taken hold of us, and pains as of a woman in labor. 
@@ -481,35 +481,35 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>“I have made you a tester of metals and a fortress among my people, that you may know and try their way. 
 <sup>28&#160;</sup>They are all grievous rebels, going around to slander. They are bronze and iron. All of them deal corruptly. 
 <sup>29&#160;</sup>The bellows blow fiercely. The lead is consumed in the fire. In vain they go on refining, for the wicked are not plucked away. 
-<sup>30&#160;</sup>Men will call them rejected silver, because Yahweh has rejected them.” 
+<sup>30&#160;</sup>Men will call them rejected silver, because Yahuah has rejected them.” 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>The word that came to Jeremiah from Yahweh, saying, 
-<sup>2&#160;</sup>“Stand in the gate of Yahweh’s house, and proclaim this word there, and say, ‘Hear Yahweh’s word, all you of Judah, who enter in at these gates to worship Yahweh.’&#160;” 
+<sup>1&#160;</sup>The word that came to Jeremiah from Yahuah, saying, 
+<sup>2&#160;</sup>“Stand in the gate of Yahuah’s house, and proclaim this word there, and say, ‘Hear Yahuah’s word, all you of Judah, who enter in at these gates to worship Yahuah.’&#160;” 
 </p><p>
-<sup>3&#160;</sup>Yahweh of Armies, the Elohim of Israel says, “Amend your ways and your doings, and I will cause you to dwell in this place. 
-<sup>4&#160;</sup>Don’t trust in lying words, saying, ‘Yahweh’s temple, Yahweh’s temple, Yahweh’s temple, are these.’ 
+<sup>3&#160;</sup>Yahuah of Armies, the Elohim of Israel says, “Amend your ways and your doings, and I will cause you to dwell in this place. 
+<sup>4&#160;</sup>Don’t trust in lying words, saying, ‘Yahuah’s temple, Yahuah’s temple, Yahuah’s temple, are these.’ 
 <sup>5&#160;</sup>For if you thoroughly amend your ways and your doings, if you thoroughly execute justice between a man and his neighbor; 
 <sup>6&#160;</sup>if you don’t oppress the foreigner, the fatherless, and the widow, and don’t shed innocent blood in this place, and don’t walk after other elohims to your own hurt, 
 <sup>7&#160;</sup>then I will cause you to dwell in this place, in the land that I gave to your fathers, from of old even forever more. 
 <sup>8&#160;</sup>Behold, you trust in lying words that can’t profit. 
 <sup>9&#160;</sup>Will you steal, murder, commit adultery, swear falsely, burn incense to Baal, and walk after other elohims that you have not known, 
 <sup>10&#160;</sup>then come and stand before me in this house, which is called by my name, and say, ‘We are delivered,’ that you may do all these abominations? 
-<sup>11&#160;</sup>Has this house, which is called by my name, become a den of robbers in your eyes? Behold, I myself have seen it,” says Yahweh. 
+<sup>11&#160;</sup>Has this house, which is called by my name, become a den of robbers in your eyes? Behold, I myself have seen it,” says Yahuah. 
 </p><p>
 <sup>12&#160;</sup>“But go now to my place which was in Shiloh, where I caused my name to dwell at the first, and see what I did to it for the wickedness of my people Israel. 
-<sup>13&#160;</sup>Now, because you have done all these works,” says Yahweh, “and I spoke to you, rising up early and speaking, but you didn’t hear; and I called you, but you didn’t answer; 
+<sup>13&#160;</sup>Now, because you have done all these works,” says Yahuah, “and I spoke to you, rising up early and speaking, but you didn’t hear; and I called you, but you didn’t answer; 
 <sup>14&#160;</sup>therefore I will do to the house which is called by my name, in which you trust, and to the place which I gave to you and to your fathers, as I did to Shiloh. 
 <sup>15&#160;</sup>I will cast you out of my sight, as I have cast out all your brothers, even the whole offspring of Ephraim. 
 </p><p>
 <sup>16&#160;</sup>“Therefore don’t pray for this people. Don’t lift up a cry or prayer for them or make intercession to me; for I will not hear you. 
 <sup>17&#160;</sup>Don’t you see what they do in the cities of Judah and in the streets of Jerusalem? 
 <sup>18&#160;</sup>The children gather wood, and the fathers kindle the fire, and the women knead the dough, to make cakes to the queen of the sky, and to pour out drink offerings to other elohims, that they may provoke me to anger. 
-<sup>19&#160;</sup>Do they provoke me to anger?” says Yahweh. “Don’t they provoke themselves, to the confusion of their own faces?” 
+<sup>19&#160;</sup>Do they provoke me to anger?” says Yahuah. “Don’t they provoke themselves, to the confusion of their own faces?” 
 </p><p>
-<sup>20&#160;</sup>Therefore the Lord Yahweh says: “Behold, my anger and my wrath will be poured out on this place, on man, on animal, on the trees of the field, and on the fruit of the ground; and it will burn and will not be quenched.” 
+<sup>20&#160;</sup>Therefore the Lord Yahuah says: “Behold, my anger and my wrath will be poured out on this place, on man, on animal, on the trees of the field, and on the fruit of the ground; and it will burn and will not be quenched.” 
 </p><p>
-<sup>21&#160;</sup>Yahweh of Armies, the Elohim of Israel says: “Add your burnt offerings to your sacrifices and eat meat. 
+<sup>21&#160;</sup>Yahuah of Armies, the Elohim of Israel says: “Add your burnt offerings to your sacrifices and eat meat. 
 <sup>22&#160;</sup>For I didn’t speak to your fathers or command them in the day that I brought them out of the land of Egypt concerning burnt offerings or sacrifices; 
 <sup>23&#160;</sup>but this thing I commanded them, saying, ‘Listen to my voice, and I will be your Elohim, and you shall be my people. Walk in all the way that I command you, that it may be well with you.’ 
 <sup>24&#160;</sup>But they didn’t listen or turn their ear, but walked in their own counsels and in the stubbornness of their evil heart, and went backward, and not forward. 
@@ -517,20 +517,20 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>Yet they didn’t listen to me or incline their ear, but made their neck stiff. They did worse than their fathers. 
 </p><p>
 <sup>27&#160;</sup>“You shall speak all these words to them, but they will not listen to you. You shall also call to them, but they will not answer you. 
-<sup>28&#160;</sup>You shall tell them, ‘This is the nation that has not listened to Yahweh their Elohim’s voice, nor received instruction. Truth has perished, and is cut off from their mouth.’ 
-<sup>29&#160;</sup>Cut off your hair, and throw it away, and take up a lamentation on the bare heights; for Yahweh has rejected and forsaken the generation of his wrath. 
+<sup>28&#160;</sup>You shall tell them, ‘This is the nation that has not listened to Yahuah their Elohim’s voice, nor received instruction. Truth has perished, and is cut off from their mouth.’ 
+<sup>29&#160;</sup>Cut off your hair, and throw it away, and take up a lamentation on the bare heights; for Yahuah has rejected and forsaken the generation of his wrath. 
 </p><p>
-<sup>30&#160;</sup>“For the children of Judah have done that which is evil in my sight,” says Yahweh. “They have set their abominations in the house which is called by my name, to defile it. 
+<sup>30&#160;</sup>“For the children of Judah have done that which is evil in my sight,” says Yahuah. “They have set their abominations in the house which is called by my name, to defile it. 
 <sup>31&#160;</sup>They have built the high places of Topheth, which is in the valley of the son of Hinnom, to burn their sons and their daughters in the fire, which I didn’t command, nor did it come into my mind. 
-<sup>32&#160;</sup>Therefore behold, the days come”, says Yahweh, “that it will no more be called ‘Topheth’ or ‘The valley of the son of Hinnom’, but ‘The valley of Slaughter’; for they will bury in Topheth until there is no place to bury. 
+<sup>32&#160;</sup>Therefore behold, the days come”, says Yahuah, “that it will no more be called ‘Topheth’ or ‘The valley of the son of Hinnom’, but ‘The valley of Slaughter’; for they will bury in Topheth until there is no place to bury. 
 <sup>33&#160;</sup>The dead bodies of this people will be food for the birds of the sky, and for the animals of the earth. No one will frighten them away. 
 <sup>34&#160;</sup>Then I will cause to cease from the cities of Judah and from the streets of Jerusalem the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride; for the land will become a waste.” 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>“At that time,” says Yahweh, “they will bring the bones of the kings of Judah, the bones of his princes, the bones of the priests, the bones of the prophets, and the bones of the inhabitants of Jerusalem, out of their graves. 
+<sup>1&#160;</sup>“At that time,” says Yahuah, “they will bring the bones of the kings of Judah, the bones of his princes, the bones of the priests, the bones of the prophets, and the bones of the inhabitants of Jerusalem, out of their graves. 
 <sup>2&#160;</sup>They will spread them before the sun, the moon, and all the army of the sky, which they have loved, which they have served, after which they have walked, which they have sought, and which they have worshiped. They will not be gathered or be buried. They will be like dung on the surface of the earth. 
-<sup>3&#160;</sup>Death will be chosen rather than life by all the residue that remain of this evil family, that remain in all the places where I have driven them,” says Yahweh of Armies. 
-<sup>4&#160;</sup>“Moreover you shall tell them, ‘Yahweh says: 
+<sup>3&#160;</sup>Death will be chosen rather than life by all the residue that remain of this evil family, that remain in all the places where I have driven them,” says Yahuah of Armies. 
+<sup>4&#160;</sup>“Moreover you shall tell them, ‘Yahuah says: 
 </p><p class="q1">“&#160;‘Do men fall, and not rise up again? 
 </p><p class="q2">Does one turn away, and not return? 
 </p><p class="q1">
@@ -545,15 +545,15 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>7&#160;</sup>Yes, the stork in the sky knows her appointed times. 
 </p><p class="q2">The turtledove, the swallow, and the crane observe the time of their coming; 
-</p><p class="q2">but my people don’t know Yahweh’s law. 
+</p><p class="q2">but my people don’t know Yahuah’s law. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>8&#160;</sup>“&#160;‘How do you say, “We are wise, and Yahweh’s law is with us”? 
+<sup>8&#160;</sup>“&#160;‘How do you say, “We are wise, and Yahuah’s law is with us”? 
 </p><p class="q2">But, behold, the false pen of the scribes has made that a lie. 
 </p><p class="q1">
 <sup>9&#160;</sup>The wise men are disappointed. 
 </p><p class="q2">They are dismayed and trapped. 
-</p><p class="q1">Behold, they have rejected Yahweh’s word. 
+</p><p class="q1">Behold, they have rejected Yahuah’s word. 
 </p><p class="q2">What kind of wisdom is in them? 
 </p><p class="q1">
 <sup>10&#160;</sup>Therefore I will give their women to others 
@@ -568,10 +568,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">No, they were not at all ashamed. 
 </p><p class="q2">They couldn’t blush. 
 </p><p class="q1">Therefore they will fall among those who fall. 
-</p><p class="q2">In the time of their visitation they will be cast down, says Yahweh. 
+</p><p class="q2">In the time of their visitation they will be cast down, says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>13&#160;</sup>“&#160;‘I will utterly consume them, says Yahweh. 
+<sup>13&#160;</sup>“&#160;‘I will utterly consume them, says Yahuah. 
 </p><p class="q2">No grapes will be on the vine, 
 </p><p class="q2">no figs on the fig tree, 
 </p><p class="q2">and the leaf will fade. 
@@ -583,9 +583,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Assemble yourselves! 
 </p><p class="q2">Let’s enter into the fortified cities, 
 </p><p class="q2">and let’s be silent there; 
-</p><p class="q1">for Yahweh our Elohim has put us to silence, 
+</p><p class="q1">for Yahuah our Elohim has put us to silence, 
 </p><p class="q2">and given us poisoned water to drink, 
-</p><p class="q2">because we have sinned against Yahweh. 
+</p><p class="q2">because we have sinned against Yahuah. 
 </p><p class="q1">
 <sup>15&#160;</sup>We looked for peace, but no good came; 
 </p><p class="q2">and for a time of healing, and behold, dismay! 
@@ -598,13 +598,13 @@ html[dir=ltr] .q2 {
 <sup>17&#160;</sup>“For, behold, I will send serpents, 
 </p><p class="q2">adders among you, 
 </p><p class="q2">which will not be charmed; 
-</p><p class="q2">and they will bite you,” says Yahweh. 
+</p><p class="q2">and they will bite you,” says Yahuah. 
 </p><p class="q1">
 <sup>18&#160;</sup>Oh that I could comfort myself against sorrow! 
 </p><p class="q2">My heart is faint within me. 
 </p><p class="q1">
 <sup>19&#160;</sup>Behold, the voice of the cry of the daughter of my people from a land that is very far off: 
-</p><p class="q2">“Isn’t Yahweh in Zion? 
+</p><p class="q2">“Isn’t Yahuah in Zion? 
 </p><p class="q2">Isn’t her King in her?” 
 </p><p class="b"> &#160; </p>
 <p class="q1">“Why have they provoked me to anger with their engraved images, 
@@ -642,7 +642,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">They have grown strong in the land, 
 </p><p class="q2">but not for truth; 
 </p><p class="q1">for they proceed from evil to evil, 
-</p><p class="q2">and they don’t know me,” says Yahweh. 
+</p><p class="q2">and they don’t know me,” says Yahuah. 
 </p><p class="q1">
 <sup>4&#160;</sup>“Everyone beware of his neighbor, 
 </p><p class="q2">and don’t trust in any brother; 
@@ -655,9 +655,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They weary themselves committing iniquity. 
 </p><p class="q1">
 <sup>6&#160;</sup>Your habitation is in the middle of deceit. 
-</p><p class="q2">Through deceit, they refuse to know me,” says Yahweh. 
+</p><p class="q2">Through deceit, they refuse to know me,” says Yahuah. 
 </p><p>
-<sup>7&#160;</sup>Therefore Yahweh of Armies says, 
+<sup>7&#160;</sup>Therefore Yahuah of Armies says, 
 </p><p class="q1">“Behold, I will melt them and test them; 
 </p><p class="q2">for how should I deal with the daughter of my people? 
 </p><p class="q1">
@@ -666,7 +666,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">One speaks peaceably to his neighbor with his mouth, 
 </p><p class="q2">but in his heart, he waits to ambush him. 
 </p><p class="q1">
-<sup>9&#160;</sup>Shouldn’t I punish them for these things?” says Yahweh. 
+<sup>9&#160;</sup>Shouldn’t I punish them for these things?” says Yahuah. 
 </p><p class="q2">“Shouldn’t my soul be avenged on a nation such as this? 
 </p><p class="q1">
 <sup>10&#160;</sup>I will weep and wail for the mountains, 
@@ -682,14 +682,14 @@ html[dir=ltr] .q2 {
 </p><p class="q1">I will make the cities of Judah a desolation, 
 </p><p class="q2">without inhabitant.” 
 </p><p>
-<sup>12&#160;</sup>Who is wise enough to understand this? Who is he to whom the mouth of Yahweh has spoken, that he may declare it? Why has the land perished and burned up like a wilderness, so that no one passes through? 
+<sup>12&#160;</sup>Who is wise enough to understand this? Who is he to whom the mouth of Yahuah has spoken, that he may declare it? Why has the land perished and burned up like a wilderness, so that no one passes through? 
 </p><p>
-<sup>13&#160;</sup>Yahweh says, “Because they have forsaken my law which I set before them, and have not obeyed my voice or walked in my ways, 
+<sup>13&#160;</sup>Yahuah says, “Because they have forsaken my law which I set before them, and have not obeyed my voice or walked in my ways, 
 <sup>14&#160;</sup>but have walked after the stubbornness of their own heart and after the Baals, which their fathers taught them.” 
-<sup>15&#160;</sup>Therefore Yahweh of Armies, the Elohim of Israel, says, “Behold, I will feed them, even this people, with wormwood and give them poisoned water to drink. 
+<sup>15&#160;</sup>Therefore Yahuah of Armies, the Elohim of Israel, says, “Behold, I will feed them, even this people, with wormwood and give them poisoned water to drink. 
 <sup>16&#160;</sup>I will scatter them also among the nations, whom neither they nor their fathers have known. I will send the sword after them, until I have consumed them.” 
 </p><p>
-<sup>17&#160;</sup>Yahweh of Armies says, 
+<sup>17&#160;</sup>Yahuah of Armies says, 
 </p><p class="q1">“Consider, and call for the mourning women, that they may come. 
 </p><p class="q2">Send for the skillful women, that they may come. 
 </p><p class="q1">
@@ -705,7 +705,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">because they have cast down our dwellings.’&#160;” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>20&#160;</sup>Yet hear Yahweh’s word, you women. 
+<sup>20&#160;</sup>Yet hear Yahuah’s word, you women. 
 </p><p class="q2">Let your ear receive the word of his mouth. 
 </p><p class="q1">Teach your daughters wailing. 
 </p><p class="q2">Everyone teach her neighbor a lamentation. 
@@ -715,27 +715,27 @@ html[dir=ltr] .q2 {
 </p><p class="q1">to cut off the children from outside, 
 </p><p class="q2">and the young men from the streets. 
 </p><p>
-<sup>22&#160;</sup>Speak, “Yahweh says, 
+<sup>22&#160;</sup>Speak, “Yahuah says, 
 </p><p class="q1">“&#160;‘The dead bodies of men will fall as dung on the open field, 
 </p><p class="q2">and as the handful after the harvester. 
 </p><p class="q2">No one will gather them.’&#160;” 
 </p><p>
-<sup>23&#160;</sup>Yahweh says, 
+<sup>23&#160;</sup>Yahuah says, 
 </p><p class="q1">“Don’t let the wise man glory in his wisdom. 
 </p><p class="q2">Don’t let the mighty man glory in his might. 
 </p><p class="q2">Don’t let the rich man glory in his riches. 
 </p><p class="q1">
 <sup>24&#160;</sup>But let him who glories glory in this, 
 </p><p class="q2">that he has understanding, and knows me, 
-</p><p class="q1">that I am Yahweh who exercises loving kindness, justice, and righteousness in the earth, 
-</p><p class="q2">for I delight in these things,” says Yahweh. 
+</p><p class="q1">that I am Yahuah who exercises loving kindness, justice, and righteousness in the earth, 
+</p><p class="q2">for I delight in these things,” says Yahuah. 
 </p><p>
-<sup>25&#160;</sup>“Behold, the days come,” says Yahweh, “that I will punish all those who are circumcised only in their flesh: 
+<sup>25&#160;</sup>“Behold, the days come,” says Yahuah, “that I will punish all those who are circumcised only in their flesh: 
 <sup>26&#160;</sup>Egypt, Judah, Edom, the children of Ammon, Moab, and all who have the corners of their hair cut off, who dwell in the wilderness, for all the nations are uncircumcised, and all the house of Israel are uncircumcised in heart.” 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p>
-<sup>1&#160;</sup>Hear the word which Yahweh speaks to you, house of Israel! 
-<sup>2&#160;</sup>Yahweh says, 
+<sup>1&#160;</sup>Hear the word which Yahuah speaks to you, house of Israel! 
+<sup>2&#160;</sup>Yahuah says, 
 </p><p class="q1">“Don’t learn the way of the nations, 
 </p><p class="q2">and don’t be dismayed at the signs of the sky; 
 </p><p class="q2">for the nations are dismayed at them. 
@@ -756,7 +756,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for they can’t do evil, 
 </p><p class="q2">neither is it in them to do good.” 
 </p><p class="q1">
-<sup>6&#160;</sup>There is no one like you, Yahweh. 
+<sup>6&#160;</sup>There is no one like you, Yahuah. 
 </p><p class="q2">You are great, 
 </p><p class="q2">and your name is great in might. 
 </p><p class="q1">
@@ -777,7 +777,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Their clothing is blue and purple. 
 </p><p class="q2">They are all the work of skillful men. 
 </p><p class="q1">
-<sup>10&#160;</sup>But Yahweh is the true Elohim. 
+<sup>10&#160;</sup>But Yahuah is the true Elohim. 
 </p><p class="q2">He is the living Elohim, 
 </p><p class="q2">and an everlasting King. 
 </p><p class="q1">At his wrath, the earth trembles. 
@@ -806,12 +806,12 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>The portion of Jacob is not like these; 
 </p><p class="q2">for he is the maker of all things; 
 </p><p class="q1">and Israel is the tribe of his inheritance. 
-</p><p class="q2">Yahweh of Armies is his name. 
+</p><p class="q2">Yahuah of Armies is his name. 
 </p><p class="q1">
 <sup>17&#160;</sup>Gather up your wares out of the land, 
 </p><p class="q2">you who live under siege. 
 </p><p class="q1">
-<sup>18&#160;</sup>For Yahweh says, 
+<sup>18&#160;</sup>For Yahuah says, 
 </p><p class="q2">“Behold, I will sling out the inhabitants of the land at this time, 
 </p><p class="q2">and will distress them, that they may feel it.” 
 </p><p class="q1">
@@ -827,7 +827,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">to set up my curtains. 
 </p><p class="q1">
 <sup>21&#160;</sup>For the shepherds have become brutish, 
-</p><p class="q2">and have not inquired of Yahweh. 
+</p><p class="q2">and have not inquired of Yahuah. 
 </p><p class="q1">Therefore they have not prospered, 
 </p><p class="q2">and all their flocks have scattered. 
 </p><p class="q1">
@@ -836,10 +836,10 @@ html[dir=ltr] .q2 {
 </p><p class="q1">to make the cities of Judah a desolation, 
 </p><p class="q2">a dwelling place of jackals. 
 </p><p class="q1">
-<sup>23&#160;</sup>Yahweh, I know that the way of man is not in himself. 
+<sup>23&#160;</sup>Yahuah, I know that the way of man is not in himself. 
 </p><p class="q2">It is not in man who walks to direct his steps. 
 </p><p class="q1">
-<sup>24&#160;</sup>Yahweh, correct me, but gently; 
+<sup>24&#160;</sup>Yahuah, correct me, but gently; 
 </p><p class="q2">not in your anger, 
 </p><p class="q2">lest you reduce me to nothing. 
 </p><p class="q1">
@@ -850,20 +850,20 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and have laid waste his habitation. 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p>
-<sup>1&#160;</sup>The word that came to Jeremiah from Yahweh, saying, 
+<sup>1&#160;</sup>The word that came to Jeremiah from Yahuah, saying, 
 <sup>2&#160;</sup>“Hear the words of this covenant, and speak to the men of Judah, and to the inhabitants of Jerusalem; 
-<sup>3&#160;</sup>and say to them, Yahweh, the Elohim of Israel says: ‘Cursed is the man who doesn’t hear the words of this covenant, 
+<sup>3&#160;</sup>and say to them, Yahuah, the Elohim of Israel says: ‘Cursed is the man who doesn’t hear the words of this covenant, 
 <sup>4&#160;</sup>which I commanded your fathers in the day that I brought them out of the land of Egypt, out of the iron furnace,’ saying, ‘Obey my voice and do them, according to all which I command you; so you shall be my people, and I will be your Elohim; 
 <sup>5&#160;</sup>that I may establish the oath which I swore to your fathers, to give them a land flowing with milk and honey,’ as it is today.” 
-</p><p>Then I answered, and said, “Amen, Yahweh.” 
+</p><p>Then I answered, and said, “Amen, Yahuah.” 
 </p><p>
-<sup>6&#160;</sup>Yahweh said to me, “Proclaim all these words in the cities of Judah, and in the streets of Jerusalem, saying, ‘Hear the words of this covenant, and do them. 
+<sup>6&#160;</sup>Yahuah said to me, “Proclaim all these words in the cities of Judah, and in the streets of Jerusalem, saying, ‘Hear the words of this covenant, and do them. 
 <sup>7&#160;</sup>For I earnestly protested to your fathers in the day that I brought them up out of the land of Egypt, even to this day, rising early and protesting, saying, “Obey my voice.” 
 <sup>8&#160;</sup>Yet they didn’t obey, nor turn their ear, but everyone walked in the stubbornness of their evil heart. Therefore I brought on them all the words of this covenant, which I commanded them to do, but they didn’t do them.’&#160;” 
 </p><p>
-<sup>9&#160;</sup>Yahweh said to me, “A conspiracy is found among the men of Judah, and among the inhabitants of Jerusalem. 
+<sup>9&#160;</sup>Yahuah said to me, “A conspiracy is found among the men of Judah, and among the inhabitants of Jerusalem. 
 <sup>10&#160;</sup>They have turned back to the iniquities of their forefathers, who refused to hear my words. They have gone after other elohims to serve them. The house of Israel and the house of Judah have broken my covenant which I made with their fathers. 
-<sup>11&#160;</sup>Therefore Yahweh says, ‘Behold, I will bring evil on them which they will not be able to escape; and they will cry to me, but I will not listen to them. 
+<sup>11&#160;</sup>Therefore Yahuah says, ‘Behold, I will bring evil on them which they will not be able to escape; and they will cry to me, but I will not listen to them. 
 <sup>12&#160;</sup>Then the cities of Judah and the inhabitants of Jerusalem will go and cry to the elohims to which they offer incense, but they will not save them at all in the time of their trouble. 
 <sup>13&#160;</sup>For according to the number of your cities are your elohims, Judah; and according to the number of the streets of Jerusalem you have set up altars to the shameful thing, even altars to burn incense to Baal.’ 
 </p><p>
@@ -876,29 +876,29 @@ html[dir=ltr] .q2 {
 </p><p class="q2">then you rejoice.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>16&#160;</sup>Yahweh called your name, “A green olive tree, 
+<sup>16&#160;</sup>Yahuah called your name, “A green olive tree, 
 </p><p class="q2">beautiful with goodly fruit.” 
 </p><p class="q1">With the noise of a great roar he has kindled fire on it, 
 </p><p class="q2">and its branches are broken. 
 </p><p class="m">
-<sup>17&#160;</sup>For Yahweh of Armies, who planted you, has pronounced evil against you, because of the evil of the house of Israel and of the house of Judah, which they have done to themselves in provoking me to anger by offering incense to Baal. 
+<sup>17&#160;</sup>For Yahuah of Armies, who planted you, has pronounced evil against you, because of the evil of the house of Israel and of the house of Judah, which they have done to themselves in provoking me to anger by offering incense to Baal. 
 </p><p>
-<sup>18&#160;</sup>Yahweh gave me knowledge of it, and I knew it. Then you showed me their doings. 
+<sup>18&#160;</sup>Yahuah gave me knowledge of it, and I knew it. Then you showed me their doings. 
 <sup>19&#160;</sup>But I was like a gentle lamb that is led to the slaughter. I didn’t know that they had devised plans against me, saying, 
 </p><p class="q1">“Let’s destroy the tree with its fruit, 
 </p><p class="q2">and let’s cut him off from the land of the living, 
 </p><p class="q2">that his name may be no more remembered.” 
 </p><p class="q1">
-<sup>20&#160;</sup>But, Yahweh of Armies, who judges righteously, 
+<sup>20&#160;</sup>But, Yahuah of Armies, who judges righteously, 
 </p><p class="q2">who tests the heart and the mind, 
 </p><p class="q1">I will see your vengeance on them; 
 </p><p class="q2">for to you I have revealed my cause. 
 </p><p>
-<sup>21&#160;</sup>“Therefore Yahweh says concerning the men of Anathoth, who seek your life, saying, ‘You shall not prophesy in Yahweh’s name, that you not die by our hand’—<sup>22&#160;</sup>therefore Yahweh of Armies says, ‘Behold, I will punish them. The young men will die by the sword. Their sons and their daughters will die by famine. 
+<sup>21&#160;</sup>“Therefore Yahuah says concerning the men of Anathoth, who seek your life, saying, ‘You shall not prophesy in Yahuah’s name, that you not die by our hand’—<sup>22&#160;</sup>therefore Yahuah of Armies says, ‘Behold, I will punish them. The young men will die by the sword. Their sons and their daughters will die by famine. 
 <sup>23&#160;</sup>There will be no remnant to them, for I will bring evil on the men of Anathoth, even the year of their visitation.’&#160;” 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p class="q1">
-<sup>1&#160;</sup>You are righteous, Yahweh, 
+<sup>1&#160;</sup>You are righteous, Yahuah, 
 </p><p class="q2">when I contend with you; 
 </p><p class="q1">yet I would like to plead a case with you. 
 </p><p class="q2">Why does the way of the wicked prosper? 
@@ -909,7 +909,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">You are near in their mouth, 
 </p><p class="q2">and far from their heart. 
 </p><p class="q1">
-<sup>3&#160;</sup>But you, Yahweh, know me. 
+<sup>3&#160;</sup>But you, Yahuah, know me. 
 </p><p class="q2">You see me, and test my heart toward you. 
 </p><p class="q1">Pull them out like sheep for the slaughter, 
 </p><p class="q2">and prepare them for the day of slaughter. 
@@ -957,7 +957,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">because no one cares. 
 </p><p class="q1">
 <sup>12&#160;</sup>Destroyers have come on all the bare heights in the wilderness; 
-</p><p class="q2">for the sword of Yahweh devours from the one end of the land even to the other end of the land. 
+</p><p class="q2">for the sword of Yahuah devours from the one end of the land even to the other end of the land. 
 </p><p class="q2">No flesh has peace. 
 </p><p class="q1">
 <sup>13&#160;</sup>They have sown wheat, 
@@ -965,42 +965,42 @@ html[dir=ltr] .q2 {
 </p><p class="q1">They have exhausted themselves, 
 </p><p class="q2">and profit nothing. 
 </p><p class="q1">You will be ashamed of your fruits, 
-</p><p class="q2">because of Yahweh’s fierce anger.” 
+</p><p class="q2">because of Yahuah’s fierce anger.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>14&#160;</sup>Yahweh says, “Concerning all my evil neighbors, who touch the inheritance which I have caused my people Israel to inherit: Behold, I will pluck them up from off their land, and will pluck up the house of Judah from among them. 
+<sup>14&#160;</sup>Yahuah says, “Concerning all my evil neighbors, who touch the inheritance which I have caused my people Israel to inherit: Behold, I will pluck them up from off their land, and will pluck up the house of Judah from among them. 
 <sup>15&#160;</sup>It will happen that after I have plucked them up, I will return and have compassion on them. I will bring them again, every man to his heritage, and every man to his land. 
-<sup>16&#160;</sup>It will happen, if they will diligently learn the ways of my people, to swear by my name, ‘As Yahweh lives;’ even as they taught my people to swear by Baal, then they will be built up in the middle of my people. 
-<sup>17&#160;</sup>But if they will not hear, then I will pluck up that nation, plucking up and destroying it,” says Yahweh. 
+<sup>16&#160;</sup>It will happen, if they will diligently learn the ways of my people, to swear by my name, ‘As Yahuah lives;’ even as they taught my people to swear by Baal, then they will be built up in the middle of my people. 
+<sup>17&#160;</sup>But if they will not hear, then I will pluck up that nation, plucking up and destroying it,” says Yahuah. 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to me, “Go, and buy yourself a linen belt, and put it on your waist, and don’t put it in water.” 
+<sup>1&#160;</sup>Yahuah said to me, “Go, and buy yourself a linen belt, and put it on your waist, and don’t put it in water.” 
 </p><p>
-<sup>2&#160;</sup>So I bought a belt according to Yahweh’s word, and put it on my waist. 
+<sup>2&#160;</sup>So I bought a belt according to Yahuah’s word, and put it on my waist. 
 </p><p>
-<sup>3&#160;</sup>Yahweh’s word came to me the second time, saying, 
+<sup>3&#160;</sup>Yahuah’s word came to me the second time, saying, 
 <sup>4&#160;</sup>“Take the belt that you have bought, which is on your waist, and arise, go to the Euphrates, and hide it there in a cleft of the rock.” 
 </p><p>
-<sup>5&#160;</sup>So I went and hid it by the Euphrates, as Yahweh commanded me. 
+<sup>5&#160;</sup>So I went and hid it by the Euphrates, as Yahuah commanded me. 
 </p><p>
-<sup>6&#160;</sup>After many days, Yahweh said to me, “Arise, go to the Euphrates, and take the belt from there, which I commanded you to hide there.” 
+<sup>6&#160;</sup>After many days, Yahuah said to me, “Arise, go to the Euphrates, and take the belt from there, which I commanded you to hide there.” 
 </p><p>
 <sup>7&#160;</sup>Then I went to the Euphrates, and dug, and took the belt from the place where I had hidden it; and behold, the belt was ruined. It was profitable for nothing. 
 </p><p>
-<sup>8&#160;</sup>Then Yahweh’s word came to me, saying, 
-<sup>9&#160;</sup>“Yahweh says, ‘In this way I will ruin the pride of Judah, and the great pride of Jerusalem. 
+<sup>8&#160;</sup>Then Yahuah’s word came to me, saying, 
+<sup>9&#160;</sup>“Yahuah says, ‘In this way I will ruin the pride of Judah, and the great pride of Jerusalem. 
 <sup>10&#160;</sup>This evil people, who refuse to hear my words, who walk in the stubbornness of their heart, and have gone after other elohims to serve them and to worship them, will even be as this belt, which is profitable for nothing. 
-<sup>11&#160;</sup>For as the belt clings to the waist of a man, so I have caused the whole house of Israel and the whole house of Judah to cling to me,’ says Yahweh; ‘that they may be to me for a people, for a name, for praise, and for glory; but they would not hear.’ 
+<sup>11&#160;</sup>For as the belt clings to the waist of a man, so I have caused the whole house of Israel and the whole house of Judah to cling to me,’ says Yahuah; ‘that they may be to me for a people, for a name, for praise, and for glory; but they would not hear.’ 
 </p><p>
-<sup>12&#160;</sup>“Therefore you shall speak to them this word: ‘Yahweh, the Elohim of Israel says, “Every container should be filled with wine.”&#160;’ They will tell you, ‘Do we not certainly know that every container should be filled with wine?’ 
-<sup>13&#160;</sup>Then tell them, ‘Yahweh says, “Behold, I will fill all the inhabitants of this land, even the kings who sit on David’s throne, the priests, the prophets, and all the inhabitants of Jerusalem, with drunkenness. 
-<sup>14&#160;</sup>I will dash them one against another, even the fathers and the sons together,” says Yahweh: “I will not pity, spare, or have compassion, that I should not destroy them.”&#160;’&#160;” 
+<sup>12&#160;</sup>“Therefore you shall speak to them this word: ‘Yahuah, the Elohim of Israel says, “Every container should be filled with wine.”&#160;’ They will tell you, ‘Do we not certainly know that every container should be filled with wine?’ 
+<sup>13&#160;</sup>Then tell them, ‘Yahuah says, “Behold, I will fill all the inhabitants of this land, even the kings who sit on David’s throne, the priests, the prophets, and all the inhabitants of Jerusalem, with drunkenness. 
+<sup>14&#160;</sup>I will dash them one against another, even the fathers and the sons together,” says Yahuah: “I will not pity, spare, or have compassion, that I should not destroy them.”&#160;’&#160;” 
 </p><p class="q1">
 <sup>15&#160;</sup>Hear, and give ear. 
 </p><p class="q2">Don’t be proud, 
-</p><p class="q2">for Yahweh has spoken. 
+</p><p class="q2">for Yahuah has spoken. 
 </p><p class="q1">
-<sup>16&#160;</sup>Give glory to Yahweh your Elohim, 
+<sup>16&#160;</sup>Give glory to Yahuah your Elohim, 
 </p><p class="q2">before he causes darkness, 
 </p><p class="q2">and before your feet stumble on the dark mountains, 
 </p><p class="q1">and while you look for light, 
@@ -1011,7 +1011,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">my soul will weep in secret for your pride. 
 </p><p class="q1">My eye will weep bitterly, 
 </p><p class="q2">and run down with tears, 
-</p><p class="q2">because Yahweh’s flock has been taken captive. 
+</p><p class="q2">because Yahuah’s flock has been taken captive. 
 </p><p class="q1">
 <sup>18&#160;</sup>Say to the king and to the queen mother, 
 </p><p class="q2">“Humble yourselves. 
@@ -1047,7 +1047,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">by the wind of the wilderness. 
 </p><p class="q1">
 <sup>25&#160;</sup>This is your lot, 
-</p><p class="q2">the portion measured to you from me,” says Yahweh, 
+</p><p class="q2">the portion measured to you from me,” says Yahuah, 
 </p><p class="q1">“because you have forgotten me, 
 </p><p class="q2">and trusted in falsehood.” 
 </p><p class="q1">
@@ -1062,7 +1062,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">How long will it yet be?” 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
-<sup>1&#160;</sup>This is Yahweh’s word that came to Jeremiah concerning the drought: 
+<sup>1&#160;</sup>This is Yahuah’s word that came to Jeremiah concerning the drought: 
 </p><p class="q1">
 <sup>2&#160;</sup>“Judah mourns, 
 </p><p class="q2">and its gates languish. 
@@ -1090,7 +1090,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">because there is no vegetation. 
 </p><p class="q1">
 <sup>7&#160;</sup>Though our iniquities testify against us, 
-</p><p class="q2">work for your name’s sake, Yahweh; 
+</p><p class="q2">work for your name’s sake, Yahuah; 
 </p><p class="q1">for our rebellions are many. 
 </p><p class="q2">We have sinned against you. 
 </p><p class="q1">
@@ -1101,24 +1101,24 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>9&#160;</sup>Why should you be like a scared man, 
 </p><p class="q2">as a mighty man who can’t save? 
-</p><p class="q1">Yet you, Yahweh, are in the middle of us, 
+</p><p class="q1">Yet you, Yahuah, are in the middle of us, 
 </p><p class="q2">and we are called by your name. 
 </p><p class="q2">Don’t leave us. 
 </p><p>
-<sup>10&#160;</sup>Yahweh says to this people: 
+<sup>10&#160;</sup>Yahuah says to this people: 
 </p><p class="q1">“Even so they have loved to wander. 
 </p><p class="q2">They have not restrained their feet. 
-</p><p class="q1">Therefore Yahweh does not accept them. 
+</p><p class="q1">Therefore Yahuah does not accept them. 
 </p><p class="q2">Now he will remember their iniquity, 
 </p><p class="q2">and punish them for their sins.” 
 </p><p>
-<sup>11&#160;</sup>Yahweh said to me, “Don’t pray for this people for their good. 
+<sup>11&#160;</sup>Yahuah said to me, “Don’t pray for this people for their good. 
 <sup>12&#160;</sup>When they fast, I will not hear their cry; and when they offer burnt offering and meal offering, I will not accept them; but I will consume them by the sword, by famine, and by pestilence.” 
 </p><p>
-<sup>13&#160;</sup>Then I said, “Ah, Lord Yahweh! Behold, the prophets tell them, ‘You will not see the sword, neither will you have famine; but I will give you assured peace in this place.’&#160;” 
+<sup>13&#160;</sup>Then I said, “Ah, Lord Yahuah! Behold, the prophets tell them, ‘You will not see the sword, neither will you have famine; but I will give you assured peace in this place.’&#160;” 
 </p><p>
-<sup>14&#160;</sup>Then Yahweh said to me, “The prophets prophesy lies in my name. I didn’t send them. I didn’t command them. I didn’t speak to them. They prophesy to you a lying vision, divination, and a thing of nothing, and the deceit of their own heart. 
-<sup>15&#160;</sup>Therefore Yahweh says concerning the prophets who prophesy in my name, but I didn’t send them, yet they say, ‘Sword and famine will not be in this land.’ Those prophets will be consumed by sword and famine. 
+<sup>14&#160;</sup>Then Yahuah said to me, “The prophets prophesy lies in my name. I didn’t send them. I didn’t command them. I didn’t speak to them. They prophesy to you a lying vision, divination, and a thing of nothing, and the deceit of their own heart. 
+<sup>15&#160;</sup>Therefore Yahuah says concerning the prophets who prophesy in my name, but I didn’t send them, yet they say, ‘Sword and famine will not be in this land.’ Those prophets will be consumed by sword and famine. 
 <sup>16&#160;</sup>The people to whom they prophesy will be cast out in the streets of Jerusalem because of the famine and the sword. They will have no one to bury them—them, their women, their sons, or their daughters, for I will pour their wickedness on them. 
 </p><p>
 <sup>17&#160;</sup>“You shall say this word to them: 
@@ -1141,7 +1141,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">We looked for peace, but no good came; 
 </p><p class="q2">and for a time of healing, and behold, dismay! 
 </p><p class="q1">
-<sup>20&#160;</sup>We acknowledge, Yahweh, our wickedness, 
+<sup>20&#160;</sup>We acknowledge, Yahuah, our wickedness, 
 </p><p class="q2">and the iniquity of our fathers; 
 </p><p class="q2">for we have sinned against you. 
 </p><p class="q1">
@@ -1151,26 +1151,26 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>22&#160;</sup>Are there any among the vanities of the nations that can cause rain? 
 </p><p class="q2">Or can the sky give showers? 
-</p><p class="q2">Aren’t you he, Yahweh our Elohim? 
+</p><p class="q2">Aren’t you he, Yahuah our Elohim? 
 </p><p class="q1">Therefore we will wait for you; 
 </p><p class="q2">for you have made all these things. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
-<sup>1&#160;</sup>Then Yahweh said to me, “Though Moses and Samuel stood before me, yet my mind would not turn toward this people. Cast them out of my sight, and let them go out! 
-<sup>2&#160;</sup>It will happen when they ask you, ‘Where shall we go out?’ then you shall tell them, ‘Yahweh says: 
+<sup>1&#160;</sup>Then Yahuah said to me, “Though Moses and Samuel stood before me, yet my mind would not turn toward this people. Cast them out of my sight, and let them go out! 
+<sup>2&#160;</sup>It will happen when they ask you, ‘Where shall we go out?’ then you shall tell them, ‘Yahuah says: 
 </p><p class="q1">“Such as are for death, to death; 
 </p><p class="q1">such as are for the sword, to the sword; 
 </p><p class="q1">such as are for the famine, to the famine; 
 </p><p class="q1">and such as are for captivity, to captivity.”&#160;’ 
 </p><p>
-<sup>3&#160;</sup>“I will appoint over them four kinds,” says Yahweh: “the sword to kill, the dogs to tear, the birds of the sky, and the animals of the earth, to devour and to destroy. 
+<sup>3&#160;</sup>“I will appoint over them four kinds,” says Yahuah: “the sword to kill, the dogs to tear, the birds of the sky, and the animals of the earth, to devour and to destroy. 
 <sup>4&#160;</sup>I will cause them to be tossed back and forth among all the kingdoms of the earth, because of Manasseh, the son of Hezekiah, king of Judah, for that which he did in Jerusalem. 
 </p><p class="q1">
 <sup>5&#160;</sup>For who will have pity on you, Jerusalem? 
 </p><p class="q2">Who will mourn you? 
 </p><p class="q2">Who will come to ask of your welfare? 
 </p><p class="q1">
-<sup>6&#160;</sup>You have rejected me,” says Yahweh. 
+<sup>6&#160;</sup>You have rejected me,” says Yahuah. 
 </p><p class="q2">“You have gone backward. 
 </p><p class="q1">Therefore I have stretched out my hand against you 
 </p><p class="q2">and destroyed you. 
@@ -1189,7 +1189,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">She has given up the spirit. 
 </p><p class="q1">Her sun has gone down while it was yet day. 
 </p><p class="q2">She has been disappointed and confounded. 
-</p><p class="q2">I will deliver their residue to the sword before their enemies,” says Yahweh. 
+</p><p class="q2">I will deliver their residue to the sword before their enemies,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>10&#160;</sup>Woe is me, my mother, that you have borne me, a man of strife, 
@@ -1197,7 +1197,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">I have not lent, neither have men lent to me; 
 </p><p class="q2">yet every one of them curses me. 
 </p><p>
-<sup>11&#160;</sup>Yahweh said, 
+<sup>11&#160;</sup>Yahuah said, 
 </p><p class="q1">“Most certainly I will strengthen you for good. 
 </p><p class="q2">Most certainly I will cause the enemy to make supplication to you in the time of evil 
 </p><p class="q2">and in the time of affliction. 
@@ -1214,7 +1214,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">which will burn on you.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>15&#160;</sup>Yahweh, you know. 
+<sup>15&#160;</sup>Yahuah, you know. 
 </p><p class="q2">Remember me, visit me, 
 </p><p class="q2">and avenge me of my persecutors. 
 </p><p class="q1">You are patient, so don’t take me away. 
@@ -1223,7 +1223,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>Your words were found, 
 </p><p class="q2">and I ate them. 
 </p><p class="q1">Your words were to me a joy and the rejoicing of my heart, 
-</p><p class="q2">for I am called by your name, Yahweh, Elohim of Armies. 
+</p><p class="q2">for I am called by your name, Yahuah, Elohim of Armies. 
 </p><p class="q1">
 <sup>17&#160;</sup>I didn’t sit in the assembly of those who make merry and rejoice. 
 </p><p class="q2">I sat alone because of your hand, 
@@ -1235,7 +1235,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Will you indeed be to me as a deceitful brook, 
 </p><p class="q2">like waters that fail? 
 </p><p>
-<sup>19&#160;</sup>Therefore Yahweh says, 
+<sup>19&#160;</sup>Therefore Yahuah says, 
 </p><p class="q1">“If you return, then I will bring you again, 
 </p><p class="q2">that you may stand before me; 
 </p><p class="q1">and if you take out the precious from the vile, 
@@ -1247,37 +1247,37 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They will fight against you, 
 </p><p class="q2">but they will not prevail against you; 
 </p><p class="q1">for I am with you to save you 
-</p><p class="q2">and to deliver you,” says Yahweh. 
+</p><p class="q2">and to deliver you,” says Yahuah. 
 </p><p class="q1">
 <sup>21&#160;</sup>“I will deliver you out of the hand of the wicked, 
 </p><p class="q2">and I will redeem you out of the hand of the terrible.” 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
-<sup>1&#160;</sup>Then Yahweh’s word came to me, saying, 
+<sup>1&#160;</sup>Then Yahuah’s word came to me, saying, 
 <sup>2&#160;</sup>“You shall not take a woman, neither shall you have sons or daughters, in this place.” 
-<sup>3&#160;</sup>For Yahweh says concerning the sons and concerning the daughters who are born in this place, and concerning their mothers who bore them, and concerning their fathers who became their father in this land: 
+<sup>3&#160;</sup>For Yahuah says concerning the sons and concerning the daughters who are born in this place, and concerning their mothers who bore them, and concerning their fathers who became their father in this land: 
 <sup>4&#160;</sup>“They will die grievous deaths. They will not be lamented, neither will they be buried. They will be as dung on the surface of the ground. They will be consumed by the sword and by famine. Their dead bodies will be food for the birds of the sky and for the animals of the earth.” 
 </p><p>
-<sup>5&#160;</sup>For Yahweh says, “Don’t enter into the house of mourning. Don’t go to lament. Don’t bemoan them, for I have taken away my peace from this people,” says Yahweh, “even loving kindness and tender mercies. 
+<sup>5&#160;</sup>For Yahuah says, “Don’t enter into the house of mourning. Don’t go to lament. Don’t bemoan them, for I have taken away my peace from this people,” says Yahuah, “even loving kindness and tender mercies. 
 <sup>6&#160;</sup>Both great and small will die in this land. They will not be buried. Men won’t lament for them, cut themselves, or make themselves bald for them. 
 <sup>7&#160;</sup>Men won’t break bread for them in mourning, to comfort them for the dead. Men won’t give them the cup of consolation to drink for their father or for their mother. 
 </p><p>
 <sup>8&#160;</sup>“You shall not go into the house of feasting to sit with them, to eat and to drink.” 
-<sup>9&#160;</sup>For Yahweh of Armies, the Elohim of Israel says: “Behold, I will cause to cease out of this place, before your eyes and in your days, the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride. 
-<sup>10&#160;</sup>It will happen, when you tell this people all these words, and they ask you, ‘Why has Yahweh pronounced all this great evil against us?’ or ‘What is our iniquity?’ or ‘What is our sin that we have committed against Yahweh our Elohim?’ 
-<sup>11&#160;</sup>then you shall tell them, ‘Because your fathers have forsaken me,’ says Yahweh, ‘and have walked after other elohims, have served them, have worshiped them, have forsaken me, and have not kept my law. 
+<sup>9&#160;</sup>For Yahuah of Armies, the Elohim of Israel says: “Behold, I will cause to cease out of this place, before your eyes and in your days, the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride. 
+<sup>10&#160;</sup>It will happen, when you tell this people all these words, and they ask you, ‘Why has Yahuah pronounced all this great evil against us?’ or ‘What is our iniquity?’ or ‘What is our sin that we have committed against Yahuah our Elohim?’ 
+<sup>11&#160;</sup>then you shall tell them, ‘Because your fathers have forsaken me,’ says Yahuah, ‘and have walked after other elohims, have served them, have worshiped them, have forsaken me, and have not kept my law. 
 <sup>12&#160;</sup>You have done evil more than your fathers, for behold, you each walk after the stubbornness of his evil heart, so that you don’t listen to me. 
 <sup>13&#160;</sup>Therefore I will cast you out of this land into the land that you have not known, neither you nor your fathers. There you will serve other elohims day and night, for I will show you no favor.’ 
 </p><p>
-<sup>14&#160;</sup>“Therefore behold, the days come,” says Yahweh, “that it will no more be said, ‘As Yahweh lives, who brought up the children of Israel out of the land of Egypt;’ 
-<sup>15&#160;</sup>but, ‘As Yahweh lives, who brought up the children of Israel from the land of the north, and from all the countries where he had driven them.’ I will bring them again into their land that I gave to their fathers. 
+<sup>14&#160;</sup>“Therefore behold, the days come,” says Yahuah, “that it will no more be said, ‘As Yahuah lives, who brought up the children of Israel out of the land of Egypt;’ 
+<sup>15&#160;</sup>but, ‘As Yahuah lives, who brought up the children of Israel from the land of the north, and from all the countries where he had driven them.’ I will bring them again into their land that I gave to their fathers. 
 </p><p>
-<sup>16&#160;</sup>“Behold, I will send for many fishermen,” says Yahweh, “and they will fish them up. Afterward I will send for many hunters, and they will hunt them from every mountain, from every hill, and out of the clefts of the rocks. 
+<sup>16&#160;</sup>“Behold, I will send for many fishermen,” says Yahuah, “and they will fish them up. Afterward I will send for many hunters, and they will hunt them from every mountain, from every hill, and out of the clefts of the rocks. 
 <sup>17&#160;</sup>For my eyes are on all their ways. They are not hidden from my face. Their iniquity isn’t concealed from my eyes. 
 <sup>18&#160;</sup>First I will recompense their iniquity and their sin double, because they have polluted my land with the carcasses of their detestable things, and have filled my inheritance with their abominations.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>19&#160;</sup>Yahweh, my strength, my stronghold, 
+<sup>19&#160;</sup>Yahuah, my strength, my stronghold, 
 </p><p class="q2">and my refuge in the day of affliction, 
 </p><p class="q1">the nations will come to you from the ends of the earth, 
 </p><p class="q2">and will say, 
@@ -1290,7 +1290,7 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>21&#160;</sup>“Therefore behold, I will cause them to know, 
 </p><p class="q2">this once I will cause them to know my hand and my might. 
-</p><p class="q2">Then they will know that my name is Yahweh.” 
+</p><p class="q2">Then they will know that my name is Yahuah.” 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p class="q1">
 <sup>1&#160;</sup>“The sin of Judah is written with a pen of iron, 
@@ -1309,10 +1309,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I will cause you to serve your enemies in the land which you don’t know, 
 </p><p class="q2">for you have kindled a fire in my anger which will burn forever.” 
 </p><p>
-<sup>5&#160;</sup>Yahweh says: 
+<sup>5&#160;</sup>Yahuah says: 
 </p><p class="q1">“Cursed is the man who trusts in man, 
 </p><p class="q2">relies on strength of flesh, 
-</p><p class="q2">and whose heart departs from Yahweh. 
+</p><p class="q2">and whose heart departs from Yahuah. 
 </p><p class="q1">
 <sup>6&#160;</sup>For he will be like a bush in the desert, 
 </p><p class="q2">and will not see when good comes, 
@@ -1320,8 +1320,8 @@ html[dir=ltr] .q2 {
 </p><p class="q2">an uninhabited salt land. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>7&#160;</sup>“Blessed is the man who trusts in Yahweh, 
-</p><p class="q2">and whose confidence is in Yahweh. 
+<sup>7&#160;</sup>“Blessed is the man who trusts in Yahuah, 
+</p><p class="q2">and whose confidence is in Yahuah. 
 </p><p class="q1">
 <sup>8&#160;</sup>For he will be as a tree planted by the waters, 
 </p><p class="q2">who spreads out its roots by the river, 
@@ -1335,7 +1335,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Who can know it? 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>“I, Yahweh, search the mind. 
+<sup>10&#160;</sup>“I, Yahuah, search the mind. 
 </p><p class="q2">I try the heart, 
 </p><p class="q1">even to give every man according to his ways, 
 </p><p class="q2">according to the fruit of his doings.” 
@@ -1349,18 +1349,18 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>A glorious throne, set on high from the beginning, 
 </p><p class="q2">is the place of our sanctuary. 
 </p><p class="q1">
-<sup>13&#160;</sup>Yahweh, the hope of Israel, 
+<sup>13&#160;</sup>Yahuah, the hope of Israel, 
 </p><p class="q2">all who forsake you will be disappointed. 
 </p><p class="q1">Those who depart from me will be written in the earth, 
-</p><p class="q2">because they have forsaken Yahweh, 
+</p><p class="q2">because they have forsaken Yahuah, 
 </p><p class="q2">the spring of living waters. 
 </p><p class="q1">
-<sup>14&#160;</sup>Heal me, O Yahweh, and I will be healed. 
+<sup>14&#160;</sup>Heal me, O Yahuah, and I will be healed. 
 </p><p class="q2">Save me, and I will be saved; 
 </p><p class="q2">for you are my praise. 
 </p><p class="q1">
 <sup>15&#160;</sup>Behold, they ask me, 
-</p><p class="q2">“Where is Yahweh’s word? 
+</p><p class="q2">“Where is Yahuah’s word? 
 </p><p class="q2">Let it be fulfilled now.” 
 </p><p class="q1">
 <sup>16&#160;</sup>As for me, I have not hurried from being a shepherd after you. 
@@ -1377,34 +1377,34 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Bring on them the day of evil, 
 </p><p class="q2">and destroy them with double destruction. 
 </p><p>
-<sup>19&#160;</sup>Yahweh said this to me: “Go and stand in the gate of the children of the people, through which the kings of Judah come in and by which they go out, and in all the gates of Jerusalem. 
-<sup>20&#160;</sup>Tell them, ‘Hear Yahweh’s word, you kings of Judah, all Judah, and all the inhabitants of Jerusalem, that enter in by these gates: 
-<sup>21&#160;</sup>Yahweh says, “Be careful, and bear no burden on the Sabbath day, nor bring it in by the gates of Jerusalem. 
+<sup>19&#160;</sup>Yahuah said this to me: “Go and stand in the gate of the children of the people, through which the kings of Judah come in and by which they go out, and in all the gates of Jerusalem. 
+<sup>20&#160;</sup>Tell them, ‘Hear Yahuah’s word, you kings of Judah, all Judah, and all the inhabitants of Jerusalem, that enter in by these gates: 
+<sup>21&#160;</sup>Yahuah says, “Be careful, and bear no burden on the Sabbath day, nor bring it in by the gates of Jerusalem. 
 <sup>22&#160;</sup>Don’t carry a burden out of your houses on the Sabbath day. Don’t do any work, but make the Sabbath day set-apart, as I commanded your fathers. 
 <sup>23&#160;</sup>But they didn’t listen. They didn’t turn their ear, but made their neck stiff, that they might not hear, and might not receive instruction. 
-<sup>24&#160;</sup>It will happen, if you diligently listen to me,” says Yahweh, “to bring in no burden through the gates of this city on the Sabbath day, but to make the Sabbath day set-apart, to do no work therein; 
+<sup>24&#160;</sup>It will happen, if you diligently listen to me,” says Yahuah, “to bring in no burden through the gates of this city on the Sabbath day, but to make the Sabbath day set-apart, to do no work therein; 
 <sup>25&#160;</sup>then there will enter in by the gates of this city kings and princes sitting on David’s throne, riding in chariots and on horses, they and their princes, the men of Judah and the inhabitants of Jerusalem; and this city will remain forever. 
-<sup>26&#160;</sup>They will come from the cities of Judah, and from the places around Jerusalem, from the land of Benjamin, from the lowland, from the hill country, and from the South, bringing burnt offerings, sacrifices, meal offerings, and frankincense, and bringing sacrifices of thanksgiving to Yahweh’s house. 
+<sup>26&#160;</sup>They will come from the cities of Judah, and from the places around Jerusalem, from the land of Benjamin, from the lowland, from the hill country, and from the South, bringing burnt offerings, sacrifices, meal offerings, and frankincense, and bringing sacrifices of thanksgiving to Yahuah’s house. 
 <sup>27&#160;</sup>But if you will not listen to me to make the Sabbath day set-apart, and not to bear a burden and enter in at the gates of Jerusalem on the Sabbath day, then I will kindle a fire in its gates, and it will devour the palaces of Jerusalem. It will not be quenched.”&#160;’&#160;” 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
-<sup>1&#160;</sup>The word which came to Jeremiah from Yahweh, saying, 
+<sup>1&#160;</sup>The word which came to Jeremiah from Yahuah, saying, 
 <sup>2&#160;</sup>“Arise, and go down to the potter’s house, and there I will cause you to hear my words.” 
 </p><p>
 <sup>3&#160;</sup>Then I went down to the potter’s house, and behold, he was making something on the wheels. 
 <sup>4&#160;</sup>When the vessel that he made of the clay was marred in the hand of the potter, he made it again another vessel, as seemed good to the potter to make it. 
 </p><p>
-<sup>5&#160;</sup>Then Yahweh’s word came to me, saying, 
-<sup>6&#160;</sup>“House of Israel, can’t I do with you as this potter?” says Yahweh. “Behold, as the clay in the potter’s hand, so are you in my hand, house of Israel. 
+<sup>5&#160;</sup>Then Yahuah’s word came to me, saying, 
+<sup>6&#160;</sup>“House of Israel, can’t I do with you as this potter?” says Yahuah. “Behold, as the clay in the potter’s hand, so are you in my hand, house of Israel. 
 <sup>7&#160;</sup>At the instant I speak concerning a nation, and concerning a kingdom, to pluck up and to break down and to destroy it, 
 <sup>8&#160;</sup>if that nation, concerning which I have spoken, turns from their evil, I will repent of the evil that I thought to do to them. 
 <sup>9&#160;</sup>At the instant I speak concerning a nation, and concerning a kingdom, to build and to plant it, 
 <sup>10&#160;</sup>if they do that which is evil in my sight, that they not obey my voice, then I will repent of the good with which I said I would benefit them. 
 </p><p>
-<sup>11&#160;</sup>“Now therefore, speak to the men of Judah, and to the inhabitants of Jerusalem, saying, ‘Yahweh says: “Behold, I frame evil against you, and devise a plan against you. Everyone return from his evil way now, and amend your ways and your doings.”&#160;’ 
+<sup>11&#160;</sup>“Now therefore, speak to the men of Judah, and to the inhabitants of Jerusalem, saying, ‘Yahuah says: “Behold, I frame evil against you, and devise a plan against you. Everyone return from his evil way now, and amend your ways and your doings.”&#160;’ 
 <sup>12&#160;</sup>But they say, ‘It is in vain; for we will walk after our own plans, and we will each follow the stubbornness of his evil heart.’&#160;” 
 </p><p>
-<sup>13&#160;</sup>Therefore Yahweh says: 
+<sup>13&#160;</sup>Therefore Yahuah says: 
 </p><p class="q1">“Ask now among the nations, 
 </p><p class="q2">‘Who has heard such things?’ 
 </p><p class="q2">The virgin of Israel has done a very horrible thing. 
@@ -1429,7 +1429,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>18&#160;</sup>Then they said, “Come! Let’s devise plans against Jeremiah; for the law won’t perish from the priest, nor counsel from the wise, nor the word from the prophet. Come, and let’s strike him with the tongue, and let’s not give heed to any of his words.” 
 </p><p class="q1">
-<sup>19&#160;</sup>Give heed to me, Yahweh, 
+<sup>19&#160;</sup>Give heed to me, Yahuah, 
 </p><p class="q2">and listen to the voice of those who contend with me. 
 </p><p class="q1">
 <sup>20&#160;</sup>Should evil be recompensed for good? 
@@ -1448,49 +1448,49 @@ html[dir=ltr] .q2 {
 </p><p class="q1">for they have dug a pit to take me 
 </p><p class="q2">and hidden snares for my feet. 
 </p><p class="q1">
-<sup>23&#160;</sup>Yet, Yahweh, you know all their counsel against me to kill me. 
+<sup>23&#160;</sup>Yet, Yahuah, you know all their counsel against me to kill me. 
 </p><p class="q2">Don’t forgive their iniquity. 
 </p><p class="q2">Don’t blot out their sin from your sight, 
 </p><p class="q1">Let them be overthrown before you. 
 </p><p class="q2">Deal with them in the time of your anger. 
 </p><h2 class="chapterlabel" id="19">19</h2>
 <p>
-<sup>1&#160;</sup>Thus said Yahweh, “Go, and buy a potter’s earthen container, and take some of the elders of the people and of the elders of the priests; 
+<sup>1&#160;</sup>Thus said Yahuah, “Go, and buy a potter’s earthen container, and take some of the elders of the people and of the elders of the priests; 
 <sup>2&#160;</sup>and go out to the valley of the son of Hinnom, which is by the entry of the gate Harsith, and proclaim there the words that I will tell you. 
-<sup>3&#160;</sup>Say, ‘Hear Yahweh’s word, kings of Judah and inhabitants of Jerusalem: Yahweh of Armies, the Elohim of Israel says, “Behold, I will bring evil on this place, which whoever hears, his ears will tingle. 
+<sup>3&#160;</sup>Say, ‘Hear Yahuah’s word, kings of Judah and inhabitants of Jerusalem: Yahuah of Armies, the Elohim of Israel says, “Behold, I will bring evil on this place, which whoever hears, his ears will tingle. 
 <sup>4&#160;</sup>Because they have forsaken me, and have defiled this place, and have burned incense in it to other elohims that they didn’t know—they, their fathers, and the kings of Judah—and have filled this place with the blood of innocents, 
 <sup>5&#160;</sup>and have built the high places of Baal to burn their children in the fire for burnt offerings to Baal, which I didn’t command, nor speak, which didn’t even enter into my mind. 
-<sup>6&#160;</sup>Therefore, behold, the days come,” says Yahweh, “that this place will no more be called ‘Topheth’, nor ‘The Valley of the son of Hinnom’, but ‘The valley of Slaughter’. 
+<sup>6&#160;</sup>Therefore, behold, the days come,” says Yahuah, “that this place will no more be called ‘Topheth’, nor ‘The Valley of the son of Hinnom’, but ‘The valley of Slaughter’. 
 </p><p>
 <sup>7&#160;</sup>“&#160;‘&#160;“I will make the counsel of Judah and Jerusalem void in this place. I will cause them to fall by the sword before their enemies, and by the hand of those who seek their life. I will give their dead bodies to be food for the birds of the sky and for the animals of the earth. 
 <sup>8&#160;</sup>I will make this city an astonishment and a hissing. Everyone who passes by it will be astonished and hiss because of all its plagues. 
 <sup>9&#160;</sup>I will cause them to eat the flesh of their sons and the flesh of their daughters. They will each eat the flesh of his friend in the siege and in the distress with which their enemies, and those who seek their life, will distress them.”&#160;’ 
 </p><p>
 <sup>10&#160;</sup>“Then you shall break the container in the sight of the men who go with you, 
-<sup>11&#160;</sup>and shall tell them, ‘Yahweh of Armies says: “Even so I will break this people and this city as one breaks a potter’s vessel, that can’t be made whole again. They will bury in Topheth until there is no place to bury. 
-<sup>12&#160;</sup>This is what I will do to this place,” says Yahweh, “and to its inhabitants, even making this city as Topheth. 
+<sup>11&#160;</sup>and shall tell them, ‘Yahuah of Armies says: “Even so I will break this people and this city as one breaks a potter’s vessel, that can’t be made whole again. They will bury in Topheth until there is no place to bury. 
+<sup>12&#160;</sup>This is what I will do to this place,” says Yahuah, “and to its inhabitants, even making this city as Topheth. 
 <sup>13&#160;</sup>The houses of Jerusalem and the houses of the kings of Judah, which are defiled, will be as the place of Topheth, even all the houses on whose roofs they have burned incense to all the army of the sky and have poured out drink offerings to other elohims.”&#160;’&#160;” 
 </p><p>
-<sup>14&#160;</sup>Then Jeremiah came from Topheth, where Yahweh had sent him to prophesy, and he stood in the court of Yahweh’s house, and said to all the people: 
-<sup>15&#160;</sup>“Yahweh of Armies, the Elohim of Israel says, ‘Behold, I will bring on this city and on all its towns all the evil that I have pronounced against it, because they have made their neck stiff, that they may not hear my words.’&#160;” 
+<sup>14&#160;</sup>Then Jeremiah came from Topheth, where Yahuah had sent him to prophesy, and he stood in the court of Yahuah’s house, and said to all the people: 
+<sup>15&#160;</sup>“Yahuah of Armies, the Elohim of Israel says, ‘Behold, I will bring on this city and on all its towns all the evil that I have pronounced against it, because they have made their neck stiff, that they may not hear my words.’&#160;” 
 </p><h2 class="chapterlabel" id="20">20</h2>
 <p>
-<sup>1&#160;</sup>Now Pashhur, the son of Immer the priest, who was chief officer in Yahweh’s house, heard Jeremiah prophesying these things. 
-<sup>2&#160;</sup>Then Pashhur struck Jeremiah the prophet and put him in the stocks that were in the upper gate of Benjamin, which was in Yahweh’s house. 
-<sup>3&#160;</sup>On the next day, Pashhur released Jeremiah out of the stocks. Then Jeremiah said to him, “Yahweh has not called your name Pashhur, but Magormissabib. 
-<sup>4&#160;</sup>For Yahweh says, ‘Behold, I will make you a terror to yourself and to all your friends. They will fall by the sword of their enemies, and your eyes will see it. I will give all Judah into the hand of the king of Babylon, and he will carry them captive to Babylon, and will kill them with the sword. 
+<sup>1&#160;</sup>Now Pashhur, the son of Immer the priest, who was chief officer in Yahuah’s house, heard Jeremiah prophesying these things. 
+<sup>2&#160;</sup>Then Pashhur struck Jeremiah the prophet and put him in the stocks that were in the upper gate of Benjamin, which was in Yahuah’s house. 
+<sup>3&#160;</sup>On the next day, Pashhur released Jeremiah out of the stocks. Then Jeremiah said to him, “Yahuah has not called your name Pashhur, but Magormissabib. 
+<sup>4&#160;</sup>For Yahuah says, ‘Behold, I will make you a terror to yourself and to all your friends. They will fall by the sword of their enemies, and your eyes will see it. I will give all Judah into the hand of the king of Babylon, and he will carry them captive to Babylon, and will kill them with the sword. 
 <sup>5&#160;</sup>Moreover I will give all the riches of this city, and all its gains, and all its precious things, yes, I will give all the treasures of the kings of Judah into the hand of their enemies. They will make them captives, take them, and carry them to Babylon. 
 <sup>6&#160;</sup>You, Pashhur, and all who dwell in your house will go into captivity. You will come to Babylon, and there you will die, and there you will be buried, you, and all your friends, to whom you have prophesied falsely.’&#160;” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>7&#160;</sup>Yahweh, you have persuaded me, and I was persuaded. 
+<sup>7&#160;</sup>Yahuah, you have persuaded me, and I was persuaded. 
 </p><p class="q2">You are stronger than I, and have prevailed. 
 </p><p class="q1">I have become a laughingstock all day. 
 </p><p class="q2">Everyone mocks me. 
 </p><p class="q1">
 <sup>8&#160;</sup>For as often as I speak, I cry out; 
 </p><p class="q2">I cry, “Violence and destruction!” 
-</p><p class="q1">because Yahweh’s word has been made a reproach to me, 
+</p><p class="q1">because Yahuah’s word has been made a reproach to me, 
 </p><p class="q2">and a derision, all day. 
 </p><p class="q1">
 <sup>9&#160;</sup>If I say that I will not make mention of him, 
@@ -1508,20 +1508,20 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and we will prevail against him, 
 </p><p class="q2">and we will take our revenge on him.” 
 </p><p class="q1">
-<sup>11&#160;</sup>But Yahweh is with me as an awesome mighty one. 
+<sup>11&#160;</sup>But Yahuah is with me as an awesome mighty one. 
 </p><p class="q2">Therefore my persecutors will stumble, 
 </p><p class="q2">and they won’t prevail. 
 </p><p class="q1">They will be utterly disappointed 
 </p><p class="q2">because they have not dealt wisely, 
 </p><p class="q2">even with an everlasting dishonor which will never be forgotten. 
 </p><p class="q1">
-<sup>12&#160;</sup>But Yahweh of Armies, who tests the righteous, 
+<sup>12&#160;</sup>But Yahuah of Armies, who tests the righteous, 
 </p><p class="q2">who sees the heart and the mind, 
 </p><p class="q1">let me see your vengeance on them, 
 </p><p class="q2">for I have revealed my cause to you. 
 </p><p class="q1">
-<sup>13&#160;</sup>Sing to Yahweh! 
-</p><p class="q2">Praise Yahweh, 
+<sup>13&#160;</sup>Sing to Yahuah! 
+</p><p class="q2">Praise Yahuah, 
 </p><p class="q2">for he has delivered the soul of the needy from the hand of evildoers. 
 </p><p class="q1">
 <sup>14&#160;</sup>Cursed is the day in which I was born. 
@@ -1530,7 +1530,7 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Cursed is the man who brought news to my father, saying, 
 </p><p class="q2">“A boy is born to you,” making him very glad. 
 </p><p class="q1">
-<sup>16&#160;</sup>Let that man be as the cities which Yahweh overthrew, 
+<sup>16&#160;</sup>Let that man be as the cities which Yahuah overthrew, 
 </p><p class="q2">and didn’t repent. 
 </p><p class="q1">Let him hear a cry in the morning, 
 </p><p class="q2">and shouting at noontime, 
@@ -1543,21 +1543,21 @@ html[dir=ltr] .q2 {
 </p><p class="q2">that my days should be consumed with shame? 
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
-<sup>1&#160;</sup>The word which came to Jeremiah from Yahweh, when King Zedekiah sent to him Pashhur the son of Malchijah, and Zephaniah the son of Maaseiah, the priest, saying, 
-<sup>2&#160;</sup>“Please inquire of Yahweh for us; for Nebuchadnezzar king of Babylon makes war against us. Perhaps Yahweh will deal with us according to all his wondrous works, that he may withdraw from us.” 
+<sup>1&#160;</sup>The word which came to Jeremiah from Yahuah, when King Zedekiah sent to him Pashhur the son of Malchijah, and Zephaniah the son of Maaseiah, the priest, saying, 
+<sup>2&#160;</sup>“Please inquire of Yahuah for us; for Nebuchadnezzar king of Babylon makes war against us. Perhaps Yahuah will deal with us according to all his wondrous works, that he may withdraw from us.” 
 </p><p>
 <sup>3&#160;</sup>Then Jeremiah said to them, “Tell Zedekiah: 
-<sup>4&#160;</sup>‘Yahweh, the Elohim of Israel says, “Behold, I will turn back the weapons of war that are in your hands, with which you fight against the king of Babylon, and against the Chaldeans who besiege you outside the walls; and I will gather them into the middle of this city. 
+<sup>4&#160;</sup>‘Yahuah, the Elohim of Israel says, “Behold, I will turn back the weapons of war that are in your hands, with which you fight against the king of Babylon, and against the Chaldeans who besiege you outside the walls; and I will gather them into the middle of this city. 
 <sup>5&#160;</sup>I myself will fight against you with an outstretched hand and with a strong arm, even in anger, in wrath, and in great indignation. 
 <sup>6&#160;</sup>I will strike the inhabitants of this city, both man and animal. They will die of a great pestilence. 
-<sup>7&#160;</sup>Afterward,” says Yahweh, “I will deliver Zedekiah king of Judah, his servants, and the people, even those who are left in this city from the pestilence, from the sword, and from the famine, into the hand of Nebuchadnezzar king of Babylon, and into the hand of their enemies, and into the hand of those who seek their life. He will strike them with the edge of the sword. He will not spare them, have pity, or have mercy.”&#160;’ 
+<sup>7&#160;</sup>Afterward,” says Yahuah, “I will deliver Zedekiah king of Judah, his servants, and the people, even those who are left in this city from the pestilence, from the sword, and from the famine, into the hand of Nebuchadnezzar king of Babylon, and into the hand of their enemies, and into the hand of those who seek their life. He will strike them with the edge of the sword. He will not spare them, have pity, or have mercy.”&#160;’ 
 </p><p>
-<sup>8&#160;</sup>“You shall say to this people, ‘Yahweh says: “Behold, I set before you the way of life and the way of death. 
+<sup>8&#160;</sup>“You shall say to this people, ‘Yahuah says: “Behold, I set before you the way of life and the way of death. 
 <sup>9&#160;</sup>He who remains in this city will die by the sword, by the famine, and by the pestilence, but he who goes out and passes over to the Chaldeans who besiege you, he will live, and he will escape with his life. 
-<sup>10&#160;</sup>For I have set my face on this city for evil, and not for good,” says Yahweh. “It will be given into the hand of the king of Babylon, and he will burn it with fire.”&#160;’ 
+<sup>10&#160;</sup>For I have set my face on this city for evil, and not for good,” says Yahuah. “It will be given into the hand of the king of Babylon, and he will burn it with fire.”&#160;’ 
 </p><p>
-<sup>11&#160;</sup>“Concerning the house of the king of Judah, hear Yahweh’s word: 
-<sup>12&#160;</sup>House of David, Yahweh says, 
+<sup>11&#160;</sup>“Concerning the house of the king of Judah, hear Yahuah’s word: 
+<sup>12&#160;</sup>House of David, Yahuah says, 
 </p><p class="q1">‘Execute justice in the morning, 
 </p><p class="q2">and deliver him who is robbed out of the hand of the oppressor, 
 </p><p class="q1">lest my wrath go out like fire, 
@@ -1565,22 +1565,22 @@ html[dir=ltr] .q2 {
 </p><p class="q2">because of the evil of your doings. 
 </p><p class="q1">
 <sup>13&#160;</sup>Behold, I am against you, O inhabitant of the valley, 
-</p><p class="q2">and of the rock of the plain,’ says Yahweh. 
+</p><p class="q2">and of the rock of the plain,’ says Yahuah. 
 </p><p class="q1">‘You that say, “Who would come down against us?” 
 </p><p class="q2">or, “Who would enter into our homes?” 
 </p><p class="q1">
-<sup>14&#160;</sup>I will punish you according to the fruit of your doings,’ says Yahweh; 
+<sup>14&#160;</sup>I will punish you according to the fruit of your doings,’ says Yahuah; 
 </p><p class="q2">‘and I will kindle a fire in her forest, 
 </p><p class="q2">and it will devour all that is around her.’&#160;” 
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said, “Go down to the house of the king of Judah, and speak this word there: 
-<sup>2&#160;</sup>‘Hear Yahweh’s word, king of Judah, who sits on David’s throne—you, your servants, and your people who enter in by these gates. 
-<sup>3&#160;</sup>Yahweh says: “Execute justice and righteousness, and deliver him who is robbed out of the hand of the oppressor. Do no wrong. Do no violence to the foreigner, the fatherless, or the widow. Don’t shed innocent blood in this place. 
+<sup>1&#160;</sup>Yahuah said, “Go down to the house of the king of Judah, and speak this word there: 
+<sup>2&#160;</sup>‘Hear Yahuah’s word, king of Judah, who sits on David’s throne—you, your servants, and your people who enter in by these gates. 
+<sup>3&#160;</sup>Yahuah says: “Execute justice and righteousness, and deliver him who is robbed out of the hand of the oppressor. Do no wrong. Do no violence to the foreigner, the fatherless, or the widow. Don’t shed innocent blood in this place. 
 <sup>4&#160;</sup>For if you do this thing indeed, then kings sitting on David’s throne will enter in by the gates of this house, riding in chariots and on horses—they, their servants, and their people. 
-<sup>5&#160;</sup>But if you will not hear these words, I swear by myself,” says Yahweh, “that this house will become a desolation.”&#160;’&#160;” 
+<sup>5&#160;</sup>But if you will not hear these words, I swear by myself,” says Yahuah, “that this house will become a desolation.”&#160;’&#160;” 
 </p><p>
-<sup>6&#160;</sup>For Yahweh says concerning the house of the king of Judah: 
+<sup>6&#160;</sup>For Yahuah says concerning the house of the king of Judah: 
 </p><p class="q1">“You are Gilead to me, 
 </p><p class="q2">the head of Lebanon. 
 </p><p class="q1">Yet surely I will make you a wilderness, 
@@ -1591,8 +1591,8 @@ html[dir=ltr] .q2 {
 </p><p class="q1">and they will cut down your choice cedars, 
 </p><p class="q2">and cast them into the fire. 
 </p><p>
-<sup>8&#160;</sup>“Many nations will pass by this city, and they will each ask his neighbor, ‘Why has Yahweh done this to this great city?’ 
-<sup>9&#160;</sup>Then they will answer, ‘Because they abandoned the covenant of Yahweh their Elohim, worshiped other elohims, and served them.’&#160;” 
+<sup>8&#160;</sup>“Many nations will pass by this city, and they will each ask his neighbor, ‘Why has Yahuah done this to this great city?’ 
+<sup>9&#160;</sup>Then they will answer, ‘Because they abandoned the covenant of Yahuah their Elohim, worshiped other elohims, and served them.’&#160;” 
 </p><p class="q1">
 <sup>10&#160;</sup>Don’t weep for the dead. 
 </p><p class="q2">Don’t bemoan him; 
@@ -1600,7 +1600,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for he will return no more, 
 </p><p class="q2">and not see his native country. 
 </p><p class="m">
-<sup>11&#160;</sup>For Yahweh says touching Shallum the son of Josiah, king of Judah, who reigned instead of Josiah his father, and who went out of this place: “He won’t return there any more. 
+<sup>11&#160;</sup>For Yahuah says touching Shallum the son of Josiah, king of Judah, who reigned instead of Josiah his father, and who went out of this place: “He won’t return there any more. 
 <sup>12&#160;</sup>But he will die in the place where they have led him captive. He will see this land no more.” 
 </p><p class="q1">
 <sup>13&#160;</sup>“Woe to him who builds his house by unrighteousness, 
@@ -1622,13 +1622,13 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>He judged the cause of the poor and needy; 
 </p><p class="q2">so then it was well. 
 </p><p class="q1">Wasn’t this to know me?” 
-</p><p class="q2">says Yahweh. 
+</p><p class="q2">says Yahuah. 
 </p><p class="q1">
 <sup>17&#160;</sup>But your eyes and your heart are only for your desire, 
 </p><p class="q2">for shedding innocent blood, 
 </p><p class="q2">for oppression, and for doing violence.” 
 </p><p class="m">
-<sup>18&#160;</sup>Therefore Yahweh says concerning Jehoiakim the son of Josiah, king of Judah: 
+<sup>18&#160;</sup>Therefore Yahuah says concerning Jehoiakim the son of Josiah, king of Judah: 
 </p><p class="q1">“They won’t lament for him, 
 </p><p class="q2">saying, ‘Ah my brother!’ or, ‘Ah sister!’ 
 </p><p class="q1">They won’t lament for him, 
@@ -1658,7 +1658,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">how greatly to be pitied you will be when pangs come on you, 
 </p><p class="q2">the pain as of a woman in travail! 
 </p><p>
-<sup>24&#160;</sup>“As I live,” says Yahweh, “though Coniah the son of Jehoiakim king of Judah were the signet on my right hand, I would still pluck you from there. 
+<sup>24&#160;</sup>“As I live,” says Yahuah, “though Coniah the son of Jehoiakim king of Judah were the signet on my right hand, I would still pluck you from there. 
 <sup>25&#160;</sup>I would give you into the hand of those who seek your life, and into the hand of them of whom you are afraid, even into the hand of Nebuchadnezzar king of Babylon, and into the hand of the Chaldeans. 
 <sup>26&#160;</sup>I will cast you out with your mother who bore you into another country, where you were not born; and there you will die. 
 <sup>27&#160;</sup>But to the land to which their soul longs to return, there they will not return.” 
@@ -1669,9 +1669,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and cast into a land which they don’t know? 
 </p><p class="q1">
 <sup>29&#160;</sup>O earth, earth, earth, 
-</p><p class="q2">hear Yahweh’s word! 
+</p><p class="q2">hear Yahuah’s word! 
 </p><p class="q1">
-<sup>30&#160;</sup>Yahweh says, 
+<sup>30&#160;</sup>Yahuah says, 
 </p><p class="q2">“Record this man as childless, 
 </p><p class="q2">a man who will not prosper in his days; 
 </p><p class="q1">for no more will a man of his offspring prosper, 
@@ -1679,12 +1679,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and ruling in Judah.” 
 </p><h2 class="chapterlabel" id="23">23</h2>
 <p>
-<sup>1&#160;</sup>“Woe to the shepherds who destroy and scatter the sheep of my pasture!” says Yahweh. 
-<sup>2&#160;</sup>Therefore Yahweh, the Elohim of Israel, says against the shepherds who feed my people: “You have scattered my flock, driven them away, and have not visited them. Behold, I will visit on you the evil of your doings,” says Yahweh. 
+<sup>1&#160;</sup>“Woe to the shepherds who destroy and scatter the sheep of my pasture!” says Yahuah. 
+<sup>2&#160;</sup>Therefore Yahuah, the Elohim of Israel, says against the shepherds who feed my people: “You have scattered my flock, driven them away, and have not visited them. Behold, I will visit on you the evil of your doings,” says Yahuah. 
 <sup>3&#160;</sup>“I will gather the remnant of my flock out of all the countries where I have driven them, and will bring them again to their folds; and they will be fruitful and multiply. 
-<sup>4&#160;</sup>I will set up shepherds over them who will feed them. They will no longer be afraid or dismayed, neither will any be lacking,” says Yahweh. 
+<sup>4&#160;</sup>I will set up shepherds over them who will feed them. They will no longer be afraid or dismayed, neither will any be lacking,” says Yahuah. 
 </p><p class="q1">
-<sup>5&#160;</sup>“Behold, the days come,” says Yahweh, 
+<sup>5&#160;</sup>“Behold, the days come,” says Yahuah, 
 </p><p class="q2">“that I will raise to David a righteous Branch; 
 </p><p class="q1">and he will reign as king and deal wisely, 
 </p><p class="q2">and will execute justice and righteousness in the land. 
@@ -1692,17 +1692,17 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>In his days Judah will be saved, 
 </p><p class="q2">and Israel will dwell safely. 
 </p><p class="q1">This is his name by which he will be called: 
-</p><p class="q2">Yahweh our righteousness. 
+</p><p class="q2">Yahuah our righteousness. 
 </p><p class="m">
-<sup>7&#160;</sup>“Therefore, behold, the days come,” says Yahweh, “that they will no more say, ‘As Yahweh lives, who brought up the children of Israel out of the land of Egypt;’ 
-<sup>8&#160;</sup>but, ‘As Yahweh lives, who brought up and who led the offspring of the house of Israel out of the north country, and from all the countries where I had driven them.’ Then they will dwell in their own land.” 
+<sup>7&#160;</sup>“Therefore, behold, the days come,” says Yahuah, “that they will no more say, ‘As Yahuah lives, who brought up the children of Israel out of the land of Egypt;’ 
+<sup>8&#160;</sup>but, ‘As Yahuah lives, who brought up and who led the offspring of the house of Israel out of the north country, and from all the countries where I had driven them.’ Then they will dwell in their own land.” 
 </p><p>
 <sup>9&#160;</sup>Concerning the prophets: 
 </p><p class="q1">My heart within me is broken. 
 </p><p class="q2">All my bones shake. 
 </p><p class="q1">I am like a drunken man, 
 </p><p class="q2">and like a man whom wine has overcome, 
-</p><p class="q1">because of Yahweh, 
+</p><p class="q1">because of Yahuah, 
 </p><p class="q2">and because of his set-apart words. 
 </p><p class="q1">
 <sup>10&#160;</sup>“For the land is full of adulterers; 
@@ -1712,13 +1712,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and their might is not right; 
 </p><p class="q1">
 <sup>11&#160;</sup>for both prophet and priest are profane. 
-</p><p class="q2">Yes, in my house I have found their wickedness,” says Yahweh. 
+</p><p class="q2">Yes, in my house I have found their wickedness,” says Yahuah. 
 </p><p class="q1">
 <sup>12&#160;</sup>Therefore their way will be to them as slippery places in the darkness. 
 </p><p class="q2">They will be driven on, 
 </p><p class="q2">and fall therein; 
 </p><p class="q1">for I will bring evil on them, 
-</p><p class="q2">even the year of their visitation,” says Yahweh. 
+</p><p class="q2">even the year of their visitation,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>13&#160;</sup>“I have seen folly in the prophets of Samaria. 
@@ -1732,31 +1732,31 @@ html[dir=ltr] .q2 {
 </p><p class="q1">They have all become to me as Sodom, 
 </p><p class="q2">and its inhabitants as Gomorrah.” 
 </p><p>
-<sup>15&#160;</sup>Therefore Yahweh of Armies says concerning the prophets: 
+<sup>15&#160;</sup>Therefore Yahuah of Armies says concerning the prophets: 
 </p><p class="q1">“Behold, I will feed them with wormwood, 
 </p><p class="q2">and make them drink poisoned water; 
 </p><p class="q2">for from the prophets of Jerusalem unelohimliness has gone out into all the land.” 
 </p><p>
-<sup>16&#160;</sup>Yahweh of Armies says, 
+<sup>16&#160;</sup>Yahuah of Armies says, 
 </p><p class="q1">“Don’t listen to the words of the prophets who prophesy to you. 
 </p><p class="q2">They teach you vanity. 
 </p><p class="q2">They speak a vision of their own heart, 
-</p><p class="q2">and not out of the mouth of Yahweh. 
+</p><p class="q2">and not out of the mouth of Yahuah. 
 </p><p class="q1">
 <sup>17&#160;</sup>They say continually to those who despise me, 
-</p><p class="q2">‘Yahweh has said, “You will have peace;”&#160;’ 
+</p><p class="q2">‘Yahuah has said, “You will have peace;”&#160;’ 
 </p><p class="q1">and to everyone who walks in the stubbornness of his own heart they say, 
 </p><p class="q2">‘No evil will come on you.’ 
 </p><p class="q1">
-<sup>18&#160;</sup>For who has stood in the council of Yahweh, 
+<sup>18&#160;</sup>For who has stood in the council of Yahuah, 
 </p><p class="q2">that he should perceive and hear his word? 
 </p><p class="q2">Who has listened to my word, and heard it? 
 </p><p class="q1">
-<sup>19&#160;</sup>Behold, Yahweh’s storm, his wrath, has gone out. 
+<sup>19&#160;</sup>Behold, Yahuah’s storm, his wrath, has gone out. 
 </p><p class="q2">Yes, a whirling storm! 
 </p><p class="q2">It will burst on the head of the wicked. 
 </p><p class="q1">
-<sup>20&#160;</sup>Yahweh’s anger will not return until he has executed 
+<sup>20&#160;</sup>Yahuah’s anger will not return until he has executed 
 </p><p class="q2">and performed the intents of his heart. 
 </p><p class="q2">In the latter days, you will understand it perfectly. 
 </p><p class="q1">
@@ -1769,72 +1769,72 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and from the evil of their doings. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>23&#160;</sup>“Am I an Elohim at hand,” says Yahweh, 
+<sup>23&#160;</sup>“Am I an Elohim at hand,” says Yahuah, 
 </p><p class="q2">“and not an Elohim afar off? 
 </p><p class="q1">
 <sup>24&#160;</sup>Can anyone hide himself in secret places 
-</p><p class="q2">so that I can’t see him?” says Yahweh. 
-</p><p class="q2">“Don’t I fill heaven and earth?” says Yahweh. 
+</p><p class="q2">so that I can’t see him?” says Yahuah. 
+</p><p class="q2">“Don’t I fill heaven and earth?” says Yahuah. 
 </p><p>
 <sup>25&#160;</sup>“I have heard what the prophets have said, who prophesy lies in my name, saying, ‘I had a dream! I had a dream!’ 
 <sup>26&#160;</sup>How long will this be in the heart of the prophets who prophesy lies, even the prophets of the deceit of their own heart? 
 <sup>27&#160;</sup>They intend to cause my people to forget my name by their dreams which they each tell his neighbor, as their fathers forgot my name because of Baal. 
-<sup>28&#160;</sup>The prophet who has a dream, let him tell a dream; and he who has my word, let him speak my word faithfully. What is the straw to the wheat?” says Yahweh. 
-<sup>29&#160;</sup>“Isn’t my word like fire?” says Yahweh; “and like a hammer that breaks the rock in pieces? 
+<sup>28&#160;</sup>The prophet who has a dream, let him tell a dream; and he who has my word, let him speak my word faithfully. What is the straw to the wheat?” says Yahuah. 
+<sup>29&#160;</sup>“Isn’t my word like fire?” says Yahuah; “and like a hammer that breaks the rock in pieces? 
 </p><p>
-<sup>30&#160;</sup>“Therefore behold, I am against the prophets,” says Yahweh, “who each steal my words from his neighbor. 
-<sup>31&#160;</sup>Behold, I am against the prophets,” says Yahweh, “who use their tongues, and say, ‘He says.’ 
-<sup>32&#160;</sup>Behold, I am against those who prophesy lying dreams,” says Yahweh, “who tell them, and cause my people to err by their lies, and by their vain boasting; yet I didn’t send them or command them. They don’t profit this people at all,” says Yahweh. 
+<sup>30&#160;</sup>“Therefore behold, I am against the prophets,” says Yahuah, “who each steal my words from his neighbor. 
+<sup>31&#160;</sup>Behold, I am against the prophets,” says Yahuah, “who use their tongues, and say, ‘He says.’ 
+<sup>32&#160;</sup>Behold, I am against those who prophesy lying dreams,” says Yahuah, “who tell them, and cause my people to err by their lies, and by their vain boasting; yet I didn’t send them or command them. They don’t profit this people at all,” says Yahuah. 
 </p><p>
-<sup>33&#160;</sup>“When this people, or the prophet, or a priest, asks you, saying, ‘What is the message from Yahweh?’ Then you shall tell them, ‘&#160;“What message? I will cast you off,” says Yahweh.’ 
-<sup>34&#160;</sup>As for the prophet, the priest, and the people, who say, ‘The message from Yahweh,’ I will even punish that man and his household. 
-<sup>35&#160;</sup>You will say everyone to his neighbor, and everyone to his brother, ‘What has Yahweh answered?’ and, ‘What has Yahweh said?’ 
-<sup>36&#160;</sup>You will mention the message from Yahweh no more, for every man’s own word has become his message; for you have perverted the words of the living Elohim, of Yahweh of Armies, our Elohim. 
-<sup>37&#160;</sup>You will say to the prophet, ‘What has Yahweh answered you?’ and, ‘What has Yahweh spoken?’ 
-<sup>38&#160;</sup>Although you say, ‘The message from Yahweh,’ therefore Yahweh says: ‘Because you say this word, “The message from Yahweh,” and I have sent to you, telling you not to say, “The message from Yahweh,” 
+<sup>33&#160;</sup>“When this people, or the prophet, or a priest, asks you, saying, ‘What is the message from Yahuah?’ Then you shall tell them, ‘&#160;“What message? I will cast you off,” says Yahuah.’ 
+<sup>34&#160;</sup>As for the prophet, the priest, and the people, who say, ‘The message from Yahuah,’ I will even punish that man and his household. 
+<sup>35&#160;</sup>You will say everyone to his neighbor, and everyone to his brother, ‘What has Yahuah answered?’ and, ‘What has Yahuah said?’ 
+<sup>36&#160;</sup>You will mention the message from Yahuah no more, for every man’s own word has become his message; for you have perverted the words of the living Elohim, of Yahuah of Armies, our Elohim. 
+<sup>37&#160;</sup>You will say to the prophet, ‘What has Yahuah answered you?’ and, ‘What has Yahuah spoken?’ 
+<sup>38&#160;</sup>Although you say, ‘The message from Yahuah,’ therefore Yahuah says: ‘Because you say this word, “The message from Yahuah,” and I have sent to you, telling you not to say, “The message from Yahuah,” 
 <sup>39&#160;</sup>therefore behold, I will utterly forget you, and I will cast you off with the city that I gave to you and to your fathers, away from my presence. 
 <sup>40&#160;</sup>I will bring an everlasting reproach on you, and a perpetual shame, which will not be forgotten.’&#160;” 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
-<sup>1&#160;</sup>Yahweh showed me, and behold, two baskets of figs were set before Yahweh’s temple, after Nebuchadnezzar king of Babylon had carried away captive Jeconiah the son of Jehoiakim, king of Judah, and the princes of Judah, with the craftsmen and smiths, from Jerusalem, and had brought them to Babylon. 
+<sup>1&#160;</sup>Yahuah showed me, and behold, two baskets of figs were set before Yahuah’s temple, after Nebuchadnezzar king of Babylon had carried away captive Jeconiah the son of Jehoiakim, king of Judah, and the princes of Judah, with the craftsmen and smiths, from Jerusalem, and had brought them to Babylon. 
 <sup>2&#160;</sup>One basket had very good figs, like the figs that are first-ripe; and the other basket had very bad figs, which could not be eaten, they were so bad. 
 </p><p>
-<sup>3&#160;</sup>Then Yahweh asked me, “What do you see, Jeremiah?” 
+<sup>3&#160;</sup>Then Yahuah asked me, “What do you see, Jeremiah?” 
 </p><p>I said, “Figs. The good figs are very good, and the bad are very bad, so bad that they can’t be eaten.” 
 </p><p>
-<sup>4&#160;</sup>Yahweh’s word came to me, saying, 
-<sup>5&#160;</sup>“Yahweh, the Elohim of Israel says: ‘Like these good figs, so I will regard the captives of Judah, whom I have sent out of this place into the land of the Chaldeans, as good. 
+<sup>4&#160;</sup>Yahuah’s word came to me, saying, 
+<sup>5&#160;</sup>“Yahuah, the Elohim of Israel says: ‘Like these good figs, so I will regard the captives of Judah, whom I have sent out of this place into the land of the Chaldeans, as good. 
 <sup>6&#160;</sup>For I will set my eyes on them for good, and I will bring them again to this land. I will build them, and not pull them down. I will plant them, and not pluck them up. 
-<sup>7&#160;</sup>I will give them a heart to know me, that I am Yahweh. They will be my people, and I will be their Elohim; for they will return to me with their whole heart. 
+<sup>7&#160;</sup>I will give them a heart to know me, that I am Yahuah. They will be my people, and I will be their Elohim; for they will return to me with their whole heart. 
 </p><p>
-<sup>8&#160;</sup>“&#160;‘As the bad figs, which can’t be eaten, they are so bad,’ surely Yahweh says, ‘So I will give up Zedekiah the king of Judah, and his princes, and the remnant of Jerusalem who remain in this land, and those who dwell in the land of Egypt. 
+<sup>8&#160;</sup>“&#160;‘As the bad figs, which can’t be eaten, they are so bad,’ surely Yahuah says, ‘So I will give up Zedekiah the king of Judah, and his princes, and the remnant of Jerusalem who remain in this land, and those who dwell in the land of Egypt. 
 <sup>9&#160;</sup>I will even give them up to be tossed back and forth among all the kingdoms of the earth for evil, to be a reproach and a proverb, a taunt and a curse, in all places where I will drive them. 
 <sup>10&#160;</sup>I will send the sword, the famine, and the pestilence among them, until they are consumed from off the land that I gave to them and to their fathers.’&#160;” 
 </p><h2 class="chapterlabel" id="25">25</h2>
 <p>
 <sup>1&#160;</sup>The word that came to Jeremiah concerning all the people of Judah, in the fourth year of Jehoiakim the son of Josiah, king of Judah (this was the first year of Nebuchadnezzar king of Babylon), 
 <sup>2&#160;</sup>which Jeremiah the prophet spoke to all the people of Judah, and to all the inhabitants of Jerusalem: 
-<sup>3&#160;</sup>From the thirteenth year of Josiah the son of Amon, king of Judah, even to this day, these twenty-three years, Yahweh’s word has come to me, and I have spoken to you, rising up early and speaking; but you have not listened. 
+<sup>3&#160;</sup>From the thirteenth year of Josiah the son of Amon, king of Judah, even to this day, these twenty-three years, Yahuah’s word has come to me, and I have spoken to you, rising up early and speaking; but you have not listened. 
 </p><p>
-<sup>4&#160;</sup>Yahweh has sent to you all his servants the prophets, rising up early and sending them (but you have not listened or inclined your ear to hear), 
-<sup>5&#160;</sup>saying, “Return now everyone from his evil way, and from the evil of your doings, and dwell in the land that Yahweh has given to you and to your fathers, from of old and even forever more. 
+<sup>4&#160;</sup>Yahuah has sent to you all his servants the prophets, rising up early and sending them (but you have not listened or inclined your ear to hear), 
+<sup>5&#160;</sup>saying, “Return now everyone from his evil way, and from the evil of your doings, and dwell in the land that Yahuah has given to you and to your fathers, from of old and even forever more. 
 <sup>6&#160;</sup>Don’t go after other elohims to serve them or worship them, and don’t provoke me to anger with the work of your hands; then I will do you no harm.” 
 </p><p>
-<sup>7&#160;</sup>“Yet you have not listened to me,” says Yahweh, “that you may provoke me to anger with the work of your hands to your own hurt.” 
+<sup>7&#160;</sup>“Yet you have not listened to me,” says Yahuah, “that you may provoke me to anger with the work of your hands to your own hurt.” 
 </p><p>
-<sup>8&#160;</sup>Therefore Yahweh of Armies says: “Because you have not heard my words, 
-<sup>9&#160;</sup>behold, I will send and take all the families of the north,” says Yahweh, “and I will send to Nebuchadnezzar the king of Babylon, my servant, and will bring them against this land, and against its inhabitants, and against all these nations around. I will utterly destroy them, and make them an astonishment, and a hissing, and perpetual desolations. 
+<sup>8&#160;</sup>Therefore Yahuah of Armies says: “Because you have not heard my words, 
+<sup>9&#160;</sup>behold, I will send and take all the families of the north,” says Yahuah, “and I will send to Nebuchadnezzar the king of Babylon, my servant, and will bring them against this land, and against its inhabitants, and against all these nations around. I will utterly destroy them, and make them an astonishment, and a hissing, and perpetual desolations. 
 <sup>10&#160;</sup>Moreover I will take from them the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride, the sound of the millstones, and the light of the lamp. 
 <sup>11&#160;</sup>This whole land will be a desolation, and an astonishment; and these nations will serve the king of Babylon seventy years. 
 </p><p>
-<sup>12&#160;</sup>“It will happen, when seventy years are accomplished, that I will punish the king of Babylon and that nation,” says Yahweh, “for their iniquity. I will make the land of the Chaldeans desolate forever. 
+<sup>12&#160;</sup>“It will happen, when seventy years are accomplished, that I will punish the king of Babylon and that nation,” says Yahuah, “for their iniquity. I will make the land of the Chaldeans desolate forever. 
 <sup>13&#160;</sup>I will bring on that land all my words which I have pronounced against it, even all that is written in this book, which Jeremiah has prophesied against all the nations. 
 <sup>14&#160;</sup>For many nations and great kings will make bondservants of them, even of them. I will recompense them according to their deeds, and according to the work of their hands.” 
 </p><p>
-<sup>15&#160;</sup>For Yahweh, the Elohim of Israel, says to me: “Take this cup of the wine of wrath from my hand, and cause all the nations to whom I send you to drink it. 
+<sup>15&#160;</sup>For Yahuah, the Elohim of Israel, says to me: “Take this cup of the wine of wrath from my hand, and cause all the nations to whom I send you to drink it. 
 <sup>16&#160;</sup>They will drink, and reel back and forth, and be insane, because of the sword that I will send among them.” 
 </p><p>
-<sup>17&#160;</sup>Then I took the cup at Yahweh’s hand, and made all the nations to drink, to whom Yahweh had sent me: 
+<sup>17&#160;</sup>Then I took the cup at Yahuah’s hand, and made all the nations to drink, to whom Yahuah had sent me: 
 <sup>18&#160;</sup>Jerusalem, and the cities of Judah, with its kings and its princes, to make them a desolation, an astonishment, a hissing, and a curse, as it is today; 
 <sup>19&#160;</sup>Pharaoh king of Egypt, with his servants, his princes, and all his people; 
 <sup>20&#160;</sup>and all the mixed people, and all the kings of the land of Uz, all the kings of the Philistines, Ashkelon, Gaza, Ekron, and the remnant of Ashdod; 
@@ -1845,27 +1845,27 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>and all the kings of Zimri, all the kings of Elam, and all the kings of the Medes; 
 <sup>26&#160;</sup>and all the kings of the north, far and near, one with another; and all the kingdoms of the world, which are on the surface of the earth. The king of Sheshach will drink after them. 
 </p><p>
-<sup>27&#160;</sup>“You shall tell them, ‘Yahweh of Armies, the Elohim of Israel says: “Drink, and be drunk, vomit, fall, and rise no more, because of the sword which I will send among you.”&#160;’ 
-<sup>28&#160;</sup>It shall be, if they refuse to take the cup at your hand to drink, then you shall tell them, ‘Yahweh of Armies says: “You shall surely drink. 
-<sup>29&#160;</sup>For, behold, I begin to work evil at the city which is called by my name; and should you be utterly unpunished? You will not be unpunished; for I will call for a sword on all the inhabitants of the earth, says Yahweh of Armies.”&#160;’ 
+<sup>27&#160;</sup>“You shall tell them, ‘Yahuah of Armies, the Elohim of Israel says: “Drink, and be drunk, vomit, fall, and rise no more, because of the sword which I will send among you.”&#160;’ 
+<sup>28&#160;</sup>It shall be, if they refuse to take the cup at your hand to drink, then you shall tell them, ‘Yahuah of Armies says: “You shall surely drink. 
+<sup>29&#160;</sup>For, behold, I begin to work evil at the city which is called by my name; and should you be utterly unpunished? You will not be unpunished; for I will call for a sword on all the inhabitants of the earth, says Yahuah of Armies.”&#160;’ 
 </p><p>
 <sup>30&#160;</sup>“Therefore prophesy against them all these words, and tell them, 
-</p><p class="q1">“&#160;‘Yahweh will roar from on high, 
+</p><p class="q1">“&#160;‘Yahuah will roar from on high, 
 </p><p class="q2">and utter his voice from his set-apart habitation. 
 </p><p class="q2">He will mightily roar against his fold. 
 </p><p class="q1">He will give a shout, as those who tread grapes, 
 </p><p class="q2">against all the inhabitants of the earth. 
 </p><p class="q1">
 <sup>31&#160;</sup>A noise will come even to the end of the earth; 
-</p><p class="q2">for Yahweh has a controversy with the nations. 
+</p><p class="q2">for Yahuah has a controversy with the nations. 
 </p><p class="q1">He will enter into judgment with all flesh. 
-</p><p class="q2">As for the wicked, he will give them to the sword,”&#160;’ says Yahweh.” 
+</p><p class="q2">As for the wicked, he will give them to the sword,”&#160;’ says Yahuah.” 
 </p><p>
-<sup>32&#160;</sup>Yahweh of Armies says, 
+<sup>32&#160;</sup>Yahuah of Armies says, 
 </p><p class="q1">“Behold, evil will go out from nation to nation, 
 </p><p class="q2">and a great storm will be raised up from the uttermost parts of the earth.” 
 </p><p class="m">
-<sup>33&#160;</sup>The slain of Yahweh will be at that day from one end of the earth even to the other end of the earth. They won’t be lamented. They won’t be gathered or buried. They will be dung on the surface of the ground. 
+<sup>33&#160;</sup>The slain of Yahuah will be at that day from one end of the earth even to the other end of the earth. They won’t be lamented. They won’t be gathered or buried. They will be dung on the surface of the ground. 
 </p><p class="q1">
 <sup>34&#160;</sup>Wail, you shepherds, and cry. 
 </p><p class="q2">Wallow in dust, you leader of the flock; 
@@ -1877,45 +1877,45 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>36&#160;</sup>A voice of the cry of the shepherds, 
 </p><p class="q2">and the wailing of the leader of the flock, 
-</p><p class="q2">for Yahweh destroys their pasture. 
+</p><p class="q2">for Yahuah destroys their pasture. 
 </p><p class="q1">
 <sup>37&#160;</sup>The peaceful folds are brought to silence 
-</p><p class="q2">because of the fierce anger of Yahweh. 
+</p><p class="q2">because of the fierce anger of Yahuah. 
 </p><p class="q1">
 <sup>38&#160;</sup>He has left his covert, as the lion; 
 </p><p class="q2">for their land has become an astonishment because of the fierceness of the oppression, 
 </p><p class="q2">and because of his fierce anger. 
 </p><h2 class="chapterlabel" id="26">26</h2>
 <p>
-<sup>1&#160;</sup>In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came from Yahweh: 
-<sup>2&#160;</sup>“Yahweh says: ‘Stand in the court of Yahweh’s house, and speak to all the cities of Judah which come to worship in Yahweh’s house, all the words that I command you to speak to them. Don’t omit a word. 
+<sup>1&#160;</sup>In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came from Yahuah: 
+<sup>2&#160;</sup>“Yahuah says: ‘Stand in the court of Yahuah’s house, and speak to all the cities of Judah which come to worship in Yahuah’s house, all the words that I command you to speak to them. Don’t omit a word. 
 <sup>3&#160;</sup>It may be they will listen, and every man turn from his evil way, that I may relent from the evil which I intend to do to them because of the evil of their doings.’&#160;” 
-<sup>4&#160;</sup>You shall tell them, “Yahweh says: ‘If you will not listen to me, to walk in my law which I have set before you, 
+<sup>4&#160;</sup>You shall tell them, “Yahuah says: ‘If you will not listen to me, to walk in my law which I have set before you, 
 <sup>5&#160;</sup>to listen to the words of my servants the prophets whom I send to you, even rising up early and sending them—but you have not listened—<sup>6&#160;</sup>then I will make this house like Shiloh, and will make this city a curse to all the nations of the earth.’&#160;” 
 </p><p>
-<sup>7&#160;</sup>The priests and the prophets and all the people heard Jeremiah speaking these words in Yahweh’s house. 
-<sup>8&#160;</sup>When Jeremiah had finished speaking all that Yahweh had commanded him to speak to all the people, the priests and the prophets and all the people seized him, saying, “You shall surely die! 
-<sup>9&#160;</sup>Why have you prophesied in Yahweh’s name, saying, ‘This house will be like Shiloh, and this city will be desolate, without inhabitant’?” All the people were crowded around Jeremiah in Yahweh’s house. 
+<sup>7&#160;</sup>The priests and the prophets and all the people heard Jeremiah speaking these words in Yahuah’s house. 
+<sup>8&#160;</sup>When Jeremiah had finished speaking all that Yahuah had commanded him to speak to all the people, the priests and the prophets and all the people seized him, saying, “You shall surely die! 
+<sup>9&#160;</sup>Why have you prophesied in Yahuah’s name, saying, ‘This house will be like Shiloh, and this city will be desolate, without inhabitant’?” All the people were crowded around Jeremiah in Yahuah’s house. 
 </p><p>
-<sup>10&#160;</sup>When the princes of Judah heard these things, they came up from the king’s house to Yahweh’s house; and they sat in the entry of the new gate of Yahweh’s house. 
+<sup>10&#160;</sup>When the princes of Judah heard these things, they came up from the king’s house to Yahuah’s house; and they sat in the entry of the new gate of Yahuah’s house. 
 <sup>11&#160;</sup>Then the priests and the prophets spoke to the princes and to all the people, saying, “This man is worthy of death, for he has prophesied against this city, as you have heard with your ears.” 
 </p><p>
-<sup>12&#160;</sup>Then Jeremiah spoke to all the princes and to all the people, saying, “Yahweh sent me to prophesy against this house and against this city all the words that you have heard. 
-<sup>13&#160;</sup>Now therefore amend your ways and your doings, and obey Yahweh your Elohim’s voice; then Yahweh will relent from the evil that he has pronounced against you. 
+<sup>12&#160;</sup>Then Jeremiah spoke to all the princes and to all the people, saying, “Yahuah sent me to prophesy against this house and against this city all the words that you have heard. 
+<sup>13&#160;</sup>Now therefore amend your ways and your doings, and obey Yahuah your Elohim’s voice; then Yahuah will relent from the evil that he has pronounced against you. 
 <sup>14&#160;</sup>But as for me, behold, I am in your hand. Do with me what is good and right in your eyes. 
-<sup>15&#160;</sup>Only know for certain that if you put me to death, you will bring innocent blood on yourselves, on this city, and on its inhabitants; for in truth Yahweh has sent me to you to speak all these words in your ears.” 
+<sup>15&#160;</sup>Only know for certain that if you put me to death, you will bring innocent blood on yourselves, on this city, and on its inhabitants; for in truth Yahuah has sent me to you to speak all these words in your ears.” 
 </p><p>
-<sup>16&#160;</sup>Then the princes and all the people said to the priests and to the prophets: “This man is not worthy of death; for he has spoken to us in the name of Yahweh our Elohim.” 
+<sup>16&#160;</sup>Then the princes and all the people said to the priests and to the prophets: “This man is not worthy of death; for he has spoken to us in the name of Yahuah our Elohim.” 
 </p><p>
 <sup>17&#160;</sup>Then certain of the elders of the land rose up, and spoke to all the assembly of the people, saying, 
-<sup>18&#160;</sup>“Micah the Morashtite prophesied in the days of Hezekiah king of Judah; and he spoke to all the people of Judah, saying, ‘Yahweh of Armies says: 
+<sup>18&#160;</sup>“Micah the Morashtite prophesied in the days of Hezekiah king of Judah; and he spoke to all the people of Judah, saying, ‘Yahuah of Armies says: 
 </p><p class="q1">“&#160;‘Zion will be plowed as a field, 
 </p><p class="q2">and Jerusalem will become heaps, 
 </p><p class="q2">and the mountain of the house as the high places of a forest.’ 
 </p><p class="m">
-<sup>19&#160;</sup>Did Hezekiah king of Judah and all Judah put him to death? Didn’t he fear Yahweh, and entreat the favor of Yahweh, and Yahweh relented of the disaster which he had pronounced against them? We would commit great evil against our own souls that way!” 
+<sup>19&#160;</sup>Did Hezekiah king of Judah and all Judah put him to death? Didn’t he fear Yahuah, and entreat the favor of Yahuah, and Yahuah relented of the disaster which he had pronounced against them? We would commit great evil against our own souls that way!” 
 </p><p>
-<sup>20&#160;</sup>There was also a man who prophesied in Yahweh’s name, Uriah the son of Shemaiah of Kiriath Jearim; and he prophesied against this city and against this land according to all the words of Jeremiah. 
+<sup>20&#160;</sup>There was also a man who prophesied in Yahuah’s name, Uriah the son of Shemaiah of Kiriath Jearim; and he prophesied against this city and against this land according to all the words of Jeremiah. 
 <sup>21&#160;</sup>When Jehoiakim the king, with all his mighty men and all the princes heard his words, the king sought to put him to death; but when Uriah heard it, he was afraid, and fled, and went into Egypt. 
 <sup>22&#160;</sup>Then Jehoiakim the king sent Elnathan the son of Achbor and certain men with him into Egypt. 
 <sup>23&#160;</sup>They fetched Uriah out of Egypt and brought him to Jehoiakim the king, who killed him with the sword and cast his dead body into the graves of the common people. 
@@ -1923,52 +1923,52 @@ html[dir=ltr] .q2 {
 <sup>24&#160;</sup>But the hand of Ahikam the son of Shaphan was with Jeremiah, so that they didn’t give him into the hand of the people to put him to death. 
 </p><h2 class="chapterlabel" id="27">27</h2>
 <p>
-<sup>1&#160;</sup>In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahweh, saying, 
-<sup>2&#160;</sup>Yahweh says to me: “Make bonds and bars, and put them on your neck. 
+<sup>1&#160;</sup>In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahuah, saying, 
+<sup>2&#160;</sup>Yahuah says to me: “Make bonds and bars, and put them on your neck. 
 <sup>3&#160;</sup>Then send them to the king of Edom, to the king of Moab, to the king of the children of Ammon, to the king of Tyre, and to the king of Sidon, by the hand of the messengers who come to Jerusalem to Zedekiah king of Judah. 
-<sup>4&#160;</sup>Give them a command to their masters, saying, ‘Yahweh of Armies, the Elohim of Israel says, “You shall tell your masters: 
+<sup>4&#160;</sup>Give them a command to their masters, saying, ‘Yahuah of Armies, the Elohim of Israel says, “You shall tell your masters: 
 <sup>5&#160;</sup>‘I have made the earth, the men, and the animals that are on the surface of the earth by my great power and by my outstretched arm. I give it to whom it seems right to me. 
 <sup>6&#160;</sup>Now I have given all these lands into the hand of Nebuchadnezzar the king of Babylon, my servant. I have also given the animals of the field to him to serve him. 
 <sup>7&#160;</sup>All the nations will serve him, his son, and his son’s son, until the time of his own land comes. Then many nations and great kings will make him their bondservant. 
 </p><p>
-<sup>8&#160;</sup>“&#160;‘&#160;“&#160;‘It will happen that I will punish the nation and the kingdom which will not serve the same Nebuchadnezzar king of Babylon, and that will not put their neck under the yoke of the king of Babylon,’ says Yahweh, ‘with the sword, with famine, and with pestilence, until I have consumed them by his hand. 
+<sup>8&#160;</sup>“&#160;‘&#160;“&#160;‘It will happen that I will punish the nation and the kingdom which will not serve the same Nebuchadnezzar king of Babylon, and that will not put their neck under the yoke of the king of Babylon,’ says Yahuah, ‘with the sword, with famine, and with pestilence, until I have consumed them by his hand. 
 <sup>9&#160;</sup>But as for you, don’t listen to your prophets, to your diviners, to your dreams, to your soothsayers, or to your sorcerers, who speak to you, saying, “You shall not serve the king of Babylon;” 
 <sup>10&#160;</sup>for they prophesy a lie to you, to remove you far from your land, so that I would drive you out, and you would perish. 
-<sup>11&#160;</sup>But the nation that brings their neck under the yoke of the king of Babylon and serves him, that nation I will let remain in their own land,’ says Yahweh; ‘and they will till it and dwell in it.’&#160;”&#160;’&#160;” 
+<sup>11&#160;</sup>But the nation that brings their neck under the yoke of the king of Babylon and serves him, that nation I will let remain in their own land,’ says Yahuah; ‘and they will till it and dwell in it.’&#160;”&#160;’&#160;” 
 </p><p>
 <sup>12&#160;</sup>I spoke to Zedekiah king of Judah according to all these words, saying, “Bring your necks under the yoke of the king of Babylon, and serve him and his people, and live. 
-<sup>13&#160;</sup>Why will you die, you and your people, by the sword, by the famine, and by the pestilence, as Yahweh has spoken concerning the nation that will not serve the king of Babylon? 
+<sup>13&#160;</sup>Why will you die, you and your people, by the sword, by the famine, and by the pestilence, as Yahuah has spoken concerning the nation that will not serve the king of Babylon? 
 <sup>14&#160;</sup>Don’t listen to the words of the prophets who speak to you, saying, ‘You shall not serve the king of Babylon;’ for they prophesy a lie to you. 
-<sup>15&#160;</sup>For I have not sent them,” says Yahweh, “but they prophesy falsely in my name; that I may drive you out, and that you may perish, you, and the prophets who prophesy to you.” 
+<sup>15&#160;</sup>For I have not sent them,” says Yahuah, “but they prophesy falsely in my name; that I may drive you out, and that you may perish, you, and the prophets who prophesy to you.” 
 </p><p>
-<sup>16&#160;</sup>Also I spoke to the priests and to all this people, saying, Yahweh says, “Don’t listen to the words of your prophets who prophesy to you, saying, ‘Behold, the vessels of Yahweh’s house will now shortly be brought again from Babylon;’ for they prophesy a lie to you. 
+<sup>16&#160;</sup>Also I spoke to the priests and to all this people, saying, Yahuah says, “Don’t listen to the words of your prophets who prophesy to you, saying, ‘Behold, the vessels of Yahuah’s house will now shortly be brought again from Babylon;’ for they prophesy a lie to you. 
 <sup>17&#160;</sup>Don’t listen to them. Serve the king of Babylon, and live. Why should this city become a desolation? 
-<sup>18&#160;</sup>But if they are prophets, and if Yahweh’s word is with them, let them now make intercession to Yahweh of Armies, that the vessels which are left in Yahweh’s house, in the house of the king of Judah, and at Jerusalem, don’t go to Babylon. 
-<sup>19&#160;</sup>For Yahweh of Armies says concerning the pillars, concerning the sea, concerning the bases, and concerning the rest of the vessels that are left in this city, 
-<sup>20&#160;</sup>which Nebuchadnezzar king of Babylon didn’t take when he carried away captive Jeconiah the son of Jehoiakim, king of Judah, from Jerusalem to Babylon, and all the nobles of Judah and Jerusalem—<sup>21&#160;</sup>yes, Yahweh of Armies, the Elohim of Israel, says concerning the vessels that are left in Yahweh’s house, and in the house of the king of Judah, and at Jerusalem: 
-<sup>22&#160;</sup>‘They will be carried to Babylon, and there they will be, until the day that I visit them,’ says Yahweh; ‘then I will bring them up, and restore them to this place.’&#160;” 
+<sup>18&#160;</sup>But if they are prophets, and if Yahuah’s word is with them, let them now make intercession to Yahuah of Armies, that the vessels which are left in Yahuah’s house, in the house of the king of Judah, and at Jerusalem, don’t go to Babylon. 
+<sup>19&#160;</sup>For Yahuah of Armies says concerning the pillars, concerning the sea, concerning the bases, and concerning the rest of the vessels that are left in this city, 
+<sup>20&#160;</sup>which Nebuchadnezzar king of Babylon didn’t take when he carried away captive Jeconiah the son of Jehoiakim, king of Judah, from Jerusalem to Babylon, and all the nobles of Judah and Jerusalem—<sup>21&#160;</sup>yes, Yahuah of Armies, the Elohim of Israel, says concerning the vessels that are left in Yahuah’s house, and in the house of the king of Judah, and at Jerusalem: 
+<sup>22&#160;</sup>‘They will be carried to Babylon, and there they will be, until the day that I visit them,’ says Yahuah; ‘then I will bring them up, and restore them to this place.’&#160;” 
 </p><h2 class="chapterlabel" id="28">28</h2>
 <p>
-<sup>1&#160;</sup>That same year, in the beginning of the reign of Zedekiah king of Judah, in the fourth year, in the fifth month, Hananiah the son of Azzur, the prophet, who was of Gibeon, spoke to me in Yahweh’s house, in the presence of the priests and of all the people, saying, 
-<sup>2&#160;</sup>“Yahweh of Armies, the Elohim of Israel, says, ‘I have broken the yoke of the king of Babylon. 
-<sup>3&#160;</sup>Within two full years I will bring again into this place all the vessels of Yahweh’s house that Nebuchadnezzar king of Babylon took away from this place and carried to Babylon. 
-<sup>4&#160;</sup>I will bring again to this place Jeconiah the son of Jehoiakim, king of Judah, with all the captives of Judah, who went to Babylon,’ says Yahweh; ‘for I will break the yoke of the king of Babylon.’&#160;” 
+<sup>1&#160;</sup>That same year, in the beginning of the reign of Zedekiah king of Judah, in the fourth year, in the fifth month, Hananiah the son of Azzur, the prophet, who was of Gibeon, spoke to me in Yahuah’s house, in the presence of the priests and of all the people, saying, 
+<sup>2&#160;</sup>“Yahuah of Armies, the Elohim of Israel, says, ‘I have broken the yoke of the king of Babylon. 
+<sup>3&#160;</sup>Within two full years I will bring again into this place all the vessels of Yahuah’s house that Nebuchadnezzar king of Babylon took away from this place and carried to Babylon. 
+<sup>4&#160;</sup>I will bring again to this place Jeconiah the son of Jehoiakim, king of Judah, with all the captives of Judah, who went to Babylon,’ says Yahuah; ‘for I will break the yoke of the king of Babylon.’&#160;” 
 </p><p>
-<sup>5&#160;</sup>Then the prophet Jeremiah said to the prophet Hananiah in the presence of the priests, and in the presence of all the people who stood in Yahweh’s house, 
-<sup>6&#160;</sup>even the prophet Jeremiah said, “Amen! May Yahweh do so. May Yahweh perform your words which you have prophesied, to bring again the vessels of Yahweh’s house, and all those who are captives, from Babylon to this place. 
+<sup>5&#160;</sup>Then the prophet Jeremiah said to the prophet Hananiah in the presence of the priests, and in the presence of all the people who stood in Yahuah’s house, 
+<sup>6&#160;</sup>even the prophet Jeremiah said, “Amen! May Yahuah do so. May Yahuah perform your words which you have prophesied, to bring again the vessels of Yahuah’s house, and all those who are captives, from Babylon to this place. 
 <sup>7&#160;</sup>Nevertheless listen now to this word that I speak in your ears, and in the ears of all the people: 
 <sup>8&#160;</sup>The prophets who have been before me and before you of old prophesied against many countries, and against great kingdoms, of war, of evil, and of pestilence. 
-<sup>9&#160;</sup>As for the prophet who prophesies of peace, when the word of the prophet happens, then the prophet will be known, that Yahweh has truly sent him.” 
+<sup>9&#160;</sup>As for the prophet who prophesies of peace, when the word of the prophet happens, then the prophet will be known, that Yahuah has truly sent him.” 
 </p><p>
 <sup>10&#160;</sup>Then Hananiah the prophet took the bar from off the prophet Jeremiah’s neck, and broke it. 
-<sup>11&#160;</sup>Hananiah spoke in the presence of all the people, saying, “Yahweh says: ‘Even so I will break the yoke of Nebuchadnezzar king of Babylon from off the neck of all the nations within two full years.’&#160;” Then the prophet Jeremiah went his way. 
+<sup>11&#160;</sup>Hananiah spoke in the presence of all the people, saying, “Yahuah says: ‘Even so I will break the yoke of Nebuchadnezzar king of Babylon from off the neck of all the nations within two full years.’&#160;” Then the prophet Jeremiah went his way. 
 </p><p>
-<sup>12&#160;</sup>Then Yahweh’s word came to Jeremiah, after Hananiah the prophet had broken the bar from off the neck of the prophet Jeremiah, saying, 
-<sup>13&#160;</sup>“Go, and tell Hananiah, saying, ‘Yahweh says, “You have broken the bars of wood, but you have made in their place bars of iron.” 
-<sup>14&#160;</sup>For Yahweh of Armies, the Elohim of Israel says, “I have put a yoke of iron on the neck of all these nations, that they may serve Nebuchadnezzar king of Babylon; and they will serve him. I have also given him the animals of the field.”&#160;’&#160;” 
+<sup>12&#160;</sup>Then Yahuah’s word came to Jeremiah, after Hananiah the prophet had broken the bar from off the neck of the prophet Jeremiah, saying, 
+<sup>13&#160;</sup>“Go, and tell Hananiah, saying, ‘Yahuah says, “You have broken the bars of wood, but you have made in their place bars of iron.” 
+<sup>14&#160;</sup>For Yahuah of Armies, the Elohim of Israel says, “I have put a yoke of iron on the neck of all these nations, that they may serve Nebuchadnezzar king of Babylon; and they will serve him. I have also given him the animals of the field.”&#160;’&#160;” 
 </p><p>
-<sup>15&#160;</sup>Then the prophet Jeremiah said to Hananiah the prophet, “Listen, Hananiah! Yahweh has not sent you, but you make this people trust in a lie. 
-<sup>16&#160;</sup>Therefore Yahweh says, ‘Behold, I will send you away from off the surface of the earth. This year you will die, because you have spoken rebellion against Yahweh.’&#160;” 
+<sup>15&#160;</sup>Then the prophet Jeremiah said to Hananiah the prophet, “Listen, Hananiah! Yahuah has not sent you, but you make this people trust in a lie. 
+<sup>16&#160;</sup>Therefore Yahuah says, ‘Behold, I will send you away from off the surface of the earth. This year you will die, because you have spoken rebellion against Yahuah.’&#160;” 
 </p><p>
 <sup>17&#160;</sup>So Hananiah the prophet died the same year in the seventh month. 
 </p><h2 class="chapterlabel" id="29">29</h2>
@@ -1977,47 +1977,47 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>(after Jeconiah the king, the queen mother, the eunuchs, the princes of Judah and Jerusalem, the craftsmen, and the smiths had departed from Jerusalem), 
 <sup>3&#160;</sup>by the hand of Elasah the son of Shaphan and Gemariah the son of Hilkiah, (whom Zedekiah king of Judah sent to Babylon to Nebuchadnezzar king of Babylon). It said: 
 </p><p class="pi1">
-<sup>4&#160;</sup>Yahweh of Armies, the Elohim of Israel, says to all the captives whom I have caused to be carried away captive from Jerusalem to Babylon: 
+<sup>4&#160;</sup>Yahuah of Armies, the Elohim of Israel, says to all the captives whom I have caused to be carried away captive from Jerusalem to Babylon: 
 <sup>5&#160;</sup>“Build houses and dwell in them. Plant gardens and eat their fruit. 
 <sup>6&#160;</sup>Take women and father sons and daughters. Take women for your sons, and give your daughters to men, that they may bear sons and daughters. Multiply there, and don’t be diminished. 
-<sup>7&#160;</sup>Seek the peace of the city where I have caused you to be carried away captive, and pray to Yahweh for it; for in its peace you will have peace.” 
-<sup>8&#160;</sup>For Yahweh of Armies, the Elohim of Israel says: “Don’t let your prophets who are among you and your diviners deceive you. Don’t listen to your dreams which you cause to be dreamed. 
-<sup>9&#160;</sup>For they prophesy falsely to you in my name. I have not sent them,” says Yahweh. 
-<sup>10&#160;</sup>For Yahweh says, “After seventy years are accomplished for Babylon, I will visit you and perform my good word toward you, in causing you to return to this place. 
-<sup>11&#160;</sup>For I know the thoughts that I think toward you,” says Yahweh, “thoughts of peace, and not of evil, to give you hope and a future. 
+<sup>7&#160;</sup>Seek the peace of the city where I have caused you to be carried away captive, and pray to Yahuah for it; for in its peace you will have peace.” 
+<sup>8&#160;</sup>For Yahuah of Armies, the Elohim of Israel says: “Don’t let your prophets who are among you and your diviners deceive you. Don’t listen to your dreams which you cause to be dreamed. 
+<sup>9&#160;</sup>For they prophesy falsely to you in my name. I have not sent them,” says Yahuah. 
+<sup>10&#160;</sup>For Yahuah says, “After seventy years are accomplished for Babylon, I will visit you and perform my good word toward you, in causing you to return to this place. 
+<sup>11&#160;</sup>For I know the thoughts that I think toward you,” says Yahuah, “thoughts of peace, and not of evil, to give you hope and a future. 
 <sup>12&#160;</sup>You shall call on me, and you shall go and pray to me, and I will listen to you. 
 <sup>13&#160;</sup>You shall seek me and find me, when you search for me with all your heart. 
-<sup>14&#160;</sup>I will be found by you,” says Yahweh, “and I will turn again your captivity, and I will gather you from all the nations, and from all the places where I have driven you, says Yahweh. I will bring you again to the place from where I caused you to be carried away captive.” 
+<sup>14&#160;</sup>I will be found by you,” says Yahuah, “and I will turn again your captivity, and I will gather you from all the nations, and from all the places where I have driven you, says Yahuah. I will bring you again to the place from where I caused you to be carried away captive.” 
 </p><p class="pi1">
-<sup>15&#160;</sup>Because you have said, “Yahweh has raised us up prophets in Babylon,” 
-<sup>16&#160;</sup>Yahweh says concerning the king who sits on David’s throne, and concerning all the people who dwell in this city, your brothers who haven’t gone with you into captivity, 
-<sup>17&#160;</sup>Yahweh of Armies says: “Behold, I will send on them the sword, the famine, and the pestilence, and will make them like rotten figs that can’t be eaten, they are so bad. 
+<sup>15&#160;</sup>Because you have said, “Yahuah has raised us up prophets in Babylon,” 
+<sup>16&#160;</sup>Yahuah says concerning the king who sits on David’s throne, and concerning all the people who dwell in this city, your brothers who haven’t gone with you into captivity, 
+<sup>17&#160;</sup>Yahuah of Armies says: “Behold, I will send on them the sword, the famine, and the pestilence, and will make them like rotten figs that can’t be eaten, they are so bad. 
 <sup>18&#160;</sup>I will pursue after them with the sword, with the famine, and with the pestilence, and will deliver them to be tossed back and forth among all the kingdoms of the earth, to be an object of horror, an astonishment, a hissing, and a reproach among all the nations where I have driven them, 
-<sup>19&#160;</sup>because they have not listened to my words,” says Yahweh, “with which I sent to them my servants the prophets, rising up early and sending them; but you would not hear,” says Yahweh. 
+<sup>19&#160;</sup>because they have not listened to my words,” says Yahuah, “with which I sent to them my servants the prophets, rising up early and sending them; but you would not hear,” says Yahuah. 
 </p><p class="pi1">
-<sup>20&#160;</sup>Hear therefore Yahweh’s word, all you captives whom I have sent away from Jerusalem to Babylon. 
-<sup>21&#160;</sup>Yahweh of Armies, the Elohim of Israel, says concerning Ahab the son of Kolaiah, and concerning Zedekiah the son of Maaseiah, who prophesy a lie to you in my name: “Behold, I will deliver them into the hand of Nebuchadnezzar king of Babylon; and he will kill them before your eyes. 
-<sup>22&#160;</sup>A curse will be taken up about them by all the captives of Judah who are in Babylon, saying, ‘Yahweh make you like Zedekiah and like Ahab, whom the king of Babylon roasted in the fire;’ 
-<sup>23&#160;</sup>because they have done foolish things in Israel, and have committed adultery with their neighbors’ women, and have spoken words in my name falsely, which I didn’t command them. I am he who knows, and am witness,” says Yahweh. 
+<sup>20&#160;</sup>Hear therefore Yahuah’s word, all you captives whom I have sent away from Jerusalem to Babylon. 
+<sup>21&#160;</sup>Yahuah of Armies, the Elohim of Israel, says concerning Ahab the son of Kolaiah, and concerning Zedekiah the son of Maaseiah, who prophesy a lie to you in my name: “Behold, I will deliver them into the hand of Nebuchadnezzar king of Babylon; and he will kill them before your eyes. 
+<sup>22&#160;</sup>A curse will be taken up about them by all the captives of Judah who are in Babylon, saying, ‘Yahuah make you like Zedekiah and like Ahab, whom the king of Babylon roasted in the fire;’ 
+<sup>23&#160;</sup>because they have done foolish things in Israel, and have committed adultery with their neighbors’ women, and have spoken words in my name falsely, which I didn’t command them. I am he who knows, and am witness,” says Yahuah. 
 </p><p>
 <sup>24&#160;</sup>Concerning Shemaiah the Nehelamite you shall speak, saying, 
-<sup>25&#160;</sup>“Yahweh of Armies, the Elohim of Israel, says, ‘Because you have sent letters in your own name to all the people who are at Jerusalem, and to Zephaniah the son of Maaseiah, the priest, and to all the priests, saying, 
-<sup>26&#160;</sup>“Yahweh has made you priest in the place of Jehoiada the priest, that there may be officers in Yahweh’s house, for every man who is crazy and makes himself a prophet, that you should put him in the stocks and in shackles. 
+<sup>25&#160;</sup>“Yahuah of Armies, the Elohim of Israel, says, ‘Because you have sent letters in your own name to all the people who are at Jerusalem, and to Zephaniah the son of Maaseiah, the priest, and to all the priests, saying, 
+<sup>26&#160;</sup>“Yahuah has made you priest in the place of Jehoiada the priest, that there may be officers in Yahuah’s house, for every man who is crazy and makes himself a prophet, that you should put him in the stocks and in shackles. 
 <sup>27&#160;</sup>Now therefore, why have you not rebuked Jeremiah of Anathoth, who makes himself a prophet to you, 
 <sup>28&#160;</sup>because he has sent to us in Babylon, saying, The captivity is long. Build houses, and dwell in them. Plant gardens, and eat their fruit?”&#160;’&#160;” 
 </p><p>
 <sup>29&#160;</sup>Zephaniah the priest read this letter in the hearing of Jeremiah the prophet. 
-<sup>30&#160;</sup>Then Yahweh’s word came to Jeremiah, saying, 
-<sup>31&#160;</sup>“Send to all of the captives, saying, ‘Yahweh says concerning Shemaiah the Nehelamite: “Because Shemaiah has prophesied to you, and I didn’t send him, and he has caused you to trust in a lie,” 
-<sup>32&#160;</sup>therefore Yahweh says, “Behold, I will punish Shemaiah the Nehelamite and his offspring. He will not have a man to dwell among this people. He won’t see the good that I will do to my people,” says Yahweh, “because he has spoken rebellion against Yahweh.”&#160;’&#160;” 
+<sup>30&#160;</sup>Then Yahuah’s word came to Jeremiah, saying, 
+<sup>31&#160;</sup>“Send to all of the captives, saying, ‘Yahuah says concerning Shemaiah the Nehelamite: “Because Shemaiah has prophesied to you, and I didn’t send him, and he has caused you to trust in a lie,” 
+<sup>32&#160;</sup>therefore Yahuah says, “Behold, I will punish Shemaiah the Nehelamite and his offspring. He will not have a man to dwell among this people. He won’t see the good that I will do to my people,” says Yahuah, “because he has spoken rebellion against Yahuah.”&#160;’&#160;” 
 </p><h2 class="chapterlabel" id="30">30</h2>
 <p>
-<sup>1&#160;</sup>The word that came to Jeremiah from Yahweh, saying, 
-<sup>2&#160;</sup>“Yahweh, the Elohim of Israel, says, ‘Write all the words that I have spoken to you in a book. 
-<sup>3&#160;</sup>For, behold, the days come,’ says Yahweh, ‘that I will reverse the captivity of my people Israel and Judah,’ says Yahweh. ‘I will cause them to return to the land that I gave to their fathers, and they will possess it.’&#160;” 
+<sup>1&#160;</sup>The word that came to Jeremiah from Yahuah, saying, 
+<sup>2&#160;</sup>“Yahuah, the Elohim of Israel, says, ‘Write all the words that I have spoken to you in a book. 
+<sup>3&#160;</sup>For, behold, the days come,’ says Yahuah, ‘that I will reverse the captivity of my people Israel and Judah,’ says Yahuah. ‘I will cause them to return to the land that I gave to their fathers, and they will possess it.’&#160;” 
 </p><p>
-<sup>4&#160;</sup>These are the words that Yahweh spoke concerning Israel and concerning Judah. 
-<sup>5&#160;</sup>For Yahweh says: 
+<sup>4&#160;</sup>These are the words that Yahuah spoke concerning Israel and concerning Judah. 
+<sup>5&#160;</sup>For Yahuah says: 
 </p><p class="q1">“We have heard a voice of trembling; 
 </p><p class="q2">a voice of fear, and not of peace. 
 </p><p class="q1">
@@ -2029,15 +2029,15 @@ html[dir=ltr] .q2 {
 </p><p class="q2">It is even the time of Jacob’s trouble; 
 </p><p class="q2">but he will be saved out of it. 
 </p><p class="q1">
-<sup>8&#160;</sup>It will come to pass in that day, says Yahweh of Armies, that I will break his yoke from off your neck, 
+<sup>8&#160;</sup>It will come to pass in that day, says Yahuah of Armies, that I will break his yoke from off your neck, 
 </p><p class="q2">and will burst your bonds. 
 </p><p class="q2">Strangers will no more make them their bondservants; 
 </p><p class="q1">
-<sup>9&#160;</sup>but they will serve Yahweh their Elohim, 
+<sup>9&#160;</sup>but they will serve Yahuah their Elohim, 
 </p><p class="q2">and David their king, 
 </p><p class="q2">whom I will raise up to them. 
 </p><p class="q1">
-<sup>10&#160;</sup>Therefore don’t be afraid, O Jacob my servant, says Yahweh. 
+<sup>10&#160;</sup>Therefore don’t be afraid, O Jacob my servant, says Yahuah. 
 </p><p class="q2">Don’t be dismayed, Israel. 
 </p><p class="q1">For, behold, I will save you from afar, 
 </p><p class="q2">and save your offspring from the land of their captivity. 
@@ -2045,13 +2045,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will be quiet and at ease. 
 </p><p class="q2">No one will make him afraid. 
 </p><p class="q1">
-<sup>11&#160;</sup>For I am with you, says Yahweh, to save you; 
+<sup>11&#160;</sup>For I am with you, says Yahuah, to save you; 
 </p><p class="q2">for I will make a full end of all the nations where I have scattered you, 
 </p><p class="q2">but I will not make a full end of you; 
 </p><p class="q1">but I will correct you in measure, 
 </p><p class="q2">and will in no way leave you unpunished.” 
 </p><p>
-<sup>12&#160;</sup>For Yahweh says, 
+<sup>12&#160;</sup>For Yahuah says, 
 </p><p class="q1">“Your hurt is incurable. 
 </p><p class="q2">Your wound is grievous. 
 </p><p class="q1">
@@ -2078,11 +2078,11 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I will make all who prey on you become prey. 
 </p><p class="q1">
 <sup>17&#160;</sup>For I will restore health to you, 
-</p><p class="q2">and I will heal you of your wounds,” says Yahweh, 
+</p><p class="q2">and I will heal you of your wounds,” says Yahuah, 
 </p><p class="q1">“because they have called you an outcast, 
 </p><p class="q2">saying, ‘It is Zion, whom no man seeks after.’&#160;” 
 </p><p>
-<sup>18&#160;</sup>Yahweh says: 
+<sup>18&#160;</sup>Yahuah says: 
 </p><p class="q1">“Behold, I will reverse the captivity of Jacob’s tents, 
 </p><p class="q2">and have compassion on his dwelling places. 
 </p><p class="q1">The city will be built on its own hill, 
@@ -2103,25 +2103,25 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and their ruler will proceed from among them. 
 </p><p class="q1">I will cause him to draw near, 
 </p><p class="q2">and he will approach me; 
-</p><p class="q2">for who is he who has had boldness to approach me?” says Yahweh. 
+</p><p class="q2">for who is he who has had boldness to approach me?” says Yahuah. 
 </p><p class="q1">
 <sup>22&#160;</sup>“You shall be my people, 
 </p><p class="q2">and I will be your Elohim. 
 </p><p class="q1">
-<sup>23&#160;</sup>Behold, Yahweh’s storm, his wrath, has gone out, 
+<sup>23&#160;</sup>Behold, Yahuah’s storm, his wrath, has gone out, 
 </p><p class="q2">a sweeping storm; 
 </p><p class="q2">it will burst on the head of the wicked. 
 </p><p class="q1">
-<sup>24&#160;</sup>The fierce anger of Yahweh will not return until he has accomplished, 
+<sup>24&#160;</sup>The fierce anger of Yahuah will not return until he has accomplished, 
 </p><p class="q2">and until he has performed the intentions of his heart. 
 </p><p class="q2">In the latter days you will understand it.” 
 </p><h2 class="chapterlabel" id="31">31</h2>
 <p>
-<sup>1&#160;</sup>“At that time,” says Yahweh, “I will be the Elohim of all the families of Israel, and they will be my people.” 
+<sup>1&#160;</sup>“At that time,” says Yahuah, “I will be the Elohim of all the families of Israel, and they will be my people.” 
 </p><p>
-<sup>2&#160;</sup>Yahweh says, “The people who survive the sword found favor in the wilderness; even Israel, when I went to cause him to rest.” 
+<sup>2&#160;</sup>Yahuah says, “The people who survive the sword found favor in the wilderness; even Israel, when I went to cause him to rest.” 
 </p><p>
-<sup>3&#160;</sup>Yahweh appeared of old to me, saying, 
+<sup>3&#160;</sup>Yahuah appeared of old to me, saying, 
 </p><p class="q1">“Yes, I have loved you with an everlasting love. 
 </p><p class="q2">Therefore I have drawn you with loving kindness. 
 </p><p class="q1">
@@ -2135,13 +2135,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will enjoy its fruit. 
 </p><p class="q1">
 <sup>6&#160;</sup>For there will be a day that the watchmen on the hills of Ephraim cry, 
-</p><p class="q2">‘Arise! Let’s go up to Zion to Yahweh our Elohim.’&#160;” 
+</p><p class="q2">‘Arise! Let’s go up to Zion to Yahuah our Elohim.’&#160;” 
 </p><p>
-<sup>7&#160;</sup>For Yahweh says, 
+<sup>7&#160;</sup>For Yahuah says, 
 </p><p class="q1">“Sing with gladness for Jacob, 
 </p><p class="q2">and shout for the chief of the nations. 
 </p><p class="q1">Publish, praise, and say, 
-</p><p class="q2">‘Yahweh, save your people, 
+</p><p class="q2">‘Yahuah, save your people, 
 </p><p class="q2">the remnant of Israel!’ 
 </p><p class="q1">
 <sup>8&#160;</sup>Behold, I will bring them from the north country, 
@@ -2158,16 +2158,16 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Ephraim is my firstborn. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>“Hear Yahweh’s word, you nations, 
+<sup>10&#160;</sup>“Hear Yahuah’s word, you nations, 
 </p><p class="q2">and declare it in the distant islands. Say, 
 </p><p class="q1">‘He who scattered Israel will gather him, 
 </p><p class="q2">and keep him, as a shepherd does his flock.’ 
 </p><p class="q1">
-<sup>11&#160;</sup>For Yahweh has ransomed Jacob, 
+<sup>11&#160;</sup>For Yahuah has ransomed Jacob, 
 </p><p class="q2">and redeemed him from the hand of him who was stronger than he. 
 </p><p class="q1">
 <sup>12&#160;</sup>They will come and sing in the height of Zion, 
-</p><p class="q2">and will flow to the goodness of Yahweh, 
+</p><p class="q2">and will flow to the goodness of Yahuah, 
 </p><p class="q1">to the grain, to the new wine, to the oil, 
 </p><p class="q2">and to the young of the flock and of the herd. 
 </p><p class="q1">Their soul will be as a watered garden. 
@@ -2179,23 +2179,23 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will comfort them, and make them rejoice from their sorrow. 
 </p><p class="q1">
 <sup>14&#160;</sup>I will satiate the soul of the priests with fatness, 
-</p><p class="q2">and my people will be satisfied with my goodness,” says Yahweh. 
+</p><p class="q2">and my people will be satisfied with my goodness,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>15&#160;</sup>Yahweh says: 
+<sup>15&#160;</sup>Yahuah says: 
 </p><p class="q1">“A voice is heard in Ramah, 
 </p><p class="q2">lamentation and bitter weeping, 
 </p><p class="q1">Rachel weeping for her children. 
 </p><p class="q2">She refuses to be comforted for her children, 
 </p><p class="q2">because they are no more.” 
 </p><p>
-<sup>16&#160;</sup>Yahweh says: 
+<sup>16&#160;</sup>Yahuah says: 
 </p><p class="q1">“Refrain your voice from weeping, 
 </p><p class="q2">and your eyes from tears, 
-</p><p class="q2">for your work will be rewarded,” says Yahweh. 
+</p><p class="q2">for your work will be rewarded,” says Yahuah. 
 </p><p class="q2">“They will come again from the land of the enemy. 
 </p><p class="q1">
-<sup>17&#160;</sup>There is hope for your latter end,” says Yahweh. 
+<sup>17&#160;</sup>There is hope for your latter end,” says Yahuah. 
 </p><p class="q2">“Your children will come again to their own territory. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -2203,7 +2203,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">‘You have chastised me, 
 </p><p class="q2">and I was chastised, as an untrained calf. 
 </p><p class="q1">Turn me, and I will be turned, 
-</p><p class="q2">for you are Yahweh my Elohim. 
+</p><p class="q2">for you are Yahuah my Elohim. 
 </p><p class="q1">
 <sup>19&#160;</sup>Surely after that I was turned. 
 </p><p class="q2">I repented. 
@@ -2217,7 +2217,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">For as often as I speak against him, 
 </p><p class="q2">I still earnestly remember him. 
 </p><p class="q1">Therefore my heart yearns for him. 
-</p><p class="q2">I will surely have mercy on him,” says Yahweh. 
+</p><p class="q2">I will surely have mercy on him,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>21&#160;</sup>“Set up road signs. 
@@ -2229,81 +2229,81 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>22&#160;</sup>How long will you go here and there, 
 </p><p class="q2">you backsliding daughter? 
-</p><p class="q1">For Yahweh has created a new thing in the earth: 
+</p><p class="q1">For Yahuah has created a new thing in the earth: 
 </p><p class="q2">a woman will encompass a man.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>23&#160;</sup>Yahweh of Armies, the Elohim of Israel, says: “Yet again they will use this speech in the land of Judah and in its cities, when I reverse their captivity: ‘Yahweh bless you, habitation of righteousness, mountain of set-apartness.’ 
+<sup>23&#160;</sup>Yahuah of Armies, the Elohim of Israel, says: “Yet again they will use this speech in the land of Judah and in its cities, when I reverse their captivity: ‘Yahuah bless you, habitation of righteousness, mountain of set-apartness.’ 
 <sup>24&#160;</sup>Judah and all its cities will dwell therein together, the farmers, and those who go about with flocks. 
 <sup>25&#160;</sup>For I have satiated the weary soul, and I have replenished every sorrowful soul.” 
 </p><p>
 <sup>26&#160;</sup>On this I awakened, and saw; and my sleep was sweet to me. 
 </p><p>
-<sup>27&#160;</sup>“Behold, the days come,” says Yahweh, “that I will sow the house of Israel and the house of Judah with the seed of man and with the seed of animal. 
-<sup>28&#160;</sup>It will happen that, like as I have watched over them to pluck up and to break down and to overthrow and to destroy and to afflict, so I will watch over them to build and to plant,” says Yahweh. 
+<sup>27&#160;</sup>“Behold, the days come,” says Yahuah, “that I will sow the house of Israel and the house of Judah with the seed of man and with the seed of animal. 
+<sup>28&#160;</sup>It will happen that, like as I have watched over them to pluck up and to break down and to overthrow and to destroy and to afflict, so I will watch over them to build and to plant,” says Yahuah. 
 <sup>29&#160;</sup>“In those days they will say no more, 
 </p><p class="q1">“&#160;‘The fathers have eaten sour grapes, 
 </p><p class="q2">and the children’s teeth are set on edge.’ 
 </p><p class="m">
 <sup>30&#160;</sup>But everyone will die for his own iniquity. Every man who eats the sour grapes, his teeth will be set on edge. 
 </p><p>
-<sup>31&#160;</sup>“Behold, the days come,” says Yahweh, “that I will make a new covenant with the house of Israel, and with the house of Judah, 
-<sup>32&#160;</sup>not according to the covenant that I made with their fathers in the day that I took them by the hand to bring them out of the land of Egypt, which covenant of mine they broke, although I was an owner to them,” says Yahweh. 
-<sup>33&#160;</sup>“But this is the covenant that I will make with the house of Israel after those days,” says Yahweh: 
+<sup>31&#160;</sup>“Behold, the days come,” says Yahuah, “that I will make a new covenant with the house of Israel, and with the house of Judah, 
+<sup>32&#160;</sup>not according to the covenant that I made with their fathers in the day that I took them by the hand to bring them out of the land of Egypt, which covenant of mine they broke, although I was an owner to them,” says Yahuah. 
+<sup>33&#160;</sup>“But this is the covenant that I will make with the house of Israel after those days,” says Yahuah: 
 </p><p class="q1">“I will put my law in their inward parts, 
 </p><p class="q2">and I will write it in their heart. 
 </p><p class="q1">I will be their Elohim, 
 </p><p class="q2">and they shall be my people. 
 </p><p class="q1">
 <sup>34&#160;</sup>They will no longer each teach his neighbor, 
-</p><p class="q2">and every man teach his brother, saying, ‘Know Yahweh;’ 
+</p><p class="q2">and every man teach his brother, saying, ‘Know Yahuah;’ 
 </p><p class="q1">for they will all know me, 
-</p><p class="q2">from their least to their greatest,” says Yahweh, 
+</p><p class="q2">from their least to their greatest,” says Yahuah, 
 </p><p class="q1">“for I will forgive their iniquity, 
 </p><p class="q2">and I will remember their sin no more.” 
 </p><p class="q1">
-<sup>35&#160;</sup>Yahweh, who gives the sun for a light by day, 
+<sup>35&#160;</sup>Yahuah, who gives the sun for a light by day, 
 </p><p class="q2">and the ordinances of the moon and of the stars for a light by night, 
-</p><p class="q1">who stirs up the sea, so that its waves roar—</p><p class="q2">Yahweh of Armies is his name, says: 
+</p><p class="q1">who stirs up the sea, so that its waves roar—</p><p class="q2">Yahuah of Armies is his name, says: 
 </p><p class="q1">
-<sup>36&#160;</sup>“If these ordinances depart from before me,” says Yahweh, 
+<sup>36&#160;</sup>“If these ordinances depart from before me,” says Yahuah, 
 </p><p class="q2">“then the offspring of Israel also will cease from being a nation before me forever.” 
 </p><p class="q1">
-<sup>37&#160;</sup>Yahweh says: “If heaven above can be measured, 
+<sup>37&#160;</sup>Yahuah says: “If heaven above can be measured, 
 </p><p class="q2">and the foundations of the earth searched out beneath, 
-</p><p class="q2">then I will also cast off all the offspring of Israel for all that they have done,” says Yahweh. 
+</p><p class="q2">then I will also cast off all the offspring of Israel for all that they have done,” says Yahuah. 
 </p><p>
-<sup>38&#160;</sup>“Behold, the days come,” says Yahweh, “that the city will be built to Yahweh from the tower of Hananel to the gate of the corner. 
+<sup>38&#160;</sup>“Behold, the days come,” says Yahuah, “that the city will be built to Yahuah from the tower of Hananel to the gate of the corner. 
 <sup>39&#160;</sup>The measuring line will go out further straight onward to the hill Gareb, and will turn toward Goah. 
-<sup>40&#160;</sup>The whole valley of the dead bodies and of the ashes, and all the fields to the brook Kidron, to the corner of the horse gate toward the east, will be set-apart to Yahweh. It will not be plucked up or thrown down any more forever.” 
+<sup>40&#160;</sup>The whole valley of the dead bodies and of the ashes, and all the fields to the brook Kidron, to the corner of the horse gate toward the east, will be set-apart to Yahuah. It will not be plucked up or thrown down any more forever.” 
 </p><h2 class="chapterlabel" id="32">32</h2>
 <p>
-<sup>1&#160;</sup>This is the word that came to Jeremiah from Yahweh in the tenth year of Zedekiah king of Judah, which was the eighteenth year of Nebuchadnezzar. 
+<sup>1&#160;</sup>This is the word that came to Jeremiah from Yahuah in the tenth year of Zedekiah king of Judah, which was the eighteenth year of Nebuchadnezzar. 
 <sup>2&#160;</sup>Now at that time the king of Babylon’s army was besieging Jerusalem. Jeremiah the prophet was shut up in the court of the guard, which was in the king of Judah’s house. 
 </p><p>
-<sup>3&#160;</sup>For Zedekiah king of Judah had shut him up, saying, “Why do you prophesy, and say, ‘Yahweh says, “Behold, I will give this city into the hand of the king of Babylon, and he will take it; 
+<sup>3&#160;</sup>For Zedekiah king of Judah had shut him up, saying, “Why do you prophesy, and say, ‘Yahuah says, “Behold, I will give this city into the hand of the king of Babylon, and he will take it; 
 <sup>4&#160;</sup>and Zedekiah king of Judah won’t escape out of the hand of the Chaldeans, but will surely be delivered into the hand of the king of Babylon, and will speak with him mouth to mouth, and his eyes will see his eyes; 
-<sup>5&#160;</sup>and he will bring Zedekiah to Babylon, and he will be there until I visit him,” says Yahweh, “though you fight with the Chaldeans, you will not prosper”&#160;’?” 
+<sup>5&#160;</sup>and he will bring Zedekiah to Babylon, and he will be there until I visit him,” says Yahuah, “though you fight with the Chaldeans, you will not prosper”&#160;’?” 
 </p><p>
-<sup>6&#160;</sup>Jeremiah said, “Yahweh’s word came to me, saying, 
+<sup>6&#160;</sup>Jeremiah said, “Yahuah’s word came to me, saying, 
 <sup>7&#160;</sup>‘Behold, Hanamel the son of Shallum your uncle will come to you, saying, “Buy my field that is in Anathoth; for the right of redemption is yours to buy it.”&#160;’&#160;” 
 </p><p>
-<sup>8&#160;</sup>“So Hanamel my uncle’s son came to me in the court of the guard according to Yahweh’s word, and said to me, ‘Please buy my field that is in Anathoth, which is in the land of Benjamin; for the right of inheritance is yours, and the redemption is yours. Buy it for yourself.’ 
-</p><p>“Then I knew that this was Yahweh’s word. 
+<sup>8&#160;</sup>“So Hanamel my uncle’s son came to me in the court of the guard according to Yahuah’s word, and said to me, ‘Please buy my field that is in Anathoth, which is in the land of Benjamin; for the right of inheritance is yours, and the redemption is yours. Buy it for yourself.’ 
+</p><p>“Then I knew that this was Yahuah’s word. 
 <sup>9&#160;</sup>I bought the field that was in Anathoth of Hanamel my uncle’s son, and weighed him the money, even seventeen shekels of silver. 
 <sup>10&#160;</sup>I signed the deed, sealed it, called witnesses, and weighed the money in the balances to him. 
 <sup>11&#160;</sup>So I took the deed of the purchase, both that which was sealed, containing the terms and conditions, and that which was open; 
 <sup>12&#160;</sup>and I delivered the deed of the purchase to Baruch the son of Neriah, the son of Mahseiah, in the presence of Hanamel my uncle’s son, and in the presence of the witnesses who signed the deed of the purchase, before all the Jews who sat in the court of the guard. 
 </p><p>
 <sup>13&#160;</sup>“I commanded Baruch before them, saying, 
-<sup>14&#160;</sup>Yahweh of Armies, the Elohim of Israel, says: ‘Take these deeds, this deed of the purchase which is sealed, and this deed which is open, and put them in an earthen vessel, that they may last many days.’ 
-<sup>15&#160;</sup>For Yahweh of Armies, the Elohim of Israel says: ‘Houses and fields and vineyards will yet again be bought in this land.’ 
+<sup>14&#160;</sup>Yahuah of Armies, the Elohim of Israel, says: ‘Take these deeds, this deed of the purchase which is sealed, and this deed which is open, and put them in an earthen vessel, that they may last many days.’ 
+<sup>15&#160;</sup>For Yahuah of Armies, the Elohim of Israel says: ‘Houses and fields and vineyards will yet again be bought in this land.’ 
 </p><p>
-<sup>16&#160;</sup>Now after I had delivered the deed of the purchase to Baruch the son of Neriah, I prayed to Yahweh, saying, 
+<sup>16&#160;</sup>Now after I had delivered the deed of the purchase to Baruch the son of Neriah, I prayed to Yahuah, saying, 
 </p><p class="b"> &#160; </p>
 <p class="mi">
-<sup>17&#160;</sup>“Ah Lord Yahweh! Behold, you have made the heavens and the earth by your great power and by your outstretched arm. There is nothing too hard for you. 
-<sup>18&#160;</sup>You show loving kindness to thousands, and repay the iniquity of the fathers into the bosom of their children after them. The great, the mighty Elohim, Yahweh of Armies is your name: 
+<sup>17&#160;</sup>“Ah Lord Yahuah! Behold, you have made the heavens and the earth by your great power and by your outstretched arm. There is nothing too hard for you. 
+<sup>18&#160;</sup>You show loving kindness to thousands, and repay the iniquity of the fathers into the bosom of their children after them. The great, the mighty Elohim, Yahuah of Armies is your name: 
 <sup>19&#160;</sup>great in counsel, and mighty in work; whose eyes are open to all the ways of the children of men, to give everyone according to his ways, and according to the fruit of his doings; 
 <sup>20&#160;</sup>who performed signs and wonders in the land of Egypt, even to this day, both in Israel and among other men; and made yourself a name, as it is today; 
 <sup>21&#160;</sup>and brought your people Israel out of the land of Egypt with signs, with wonders, with a strong hand, with an outstretched arm, and with great terror; 
@@ -2311,49 +2311,49 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>They came in and possessed it, but they didn’t obey your voice and didn’t walk in your law. They have done nothing of all that you commanded them to do. Therefore you have caused all this evil to come upon them. 
 </p><p class="pi1">
 <sup>24&#160;</sup>“Behold, siege ramps have been built against the city to take it. The city is given into the hand of the Chaldeans who fight against it, because of the sword, of the famine, and of the pestilence. What you have spoken has happened. Behold, you see it. 
-<sup>25&#160;</sup>You have said to me, Lord Yahweh, ‘Buy the field for money, and call witnesses;’ whereas the city is given into the hand of the Chaldeans.” 
+<sup>25&#160;</sup>You have said to me, Lord Yahuah, ‘Buy the field for money, and call witnesses;’ whereas the city is given into the hand of the Chaldeans.” 
 </p><p>
-<sup>26&#160;</sup>Then Yahweh’s word came to Jeremiah, saying, 
-<sup>27&#160;</sup>“Behold, I am Yahweh, the Elohim of all flesh. Is there anything too hard for me? 
-<sup>28&#160;</sup>Therefore Yahweh says: Behold, I will give this city into the hand of the Chaldeans, and into the hand of Nebuchadnezzar king of Babylon, and he will take it. 
+<sup>26&#160;</sup>Then Yahuah’s word came to Jeremiah, saying, 
+<sup>27&#160;</sup>“Behold, I am Yahuah, the Elohim of all flesh. Is there anything too hard for me? 
+<sup>28&#160;</sup>Therefore Yahuah says: Behold, I will give this city into the hand of the Chaldeans, and into the hand of Nebuchadnezzar king of Babylon, and he will take it. 
 <sup>29&#160;</sup>The Chaldeans, who fight against this city, will come and set this city on fire, and burn it with the houses on whose roofs they have offered incense to Baal, and poured out drink offerings to other elohims, to provoke me to anger. 
 </p><p>
-<sup>30&#160;</sup>“For the children of Israel and the children of Judah have done only that which was evil in my sight from their youth; for the children of Israel have only provoked me to anger with the work of their hands, says Yahweh. 
+<sup>30&#160;</sup>“For the children of Israel and the children of Judah have done only that which was evil in my sight from their youth; for the children of Israel have only provoked me to anger with the work of their hands, says Yahuah. 
 <sup>31&#160;</sup>For this city has been to me a provocation of my anger and of my wrath from the day that they built it even to this day, so that I should remove it from before my face, 
 <sup>32&#160;</sup>because of all the evil of the children of Israel and of the children of Judah, which they have done to provoke me to anger—they, their kings, their princes, their priests, their prophets, the men of Judah, and the inhabitants of Jerusalem. 
 <sup>33&#160;</sup>They have turned their backs to me, and not their faces. Although I taught them, rising up early and teaching them, yet they have not listened to receive instruction. 
 <sup>34&#160;</sup>But they set their abominations in the house which is called by my name, to defile it. 
 <sup>35&#160;</sup>They built the high places of Baal, which are in the valley of the son of Hinnom, to cause their sons and their daughters to pass through fire to Molech, which I didn’t command them. It didn’t even come into my mind, that they should do this abomination, to cause Judah to sin.” 
 </p><p>
-<sup>36&#160;</sup>Now therefore Yahweh, the Elohim of Israel, says concerning this city, about which you say, “It is given into the hand of the king of Babylon by the sword, by the famine, and by the pestilence:” 
+<sup>36&#160;</sup>Now therefore Yahuah, the Elohim of Israel, says concerning this city, about which you say, “It is given into the hand of the king of Babylon by the sword, by the famine, and by the pestilence:” 
 <sup>37&#160;</sup>“Behold, I will gather them out of all the countries where I have driven them in my anger, and in my wrath, and in great indignation; and I will bring them again to this place. I will cause them to dwell safely. 
 <sup>38&#160;</sup>Then they will be my people, and I will be their Elohim. 
 <sup>39&#160;</sup>I will give them one heart and one way, that they may fear me forever, for their good and the good of their children after them. 
 <sup>40&#160;</sup>I will make an everlasting covenant with them, that I will not turn away from following them, to do them good. I will put my fear in their hearts, that they may not depart from me. 
 <sup>41&#160;</sup>Yes, I will rejoice over them to do them good, and I will plant them in this land assuredly with my whole heart and with my whole soul.” 
 </p><p>
-<sup>42&#160;</sup>For Yahweh says: “Just as I have brought all this great evil on this people, so I will bring on them all the good that I have promised them. 
+<sup>42&#160;</sup>For Yahuah says: “Just as I have brought all this great evil on this people, so I will bring on them all the good that I have promised them. 
 <sup>43&#160;</sup>Fields will be bought in this land, about which you say, ‘It is desolate, without man or animal. It is given into the hand of the Chaldeans.’ 
-<sup>44&#160;</sup>Men will buy fields for money, sign the deeds, seal them, and call witnesses, in the land of Benjamin, and in the places around Jerusalem, in the cities of Judah, in the cities of the hill country, in the cities of the lowland, and in the cities of the South; for I will cause their captivity to be reversed,” says Yahweh. 
+<sup>44&#160;</sup>Men will buy fields for money, sign the deeds, seal them, and call witnesses, in the land of Benjamin, and in the places around Jerusalem, in the cities of Judah, in the cities of the hill country, in the cities of the lowland, and in the cities of the South; for I will cause their captivity to be reversed,” says Yahuah. 
 </p><h2 class="chapterlabel" id="33">33</h2>
 <p class="nb">
-<sup>1&#160;</sup>Moreover Yahweh’s word came to Jeremiah the second time, while he was still locked up in the court of the guard, saying, 
-<sup>2&#160;</sup>“Yahweh who does it, Yahweh who forms it to establish it—Yahweh is his name, says: 
+<sup>1&#160;</sup>Moreover Yahuah’s word came to Jeremiah the second time, while he was still locked up in the court of the guard, saying, 
+<sup>2&#160;</sup>“Yahuah who does it, Yahuah who forms it to establish it—Yahuah is his name, says: 
 <sup>3&#160;</sup>‘Call to me, and I will answer you, and will show you great and difficult things, which you don’t know.’ 
-<sup>4&#160;</sup>For Yahweh, the Elohim of Israel, says concerning the houses of this city and concerning the houses of the kings of Judah, which are broken down to make a defense against the mounds and against the sword: 
+<sup>4&#160;</sup>For Yahuah, the Elohim of Israel, says concerning the houses of this city and concerning the houses of the kings of Judah, which are broken down to make a defense against the mounds and against the sword: 
 <sup>5&#160;</sup>‘While men come to fight with the Chaldeans, and to fill them with the dead bodies of men, whom I have killed in my anger and in my wrath, and for all whose wickedness I have hidden my face from this city, 
 <sup>6&#160;</sup>behold, I will bring it health and healing, and I will cure them; and I will reveal to them abundance of peace and truth. 
 <sup>7&#160;</sup>I will restore the fortunes of Judah and Israel, and will build them as at the first. 
 <sup>8&#160;</sup>I will cleanse them from all their iniquity by which they have sinned against me. I will pardon all their iniquities by which they have sinned against me and by which they have transgressed against me. 
 <sup>9&#160;</sup>This city will be to me for a name of joy, for praise, and for glory, before all the nations of the earth, which will hear all the good that I do to them, and will fear and tremble for all the good and for all the peace that I provide to it.’&#160;” 
 </p><p>
-<sup>10&#160;</sup>Yahweh says: “Yet again there will be heard in this place, about which you say, ‘It is waste, without man and without animal, even in the cities of Judah, and in the streets of Jerusalem, that are desolate, without man and without inhabitant and without animal,’ 
-<sup>11&#160;</sup>the voice of joy and the voice of gladness, the voice of the bridegroom and the voice of the bride, the voice of those who say, ‘Give thanks to Yahweh of Armies, for Yahweh is good, for his loving kindness endures forever;’ who bring thanksgiving into Yahweh’s house. For I will cause the captivity of the land to be reversed as at the first,” says Yahweh. 
+<sup>10&#160;</sup>Yahuah says: “Yet again there will be heard in this place, about which you say, ‘It is waste, without man and without animal, even in the cities of Judah, and in the streets of Jerusalem, that are desolate, without man and without inhabitant and without animal,’ 
+<sup>11&#160;</sup>the voice of joy and the voice of gladness, the voice of the bridegroom and the voice of the bride, the voice of those who say, ‘Give thanks to Yahuah of Armies, for Yahuah is good, for his loving kindness endures forever;’ who bring thanksgiving into Yahuah’s house. For I will cause the captivity of the land to be reversed as at the first,” says Yahuah. 
 </p><p>
-<sup>12&#160;</sup>Yahweh of Armies says: “Yet again there will be in this place, which is waste, without man and without animal, and in all its cities, a habitation of shepherds causing their flocks to lie down. 
-<sup>13&#160;</sup>In the cities of the hill country, in the cities of the lowland, in the cities of the South, in the land of Benjamin, in the places around Jerusalem, and in the cities of Judah, the flocks will again pass under the hands of him who counts them,” says Yahweh. 
+<sup>12&#160;</sup>Yahuah of Armies says: “Yet again there will be in this place, which is waste, without man and without animal, and in all its cities, a habitation of shepherds causing their flocks to lie down. 
+<sup>13&#160;</sup>In the cities of the hill country, in the cities of the lowland, in the cities of the South, in the land of Benjamin, in the places around Jerusalem, and in the cities of Judah, the flocks will again pass under the hands of him who counts them,” says Yahuah. 
 </p><p>
-<sup>14&#160;</sup>“Behold, the days come,” says Yahweh, “that I will perform that good word which I have spoken concerning the house of Israel and concerning the house of Judah. 
+<sup>14&#160;</sup>“Behold, the days come,” says Yahuah, “that I will perform that good word which I have spoken concerning the house of Israel and concerning the house of Judah. 
 </p><p class="q1">
 <sup>15&#160;</sup>“In those days and at that time, 
 </p><p class="q2">I will cause a Branch of righteousness to grow up to David. 
@@ -2362,57 +2362,57 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>In those days Judah will be saved, 
 </p><p class="q2">and Jerusalem will dwell safely. 
 </p><p class="q1">This is the name by which she will be called: 
-</p><p class="q2">Yahweh our righteousness.” 
+</p><p class="q2">Yahuah our righteousness.” 
 </p><p>
-<sup>17&#160;</sup>For Yahweh says: “David will never lack a man to sit on the throne of the house of Israel. 
+<sup>17&#160;</sup>For Yahuah says: “David will never lack a man to sit on the throne of the house of Israel. 
 <sup>18&#160;</sup>The Levitical priests won’t lack a man before me to offer burnt offerings, to burn meal offerings, and to do sacrifice continually.” 
 </p><p>
-<sup>19&#160;</sup>Yahweh’s word came to Jeremiah, saying, 
-<sup>20&#160;</sup>“Yahweh says: ‘If you can break my covenant of the day and my covenant of the night, so that there will not be day and night in their time, 
+<sup>19&#160;</sup>Yahuah’s word came to Jeremiah, saying, 
+<sup>20&#160;</sup>“Yahuah says: ‘If you can break my covenant of the day and my covenant of the night, so that there will not be day and night in their time, 
 <sup>21&#160;</sup>then my covenant could also be broken with David my servant, that he won’t have a son to reign on his throne; and with the Levitical priests, my ministers. 
 <sup>22&#160;</sup>As the army of the sky can’t be counted, and the sand of the sea can’t be measured, so I will multiply the offspring of David my servant and the Levites who minister to me.’&#160;” 
 </p><p>
-<sup>23&#160;</sup>Yahweh’s word came to Jeremiah, saying, 
-<sup>24&#160;</sup>“Don’t consider what this people has spoken, saying, ‘Has Yahweh cast off the two families which he chose?’ Thus they despise my people, that they should be no more a nation before them.” 
-<sup>25&#160;</sup>Yahweh says: “If my covenant of day and night fails, if I have not appointed the ordinances of heaven and earth, 
+<sup>23&#160;</sup>Yahuah’s word came to Jeremiah, saying, 
+<sup>24&#160;</sup>“Don’t consider what this people has spoken, saying, ‘Has Yahuah cast off the two families which he chose?’ Thus they despise my people, that they should be no more a nation before them.” 
+<sup>25&#160;</sup>Yahuah says: “If my covenant of day and night fails, if I have not appointed the ordinances of heaven and earth, 
 <sup>26&#160;</sup>then I will also cast away the offspring of Jacob, and of David my servant, so that I will not take of his offspring to be rulers over the offspring of Abraham, Isaac, and Jacob; for I will cause their captivity to be reversed and will have mercy on them.” 
 </p><h2 class="chapterlabel" id="34">34</h2>
 <p>
-<sup>1&#160;</sup>The word which came to Jeremiah from Yahweh, when Nebuchadnezzar king of Babylon, with all his army, all the kingdoms of the earth that were under his dominion, and all the peoples, were fighting against Jerusalem and against all its cities, saying: 
-<sup>2&#160;</sup>“Yahweh, the Elohim of Israel, says, ‘Go, and speak to Zedekiah king of Judah, and tell him, Yahweh says, “Behold, I will give this city into the hand of the king of Babylon and he will burn it with fire. 
+<sup>1&#160;</sup>The word which came to Jeremiah from Yahuah, when Nebuchadnezzar king of Babylon, with all his army, all the kingdoms of the earth that were under his dominion, and all the peoples, were fighting against Jerusalem and against all its cities, saying: 
+<sup>2&#160;</sup>“Yahuah, the Elohim of Israel, says, ‘Go, and speak to Zedekiah king of Judah, and tell him, Yahuah says, “Behold, I will give this city into the hand of the king of Babylon and he will burn it with fire. 
 <sup>3&#160;</sup>You won’t escape out of his hand, but will surely be taken and delivered into his hand. Your eyes will see the eyes of the king of Babylon, and he will speak with you mouth to mouth. You will go to Babylon.”&#160;’ 
 </p><p>
-<sup>4&#160;</sup>“Yet hear Yahweh’s word, O Zedekiah king of Judah. Yahweh says concerning you, ‘You won’t die by the sword. 
-<sup>5&#160;</sup>You will die in peace; and with the burnings of your fathers, the former kings who were before you, so they will make a burning for you. They will lament you, saying, “Ah Lord!” for I have spoken the word,’ says Yahweh.” 
+<sup>4&#160;</sup>“Yet hear Yahuah’s word, O Zedekiah king of Judah. Yahuah says concerning you, ‘You won’t die by the sword. 
+<sup>5&#160;</sup>You will die in peace; and with the burnings of your fathers, the former kings who were before you, so they will make a burning for you. They will lament you, saying, “Ah Lord!” for I have spoken the word,’ says Yahuah.” 
 </p><p>
 <sup>6&#160;</sup>Then Jeremiah the prophet spoke all these words to Zedekiah king of Judah in Jerusalem, 
 <sup>7&#160;</sup>when the king of Babylon’s army was fighting against Jerusalem and against all the cities of Judah that were left, against Lachish and against Azekah; for these alone remained of the cities of Judah as fortified cities. 
 </p><p>
-<sup>8&#160;</sup>The word came to Jeremiah from Yahweh, after King Zedekiah had made a covenant with all the people who were at Jerusalem, to proclaim liberty to them, 
+<sup>8&#160;</sup>The word came to Jeremiah from Yahuah, after King Zedekiah had made a covenant with all the people who were at Jerusalem, to proclaim liberty to them, 
 <sup>9&#160;</sup>that every man should let his male servant, and every man his female servant, who is a Hebrew or a Hebrewess, go free, that no one should make bondservants of them, of a Jew his brother. 
 <sup>10&#160;</sup>All the princes and all the people obeyed who had entered into the covenant, that everyone should let his male servant and everyone his female servant go free, that no one should make bondservants of them any more. They obeyed and let them go, 
 <sup>11&#160;</sup>but afterwards they turned, and caused the servants and the handmaids whom they had let go free to return, and brought them into subjection for servants and for handmaids. 
 </p><p>
-<sup>12&#160;</sup>Therefore Yahweh’s word came to Jeremiah from Yahweh, saying, 
-<sup>13&#160;</sup>“Yahweh, the Elohim of Israel, says: ‘I made a covenant with your fathers in the day that I brought them out of the land of Egypt, out of the house of bondage, saying: 
+<sup>12&#160;</sup>Therefore Yahuah’s word came to Jeremiah from Yahuah, saying, 
+<sup>13&#160;</sup>“Yahuah, the Elohim of Israel, says: ‘I made a covenant with your fathers in the day that I brought them out of the land of Egypt, out of the house of bondage, saying: 
 <sup>14&#160;</sup>At the end of seven years, every man of you shall release his brother who is a Hebrew, who has been sold to you, and has served you six years. You shall let him go free from you. But your fathers didn’t listen to me, and didn’t incline their ear. 
 <sup>15&#160;</sup>You had now turned, and had done that which is right in my eyes, in every man proclaiming liberty to his neighbor. You had made a covenant before me in the house which is called by my name; 
 <sup>16&#160;</sup>but you turned and profaned my name, and every man caused his servant and every man his handmaid, whom you had let go free at their pleasure, to return. You brought them into subjection, to be to you for servants and for handmaids.’&#160;” 
 </p><p>
-<sup>17&#160;</sup>Therefore Yahweh says: “You have not listened to me, to proclaim liberty, every man to his brother, and every man to his neighbor. Behold, I proclaim to you a liberty,” says Yahweh, “to the sword, to the pestilence, and to the famine. I will make you be tossed back and forth among all the kingdoms of the earth. 
+<sup>17&#160;</sup>Therefore Yahuah says: “You have not listened to me, to proclaim liberty, every man to his brother, and every man to his neighbor. Behold, I proclaim to you a liberty,” says Yahuah, “to the sword, to the pestilence, and to the famine. I will make you be tossed back and forth among all the kingdoms of the earth. 
 <sup>18&#160;</sup>I will give the men who have transgressed my covenant, who have not performed the words of the covenant which they made before me when they cut the calf in two and passed between its parts: 
 <sup>19&#160;</sup>the princes of Judah, the princes of Jerusalem, the eunuchs, the priests, and all the people of the land, who passed between the parts of the calf. 
 <sup>20&#160;</sup>I will even give them into the hand of their enemies and into the hand of those who seek their life. Their dead bodies will be food for the birds of the sky and for the animals of the earth. 
 </p><p>
 <sup>21&#160;</sup>“I will give Zedekiah king of Judah and his princes into the hands of their enemies, into the hands of those who seek their life and into the hands of the king of Babylon’s army, who has gone away from you. 
-<sup>22&#160;</sup>Behold, I will command,” says Yahweh, “and cause them to return to this city. They will fight against it, take it, and burn it with fire. I will make the cities of Judah a desolation, without inhabitant.” 
+<sup>22&#160;</sup>Behold, I will command,” says Yahuah, “and cause them to return to this city. They will fight against it, take it, and burn it with fire. I will make the cities of Judah a desolation, without inhabitant.” 
 </p><h2 class="chapterlabel" id="35">35</h2>
 <p>
-<sup>1&#160;</sup>The word which came to Jeremiah from Yahweh in the days of Jehoiakim the son of Josiah, king of Judah, saying, 
-<sup>2&#160;</sup>“Go to the house of the Rechabites, and speak to them, and bring them into Yahweh’s house, into one of the rooms, and give them wine to drink.” 
+<sup>1&#160;</sup>The word which came to Jeremiah from Yahuah in the days of Jehoiakim the son of Josiah, king of Judah, saying, 
+<sup>2&#160;</sup>“Go to the house of the Rechabites, and speak to them, and bring them into Yahuah’s house, into one of the rooms, and give them wine to drink.” 
 </p><p>
 <sup>3&#160;</sup>Then I took Jaazaniah the son of Jeremiah, the son of Habazziniah, with his brothers, all his sons, and the whole house of the Rechabites; 
-<sup>4&#160;</sup>and I brought them into Yahweh’s house, into the room of the sons of Hanan the son of Igdaliah, the man of Elohim, which was by the room of the princes, which was above the room of Maaseiah the son of Shallum, the keeper of the threshold. 
+<sup>4&#160;</sup>and I brought them into Yahuah’s house, into the room of the sons of Hanan the son of Igdaliah, the man of Elohim, which was by the room of the princes, which was above the room of Maaseiah the son of Shallum, the keeper of the threshold. 
 <sup>5&#160;</sup>I set before the sons of the house of the Rechabites bowls full of wine, and cups; and I said to them, “Drink wine!” 
 </p><p>
 <sup>6&#160;</sup>But they said, “We will drink no wine; for Jonadab the son of Rechab, our father, commanded us, saying, ‘You shall drink no wine, neither you nor your children, forever. 
@@ -2422,32 +2422,32 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>but we have lived in tents, and have obeyed, and done according to all that Jonadab our father commanded us. 
 <sup>11&#160;</sup>But when Nebuchadnezzar king of Babylon came up into the land, we said, ‘Come! Let’s go to Jerusalem for fear of the army of the Chaldeans, and for fear of the army of the Syrians; so we will dwell at Jerusalem.’&#160;” 
 </p><p>
-<sup>12&#160;</sup>Then Yahweh’s word came to Jeremiah, saying, 
-<sup>13&#160;</sup>“Yahweh of Armies, the Elohim of Israel, says: ‘Go and tell the men of Judah and the inhabitants of Jerusalem, “Will you not receive instruction to listen to my words?” says Yahweh. 
+<sup>12&#160;</sup>Then Yahuah’s word came to Jeremiah, saying, 
+<sup>13&#160;</sup>“Yahuah of Armies, the Elohim of Israel, says: ‘Go and tell the men of Judah and the inhabitants of Jerusalem, “Will you not receive instruction to listen to my words?” says Yahuah. 
 <sup>14&#160;</sup>“The words of Jonadab the son of Rechab that he commanded his sons, not to drink wine, are performed; and to this day they drink none, for they obey their father’s commandment; but I have spoken to you, rising up early and speaking, and you have not listened to me. 
 <sup>15&#160;</sup>I have sent also to you all my servants the prophets, rising up early and sending them, saying, ‘Every one of you must return now from his evil way, amend your doings, and don’t go after other elohims to serve them. Then you will dwell in the land which I have given to you and to your fathers;’ but you have not inclined your ear, nor listened to me. 
 <sup>16&#160;</sup>The sons of Jonadab the son of Rechab have performed the commandment of their father which he commanded them, but this people has not listened to me.”&#160;’ 
 </p><p>
-<sup>17&#160;</sup>“Therefore Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘Behold, I will bring on Judah and on all the inhabitants of Jerusalem all the evil that I have pronounced against them, because I have spoken to them, but they have not heard; and I have called to them, but they have not answered.’&#160;” 
+<sup>17&#160;</sup>“Therefore Yahuah, the Elohim of Armies, the Elohim of Israel, says: ‘Behold, I will bring on Judah and on all the inhabitants of Jerusalem all the evil that I have pronounced against them, because I have spoken to them, but they have not heard; and I have called to them, but they have not answered.’&#160;” 
 </p><p>
-<sup>18&#160;</sup>Jeremiah said to the house of the Rechabites, “Yahweh of Armies, the Elohim of Israel, says: ‘Because you have obeyed the commandment of Jonadab your father, and kept all his precepts, and done according to all that he commanded you,’ 
-<sup>19&#160;</sup>therefore Yahweh of Armies, the Elohim of Israel, says: ‘Jonadab the son of Rechab will not lack a man to stand before me forever.’&#160;” 
+<sup>18&#160;</sup>Jeremiah said to the house of the Rechabites, “Yahuah of Armies, the Elohim of Israel, says: ‘Because you have obeyed the commandment of Jonadab your father, and kept all his precepts, and done according to all that he commanded you,’ 
+<sup>19&#160;</sup>therefore Yahuah of Armies, the Elohim of Israel, says: ‘Jonadab the son of Rechab will not lack a man to stand before me forever.’&#160;” 
 </p><h2 class="chapterlabel" id="36">36</h2>
 <p>
-<sup>1&#160;</sup>In the fourth year of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahweh, saying, 
+<sup>1&#160;</sup>In the fourth year of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahuah, saying, 
 <sup>2&#160;</sup>“Take a scroll of a book, and write in it all the words that I have spoken to you against Israel, against Judah, and against all the nations, from the day I spoke to you, from the days of Josiah even to this day. 
 <sup>3&#160;</sup>It may be that the house of Judah will hear all the evil which I intend to do to them, that they may each return from his evil way; that I may forgive their iniquity and their sin.” 
 </p><p>
-<sup>4&#160;</sup>Then Jeremiah called Baruch the son of Neriah; and Baruch wrote from the mouth of Jeremiah all Yahweh’s words, which he had spoken to him, on a scroll of a book. 
-<sup>5&#160;</sup>Jeremiah commanded Baruch, saying, “I am restricted. I can’t go into Yahweh’s house. 
-<sup>6&#160;</sup>Therefore you go, and read from the scroll which you have written from my mouth, Yahweh’s words, in the ears of the people in Yahweh’s house on the fast day. Also you shall read them in the ears of all Judah who come out of their cities. 
-<sup>7&#160;</sup>It may be they will present their supplication before Yahweh, and will each return from his evil way; for Yahweh has pronounced great anger and wrath against this people.” 
+<sup>4&#160;</sup>Then Jeremiah called Baruch the son of Neriah; and Baruch wrote from the mouth of Jeremiah all Yahuah’s words, which he had spoken to him, on a scroll of a book. 
+<sup>5&#160;</sup>Jeremiah commanded Baruch, saying, “I am restricted. I can’t go into Yahuah’s house. 
+<sup>6&#160;</sup>Therefore you go, and read from the scroll which you have written from my mouth, Yahuah’s words, in the ears of the people in Yahuah’s house on the fast day. Also you shall read them in the ears of all Judah who come out of their cities. 
+<sup>7&#160;</sup>It may be they will present their supplication before Yahuah, and will each return from his evil way; for Yahuah has pronounced great anger and wrath against this people.” 
 </p><p>
-<sup>8&#160;</sup>Baruch the son of Neriah did according to all that Jeremiah the prophet commanded him, reading in the book Yahweh’s words in Yahweh’s house. 
-<sup>9&#160;</sup>Now in the fifth year of Jehoiakim the son of Josiah, king of Judah, in the ninth month, all the people in Jerusalem and all the people who came from the cities of Judah to Jerusalem, proclaimed a fast before Yahweh. 
-<sup>10&#160;</sup>Then Baruch read the words of Jeremiah from the book in Yahweh’s house, in the room of Gemariah the son of Shaphan the scribe, in the upper court, at the entry of the new gate of Yahweh’s house, in the ears of all the people. 
+<sup>8&#160;</sup>Baruch the son of Neriah did according to all that Jeremiah the prophet commanded him, reading in the book Yahuah’s words in Yahuah’s house. 
+<sup>9&#160;</sup>Now in the fifth year of Jehoiakim the son of Josiah, king of Judah, in the ninth month, all the people in Jerusalem and all the people who came from the cities of Judah to Jerusalem, proclaimed a fast before Yahuah. 
+<sup>10&#160;</sup>Then Baruch read the words of Jeremiah from the book in Yahuah’s house, in the room of Gemariah the son of Shaphan the scribe, in the upper court, at the entry of the new gate of Yahuah’s house, in the ears of all the people. 
 </p><p>
-<sup>11&#160;</sup>When Micaiah the son of Gemariah, the son of Shaphan, had heard out of the book all Yahweh’s words, 
+<sup>11&#160;</sup>When Micaiah the son of Gemariah, the son of Shaphan, had heard out of the book all Yahuah’s words, 
 <sup>12&#160;</sup>he went down into the king’s house, into the scribe’s room; and behold, all the princes were sitting there, Elishama the scribe, Delaiah the son of Shemaiah, Elnathan the son of Achbor, Gemariah the son of Shaphan, Zedekiah the son of Hananiah, and all the princes. 
 <sup>13&#160;</sup>Then Micaiah declared to them all the words that he had heard, when Baruch read the book in the ears of the people. 
 <sup>14&#160;</sup>Therefore all the princes sent Jehudi the son of Nethaniah, the son of Shelemiah, the son of Cushi, to Baruch, saying, “Take in your hand the scroll in which you have read in the ears of the people, and come.” 
@@ -2468,30 +2468,30 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>When Jehudi had read three or four columns, the king cut it with the penknife, and cast it into the fire that was in the brazier, until all the scroll was consumed in the fire that was in the brazier. 
 <sup>24&#160;</sup>The king and his servants who heard all these words were not afraid, and didn’t tear their garments. 
 <sup>25&#160;</sup>Moreover Elnathan and Delaiah and Gemariah had made intercession to the king that he would not burn the scroll; but he would not listen to them. 
-<sup>26&#160;</sup>The king commanded Jerahmeel the king’s son, and Seraiah the son of Azriel, and Shelemiah the son of Abdeel, to arrest Baruch the scribe and Jeremiah the prophet; but Yahweh hid them. 
+<sup>26&#160;</sup>The king commanded Jerahmeel the king’s son, and Seraiah the son of Azriel, and Shelemiah the son of Abdeel, to arrest Baruch the scribe and Jeremiah the prophet; but Yahuah hid them. 
 </p><p>
-<sup>27&#160;</sup>Then Yahweh’s word came to Jeremiah, after the king had burned the scroll, and the words which Baruch wrote at the mouth of Jeremiah, saying, 
+<sup>27&#160;</sup>Then Yahuah’s word came to Jeremiah, after the king had burned the scroll, and the words which Baruch wrote at the mouth of Jeremiah, saying, 
 <sup>28&#160;</sup>“Take again another scroll, and write in it all the former words that were in the first scroll, which Jehoiakim the king of Judah has burned. 
-<sup>29&#160;</sup>Concerning Jehoiakim king of Judah you shall say, ‘Yahweh says: “You have burned this scroll, saying, ‘Why have you written therein, saying, “The king of Babylon will certainly come and destroy this land, and will cause to cease from there man and animal”?’&#160;” 
-<sup>30&#160;</sup>Therefore Yahweh says concerning Jehoiakim king of Judah: “He will have no one to sit on David’s throne. His dead body will be cast out in the day to the heat, and in the night to the frost. 
+<sup>29&#160;</sup>Concerning Jehoiakim king of Judah you shall say, ‘Yahuah says: “You have burned this scroll, saying, ‘Why have you written therein, saying, “The king of Babylon will certainly come and destroy this land, and will cause to cease from there man and animal”?’&#160;” 
+<sup>30&#160;</sup>Therefore Yahuah says concerning Jehoiakim king of Judah: “He will have no one to sit on David’s throne. His dead body will be cast out in the day to the heat, and in the night to the frost. 
 <sup>31&#160;</sup>I will punish him, his offspring, and his servants for their iniquity. I will bring on them, on the inhabitants of Jerusalem, and on the men of Judah, all the evil that I have pronounced against them, but they didn’t listen.”&#160;’&#160;” 
 </p><p>
 <sup>32&#160;</sup>Then Jeremiah took another scroll, and gave it to Baruch the scribe, the son of Neriah, who wrote therein from the mouth of Jeremiah all the words of the book which Jehoiakim king of Judah had burned in the fire; and many similar words were added to them. 
 </p><h2 class="chapterlabel" id="37">37</h2>
 <p>
 <sup>1&#160;</sup>Zedekiah the son of Josiah reigned as king instead of Coniah the son of Jehoiakim, whom Nebuchadnezzar king of Babylon made king in the land of Judah. 
-<sup>2&#160;</sup>But neither he, nor his servants, nor the people of the land, listened to Yahweh’s words, which he spoke by the prophet Jeremiah. 
+<sup>2&#160;</sup>But neither he, nor his servants, nor the people of the land, listened to Yahuah’s words, which he spoke by the prophet Jeremiah. 
 </p><p>
-<sup>3&#160;</sup>Zedekiah the king sent Jehucal the son of Shelemiah and Zephaniah the son of Maaseiah, the priest, to the prophet Jeremiah, saying, “Pray now to Yahweh our Elohim for us.” 
+<sup>3&#160;</sup>Zedekiah the king sent Jehucal the son of Shelemiah and Zephaniah the son of Maaseiah, the priest, to the prophet Jeremiah, saying, “Pray now to Yahuah our Elohim for us.” 
 </p><p>
 <sup>4&#160;</sup>Now Jeremiah came in and went out among the people, for they had not put him into prison. 
 <sup>5&#160;</sup>Pharaoh’s army had come out of Egypt; and when the Chaldeans who were besieging Jerusalem heard news of them, they withdrew from Jerusalem. 
 </p><p>
-<sup>6&#160;</sup>Then Yahweh’s word came to the prophet Jeremiah, saying, 
-<sup>7&#160;</sup>“Yahweh, the Elohim of Israel, says, ‘You shall tell the king of Judah, who sent you to me to inquire of me: “Behold, Pharaoh’s army, which has come out to help you, will return to Egypt into their own land. 
+<sup>6&#160;</sup>Then Yahuah’s word came to the prophet Jeremiah, saying, 
+<sup>7&#160;</sup>“Yahuah, the Elohim of Israel, says, ‘You shall tell the king of Judah, who sent you to me to inquire of me: “Behold, Pharaoh’s army, which has come out to help you, will return to Egypt into their own land. 
 <sup>8&#160;</sup>The Chaldeans will come again, and fight against this city. They will take it and burn it with fire.”&#160;’ 
 </p><p>
-<sup>9&#160;</sup>“Yahweh says, ‘Don’t deceive yourselves, saying, “The Chaldeans will surely depart from us;” for they will not depart. 
+<sup>9&#160;</sup>“Yahuah says, ‘Don’t deceive yourselves, saying, “The Chaldeans will surely depart from us;” for they will not depart. 
 <sup>10&#160;</sup>For though you had struck the whole army of the Chaldeans who fight against you, and only wounded men remained among them, they would each rise up in his tent and burn this city with fire.’&#160;” 
 </p><p>
 <sup>11&#160;</sup>When the army of the Chaldeans had withdrawn from Jerusalem for fear of Pharaoh’s army, 
@@ -2503,7 +2503,7 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>The princes were angry with Jeremiah, and struck him, and put him in prison in the house of Jonathan the scribe; for they had made that the prison. 
 </p><p>
 <sup>16&#160;</sup>When Jeremiah had come into the dungeon house and into the cells, and Jeremiah had remained there many days, 
-<sup>17&#160;</sup>then Zedekiah the king sent and had him brought out. The king asked him secretly in his house, “Is there any word from Yahweh?” 
+<sup>17&#160;</sup>then Zedekiah the king sent and had him brought out. The king asked him secretly in his house, “Is there any word from Yahuah?” 
 </p><p>Jeremiah said, “There is.” He also said, “You will be delivered into the hand of the king of Babylon.” 
 </p><p>
 <sup>18&#160;</sup>Moreover Jeremiah said to King Zedekiah, “How have I sinned against you, against your servants, or against this people, that you have put me in prison? 
@@ -2514,8 +2514,8 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="38">38</h2>
 <p>
 <sup>1&#160;</sup>Shephatiah the son of Mattan, Gedaliah the son of Pashhur, Jucal the son of Shelemiah, and Pashhur the son of Malchijah heard the words that Jeremiah spoke to all the people, saying, 
-<sup>2&#160;</sup>“Yahweh says, ‘He who remains in this city will die by the sword, by the famine, and by the pestilence, but he who goes out to the Chaldeans will live. He will escape with his life and he will live.’ 
-<sup>3&#160;</sup>Yahweh says, ‘This city will surely be given into the hand of the army of the king of Babylon, and he will take it.’&#160;” 
+<sup>2&#160;</sup>“Yahuah says, ‘He who remains in this city will die by the sword, by the famine, and by the pestilence, but he who goes out to the Chaldeans will live. He will escape with his life and he will live.’ 
+<sup>3&#160;</sup>Yahuah says, ‘This city will surely be given into the hand of the army of the king of Babylon, and he will take it.’&#160;” 
 </p><p>
 <sup>4&#160;</sup>Then the princes said to the king, “Please let this man be put to death, because he weakens the hands of the men of war who remain in this city, and the hands of all the people, in speaking such words to them; for this man doesn’t seek the welfare of this people, but harm.” 
 </p><p>
@@ -2534,19 +2534,19 @@ html[dir=ltr] .q2 {
 </p><p>Jeremiah did so. 
 <sup>13&#160;</sup>So they lifted Jeremiah up with the cords, and took him up out of the dungeon; and Jeremiah remained in the court of the guard. 
 </p><p>
-<sup>14&#160;</sup>Then Zedekiah the king sent and took Jeremiah the prophet to himself into the third entry that is in Yahweh’s house. Then the king said to Jeremiah, “I will ask you something. Hide nothing from me.” 
+<sup>14&#160;</sup>Then Zedekiah the king sent and took Jeremiah the prophet to himself into the third entry that is in Yahuah’s house. Then the king said to Jeremiah, “I will ask you something. Hide nothing from me.” 
 </p><p>
 <sup>15&#160;</sup>Then Jeremiah said to Zedekiah, “If I declare it to you, will you not surely put me to death? If I give you counsel, you will not listen to me.” 
 </p><p>
-<sup>16&#160;</sup>So Zedekiah the king swore secretly to Jeremiah, saying, “As Yahweh lives, who made our souls, I will not put you to death, neither will I give you into the hand of these men who seek your life.” 
+<sup>16&#160;</sup>So Zedekiah the king swore secretly to Jeremiah, saying, “As Yahuah lives, who made our souls, I will not put you to death, neither will I give you into the hand of these men who seek your life.” 
 </p><p>
-<sup>17&#160;</sup>Then Jeremiah said to Zedekiah, “Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘If you will go out to the king of Babylon’s princes, then your soul will live, and this city will not be burned with fire. You will live, along with your house. 
+<sup>17&#160;</sup>Then Jeremiah said to Zedekiah, “Yahuah, the Elohim of Armies, the Elohim of Israel, says: ‘If you will go out to the king of Babylon’s princes, then your soul will live, and this city will not be burned with fire. You will live, along with your house. 
 <sup>18&#160;</sup>But if you will not go out to the king of Babylon’s princes, then this city will be given into the hand of the Chaldeans, and they will burn it with fire, and you won’t escape out of their hand.’&#160;” 
 </p><p>
 <sup>19&#160;</sup>Zedekiah the king said to Jeremiah, “I am afraid of the Jews who have defected to the Chaldeans, lest they deliver me into their hand, and they mock me.” 
 </p><p>
-<sup>20&#160;</sup>But Jeremiah said, “They won’t deliver you. Obey, I beg you, Yahweh’s voice, in that which I speak to you; so it will be well with you, and your soul will live. 
-<sup>21&#160;</sup>But if you refuse to go out, this is the word that Yahweh has shown me: 
+<sup>20&#160;</sup>But Jeremiah said, “They won’t deliver you. Obey, I beg you, Yahuah’s voice, in that which I speak to you; so it will be well with you, and your soul will live. 
+<sup>21&#160;</sup>But if you refuse to go out, this is the word that Yahuah has shown me: 
 <sup>22&#160;</sup>‘Behold, all the women who are left in the king of Judah’s house will be brought out to the king of Babylon’s princes, and those women will say, 
 </p><p class="q1">“Your familiar friends have turned on you, 
 </p><p class="q2">and have prevailed over you. 
@@ -2583,15 +2583,15 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>So Nebuzaradan the captain of the guard, Nebushazban, Rabsaris, and Nergal Sharezer, Rabmag, and all the chief officers of the king of Babylon 
 <sup>14&#160;</sup>sent and took Jeremiah out of the court of the guard, and committed him to Gedaliah the son of Ahikam, the son of Shaphan, that he should bring him home. So he lived among the people. 
 </p><p>
-<sup>15&#160;</sup>Now Yahweh’s word came to Jeremiah while he was shut up in the court of the guard, saying, 
-<sup>16&#160;</sup>“Go, and speak to Ebedmelech the Ethiopian, saying, ‘Yahweh of Armies, the Elohim of Israel, says: “Behold, I will bring my words on this city for evil, and not for good; and they will be accomplished before you in that day. 
-<sup>17&#160;</sup>But I will deliver you in that day,” says Yahweh; “and you will not be given into the hand of the men of whom you are afraid. 
-<sup>18&#160;</sup>For I will surely save you. You won’t fall by the sword, but you will escape with your life, because you have put your trust in me,” says Yahweh.’&#160;” 
+<sup>15&#160;</sup>Now Yahuah’s word came to Jeremiah while he was shut up in the court of the guard, saying, 
+<sup>16&#160;</sup>“Go, and speak to Ebedmelech the Ethiopian, saying, ‘Yahuah of Armies, the Elohim of Israel, says: “Behold, I will bring my words on this city for evil, and not for good; and they will be accomplished before you in that day. 
+<sup>17&#160;</sup>But I will deliver you in that day,” says Yahuah; “and you will not be given into the hand of the men of whom you are afraid. 
+<sup>18&#160;</sup>For I will surely save you. You won’t fall by the sword, but you will escape with your life, because you have put your trust in me,” says Yahuah.’&#160;” 
 </p><h2 class="chapterlabel" id="40">40</h2>
 <p>
-<sup>1&#160;</sup>The word which came to Jeremiah from Yahweh, after Nebuzaradan the captain of the guard had let him go from Ramah, when he had taken him being bound in chains among all the captives of Jerusalem and Judah who were carried away captive to Babylon. 
-<sup>2&#160;</sup>The captain of the guard took Jeremiah and said to him, “Yahweh your Elohim pronounced this evil on this place; 
-<sup>3&#160;</sup>and Yahweh has brought it, and done according as he spoke. Because you have sinned against Yahweh, and have not obeyed his voice, therefore this thing has come on you. 
+<sup>1&#160;</sup>The word which came to Jeremiah from Yahuah, after Nebuzaradan the captain of the guard had let him go from Ramah, when he had taken him being bound in chains among all the captives of Jerusalem and Judah who were carried away captive to Babylon. 
+<sup>2&#160;</sup>The captain of the guard took Jeremiah and said to him, “Yahuah your Elohim pronounced this evil on this place; 
+<sup>3&#160;</sup>and Yahuah has brought it, and done according as he spoke. Because you have sinned against Yahuah, and have not obeyed his voice, therefore this thing has come on you. 
 <sup>4&#160;</sup>Now, behold, I release you today from the chains which are on your hand. If it seems good to you to come with me into Babylon, come, and I will take care of you; but if it seems bad to you to come with me into Babylon, don’t. Behold, all the land is before you. Where it seems good and right to you to go, go there.” 
 <sup>5&#160;</sup>Now while he had not yet gone back, “Go back then,” he said, “to Gedaliah the son of Ahikam, the son of Shaphan, whom the king of Babylon has made governor over the cities of Judah, and dwell with him among the people; or go wherever it seems right to you to go.” 
 </p><p>So the captain of the guard gave him food and a present, and let him go. 
@@ -2619,7 +2619,7 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>Ishmael also killed all the Jews who were with Gedaliah at Mizpah, and the Chaldean men of war who were found there. 
 </p><p>
 <sup>4&#160;</sup>The second day after he had killed Gedaliah, and no man knew it, 
-<sup>5&#160;</sup>men came from Shechem, from Shiloh, and from Samaria, even eighty men, having their beards shaved and their clothes torn, and having cut themselves, with meal offerings and frankincense in their hand, to bring them to Yahweh’s house. 
+<sup>5&#160;</sup>men came from Shechem, from Shiloh, and from Samaria, even eighty men, having their beards shaved and their clothes torn, and having cut themselves, with meal offerings and frankincense in their hand, to bring them to Yahuah’s house. 
 <sup>6&#160;</sup>Ishmael the son of Nethaniah went out from Mizpah to meet them, weeping all along as he went, and as he met them, he said to them, “Come to Gedaliah the son of Ahikam.” 
 <sup>7&#160;</sup>It was so, when they came into the middle of the city, that Ishmael the son of Nethaniah killed them, and cast them into the middle of the pit, he, and the men who were with him. 
 <sup>8&#160;</sup>But ten men were found among those who said to Ishmael, “Don’t kill us; for we have stores hidden in the field, of wheat, and of barley, and of oil, and of honey.” 
@@ -2640,100 +2640,100 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="42">42</h2>
 <p>
 <sup>1&#160;</sup>Then all the captains of the forces, and Johanan the son of Kareah, and Jezaniah the son of Hoshaiah, and all the people from the least even to the greatest, came near, 
-<sup>2&#160;</sup>and said to Jeremiah the prophet, “Please let our supplication be presented before you, and pray for us to Yahweh your Elohim, even for all this remnant, for we are left but a few of many, as your eyes see us, 
-<sup>3&#160;</sup>that Yahweh your Elohim may show us the way in which we should walk, and the things that we should do.” 
+<sup>2&#160;</sup>and said to Jeremiah the prophet, “Please let our supplication be presented before you, and pray for us to Yahuah your Elohim, even for all this remnant, for we are left but a few of many, as your eyes see us, 
+<sup>3&#160;</sup>that Yahuah your Elohim may show us the way in which we should walk, and the things that we should do.” 
 </p><p>
-<sup>4&#160;</sup>Then Jeremiah the prophet said to them, “I have heard you. Behold, I will pray to Yahweh your Elohim according to your words; and it will happen that whatever thing Yahweh answers you, I will declare it to you. I will keep nothing back from you.” 
+<sup>4&#160;</sup>Then Jeremiah the prophet said to them, “I have heard you. Behold, I will pray to Yahuah your Elohim according to your words; and it will happen that whatever thing Yahuah answers you, I will declare it to you. I will keep nothing back from you.” 
 </p><p>
-<sup>5&#160;</sup>Then they said to Jeremiah, “May Yahweh be a true and faithful witness among us, if we don’t do according to all the word with which Yahweh your Elohim sends you to tell us. 
-<sup>6&#160;</sup>Whether it is good, or whether it is bad, we will obey the voice of Yahweh our Elohim, to whom we send you; that it may be well with us, when we obey the voice of Yahweh our Elohim.” 
+<sup>5&#160;</sup>Then they said to Jeremiah, “May Yahuah be a true and faithful witness among us, if we don’t do according to all the word with which Yahuah your Elohim sends you to tell us. 
+<sup>6&#160;</sup>Whether it is good, or whether it is bad, we will obey the voice of Yahuah our Elohim, to whom we send you; that it may be well with us, when we obey the voice of Yahuah our Elohim.” 
 </p><p>
-<sup>7&#160;</sup>After ten days, Yahweh’s word came to Jeremiah. 
+<sup>7&#160;</sup>After ten days, Yahuah’s word came to Jeremiah. 
 <sup>8&#160;</sup>Then he called Johanan the son of Kareah, and all the captains of the forces who were with him, and all the people from the least even to the greatest, 
-<sup>9&#160;</sup>and said to them, “Yahweh, the Elohim of Israel, to whom you sent me to present your supplication before him, says: 
+<sup>9&#160;</sup>and said to them, “Yahuah, the Elohim of Israel, to whom you sent me to present your supplication before him, says: 
 <sup>10&#160;</sup>‘If you will still live in this land, then I will build you, and not pull you down, and I will plant you, and not pluck you up; for I grieve over the distress that I have brought on you. 
-<sup>11&#160;</sup>Don’t be afraid of the king of Babylon, of whom you are afraid. Don’t be afraid of him,’ says Yahweh, ‘for I am with you to save you, and to deliver you from his hand. 
+<sup>11&#160;</sup>Don’t be afraid of the king of Babylon, of whom you are afraid. Don’t be afraid of him,’ says Yahuah, ‘for I am with you to save you, and to deliver you from his hand. 
 <sup>12&#160;</sup>I will grant you mercy, that he may have mercy on you, and cause you to return to your own land. 
 </p><p>
-<sup>13&#160;</sup>“&#160;‘But if you say, “We will not dwell in this land,” so that you don’t obey Yahweh your Elohim’s voice, 
+<sup>13&#160;</sup>“&#160;‘But if you say, “We will not dwell in this land,” so that you don’t obey Yahuah your Elohim’s voice, 
 <sup>14&#160;</sup>saying, “No, but we will go into the land of Egypt, where we will see no war, nor hear the sound of the trumpet, nor have hunger of bread; and there we will dwell;”&#160;’ 
-<sup>15&#160;</sup>now therefore hear Yahweh’s word, O remnant of Judah! Yahweh of Armies, the Elohim of Israel, says, ‘If you indeed set your faces to enter into Egypt, and go to live there, 
+<sup>15&#160;</sup>now therefore hear Yahuah’s word, O remnant of Judah! Yahuah of Armies, the Elohim of Israel, says, ‘If you indeed set your faces to enter into Egypt, and go to live there, 
 <sup>16&#160;</sup>then it will happen that the sword, which you fear, will overtake you there in the land of Egypt; and the famine, about which you are afraid, will follow close behind you there in Egypt; and you will die there. 
 <sup>17&#160;</sup>So will it be with all the men who set their faces to go into Egypt to live there. They will die by the sword, by the famine, and by the pestilence. None of them will remain or escape from the evil that I will bring on them.’ 
-<sup>18&#160;</sup>For Yahweh of Armies, the Elohim of Israel, says: ‘As my anger and my wrath has been poured out on the inhabitants of Jerusalem, so my wrath will be poured out on you, when you enter into Egypt; and you will be an object of horror, an astonishment, a curse, and a reproach; and you will see this place no more.’ 
+<sup>18&#160;</sup>For Yahuah of Armies, the Elohim of Israel, says: ‘As my anger and my wrath has been poured out on the inhabitants of Jerusalem, so my wrath will be poured out on you, when you enter into Egypt; and you will be an object of horror, an astonishment, a curse, and a reproach; and you will see this place no more.’ 
 </p><p>
-<sup>19&#160;</sup>“Yahweh has spoken concerning you, remnant of Judah, ‘Don’t go into Egypt!’ Know certainly that I have testified to you today. 
-<sup>20&#160;</sup>For you have dealt deceitfully against your own souls; for you sent me to Yahweh your Elohim, saying, ‘Pray for us to Yahweh our Elohim; and according to all that Yahweh our Elohim says, so declare to us, and we will do it.’ 
-<sup>21&#160;</sup>I have declared it to you today; but you have not obeyed Yahweh your Elohim’s voice in anything for which he has sent me to you. 
+<sup>19&#160;</sup>“Yahuah has spoken concerning you, remnant of Judah, ‘Don’t go into Egypt!’ Know certainly that I have testified to you today. 
+<sup>20&#160;</sup>For you have dealt deceitfully against your own souls; for you sent me to Yahuah your Elohim, saying, ‘Pray for us to Yahuah our Elohim; and according to all that Yahuah our Elohim says, so declare to us, and we will do it.’ 
+<sup>21&#160;</sup>I have declared it to you today; but you have not obeyed Yahuah your Elohim’s voice in anything for which he has sent me to you. 
 <sup>22&#160;</sup>Now therefore know certainly that you will die by the sword, by the famine, and by the pestilence in the place where you desire to go to live.” 
 </p><h2 class="chapterlabel" id="43">43</h2>
 <p>
-<sup>1&#160;</sup>When Jeremiah had finished speaking to all the people all the words of Yahweh their Elohim, with which Yahweh their Elohim had sent him to them, even all these words, 
-<sup>2&#160;</sup>then Azariah the son of Hoshaiah, Johanan the son of Kareah, and all the proud men spoke, saying to Jeremiah, “You speak falsely. Yahweh our Elohim has not sent you to say, ‘You shall not go into Egypt to live there;’ 
+<sup>1&#160;</sup>When Jeremiah had finished speaking to all the people all the words of Yahuah their Elohim, with which Yahuah their Elohim had sent him to them, even all these words, 
+<sup>2&#160;</sup>then Azariah the son of Hoshaiah, Johanan the son of Kareah, and all the proud men spoke, saying to Jeremiah, “You speak falsely. Yahuah our Elohim has not sent you to say, ‘You shall not go into Egypt to live there;’ 
 <sup>3&#160;</sup>but Baruch the son of Neriah has turned you against us, to deliver us into the hand of the Chaldeans, that they may put us to death or carry us away captive to Babylon.” 
 </p><p>
-<sup>4&#160;</sup>So Johanan the son of Kareah, and all the captains of the forces, and all the people, didn’t obey Yahweh’s voice, to dwell in the land of Judah. 
+<sup>4&#160;</sup>So Johanan the son of Kareah, and all the captains of the forces, and all the people, didn’t obey Yahuah’s voice, to dwell in the land of Judah. 
 <sup>5&#160;</sup>But Johanan the son of Kareah and all the captains of the forces took all the remnant of Judah, who had returned from all the nations where they had been driven, to live in the land of Judah—<sup>6&#160;</sup>the men, the women, the children, the king’s daughters, and every person who Nebuzaradan the captain of the guard had left with Gedaliah the son of Ahikam, the son of Shaphan; and Jeremiah the prophet, and Baruch the son of Neriah. 
-<sup>7&#160;</sup>They came into the land of Egypt, for they didn’t obey Yahweh’s voice; and they came to Tahpanhes. 
+<sup>7&#160;</sup>They came into the land of Egypt, for they didn’t obey Yahuah’s voice; and they came to Tahpanhes. 
 </p><p>
-<sup>8&#160;</sup>Then Yahweh’s word came to Jeremiah in Tahpanhes, saying, 
+<sup>8&#160;</sup>Then Yahuah’s word came to Jeremiah in Tahpanhes, saying, 
 <sup>9&#160;</sup>“Take great stones in your hand and hide them in mortar in the brick work which is at the entry of Pharaoh’s house in Tahpanhes, in the sight of the men of Judah. 
-<sup>10&#160;</sup>Tell them, Yahweh of Armies, the Elohim of Israel, says: ‘Behold, I will send and take Nebuchadnezzar the king of Babylon, my servant, and will set his throne on these stones that I have hidden; and he will spread his royal pavilion over them. 
+<sup>10&#160;</sup>Tell them, Yahuah of Armies, the Elohim of Israel, says: ‘Behold, I will send and take Nebuchadnezzar the king of Babylon, my servant, and will set his throne on these stones that I have hidden; and he will spread his royal pavilion over them. 
 <sup>11&#160;</sup>He will come, and will strike the land of Egypt; such as are for death will be put to death, and such as are for captivity to captivity, and such as are for the sword to the sword. 
 <sup>12&#160;</sup>I will kindle a fire in the houses of the elohims of Egypt. He will burn them, and carry them away captive. He will array himself with the land of Egypt, as a shepherd puts on his garment; and he will go out from there in peace. 
 <sup>13&#160;</sup>He will also break the pillars of Beth Shemesh that is in the land of Egypt; and he will burn the houses of the elohims of Egypt with fire.’&#160;” 
 </p><h2 class="chapterlabel" id="44">44</h2>
 <p>
 <sup>1&#160;</sup>The word that came to Jeremiah concerning all the Jews who lived in the land of Egypt, who lived at Migdol, and at Tahpanhes, and at Memphis, and in the country of Pathros, saying, 
-<sup>2&#160;</sup>“Yahweh of Armies, the Elohim of Israel, says: ‘You have seen all the evil that I have brought on Jerusalem, and on all the cities of Judah. Behold, today they are a desolation, and no man dwells in them, 
+<sup>2&#160;</sup>“Yahuah of Armies, the Elohim of Israel, says: ‘You have seen all the evil that I have brought on Jerusalem, and on all the cities of Judah. Behold, today they are a desolation, and no man dwells in them, 
 <sup>3&#160;</sup>because of their wickedness which they have committed to provoke me to anger, in that they went to burn incense, to serve other elohims that they didn’t know, neither they, nor you, nor your fathers. 
 <sup>4&#160;</sup>However I sent to you all my servants the prophets, rising up early and sending them, saying, “Oh, don’t do this abominable thing that I hate.” 
 <sup>5&#160;</sup>But they didn’t listen and didn’t incline their ear. They didn’t turn from their wickedness, to stop burning incense to other elohims. 
 <sup>6&#160;</sup>Therefore my wrath and my anger was poured out, and was kindled in the cities of Judah and in the streets of Jerusalem; and they are wasted and desolate, as it is today.’ 
 </p><p>
-<sup>7&#160;</sup>“Therefore now Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘Why do you commit great evil against your own souls, to cut off from yourselves man and woman, infant and nursing child out of the middle of Judah, to leave yourselves no one remaining, 
+<sup>7&#160;</sup>“Therefore now Yahuah, the Elohim of Armies, the Elohim of Israel, says: ‘Why do you commit great evil against your own souls, to cut off from yourselves man and woman, infant and nursing child out of the middle of Judah, to leave yourselves no one remaining, 
 <sup>8&#160;</sup>in that you provoke me to anger with the works of your hands, burning incense to other elohims in the land of Egypt where you have gone to live, that you may be cut off, and that you may be a curse and a reproach among all the nations of the earth? 
 <sup>9&#160;</sup>Have you forgotten the wickedness of your fathers, the wickedness of the kings of Judah, the wickedness of their women, your own wickedness, and the wickedness of your women which they committed in the land of Judah and in the streets of Jerusalem? 
 <sup>10&#160;</sup>They are not humbled even to this day, neither have they feared, nor walked in my law, nor in my statutes, that I set before you and before your fathers.’ 
 </p><p>
-<sup>11&#160;</sup>“Therefore Yahweh of Armies, the Elohim of Israel, says: ‘Behold, I will set my face against you for evil, even to cut off all Judah. 
+<sup>11&#160;</sup>“Therefore Yahuah of Armies, the Elohim of Israel, says: ‘Behold, I will set my face against you for evil, even to cut off all Judah. 
 <sup>12&#160;</sup>I will take the remnant of Judah that have set their faces to go into the land of Egypt to live there, and they will all be consumed. They will fall in the land of Egypt. They will be consumed by the sword and by the famine. They will die, from the least even to the greatest, by the sword and by the famine. They will be an object of horror, an astonishment, a curse, and a reproach. 
 <sup>13&#160;</sup>For I will punish those who dwell in the land of Egypt, as I have punished Jerusalem, by the sword, by the famine, and by the pestilence; 
 <sup>14&#160;</sup>so that none of the remnant of Judah, who have gone into the land of Egypt to live there, will escape or be left to return into the land of Judah, to which they have a desire to return to dwell there; for no one will return except those who will escape.’&#160;” 
 </p><p>
 <sup>15&#160;</sup>Then all the men who knew that their women burned incense to other elohims, and all the women who stood by, a great assembly, even all the people who lived in the land of Egypt, in Pathros, answered Jeremiah, saying, 
-<sup>16&#160;</sup>“As for the word that you have spoken to us in Yahweh’s name, we will not listen to you. 
+<sup>16&#160;</sup>“As for the word that you have spoken to us in Yahuah’s name, we will not listen to you. 
 <sup>17&#160;</sup>But we will certainly perform every word that has gone out of our mouth, to burn incense to the queen of the sky and to pour out drink offerings to her, as we have done, we and our fathers, our kings and our princes, in the cities of Judah and in the streets of Jerusalem; for then we had plenty of food, and were well, and saw no evil. 
 <sup>18&#160;</sup>But since we stopped burning incense to the queen of the sky, and pouring out drink offerings to her, we have lacked all things, and have been consumed by the sword and by the famine.” 
 </p><p>
 <sup>19&#160;</sup>The women said, “When we burned incense to the queen of the sky and poured out drink offerings to her, did we make her cakes to worship her, and pour out drink offerings to her, without our men?” 
 </p><p>
 <sup>20&#160;</sup>Then Jeremiah said to all the people—to the men and to the women, even to all the people who had given him an answer, saying, 
-<sup>21&#160;</sup>“The incense that you burned in the cities of Judah, and in the streets of Jerusalem, you and your fathers, your kings and your princes, and the people of the land, didn’t Yahweh remember them, and didn’t it come into his mind? 
-<sup>22&#160;</sup>Thus Yahweh could no longer bear it, because of the evil of your doings and because of the abominations which you have committed. Therefore your land has become a desolation, an astonishment, and a curse, without inhabitant, as it is today. 
-<sup>23&#160;</sup>Because you have burned incense and because you have sinned against Yahweh, and have not obeyed Yahweh’s voice, nor walked in his law, nor in his statutes, nor in his testimonies; therefore this evil has happened to you, as it is today.” 
+<sup>21&#160;</sup>“The incense that you burned in the cities of Judah, and in the streets of Jerusalem, you and your fathers, your kings and your princes, and the people of the land, didn’t Yahuah remember them, and didn’t it come into his mind? 
+<sup>22&#160;</sup>Thus Yahuah could no longer bear it, because of the evil of your doings and because of the abominations which you have committed. Therefore your land has become a desolation, an astonishment, and a curse, without inhabitant, as it is today. 
+<sup>23&#160;</sup>Because you have burned incense and because you have sinned against Yahuah, and have not obeyed Yahuah’s voice, nor walked in his law, nor in his statutes, nor in his testimonies; therefore this evil has happened to you, as it is today.” 
 </p><p>
-<sup>24&#160;</sup>Moreover Jeremiah said to all the people, including all the women, “Hear Yahweh’s word, all Judah who are in the land of Egypt! 
-<sup>25&#160;</sup>Yahweh of Armies, the Elohim of Israel, says, ‘You and your women have both spoken with your mouths, and with your hands have fulfilled it, saying, “We will surely perform our vows that we have vowed, to burn incense to the queen of the sky, and to pour out drink offerings to her.” 
+<sup>24&#160;</sup>Moreover Jeremiah said to all the people, including all the women, “Hear Yahuah’s word, all Judah who are in the land of Egypt! 
+<sup>25&#160;</sup>Yahuah of Armies, the Elohim of Israel, says, ‘You and your women have both spoken with your mouths, and with your hands have fulfilled it, saying, “We will surely perform our vows that we have vowed, to burn incense to the queen of the sky, and to pour out drink offerings to her.” 
 </p><p>“&#160;‘Establish then your vows, and perform your vows.’ 
 </p><p>
-<sup>26&#160;</sup>“Therefore hear Yahweh’s word, all Judah who dwell in the land of Egypt: ‘Behold, I have sworn by my great name,’ says Yahweh, ‘that my name will no more be named in the mouth of any man of Judah in all the land of Egypt, saying, “As the Lord Yahweh lives.” 
+<sup>26&#160;</sup>“Therefore hear Yahuah’s word, all Judah who dwell in the land of Egypt: ‘Behold, I have sworn by my great name,’ says Yahuah, ‘that my name will no more be named in the mouth of any man of Judah in all the land of Egypt, saying, “As the Lord Yahuah lives.” 
 <sup>27&#160;</sup>Behold, I watch over them for evil, and not for good; and all the men of Judah who are in the land of Egypt will be consumed by the sword and by the famine, until they are all gone. 
 <sup>28&#160;</sup>Those who escape the sword will return out of the land of Egypt into the land of Judah few in number. All the remnant of Judah, who have gone into the land of Egypt to live there, will know whose word will stand, mine or theirs. 
 </p><p>
-<sup>29&#160;</sup>“&#160;‘This will be the sign to you,’ says Yahweh, ‘that I will punish you in this place, that you may know that my words will surely stand against you for evil.’ 
-<sup>30&#160;</sup>Yahweh says, ‘Behold, I will give Pharaoh Hophra king of Egypt into the hand of his enemies and into the hand of those who seek his life, just as I gave Zedekiah king of Judah into the hand of Nebuchadnezzar king of Babylon, who was his enemy and sought his life.’&#160;” 
+<sup>29&#160;</sup>“&#160;‘This will be the sign to you,’ says Yahuah, ‘that I will punish you in this place, that you may know that my words will surely stand against you for evil.’ 
+<sup>30&#160;</sup>Yahuah says, ‘Behold, I will give Pharaoh Hophra king of Egypt into the hand of his enemies and into the hand of those who seek his life, just as I gave Zedekiah king of Judah into the hand of Nebuchadnezzar king of Babylon, who was his enemy and sought his life.’&#160;” 
 </p><h2 class="chapterlabel" id="45">45</h2>
 <p>
 <sup>1&#160;</sup>The message that Jeremiah the prophet spoke to Baruch the son of Neriah, when he wrote these words in a book at the mouth of Jeremiah, in the fourth year of Jehoiakim the son of Josiah, king of Judah, saying, 
-<sup>2&#160;</sup>“Yahweh, the Elohim of Israel, says to you, Baruch: 
-<sup>3&#160;</sup>‘You said, “Woe is me now! For Yahweh has added sorrow to my pain! I am weary with my groaning, and I find no rest.”&#160;’ 
+<sup>2&#160;</sup>“Yahuah, the Elohim of Israel, says to you, Baruch: 
+<sup>3&#160;</sup>‘You said, “Woe is me now! For Yahuah has added sorrow to my pain! I am weary with my groaning, and I find no rest.”&#160;’ 
 </p><p>
-<sup>4&#160;</sup>“You shall tell him, Yahweh says: ‘Behold, that which I have built, I will break down, and that which I have planted I will pluck up; and this in the whole land. 
-<sup>5&#160;</sup>Do you seek great things for yourself? Don’t seek them; for, behold, I will bring evil on all flesh,’ says Yahweh, ‘but I will let you escape with your life wherever you go.’&#160;” 
+<sup>4&#160;</sup>“You shall tell him, Yahuah says: ‘Behold, that which I have built, I will break down, and that which I have planted I will pluck up; and this in the whole land. 
+<sup>5&#160;</sup>Do you seek great things for yourself? Don’t seek them; for, behold, I will bring evil on all flesh,’ says Yahuah, ‘but I will let you escape with your life wherever you go.’&#160;” 
 </p><h2 class="chapterlabel" id="46">46</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word which came to Jeremiah the prophet concerning the nations. 
+<sup>1&#160;</sup>Yahuah’s word which came to Jeremiah the prophet concerning the nations. 
 </p><p>
 <sup>2&#160;</sup>Of Egypt: concerning the army of Pharaoh Necoh king of Egypt, which was by the river Euphrates in Carchemish, which Nebuchadnezzar king of Babylon struck in the fourth year of Jehoiakim the son of Josiah, king of Judah. 
 </p><p class="q1">
@@ -2751,7 +2751,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">have fled in haste, 
 </p><p class="q2">and don’t look back. 
 </p><p class="q1">Terror is on every side,” 
-</p><p class="q2">says Yahweh. 
+</p><p class="q2">says Yahuah. 
 </p><p class="q1">
 <sup>6&#160;</sup>“Don’t let the swift flee away, 
 </p><p class="q2">nor the mighty man escape. 
@@ -2773,12 +2773,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Cush and Put, who handle the shield; 
 </p><p class="q2">and the Ludim, who handle and bend the bow. 
 </p><p class="q1">
-<sup>10&#160;</sup>For that day is of the Lord, Yahweh of Armies, 
+<sup>10&#160;</sup>For that day is of the Lord, Yahuah of Armies, 
 </p><p class="q2">a day of vengeance, 
 </p><p class="q2">that he may avenge himself of his adversaries. 
 </p><p class="q1">The sword will devour and be satiated, 
 </p><p class="q2">and will drink its fill of their blood; 
-</p><p class="q2">for the Lord, Yahweh of Armies, has a sacrifice in the north country by the river Euphrates. 
+</p><p class="q2">for the Lord, Yahuah of Armies, has a sacrifice in the north country by the river Euphrates. 
 </p><p class="q1">
 <sup>11&#160;</sup>Go up into Gilead, and take balm, virgin daughter of Egypt. 
 </p><p class="q2">You use many medicines in vain. 
@@ -2790,7 +2790,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">they both fall together.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>13&#160;</sup>The word that Yahweh spoke to Jeremiah the prophet, how that Nebuchadnezzar king of Babylon should come and strike the land of Egypt: 
+<sup>13&#160;</sup>The word that Yahuah spoke to Jeremiah the prophet, how that Nebuchadnezzar king of Babylon should come and strike the land of Egypt: 
 </p><p class="q1">
 <sup>14&#160;</sup>“Declare in Egypt, 
 </p><p class="q2">publish in Migdol, 
@@ -2799,7 +2799,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for the sword has devoured around you.’ 
 </p><p class="q1">
 <sup>15&#160;</sup>Why are your strong ones swept away? 
-</p><p class="q2">They didn’t stand, because Yahweh pushed them. 
+</p><p class="q2">They didn’t stand, because Yahuah pushed them. 
 </p><p class="q1">
 <sup>16&#160;</sup>He made many to stumble. 
 </p><p class="q2">Yes, they fell on one another. 
@@ -2812,7 +2812,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>18&#160;</sup>“As I live,” says the King, 
-</p><p class="q2">whose name is Yahweh of Armies, 
+</p><p class="q2">whose name is Yahuah of Armies, 
 </p><p class="q1">“surely like Tabor among the mountains, 
 </p><p class="q2">and like Carmel by the sea, 
 </p><p class="q2">so he will come. 
@@ -2839,7 +2839,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for they will march with an army, 
 </p><p class="q2">and come against her with axes, as wood cutters. 
 </p><p class="q1">
-<sup>23&#160;</sup>They will cut down her forest,” says Yahweh, 
+<sup>23&#160;</sup>They will cut down her forest,” says Yahuah, 
 </p><p class="q2">“though it can’t be searched; 
 </p><p class="q1">because they are more than the locusts, 
 </p><p class="q2">and are innumerable. 
@@ -2847,8 +2847,8 @@ html[dir=ltr] .q2 {
 <sup>24&#160;</sup>The daughter of Egypt will be disappointed; 
 </p><p class="q2">she will be delivered into the hand of the people of the north.” 
 </p><p>
-<sup>25&#160;</sup>Yahweh of Armies, the Elohim of Israel, says: “Behold, I will punish Amon of No, and Pharaoh, and Egypt, with her elohims and her kings, even Pharaoh, and those who trust in him. 
-<sup>26&#160;</sup>I will deliver them into the hand of those who seek their lives, and into the hand of Nebuchadnezzar king of Babylon, and into the hand of his servants. Afterwards it will be inhabited, as in the days of old,” says Yahweh. 
+<sup>25&#160;</sup>Yahuah of Armies, the Elohim of Israel, says: “Behold, I will punish Amon of No, and Pharaoh, and Egypt, with her elohims and her kings, even Pharaoh, and those who trust in him. 
+<sup>26&#160;</sup>I will deliver them into the hand of those who seek their lives, and into the hand of Nebuchadnezzar king of Babylon, and into the hand of his servants. Afterwards it will be inhabited, as in the days of old,” says Yahuah. 
 </p><p class="q1">
 <sup>27&#160;</sup>“But don’t you be afraid, Jacob my servant. 
 </p><p class="q2">Don’t be dismayed, Israel; 
@@ -2858,7 +2858,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will be quiet and at ease. 
 </p><p class="q2">No one will make him afraid. 
 </p><p class="q1">
-<sup>28&#160;</sup>Don’t be afraid, O Jacob my servant,” says Yahweh, 
+<sup>28&#160;</sup>Don’t be afraid, O Jacob my servant,” says Yahuah, 
 </p><p class="q2">“for I am with you; 
 </p><p class="q2">for I will make a full end of all the nations where I have driven you, 
 </p><p class="q1">but I will not make a full end of you, 
@@ -2866,9 +2866,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will in no way leave you unpunished.” 
 </p><h2 class="chapterlabel" id="47">47</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word that came to Jeremiah the prophet concerning the Philistines, before Pharaoh struck Gaza. 
+<sup>1&#160;</sup>Yahuah’s word that came to Jeremiah the prophet concerning the Philistines, before Pharaoh struck Gaza. 
 </p><p>
-<sup>2&#160;</sup>Yahweh says: 
+<sup>2&#160;</sup>Yahuah says: 
 </p><p class="q1">“Behold, waters rise up out of the north, 
 </p><p class="q2">and will become an overflowing stream, 
 </p><p class="q1">and will overflow the land and all that is therein, 
@@ -2884,7 +2884,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>4&#160;</sup>because of the day that comes to destroy all the Philistines, 
 </p><p class="q2">to cut off from Tyre and Sidon every helper who remains; 
-</p><p class="q1">for Yahweh will destroy the Philistines, 
+</p><p class="q1">for Yahuah will destroy the Philistines, 
 </p><p class="q2">the remnant of the isle of Caphtor. 
 </p><p class="q1">
 <sup>5&#160;</sup>Baldness has come on Gaza; 
@@ -2893,18 +2893,18 @@ html[dir=ltr] .q2 {
 </p><p class="q2">how long will you cut yourself? 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>6&#160;</sup>“&#160;‘You sword of Yahweh, how long will it be before you are quiet? 
+<sup>6&#160;</sup>“&#160;‘You sword of Yahuah, how long will it be before you are quiet? 
 </p><p class="q2">Put yourself back into your scabbard; 
 </p><p class="q2">rest, and be still.’ 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>7&#160;</sup>“How can you be quiet, 
-</p><p class="q2">since Yahweh has given you a command? 
+</p><p class="q2">since Yahuah has given you a command? 
 </p><p class="q1">Against Ashkelon, and against the seashore, 
 </p><p class="q2">there he has appointed it.” 
 </p><h2 class="chapterlabel" id="48">48</h2>
 <p>
-<sup>1&#160;</sup>Of Moab. Yahweh of Armies, the Elohim of Israel, says: 
+<sup>1&#160;</sup>Of Moab. Yahuah of Armies, the Elohim of Israel, says: 
 </p><p class="q1">“Woe to Nebo! 
 </p><p class="q2">For it is laid waste. 
 </p><p class="q1">Kiriathaim is disappointed. 
@@ -2938,7 +2938,7 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>The destroyer will come on every city, 
 </p><p class="q2">and no city will escape; 
 </p><p class="q1">the valley also will perish, 
-</p><p class="q2">and the plain will be destroyed, as Yahweh has spoken. 
+</p><p class="q2">and the plain will be destroyed, as Yahuah has spoken. 
 </p><p class="q1">
 <sup>9&#160;</sup>Give wings to Moab, 
 </p><p class="q2">that she may fly and get herself away: 
@@ -2946,7 +2946,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">without anyone to dwell in them. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>“Cursed is he who does the work of Yahweh negligently; 
+<sup>10&#160;</sup>“Cursed is he who does the work of Yahuah negligently; 
 </p><p class="q2">and cursed is he who keeps back his sword from blood. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -2957,7 +2957,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">therefore his taste remains in him, 
 </p><p class="q2">and his scent is not changed. 
 </p><p class="q1">
-<sup>12&#160;</sup>Therefore behold, the days come,” says Yahweh, 
+<sup>12&#160;</sup>Therefore behold, the days come,” says Yahuah, 
 </p><p class="q2">“that I will send to him those who pour off, 
 </p><p class="q1">and they will pour him off; 
 </p><p class="q2">and they will empty his vessels, 
@@ -2973,7 +2973,7 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Moab is laid waste, 
 </p><p class="q2">and they have gone up into his cities, 
 </p><p class="q2">and his chosen young men have gone down to the slaughter,” 
-</p><p class="q2">says the King, whose name is Yahweh of Armies. 
+</p><p class="q2">says the King, whose name is Yahuah of Armies. 
 </p><p class="q1">
 <sup>16&#160;</sup>“The calamity of Moab is near to come, 
 </p><p class="q2">and his affliction hurries fast. 
@@ -3009,11 +3009,11 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and on all the cities of the land of Moab, far or near. 
 </p><p class="q1">
 <sup>25&#160;</sup>The horn of Moab is cut off, 
-</p><p class="q2">and his arm is broken,” says Yahweh. 
+</p><p class="q2">and his arm is broken,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>26&#160;</sup>“Make him drunk, 
-</p><p class="q2">for he magnified himself against Yahweh. 
+</p><p class="q2">for he magnified himself against Yahuah. 
 </p><p class="q1">Moab will wallow in his vomit, 
 </p><p class="q2">and he also will be in derision. 
 </p><p class="q1">
@@ -3030,7 +3030,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He is very proud in his loftiness, his pride, 
 </p><p class="q2">his arrogance, and the arrogance of his heart. 
 </p><p class="q1">
-<sup>30&#160;</sup>I know his wrath,” says Yahweh, “that it is nothing; 
+<sup>30&#160;</sup>I know his wrath,” says Yahuah, “that it is nothing; 
 </p><p class="q2">his boastings have done nothing. 
 </p><p class="q1">
 <sup>31&#160;</sup>Therefore I will wail for Moab. 
@@ -3055,7 +3055,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">from Zoar even to Horonaim, to Eglath Shelishiyah; 
 </p><p class="q2">for the waters of Nimrim will also become desolate. 
 </p><p class="q1">
-<sup>35&#160;</sup>Moreover I will cause to cease in Moab,” says Yahweh, 
+<sup>35&#160;</sup>Moreover I will cause to cease in Moab,” says Yahuah, 
 </p><p class="q2">“him who offers in the high place, 
 </p><p class="q2">and him who burns incense to his elohims. 
 </p><p class="q1">
@@ -3070,7 +3070,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>38&#160;</sup>On all the housetops of Moab, 
 </p><p class="q2">and in its streets, there is lamentation everywhere; 
-</p><p class="q2">for I have broken Moab like a vessel in which no one delights,” says Yahweh. 
+</p><p class="q2">for I have broken Moab like a vessel in which no one delights,” says Yahuah. 
 </p><p class="q1">
 <sup>39&#160;</sup>“How it is broken down! 
 </p><p class="q2">How they wail! 
@@ -3078,7 +3078,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">So will Moab become a derision 
 </p><p class="q2">and a terror to all who are around him.” 
 </p><p class="q1">
-<sup>40&#160;</sup>For Yahweh says: “Behold, he will fly as an eagle, 
+<sup>40&#160;</sup>For Yahuah says: “Behold, he will fly as an eagle, 
 </p><p class="q2">and will spread out his wings against Moab. 
 </p><p class="q1">
 <sup>41&#160;</sup>Kerioth is taken, 
@@ -3087,15 +3087,15 @@ html[dir=ltr] .q2 {
 </p><p class="q2">will be as the heart of a woman in her pangs. 
 </p><p class="q1">
 <sup>42&#160;</sup>Moab will be destroyed from being a people, 
-</p><p class="q2">because he has magnified himself against Yahweh. 
+</p><p class="q2">because he has magnified himself against Yahuah. 
 </p><p class="q1">
 <sup>43&#160;</sup>Terror, the pit, and the snare are on you, 
-</p><p class="q2">inhabitant of Moab,” says Yahweh. 
+</p><p class="q2">inhabitant of Moab,” says Yahuah. 
 </p><p class="q1">
 <sup>44&#160;</sup>“He who flees from the terror will fall into the pit; 
 </p><p class="q2">and he who gets up out of the pit will be taken in the snare, 
 </p><p class="q1">for I will bring on him, even on Moab, 
-</p><p class="q2">the year of their visitation,” says Yahweh. 
+</p><p class="q2">the year of their visitation,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>45&#160;</sup>“Those who fled stand without strength under the shadow of Heshbon; 
@@ -3111,23 +3111,23 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>47&#160;</sup>“Yet I will reverse the captivity of Moab in the latter days,” 
-</p><p class="q2">says Yahweh. 
+</p><p class="q2">says Yahuah. 
 </p><p>Thus far is the judgment of Moab. 
 </p><h2 class="chapterlabel" id="49">49</h2>
 <p>
-<sup>1&#160;</sup>Of the children of Ammon. Yahweh says: 
+<sup>1&#160;</sup>Of the children of Ammon. Yahuah says: 
 </p><p class="q1">“Has Israel no sons? 
 </p><p class="q2">Has he no heir? 
 </p><p class="q1">Why then does Malcam possess Gad, 
 </p><p class="q2">and his people dwell in its cities? 
 </p><p class="q1">
 <sup>2&#160;</sup>Therefore behold, the days come,” 
-</p><p class="q2">says Yahweh, 
+</p><p class="q2">says Yahuah, 
 </p><p class="q1">“that I will cause an alarm of war to be heard against Rabbah of the children of Ammon, 
 </p><p class="q2">and it will become a desolate heap, 
 </p><p class="q2">and her daughters will be burned with fire; 
 </p><p class="q1">then Israel will possess those who possessed him,” 
-</p><p class="q2">says Yahweh. 
+</p><p class="q2">says Yahuah. 
 </p><p class="q1">
 <sup>3&#160;</sup>“Wail, Heshbon, for Ai is laid waste! 
 </p><p class="q2">Cry, you daughters of Rabbah! 
@@ -3142,17 +3142,17 @@ html[dir=ltr] .q2 {
 </p><p class="q2">saying, ‘Who will come to me?’ 
 </p><p class="q1">
 <sup>5&#160;</sup>Behold, I will bring a terror on you,” 
-</p><p class="q2">says the Lord, Yahweh of Armies, 
+</p><p class="q2">says the Lord, Yahuah of Armies, 
 </p><p class="q1">“from all who are around you. 
 </p><p class="q2">All of you will be driven completely out, 
 </p><p class="q2">and there will be no one to gather together the fugitives. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>6&#160;</sup>“But afterward I will reverse the captivity of the children of Ammon,” 
-</p><p class="q2">says Yahweh. 
+</p><p class="q2">says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>7&#160;</sup>Of Edom, Yahweh of Armies says: 
+<sup>7&#160;</sup>Of Edom, Yahuah of Armies says: 
 </p><p class="q1">“Is wisdom no more in Teman? 
 </p><p class="q2">Has counsel perished from the prudent? 
 </p><p class="q2">Has their wisdom vanished? 
@@ -3177,10 +3177,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I will preserve them alive. 
 </p><p class="q2">Let your widows trust in me.” 
 </p><p>
-<sup>12&#160;</sup>For Yahweh says: “Behold, they to whom it didn’t pertain to drink of the cup will certainly drink; and are you he who will altogether go unpunished? You won’t go unpunished, but you will surely drink. 
-<sup>13&#160;</sup>For I have sworn by myself,” says Yahweh, “that Bozrah will become an astonishment, a reproach, a waste, and a curse. All its cities will be perpetual wastes.” 
+<sup>12&#160;</sup>For Yahuah says: “Behold, they to whom it didn’t pertain to drink of the cup will certainly drink; and are you he who will altogether go unpunished? You won’t go unpunished, but you will surely drink. 
+<sup>13&#160;</sup>For I have sworn by myself,” says Yahuah, “that Bozrah will become an astonishment, a reproach, a waste, and a curse. All its cities will be perpetual wastes.” 
 </p><p class="q1">
-<sup>14&#160;</sup>I have heard news from Yahweh, 
+<sup>14&#160;</sup>I have heard news from Yahuah, 
 </p><p class="q2">and an ambassador is sent among the nations, 
 </p><p class="q1">saying, “Gather yourselves together! 
 </p><p class="q2">Come against her! 
@@ -3195,13 +3195,13 @@ html[dir=ltr] .q2 {
 </p><p class="q1">O you who dwell in the clefts of the rock, 
 </p><p class="q2">who hold the height of the hill, 
 </p><p class="q1">though you should make your nest as high as the eagle, 
-</p><p class="q2">I will bring you down from there,” says Yahweh. 
+</p><p class="q2">I will bring you down from there,” says Yahuah. 
 </p><p class="q1">
 <sup>17&#160;</sup>“Edom will become an astonishment. 
 </p><p class="q2">Everyone who passes by it will be astonished, 
 </p><p class="q2">and will hiss at all its plagues. 
 </p><p class="q1">
-<sup>18&#160;</sup>As in the overthrow of Sodom and Gomorrah and its neighbor cities,” says Yahweh, 
+<sup>18&#160;</sup>As in the overthrow of Sodom and Gomorrah and its neighbor cities,” says Yahuah, 
 </p><p class="q2">“no man will dwell there, 
 </p><p class="q2">neither will any son of man live therein. 
 </p><p class="b"> &#160; </p>
@@ -3214,7 +3214,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Who will appoint me a time? 
 </p><p class="q2">Who is the shepherd who will stand before me?” 
 </p><p class="q1">
-<sup>20&#160;</sup>Therefore hear the counsel of Yahweh, that he has taken against Edom, 
+<sup>20&#160;</sup>Therefore hear the counsel of Yahuah, that he has taken against Edom, 
 </p><p class="q2">and his purposes that he has purposed against the inhabitants of Teman: 
 </p><p class="q1">Surely they will drag them away, 
 </p><p class="q2">the little ones of the flock. 
@@ -3246,13 +3246,13 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>26&#160;</sup>Therefore her young men will fall in her streets, 
 </p><p class="q2">and all the men of war will be brought to silence in that day,” 
-</p><p class="q2">says Yahweh of Armies. 
+</p><p class="q2">says Yahuah of Armies. 
 </p><p class="q1">
 <sup>27&#160;</sup>“I will kindle a fire in the wall of Damascus, 
 </p><p class="q2">and it will devour the palaces of Ben Hadad.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>28&#160;</sup>Of Kedar, and of the kingdoms of Hazor, which Nebuchadnezzar king of Babylon struck, Yahweh says: 
+<sup>28&#160;</sup>Of Kedar, and of the kingdoms of Hazor, which Nebuchadnezzar king of Babylon struck, Yahuah says: 
 </p><p class="q1">“Arise, go up to Kedar, 
 </p><p class="q2">and destroy the children of the east. 
 </p><p class="q1">
@@ -3263,12 +3263,12 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>30&#160;</sup>Flee! 
 </p><p class="q2">Wander far off! 
-</p><p class="q1">Dwell in the depths, you inhabitants of Hazor,” says Yahweh; 
+</p><p class="q1">Dwell in the depths, you inhabitants of Hazor,” says Yahuah; 
 </p><p class="q2">“for Nebuchadnezzar king of Babylon has taken counsel against you, 
 </p><p class="q2">and has conceived a purpose against you. 
 </p><p class="q1">
 <sup>31&#160;</sup>Arise! Go up to a nation that is at ease, 
-</p><p class="q2">that dwells without care,” says Yahweh; 
+</p><p class="q2">that dwells without care,” says Yahuah; 
 </p><p class="q2">“that has neither gates nor bars, 
 </p><p class="q2">that dwells alone. 
 </p><p class="q1">
@@ -3276,7 +3276,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and the multitude of their livestock a plunder. 
 </p><p class="q1">I will scatter to all winds those who have the corners of their beards cut off; 
 </p><p class="q2">and I will bring their calamity from every side of them,” 
-</p><p class="q2">says Yahweh. 
+</p><p class="q2">says Yahuah. 
 </p><p class="q1">
 <sup>33&#160;</sup>Hazor will be a dwelling place of jackals, 
 </p><p class="q2">a desolation forever. 
@@ -3284,8 +3284,8 @@ html[dir=ltr] .q2 {
 </p><p class="q2">neither will any son of man live therein.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>34&#160;</sup>Yahweh’s word that came to Jeremiah the prophet concerning Elam, in the beginning of the reign of Zedekiah king of Judah, saying, 
-<sup>35&#160;</sup>“Yahweh of Armies says: 
+<sup>34&#160;</sup>Yahuah’s word that came to Jeremiah the prophet concerning Elam, in the beginning of the reign of Zedekiah king of Judah, saying, 
+<sup>35&#160;</sup>“Yahuah of Armies says: 
 </p><p class="q1">‘Behold, I will break the bow of Elam, 
 </p><p class="q2">the chief of their might. 
 </p><p class="q1">
@@ -3295,18 +3295,18 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>37&#160;</sup>I will cause Elam to be dismayed before their enemies, 
 </p><p class="q2">and before those who seek their life. 
-</p><p class="q1">I will bring evil on them, even my fierce anger,’ says Yahweh; 
+</p><p class="q1">I will bring evil on them, even my fierce anger,’ says Yahuah; 
 </p><p class="q2">‘and I will send the sword after them, 
 </p><p class="q2">until I have consumed them. 
 </p><p class="q1">
 <sup>38&#160;</sup>I will set my throne in Elam, 
-</p><p class="q2">and will destroy from there king and princes,’ says Yahweh. 
+</p><p class="q2">and will destroy from there king and princes,’ says Yahuah. 
 </p><p class="q1">
 <sup>39&#160;</sup>‘But it will happen in the latter days 
-</p><p class="q2">that I will reverse the captivity of Elam,’ says Yahweh.” 
+</p><p class="q2">that I will reverse the captivity of Elam,’ says Yahuah.” 
 </p><h2 class="chapterlabel" id="50">50</h2>
 <p>
-<sup>1&#160;</sup>The word that Yahweh spoke concerning Babylon, concerning the land of the Chaldeans, by Jeremiah the prophet. 
+<sup>1&#160;</sup>The word that Yahuah spoke concerning Babylon, concerning the land of the Chaldeans, by Jeremiah the prophet. 
 </p><p class="q1">
 <sup>2&#160;</sup>“Declare among the nations and publish, 
 </p><p class="q2">and set up a standard; 
@@ -3325,14 +3325,14 @@ html[dir=ltr] .q2 {
 </p><p class="q2">both man and animal. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>4&#160;</sup>“In those days, and in that time,” says Yahweh, 
+<sup>4&#160;</sup>“In those days, and in that time,” says Yahuah, 
 </p><p class="q2">“the children of Israel will come, 
 </p><p class="q2">they and the children of Judah together; 
 </p><p class="q1">they will go on their way weeping, 
-</p><p class="q2">and will seek Yahweh their Elohim. 
+</p><p class="q2">and will seek Yahuah their Elohim. 
 </p><p class="q1">
 <sup>5&#160;</sup>They will inquire concerning Zion with their faces turned toward it, 
-</p><p class="q2">saying, ‘Come, and join yourselves to Yahweh in an everlasting covenant 
+</p><p class="q2">saying, ‘Come, and join yourselves to Yahuah in an everlasting covenant 
 </p><p class="q2">that will not be forgotten.’ 
 </p><p class="q1">
 <sup>6&#160;</sup>My people have been lost sheep. 
@@ -3343,9 +3343,9 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>7&#160;</sup>All who found them have devoured them. 
 </p><p class="q2">Their adversaries said, ‘We are not guilty, 
-</p><p class="q1">because they have sinned against Yahweh, 
+</p><p class="q1">because they have sinned against Yahuah, 
 </p><p class="q2">the habitation of righteousness, 
-</p><p class="q2">even Yahweh, the hope of their fathers.’ 
+</p><p class="q2">even Yahuah, the hope of their fathers.’ 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>8&#160;</sup>“Flee out of the middle of Babylon! 
@@ -3360,7 +3360,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">None of them will return in vain. 
 </p><p class="q1">
 <sup>10&#160;</sup>Chaldea will be a prey. 
-</p><p class="q2">All who prey on her will be satisfied,” says Yahweh. 
+</p><p class="q2">All who prey on her will be satisfied,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>11&#160;</sup>“Because you are glad, 
@@ -3374,7 +3374,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Behold, she will be the least of the nations, 
 </p><p class="q2">a wilderness, a dry land, and a desert. 
 </p><p class="q1">
-<sup>13&#160;</sup>Because of Yahweh’s wrath she won’t be inhabited, 
+<sup>13&#160;</sup>Because of Yahuah’s wrath she won’t be inhabited, 
 </p><p class="q2">but she will be wholly desolate. 
 </p><p class="q1">Everyone who goes by Babylon will be astonished, 
 </p><p class="q2">and hiss at all her plagues. 
@@ -3383,13 +3383,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">all you who bend the bow; 
 </p><p class="q2">shoot at her. 
 </p><p class="q1">Spare no arrows, 
-</p><p class="q2">for she has sinned against Yahweh. 
+</p><p class="q2">for she has sinned against Yahuah. 
 </p><p class="q1">
 <sup>15&#160;</sup>Shout against her all around. 
 </p><p class="q2">She has submitted herself. 
 </p><p class="q2">Her bulwarks have fallen. 
 </p><p class="q1">Her walls have been thrown down, 
-</p><p class="q2">for it is the vengeance of Yahweh. 
+</p><p class="q2">for it is the vengeance of Yahuah. 
 </p><p class="q1">Take vengeance on her. 
 </p><p class="q2">As she has done, do to her. 
 </p><p class="q1">
@@ -3405,7 +3405,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">First, the king of Assyria devoured him, 
 </p><p class="q2">and now at last Nebuchadnezzar king of Babylon has broken his bones.” 
 </p><p>
-<sup>18&#160;</sup>Therefore Yahweh of Armies, the Elohim of Israel, says: 
+<sup>18&#160;</sup>Therefore Yahuah of Armies, the Elohim of Israel, says: 
 </p><p class="q1">“Behold, I will punish the king of Babylon and his land, 
 </p><p class="q2">as I have punished the king of Assyria. 
 </p><p class="q1">
@@ -3413,7 +3413,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and he will feed on Carmel and Bashan. 
 </p><p class="q2">His soul will be satisfied on the hills of Ephraim and in Gilead. 
 </p><p class="q1">
-<sup>20&#160;</sup>In those days, and in that time,” says Yahweh, 
+<sup>20&#160;</sup>In those days, and in that time,” says Yahuah, 
 </p><p class="q2">“the iniquity of Israel will be sought for, 
 </p><p class="q2">and there will be none, 
 </p><p class="q1">also the sins of Judah, 
@@ -3423,7 +3423,7 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>21&#160;</sup>“Go up against the land of Merathaim, 
 </p><p class="q2">even against it, and against the inhabitants of Pekod. 
-</p><p class="q1">Kill and utterly destroy after them,” says Yahweh, 
+</p><p class="q1">Kill and utterly destroy after them,” says Yahuah, 
 </p><p class="q2">“and do according to all that I have commanded you. 
 </p><p class="q1">
 <sup>22&#160;</sup>A sound of battle is in the land, 
@@ -3437,11 +3437,11 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and you weren’t aware. 
 </p><p class="q1">You are found, 
 </p><p class="q2">and also caught, 
-</p><p class="q2">because you have fought against Yahweh. 
+</p><p class="q2">because you have fought against Yahuah. 
 </p><p class="q1">
-<sup>25&#160;</sup>Yahweh has opened his armory, 
+<sup>25&#160;</sup>Yahuah has opened his armory, 
 </p><p class="q2">and has brought out the weapons of his indignation; 
-</p><p class="q2">for the Lord, Yahweh of Armies, has a work to do in the land of the Chaldeans. 
+</p><p class="q2">for the Lord, Yahuah of Armies, has a work to do in the land of the Chaldeans. 
 </p><p class="q1">
 <sup>26&#160;</sup>Come against her from the farthest border. 
 </p><p class="q2">Open her storehouses. 
@@ -3455,7 +3455,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the time of their visitation. 
 </p><p class="q1">
 <sup>28&#160;</sup>Listen to those who flee and escape out of the land of Babylon, 
-</p><p class="q2">to declare in Zion the vengeance of Yahweh our Elohim, 
+</p><p class="q2">to declare in Zion the vengeance of Yahuah our Elohim, 
 </p><p class="q2">the vengeance of his temple. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -3465,13 +3465,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Let none of it escape. 
 </p><p class="q1">Pay her back according to her work. 
 </p><p class="q2">According to all that she has done, do to her; 
-</p><p class="q1">for she has been proud against Yahweh, 
+</p><p class="q1">for she has been proud against Yahuah, 
 </p><p class="q2">against the Set-Apart One of Israel. 
 </p><p class="q1">
 <sup>30&#160;</sup>Therefore her young men will fall in her streets. 
-</p><p class="q2">All her men of war will be brought to silence in that day,” says Yahweh. 
+</p><p class="q2">All her men of war will be brought to silence in that day,” says Yahuah. 
 </p><p class="q1">
-<sup>31&#160;</sup>“Behold, I am against you, you proud one,” says the Lord, Yahweh of Armies; 
+<sup>31&#160;</sup>“Behold, I am against you, you proud one,” says the Lord, Yahuah of Armies; 
 </p><p class="q2">“for your day has come, 
 </p><p class="q2">the time that I will visit you. 
 </p><p class="q1">
@@ -3480,18 +3480,18 @@ html[dir=ltr] .q2 {
 </p><p class="q1">I will kindle a fire in his cities, 
 </p><p class="q2">and it will devour all who are around him.” 
 </p><p class="q1">
-<sup>33&#160;</sup>Yahweh of Armies says: “The children of Israel and the children of Judah are oppressed together. 
+<sup>33&#160;</sup>Yahuah of Armies says: “The children of Israel and the children of Judah are oppressed together. 
 </p><p class="q2">All who took them captive hold them fast. 
 </p><p class="q2">They refuse to let them go. 
 </p><p class="q1">
 <sup>34&#160;</sup>Their Redeemer is strong. 
-</p><p class="q2">Yahweh of Armies is his name. 
+</p><p class="q2">Yahuah of Armies is his name. 
 </p><p class="q1">He will thoroughly plead their cause, 
 </p><p class="q2">that he may give rest to the earth, 
 </p><p class="q2">and disquiet the inhabitants of Babylon. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>35&#160;</sup>“A sword is on the Chaldeans,” says Yahweh, 
+<sup>35&#160;</sup>“A sword is on the Chaldeans,” says Yahuah, 
 </p><p class="q2">“and on the inhabitants of Babylon, 
 </p><p class="q2">on her princes, 
 </p><p class="q2">and on her wise men. 
@@ -3519,7 +3519,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">It will be inhabited no more forever, 
 </p><p class="q2">neither will it be lived in from generation to generation. 
 </p><p class="q1">
-<sup>40&#160;</sup>As when Elohim overthrew Sodom and Gomorrah and its neighbor cities,” says Yahweh, 
+<sup>40&#160;</sup>As when Elohim overthrew Sodom and Gomorrah and its neighbor cities,” says Yahuah, 
 </p><p class="q2">“so no man will dwell there, 
 </p><p class="q2">neither will any son of man live therein. 
 </p><p class="b"> &#160; </p>
@@ -3549,7 +3549,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Who will appoint me a time? 
 </p><p class="q2">Who is the shepherd who can stand before me?” 
 </p><p class="q1">
-<sup>45&#160;</sup>Therefore hear the counsel of Yahweh 
+<sup>45&#160;</sup>Therefore hear the counsel of Yahuah 
 </p><p class="q2">that he has taken against Babylon; 
 </p><p class="q1">and his purposes 
 </p><p class="q2">that he has purposed against the land of the Chaldeans: 
@@ -3561,7 +3561,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">The cry is heard among the nations. 
 </p><h2 class="chapterlabel" id="51">51</h2>
 <p>
-<sup>1&#160;</sup>Yahweh says: 
+<sup>1&#160;</sup>Yahuah says: 
 </p><p class="q1">“Behold, I will raise up against Babylon, 
 </p><p class="q2">and against those who dwell in Lebkamai, a destroying wind. 
 </p><p class="q1">
@@ -3578,17 +3578,17 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and thrust through in her streets. 
 </p><p class="q1">
 <sup>5&#160;</sup>For Israel is not forsaken, nor Judah, by his Elohim, 
-</p><p class="q2">by Yahweh of Armies; 
+</p><p class="q2">by Yahuah of Armies; 
 </p><p class="q2">though their land is full of guilt against the Set-Apart One of Israel. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>6&#160;</sup>“Flee out of the middle of Babylon! 
 </p><p class="q2">Everyone save his own life! 
 </p><p class="q1">Don’t be cut off in her iniquity, 
-</p><p class="q2">for it is the time of Yahweh’s vengeance. 
+</p><p class="q2">for it is the time of Yahuah’s vengeance. 
 </p><p class="q2">He will render to her a recompense. 
 </p><p class="q1">
-<sup>7&#160;</sup>Babylon has been a golden cup in Yahweh’s hand, 
+<sup>7&#160;</sup>Babylon has been a golden cup in Yahuah’s hand, 
 </p><p class="q2">who made all the earth drunk. 
 </p><p class="q1">The nations have drunk of her wine; 
 </p><p class="q2">therefore the nations have gone mad. 
@@ -3606,28 +3606,28 @@ html[dir=ltr] .q2 {
 </p><p class="q1">for her judgment reaches to heaven, 
 </p><p class="q2">and is lifted up even to the skies. 
 </p><p class="q1">
-<sup>10&#160;</sup>‘Yahweh has produced our righteousness. 
-</p><p class="q2">Come, and let’s declare in Zion the work of Yahweh our Elohim.’ 
+<sup>10&#160;</sup>‘Yahuah has produced our righteousness. 
+</p><p class="q2">Come, and let’s declare in Zion the work of Yahuah our Elohim.’ 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>11&#160;</sup>“Make the arrows sharp! 
 </p><p class="q2">Hold the shields firmly! 
-</p><p class="q1">Yahweh has stirred up the spirit of the kings of the Medes, 
+</p><p class="q1">Yahuah has stirred up the spirit of the kings of the Medes, 
 </p><p class="q2">because his purpose is against Babylon, to destroy it; 
-</p><p class="q1">for it is the vengeance of Yahweh, 
+</p><p class="q1">for it is the vengeance of Yahuah, 
 </p><p class="q2">the vengeance of his temple. 
 </p><p class="q1">
 <sup>12&#160;</sup>Set up a standard against the walls of Babylon! 
 </p><p class="q2">Make the watch strong! 
 </p><p class="q1">Set the watchmen, 
 </p><p class="q2">and prepare the ambushes; 
-</p><p class="q1">for Yahweh has both purposed and done 
+</p><p class="q1">for Yahuah has both purposed and done 
 </p><p class="q2">that which he spoke concerning the inhabitants of Babylon. 
 </p><p class="q1">
 <sup>13&#160;</sup>You who dwell on many waters, abundant in treasures, 
 </p><p class="q2">your end has come, the measure of your desire. 
 </p><p class="q1">
-<sup>14&#160;</sup>Yahweh of Armies has sworn by himself, saying, 
+<sup>14&#160;</sup>Yahuah of Armies has sworn by himself, saying, 
 </p><p class="q2">‘Surely I will fill you with men, 
 </p><p class="q2">as with locusts, 
 </p><p class="q2">and they will lift up a shout against you.’ 
@@ -3656,7 +3656,7 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>The portion of Jacob is not like these, 
 </p><p class="q2">for he formed all things, 
 </p><p class="q2">including the tribe of his inheritance. 
-</p><p class="q2">Yahweh of Armies is his name. 
+</p><p class="q2">Yahuah of Armies is his name. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>20&#160;</sup>“You are my battle ax and weapons of war. 
@@ -3682,9 +3682,9 @@ html[dir=ltr] .q2 {
 </p><p class="q1">With you I will break in pieces 
 </p><p class="q2">governors and deputies. 
 </p><p>
-<sup>24&#160;</sup>“I will render to Babylon and to all the inhabitants of Chaldea all their evil that they have done in Zion in your sight,” says Yahweh. 
+<sup>24&#160;</sup>“I will render to Babylon and to all the inhabitants of Chaldea all their evil that they have done in Zion in your sight,” says Yahuah. 
 </p><p class="q1">
-<sup>25&#160;</sup>“Behold, I am against you, destroying mountain,” says Yahweh, 
+<sup>25&#160;</sup>“Behold, I am against you, destroying mountain,” says Yahuah, 
 </p><p class="q2">“which destroys all the earth. 
 </p><p class="q1">I will stretch out my hand on you, 
 </p><p class="q2">roll you down from the rocks, 
@@ -3692,7 +3692,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>26&#160;</sup>They won’t take a cornerstone from you, 
 </p><p class="q2">nor a stone for foundations; 
-</p><p class="q2">but you will be desolate forever,” says Yahweh. 
+</p><p class="q2">but you will be desolate forever,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>27&#160;</sup>“Set up a standard in the land! 
@@ -3706,7 +3706,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the kings of the Medes, its governors, and all its deputies, and all the land of their dominion! 
 </p><p class="q1">
 <sup>29&#160;</sup>The land trembles and is in pain; 
-</p><p class="q2">for the purposes of Yahweh against Babylon stand, 
+</p><p class="q2">for the purposes of Yahuah against Babylon stand, 
 </p><p class="q2">to make the land of Babylon a desolation, without inhabitant. 
 </p><p class="q1">
 <sup>30&#160;</sup>The mighty men of Babylon have stopped fighting, 
@@ -3724,7 +3724,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They have burned the reeds with fire. 
 </p><p class="q2">The men of war are frightened.” 
 </p><p>
-<sup>33&#160;</sup>For Yahweh of Armies, the Elohim of Israel says: 
+<sup>33&#160;</sup>For Yahuah of Armies, the Elohim of Israel says: 
 </p><p class="q1">“The daughter of Babylon is like a threshing floor at the time when it is trodden. 
 </p><p class="q2">Yet a little while, and the time of harvest comes for her.” 
 </p><p class="b"> &#160; </p>
@@ -3742,7 +3742,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">will Jerusalem say. 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>36&#160;</sup>Therefore Yahweh says: 
+<sup>36&#160;</sup>Therefore Yahuah says: 
 </p><p class="q1">“Behold, I will plead your cause, 
 </p><p class="q2">and take vengeance for you. 
 </p><p class="q1">I will dry up her sea, 
@@ -3760,7 +3760,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and I will make them drunk, 
 </p><p class="q1">that they may rejoice, 
 </p><p class="q2">and sleep a perpetual sleep, 
-</p><p class="q2">and not wake up,” says Yahweh. 
+</p><p class="q2">and not wake up,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>40&#160;</sup>“I will bring them down like lambs to the slaughter, 
@@ -3786,7 +3786,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>45&#160;</sup>“My people, go away from the middle of her, 
-</p><p class="q2">and each of you save yourselves from Yahweh’s fierce anger. 
+</p><p class="q2">and each of you save yourselves from Yahuah’s fierce anger. 
 </p><p class="q1">
 <sup>46&#160;</sup>Don’t let your heart faint. 
 </p><p class="q2">Don’t fear for the news that will be heard in the land. 
@@ -3802,7 +3802,7 @@ html[dir=ltr] .q2 {
 <sup>48&#160;</sup>Then the heavens and the earth, 
 </p><p class="q2">and all that is therein, 
 </p><p class="q1">will sing for joy over Babylon; 
-</p><p class="q2">for the destroyers will come to her from the north,” says Yahweh. 
+</p><p class="q2">for the destroyers will come to her from the north,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>49&#160;</sup>“As Babylon has caused the slain of Israel to fall, 
@@ -3810,29 +3810,29 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>50&#160;</sup>You who have escaped the sword, go! 
 </p><p class="q2">Don’t stand still! 
-</p><p class="q1">Remember Yahweh from afar, 
+</p><p class="q1">Remember Yahuah from afar, 
 </p><p class="q2">and let Jerusalem come into your mind.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>51&#160;</sup>“We are confounded 
 </p><p class="q2">because we have heard reproach. 
 </p><p class="q1">Confusion has covered our faces, 
-</p><p class="q2">for strangers have come into the sanctuaries of Yahweh’s house.” 
+</p><p class="q2">for strangers have come into the sanctuaries of Yahuah’s house.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>52&#160;</sup>“Therefore behold, the days come,” says Yahweh, 
+<sup>52&#160;</sup>“Therefore behold, the days come,” says Yahuah, 
 </p><p class="q2">“that I will execute judgment on her engraved images; 
 </p><p class="q2">and through all her land the wounded will groan. 
 </p><p class="q1">
 <sup>53&#160;</sup>Though Babylon should mount up to the sky, 
 </p><p class="q2">and though she should fortify the height of her strength, 
-</p><p class="q2">yet destroyers will come to her from me,” says Yahweh. 
+</p><p class="q2">yet destroyers will come to her from me,” says Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>54&#160;</sup>“The sound of a cry comes from Babylon, 
 </p><p class="q2">and of great destruction from the land of the Chaldeans! 
 </p><p class="q1">
-<sup>55&#160;</sup>For Yahweh lays Babylon waste, 
+<sup>55&#160;</sup>For Yahuah lays Babylon waste, 
 </p><p class="q2">and destroys out of her the great voice! 
 </p><p class="q1">Their waves roar like many waters. 
 </p><p class="q2">The noise of their voice is uttered. 
@@ -3841,16 +3841,16 @@ html[dir=ltr] .q2 {
 </p><p class="q2">even on Babylon. 
 </p><p class="q1">Her mighty men are taken. 
 </p><p class="q2">Their bows are broken in pieces, 
-</p><p class="q1">for Yahweh is an Elohim of retribution. 
+</p><p class="q1">for Yahuah is an Elohim of retribution. 
 </p><p class="q2">He will surely repay. 
 </p><p class="q1">
 <sup>57&#160;</sup>I will make her princes, her wise men, 
 </p><p class="q2">her governors, her deputies, and her mighty men drunk. 
 </p><p class="q1">They will sleep a perpetual sleep, 
 </p><p class="q2">and not wake up,” 
-</p><p class="q2">says the King, whose name is Yahweh of Armies. 
+</p><p class="q2">says the King, whose name is Yahuah of Armies. 
 </p><p>
-<sup>58&#160;</sup>Yahweh of Armies says: 
+<sup>58&#160;</sup>Yahuah of Armies says: 
 </p><p class="q1">“The wide walls of Babylon will be utterly overthrown. 
 </p><p class="q2">Her high gates will be burned with fire. 
 </p><p class="q1">The peoples will labor for vanity, 
@@ -3860,15 +3860,15 @@ html[dir=ltr] .q2 {
 <sup>59&#160;</sup>The word which Jeremiah the prophet commanded Seraiah the son of Neriah, the son of Mahseiah, when he went with Zedekiah the king of Judah to Babylon in the fourth year of his reign. Now Seraiah was chief quartermaster. 
 <sup>60&#160;</sup>Jeremiah wrote in a book all the evil that should come on Babylon, even all these words that are written concerning Babylon. 
 <sup>61&#160;</sup>Jeremiah said to Seraiah, “When you come to Babylon, then see that you read all these words, 
-<sup>62&#160;</sup>and say, ‘Yahweh, you have spoken concerning this place, to cut it off, that no one will dwell in it, neither man nor animal, but that it will be desolate forever.’ 
+<sup>62&#160;</sup>and say, ‘Yahuah, you have spoken concerning this place, to cut it off, that no one will dwell in it, neither man nor animal, but that it will be desolate forever.’ 
 <sup>63&#160;</sup>It will be, when you have finished reading this book, that you shall bind a stone to it, and cast it into the middle of the Euphrates. 
 <sup>64&#160;</sup>Then you shall say, ‘Thus will Babylon sink, and will not rise again because of the evil that I will bring on her; and they will be weary.’&#160;” 
 </p><p>Thus far are the words of Jeremiah. 
 </p><h2 class="chapterlabel" id="52">52</h2>
 <p>
 <sup>1&#160;</sup>Zedekiah was twenty-one years old when he began to reign. He reigned eleven years in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
-<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, according to all that Jehoiakim had done. 
-<sup>3&#160;</sup>For through Yahweh’s anger this happened in Jerusalem and Judah, until he had cast them out from his presence. 
+<sup>2&#160;</sup>He did that which was evil in Yahuah’s sight, according to all that Jehoiakim had done. 
+<sup>3&#160;</sup>For through Yahuah’s anger this happened in Jerusalem and Judah, until he had cast them out from his presence. 
 </p><p>Zedekiah rebelled against the king of Babylon. 
 <sup>4&#160;</sup>In the ninth year of his reign, in the tenth month, in the tenth day of the month, Nebuchadnezzar king of Babylon came, he and all his army, against Jerusalem, and encamped against it; and they built forts against it round about. 
 <sup>5&#160;</sup>So the city was besieged to the eleventh year of King Zedekiah. 
@@ -3881,16 +3881,16 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>He put out the eyes of Zedekiah; and the king of Babylon bound him in fetters, and carried him to Babylon, and put him in prison until the day of his death. 
 </p><p>
 <sup>12&#160;</sup>Now in the fifth month, in the tenth day of the month, which was the nineteenth year of King Nebuchadnezzar, king of Babylon, Nebuzaradan the captain of the guard, who stood before the king of Babylon, came into Jerusalem. 
-<sup>13&#160;</sup>He burned Yahweh’s house, and the king’s house; and all the houses of Jerusalem, even every great house, he burned with fire. 
+<sup>13&#160;</sup>He burned Yahuah’s house, and the king’s house; and all the houses of Jerusalem, even every great house, he burned with fire. 
 <sup>14&#160;</sup>All the army of the Chaldeans, who were with the captain of the guard, broke down all the walls of Jerusalem all around. 
 <sup>15&#160;</sup>Then Nebuzaradan the captain of the guard carried away captive of the poorest of the people, and the rest of the people who were left in the city, and those who fell away, who defected to the king of Babylon, and the rest of the multitude. 
 <sup>16&#160;</sup>But Nebuzaradan the captain of the guard left of the poorest of the land to be vineyard keepers and farmers. 
 </p><p>
-<sup>17&#160;</sup>The Chaldeans broke the pillars of bronze that were in Yahweh’s house and the bases and the bronze sea that were in Yahweh’s house in pieces, and carried all of their bronze to Babylon. 
+<sup>17&#160;</sup>The Chaldeans broke the pillars of bronze that were in Yahuah’s house and the bases and the bronze sea that were in Yahuah’s house in pieces, and carried all of their bronze to Babylon. 
 <sup>18&#160;</sup>They also took away the pots, the shovels, the snuffers, the basins, the spoons, and all the vessels of bronze with which they ministered. 
 <sup>19&#160;</sup>The captain of the guard took away the cups, the fire pans, the basins, the pots, the lamp stands, the spoons, and the bowls; that which was of gold, as gold, and that which was of silver, as silver. 
 </p><p>
-<sup>20&#160;</sup>They took the two pillars, the one sea, and the twelve bronze bulls that were under the bases, which King Solomon had made for Yahweh’s house. The bronze of all these vessels was without weight. 
+<sup>20&#160;</sup>They took the two pillars, the one sea, and the twelve bronze bulls that were under the bases, which King Solomon had made for Yahuah’s house. The bronze of all these vessels was without weight. 
 <sup>21&#160;</sup>As for the pillars, the height of the one pillar was eighteen cubits; and a line of twelve cubits encircled it; and its thickness was four fingers. It was hollow. 
 <sup>22&#160;</sup>A capital of bronze was on it; and the height of the one capital was five cubits, with network and pomegranates on the capital all around, all of bronze. The second pillar also had the same, with pomegranates. 
 <sup>23&#160;</sup>There were ninety-six pomegranates on the sides; all the pomegranates were one hundred on the network all around. 

--- a/book/job.html
+++ b/book/job.html
@@ -107,18 +107,18 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>His sons went and held a feast in the house of each one on his birthday; and they sent and called for their three sisters to eat and to drink with them. 
 <sup>5&#160;</sup>It was so, when the days of their feasting had run their course, that Job sent and sanctified them, and rose up early in the morning, and offered burnt offerings according to the number of them all. For Job said, “It may be that my sons have sinned, and renounced Elohim in their hearts.” Job did so continually. 
 </p><p>
-<sup>6&#160;</sup>Now on the day when Elohim’s sons came to present themselves before Yahweh, Satan also came among them. 
-<sup>7&#160;</sup>Yahweh said to Satan, “Where have you come from?” 
-</p><p>Then Satan answered Yahweh, and said, “From going back and forth in the earth, and from walking up and down in it.” 
+<sup>6&#160;</sup>Now on the day when Elohim’s sons came to present themselves before Yahuah, Satan also came among them. 
+<sup>7&#160;</sup>Yahuah said to Satan, “Where have you come from?” 
+</p><p>Then Satan answered Yahuah, and said, “From going back and forth in the earth, and from walking up and down in it.” 
 </p><p>
-<sup>8&#160;</sup>Yahweh said to Satan, “Have you considered my servant, Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil.” 
+<sup>8&#160;</sup>Yahuah said to Satan, “Have you considered my servant, Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil.” 
 </p><p>
-<sup>9&#160;</sup>Then Satan answered Yahweh, and said, “Does Job fear Elohim for nothing? 
+<sup>9&#160;</sup>Then Satan answered Yahuah, and said, “Does Job fear Elohim for nothing? 
 <sup>10&#160;</sup>Haven’t you made a hedge around him, and around his house, and around all that he has, on every side? You have blessed the work of his hands, and his substance is increased in the land. 
 <sup>11&#160;</sup>But stretch out your hand now, and touch all that he has, and he will renounce you to your face.” 
 </p><p>
-<sup>12&#160;</sup>Yahweh said to Satan, “Behold, all that he has is in your power. Only on himself don’t stretch out your hand.” 
-</p><p>So Satan went out from the presence of Yahweh. 
+<sup>12&#160;</sup>Yahuah said to Satan, “Behold, all that he has is in your power. Only on himself don’t stretch out your hand.” 
+</p><p>So Satan went out from the presence of Yahuah. 
 <sup>13&#160;</sup>It fell on a day when his sons and his daughters were eating and drinking wine in their oldest brother’s house, 
 <sup>14&#160;</sup>that a messenger came to Job, and said, “The oxen were plowing, and the donkeys feeding beside them, 
 <sup>15&#160;</sup>and the Sabeans attacked, and took them away. Yes, they have killed the servants with the edge of the sword, and I alone have escaped to tell you.” 
@@ -131,22 +131,22 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>and behold, there came a great wind from the wilderness, and struck the four corners of the house, and it fell on the young men, and they are dead. I alone have escaped to tell you.” 
 </p><p>
 <sup>20&#160;</sup>Then Job arose, and tore his robe, and shaved his head, and fell down on the ground, and worshiped. 
-<sup>21&#160;</sup>He said, “Naked I came out of my mother’s womb, and naked will I return there. Yahweh gave, and Yahweh has taken away. Blessed be Yahweh’s name.” 
+<sup>21&#160;</sup>He said, “Naked I came out of my mother’s womb, and naked will I return there. Yahuah gave, and Yahuah has taken away. Blessed be Yahuah’s name.” 
 <sup>22&#160;</sup>In all this, Job didn’t sin, nor charge Elohim with wrongdoing. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>Again, on the day when Elohim’s sons came to present themselves before Yahweh, Satan came also among them to present himself before Yahweh. 
-<sup>2&#160;</sup>Yahweh said to Satan, “Where have you come from?” 
-</p><p>Satan answered Yahweh, and said, “From going back and forth in the earth, and from walking up and down in it.” 
+<sup>1&#160;</sup>Again, on the day when Elohim’s sons came to present themselves before Yahuah, Satan came also among them to present himself before Yahuah. 
+<sup>2&#160;</sup>Yahuah said to Satan, “Where have you come from?” 
+</p><p>Satan answered Yahuah, and said, “From going back and forth in the earth, and from walking up and down in it.” 
 </p><p>
-<sup>3&#160;</sup>Yahweh said to Satan, “Have you considered my servant Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil. He still maintains his integrity, although you incited me against him, to ruin him without cause.” 
+<sup>3&#160;</sup>Yahuah said to Satan, “Have you considered my servant Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil. He still maintains his integrity, although you incited me against him, to ruin him without cause.” 
 </p><p>
-<sup>4&#160;</sup>Satan answered Yahweh, and said, “Skin for skin. Yes, all that a man has he will give for his life. 
+<sup>4&#160;</sup>Satan answered Yahuah, and said, “Skin for skin. Yes, all that a man has he will give for his life. 
 <sup>5&#160;</sup>But stretch out your hand now, and touch his bone and his flesh, and he will renounce you to your face.” 
 </p><p>
-<sup>6&#160;</sup>Yahweh said to Satan, “Behold, he is in your hand. Only spare his life.” 
+<sup>6&#160;</sup>Yahuah said to Satan, “Behold, he is in your hand. Only spare his life.” 
 </p><p>
-<sup>7&#160;</sup>So Satan went out from the presence of Yahweh, and struck Job with painful sores from the sole of his foot to his head. 
+<sup>7&#160;</sup>So Satan went out from the presence of Yahuah, and struck Job with painful sores from the sole of his foot to his head. 
 <sup>8&#160;</sup>He took for himself a potsherd to scrape himself with, and he sat among the ashes. 
 <sup>9&#160;</sup>Then his woman said to him, “Do you still maintain your integrity? Renounce Elohim, and die.” 
 </p><p>
@@ -915,7 +915,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">The fish of the sea will declare to you. 
 </p><p class="q1">
 <sup>9&#160;</sup>Who doesn’t know that in all these, 
-</p><p class="q2">Yahweh’s hand has done this, 
+</p><p class="q2">Yahuah’s hand has done this, 
 </p><p class="q1">
 <sup>10&#160;</sup>in whose hand is the life of every living thing, 
 </p><p class="q2">and the breath of all mankind? 
@@ -3045,7 +3045,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <h2 class="chapterlabel" id="38">38</h2>
 <p>
-<sup>1&#160;</sup>Then Yahweh answered Job out of the whirlwind, 
+<sup>1&#160;</sup>Then Yahuah answered Job out of the whirlwind, 
 </p><p class="q1">
 <sup>2&#160;</sup>“Who is this who darkens counsel 
 </p><p class="q2">by words without knowledge? 
@@ -3278,13 +3278,13 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <h2 class="chapterlabel" id="40">40</h2>
 <p>
-<sup>1&#160;</sup>Moreover Yahweh answered Job, 
+<sup>1&#160;</sup>Moreover Yahuah answered Job, 
 </p><p class="q1">
 <sup>2&#160;</sup>“Shall he who argues contend with the Almighty? 
 </p><p class="q2">He who argues with Elohim, let him answer it.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>3&#160;</sup>Then Job answered Yahweh, 
+<sup>3&#160;</sup>Then Job answered Yahuah, 
 </p><p class="q1">
 <sup>4&#160;</sup>“Behold, I am of small account. What will I answer you? 
 </p><p class="q2">I lay my hand on my mouth. 
@@ -3293,7 +3293,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Yes, twice, but I will proceed no further.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>6&#160;</sup>Then Yahweh answered Job out of the whirlwind: 
+<sup>6&#160;</sup>Then Yahuah answered Job out of the whirlwind: 
 </p><p class="q1">
 <sup>7&#160;</sup>“Now brace yourself like a man. 
 </p><p class="q2">I will question you, and you will answer me. 
@@ -3463,7 +3463,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <h2 class="chapterlabel" id="42">42</h2>
 <p>
-<sup>1&#160;</sup>Then Job answered Yahweh: 
+<sup>1&#160;</sup>Then Job answered Yahuah: 
 </p><p class="q1">
 <sup>2&#160;</sup>“I know that you can do all things, 
 </p><p class="q2">and that no purpose of yours can be restrained. 
@@ -3482,15 +3482,15 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and repent in dust and ashes.” 
 </p><p class="b"> &#160; </p>
 <p>
-<sup>7&#160;</sup>It was so, that after Yahweh had spoken these words to Job, Yahweh said to Eliphaz the Temanite, “My wrath is kindled against you, and against your two friends; for you have not spoken of me the thing that is right, as my servant Job has. 
+<sup>7&#160;</sup>It was so, that after Yahuah had spoken these words to Job, Yahuah said to Eliphaz the Temanite, “My wrath is kindled against you, and against your two friends; for you have not spoken of me the thing that is right, as my servant Job has. 
 <sup>8&#160;</sup>Now therefore, take to yourselves seven bulls and seven rams, and go to my servant Job, and offer up for yourselves a burnt offering; and my servant Job shall pray for you, for I will accept him, that I not deal with you according to your folly. For you have not spoken of me the thing that is right, as my servant Job has.” 
 </p><p>
-<sup>9&#160;</sup>So Eliphaz the Temanite and Bildad the Shuhite and Zophar the Naamathite went and did what Yahweh commanded them, and Yahweh accepted Job. 
+<sup>9&#160;</sup>So Eliphaz the Temanite and Bildad the Shuhite and Zophar the Naamathite went and did what Yahuah commanded them, and Yahuah accepted Job. 
 </p><p>
-<sup>10&#160;</sup>Yahweh restored Job’s prosperity when he prayed for his friends. Yahweh gave Job twice as much as he had before. 
-<sup>11&#160;</sup>Then all his brothers, all his sisters, and all those who had been of his acquaintance before, came to him and ate bread with him in his house. They comforted him, and consoled him concerning all the evil that Yahweh had brought on him. Everyone also gave him a piece of money, and everyone a ring of gold. 
+<sup>10&#160;</sup>Yahuah restored Job’s prosperity when he prayed for his friends. Yahuah gave Job twice as much as he had before. 
+<sup>11&#160;</sup>Then all his brothers, all his sisters, and all those who had been of his acquaintance before, came to him and ate bread with him in his house. They comforted him, and consoled him concerning all the evil that Yahuah had brought on him. Everyone also gave him a piece of money, and everyone a ring of gold. 
 </p><p>
-<sup>12&#160;</sup>So Yahweh blessed the latter end of Job more than his beginning. He had fourteen thousand sheep, six thousand camels, one thousand yoke of oxen, and a thousand female donkeys. 
+<sup>12&#160;</sup>So Yahuah blessed the latter end of Job more than his beginning. He had fourteen thousand sheep, six thousand camels, one thousand yoke of oxen, and a thousand female donkeys. 
 <sup>13&#160;</sup>He had also seven sons and three daughters. 
 <sup>14&#160;</sup>He called the name of the first, Jemimah; and the name of the second, Keziah; and the name of the third, Keren Happuch. 
 <sup>15&#160;</sup>In all the land were no women found so beautiful as the daughters of Job. Their father gave them an inheritance among their brothers. 

--- a/book/joel.html
+++ b/book/joel.html
@@ -62,7 +62,7 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>Yahweh’s word that came to Joel, the son of Pethuel. 
+<sup>1&#160;</sup>Yahuah’s word that came to Joel, the son of Pethuel. 
 </p><p class="q1">
 <sup>2&#160;</sup>Hear this, you elders, 
 </p><p class="q2">and listen, all you inhabitants of the land! 
@@ -93,8 +93,8 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>Mourn like a virgin dressed in sackcloth 
 </p><p class="q2">for the owner of her youth! 
 </p><p class="q1">
-<sup>9&#160;</sup>The meal offering and the drink offering are cut off from Yahweh’s house. 
-</p><p class="q2">The priests, Yahweh’s ministers, mourn. 
+<sup>9&#160;</sup>The meal offering and the drink offering are cut off from Yahuah’s house. 
+</p><p class="q2">The priests, Yahuah’s ministers, mourn. 
 </p><p class="q1">
 <sup>10&#160;</sup>The field is laid waste. 
 </p><p class="q2">The land mourns, for the grain is destroyed, 
@@ -117,11 +117,11 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>14&#160;</sup>Sanctify a fast. 
 </p><p class="q2">Call a solemn assembly. 
-</p><p class="q2">Gather the elders and all the inhabitants of the land to the house of Yahweh, your Elohim, 
-</p><p class="q2">and cry to Yahweh. 
+</p><p class="q2">Gather the elders and all the inhabitants of the land to the house of Yahuah, your Elohim, 
+</p><p class="q2">and cry to Yahuah. 
 </p><p class="q1">
 <sup>15&#160;</sup>Alas for the day! 
-</p><p class="q2">For the day of Yahweh is at hand, 
+</p><p class="q2">For the day of Yahuah is at hand, 
 </p><p class="q2">and it will come as destruction from the Almighty. 
 </p><p class="q1">
 <sup>16&#160;</sup>Isn’t the food cut off before our eyes, 
@@ -135,7 +135,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">The herds of livestock are perplexed, because they have no pasture. 
 </p><p class="q2">Yes, the flocks of sheep are made desolate. 
 </p><p class="q1">
-<sup>19&#160;</sup>Yahweh, I cry to you, 
+<sup>19&#160;</sup>Yahuah, I cry to you, 
 </p><p class="q2">for the fire has devoured the pastures of the wilderness, 
 </p><p class="q2">and the flame has burned all the trees of the field. 
 </p><p class="q1">
@@ -148,7 +148,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>Blow the trumpet in Zion, 
 </p><p class="q2">and sound an alarm in my set-apart mountain! 
 </p><p class="q1">Let all the inhabitants of the land tremble, 
-</p><p class="q2">for the day of Yahweh comes, 
+</p><p class="q2">for the day of Yahuah comes, 
 </p><p class="q2">for it is close at hand: 
 </p><p class="q1">
 <sup>2&#160;</sup>A day of darkness and gloominess, 
@@ -194,24 +194,24 @@ html[dir=ltr] .q2 {
 </p><p class="q2">The sun and the moon are darkened, 
 </p><p class="q2">and the stars withdraw their shining. 
 </p><p class="q1">
-<sup>11&#160;</sup>Yahweh thunders his voice before his army, 
+<sup>11&#160;</sup>Yahuah thunders his voice before his army, 
 </p><p class="q2">for his forces are very great; 
 </p><p class="q2">for he is strong who obeys his command; 
-</p><p class="q2">for the day of Yahweh is great and very awesome, 
+</p><p class="q2">for the day of Yahuah is great and very awesome, 
 </p><p class="q2">and who can endure it? 
 </p><p class="q1">
-<sup>12&#160;</sup>“Yet even now,” says Yahweh, “turn to me with all your heart, 
+<sup>12&#160;</sup>“Yet even now,” says Yahuah, “turn to me with all your heart, 
 </p><p class="q2">and with fasting, and with weeping, and with mourning.” 
 </p><p class="q1">
 <sup>13&#160;</sup>Tear your heart and not your garments, 
-</p><p class="q2">and turn to Yahweh, your Elohim; 
+</p><p class="q2">and turn to Yahuah, your Elohim; 
 </p><p class="q2">for he is gracious and merciful, 
 </p><p class="q2">slow to anger, and abundant in loving kindness, 
 </p><p class="q2">and relents from sending calamity. 
 </p><p class="q1">
 <sup>14&#160;</sup>Who knows? He may turn and relent, 
 </p><p class="q2">and leave a blessing behind him, 
-</p><p class="q2">even a meal offering and a drink offering to Yahweh, your Elohim. 
+</p><p class="q2">even a meal offering and a drink offering to Yahuah, your Elohim. 
 </p><p class="q1">
 <sup>15&#160;</sup>Blow the trumpet in Zion! 
 </p><p class="q2">Sanctify a fast. 
@@ -224,17 +224,17 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Let the bridegroom go out of his room, 
 </p><p class="q2">and the bride out of her chamber. 
 </p><p class="q1">
-<sup>17&#160;</sup>Let the priests, the ministers of Yahweh, weep between the porch and the altar, 
-</p><p class="q2">and let them say, “Spare your people, Yahweh, 
+<sup>17&#160;</sup>Let the priests, the ministers of Yahuah, weep between the porch and the altar, 
+</p><p class="q2">and let them say, “Spare your people, Yahuah, 
 </p><p class="q2">and don’t give your heritage to reproach, 
 </p><p class="q2">that the nations should rule over them. 
 </p><p class="q1">Why should they say among the peoples, 
 </p><p class="q2">‘Where is their Elohim?’&#160;” 
 </p><p class="q1">
-<sup>18&#160;</sup>Then Yahweh was jealous for his land, 
+<sup>18&#160;</sup>Then Yahuah was jealous for his land, 
 </p><p class="q2">and had pity on his people. 
 </p><p class="q1">
-<sup>19&#160;</sup>Yahweh answered his people, 
+<sup>19&#160;</sup>Yahuah answered his people, 
 </p><p class="q2">“Behold, I will send you grain, new wine, and oil, 
 </p><p class="q2">and you will be satisfied with them; 
 </p><p class="q2">and I will no more make you a reproach among the nations. 
@@ -248,7 +248,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Surely he has done great things. 
 </p><p class="q1">
 <sup>21&#160;</sup>Land, don’t be afraid. 
-</p><p class="q2">Be glad and rejoice, for Yahweh has done great things. 
+</p><p class="q2">Be glad and rejoice, for Yahuah has done great things. 
 </p><p class="q1">
 <sup>22&#160;</sup>Don’t be afraid, you animals of the field; 
 </p><p class="q2">for the pastures of the wilderness spring up, 
@@ -257,7 +257,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>23&#160;</sup>“Be glad then, you children of Zion, 
-</p><p class="q2">and rejoice in Yahweh, your Elohim; 
+</p><p class="q2">and rejoice in Yahuah, your Elohim; 
 </p><p class="q2">for he gives you the early rain in just measure, 
 </p><p class="q2">and he causes the rain to come down for you, 
 </p><p class="q2">the early rain and the latter rain, as before. 
@@ -270,12 +270,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">my great army, which I sent among you. 
 </p><p class="q1">
 <sup>26&#160;</sup>You will have plenty to eat and be satisfied, 
-</p><p class="q2">and will praise the name of Yahweh, your Elohim, 
+</p><p class="q2">and will praise the name of Yahuah, your Elohim, 
 </p><p class="q2">who has dealt wondrously with you; 
 </p><p class="q2">and my people will never again be disappointed. 
 </p><p class="q1">
 <sup>27&#160;</sup>You will know that I am among Israel, 
-</p><p class="q2">and that I am Yahweh, your Elohim, and there is no one else; 
+</p><p class="q2">and that I am Yahuah, your Elohim, and there is no one else; 
 </p><p class="q2">and my people will never again be disappointed. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -292,12 +292,12 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>31&#160;</sup>The sun will be turned into darkness, 
 </p><p class="q2">and the moon into blood, 
-</p><p class="q2">before the great and terrible day of Yahweh comes. 
+</p><p class="q2">before the great and terrible day of Yahuah comes. 
 </p><p class="q1">
-<sup>32&#160;</sup>It will happen that whoever will call on Yahweh’s name shall be saved; 
+<sup>32&#160;</sup>It will happen that whoever will call on Yahuah’s name shall be saved; 
 </p><p class="q2">for in Mount Zion and in Jerusalem there will be those who escape, 
-</p><p class="q2">as Yahweh has said, 
-</p><p class="q2">and among the remnant, those whom Yahweh calls. 
+</p><p class="q2">as Yahuah has said, 
+</p><p class="q2">and among the remnant, those whom Yahuah calls. 
 </p><p class="b"> &#160; </p>
 <h2 class="chapterlabel" id="3">3</h2>
 <p class="q1">
@@ -334,7 +334,7 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>and I will sell your sons and your daughters into the hands of the children of Judah, 
 </p><p class="q2">and they will sell them to the men of Sheba, 
 </p><p class="q2">to a faraway nation, 
-</p><p class="q2">for Yahweh has spoken it.” 
+</p><p class="q2">for Yahuah has spoken it.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>9&#160;</sup>Proclaim this among the nations: 
@@ -348,7 +348,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>11&#160;</sup>Hurry and come, all you surrounding nations, 
 </p><p class="q2">and gather yourselves together.” 
-</p><p class="q1">Cause your mighty ones to come down there, Yahweh. 
+</p><p class="q1">Cause your mighty ones to come down there, Yahuah. 
 </p><p class="q1">
 <sup>12&#160;</sup>“Let the nations arouse themselves, 
 </p><p class="q2">and come up to the valley of Jehoshaphat; 
@@ -360,18 +360,18 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the vats overflow, for their wickedness is great.” 
 </p><p class="q1">
 <sup>14&#160;</sup>Multitudes, multitudes in the valley of decision! 
-</p><p class="q2">For the day of Yahweh is near in the valley of decision. 
+</p><p class="q2">For the day of Yahuah is near in the valley of decision. 
 </p><p class="q1">
 <sup>15&#160;</sup>The sun and the moon are darkened, 
 </p><p class="q2">and the stars withdraw their shining. 
 </p><p class="q1">
-<sup>16&#160;</sup>Yahweh will roar from Zion, 
+<sup>16&#160;</sup>Yahuah will roar from Zion, 
 </p><p class="q2">and thunder from Jerusalem; 
 </p><p class="q2">and the heavens and the earth will shake; 
-</p><p class="q2">but Yahweh will be a refuge to his people, 
+</p><p class="q2">but Yahuah will be a refuge to his people, 
 </p><p class="q2">and a stronghold to the children of Israel. 
 </p><p class="q1">
-<sup>17&#160;</sup>“So you will know that I am Yahweh, your Elohim, 
+<sup>17&#160;</sup>“So you will know that I am Yahuah, your Elohim, 
 </p><p class="q2">dwelling in Zion, my set-apart mountain. 
 </p><p class="q1">Then Jerusalem will be set-apart, 
 </p><p class="q2">and no strangers will pass through her any more. 
@@ -380,7 +380,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">that the mountains will drop down sweet wine, 
 </p><p class="q2">the hills will flow with milk, 
 </p><p class="q2">all the brooks of Judah will flow with waters; 
-</p><p class="q2">and a fountain will flow out from Yahweh’s house, 
+</p><p class="q2">and a fountain will flow out from Yahuah’s house, 
 </p><p class="q2">and will water the valley of Shittim. 
 </p><p class="q1">
 <sup>19&#160;</sup>Egypt will be a desolation 
@@ -393,4 +393,4 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>21&#160;</sup>I will cleanse their blood 
 </p><p class="q2">that I have not cleansed, 
-</p><p class="q2">for Yahweh dwells in Zion.” </p></div><script src="../main.js"></script></body></html>
+</p><p class="q2">for Yahuah dwells in Zion.” </p></div><script src="../main.js"></script></body></html>

--- a/book/jonah.html
+++ b/book/jonah.html
@@ -63,36 +63,36 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>Now Yahweh’s word came to Jonah the son of Amittai, saying, 
+<sup>1&#160;</sup>Now Yahuah’s word came to Jonah the son of Amittai, saying, 
 <sup>2&#160;</sup>“Arise, go to Nineveh, that great city, and preach against it, for their wickedness has come up before me.” 
 </p><p>
-<sup>3&#160;</sup>But Jonah rose up to flee to Tarshish from the presence of Yahweh. He went down to Joppa, and found a ship going to Tarshish; so he paid its fare, and went down into it, to go with them to Tarshish from the presence of Yahweh. 
+<sup>3&#160;</sup>But Jonah rose up to flee to Tarshish from the presence of Yahuah. He went down to Joppa, and found a ship going to Tarshish; so he paid its fare, and went down into it, to go with them to Tarshish from the presence of Yahuah. 
 </p><p>
-<sup>4&#160;</sup>But Yahweh sent out a great wind on the sea, and there was a mighty storm on the sea, so that the ship was likely to break up. 
+<sup>4&#160;</sup>But Yahuah sent out a great wind on the sea, and there was a mighty storm on the sea, so that the ship was likely to break up. 
 <sup>5&#160;</sup>Then the mariners were afraid, and every man cried to his elohim. They threw the cargo that was in the ship into the sea to lighten the ship. But Jonah had gone down into the innermost parts of the ship and he was laying down, and was fast asleep. 
 <sup>6&#160;</sup>So the ship master came to him, and said to him, “What do you mean, sleeper? Arise, call on your Elohim! Maybe your Elohim will notice us, so that we won’t perish.” 
 </p><p>
 <sup>7&#160;</sup>They all said to each other, “Come! Let’s cast lots, that we may know who is responsible for this evil that is on us.” So they cast lots, and the lot fell on Jonah. 
 <sup>8&#160;</sup>Then they asked him, “Tell us, please, for whose cause this evil is on us. What is your occupation? Where do you come from? What is your country? Of what people are you?” 
 </p><p>
-<sup>9&#160;</sup>He said to them, “I am a Hebrew, and I fear Yahweh, the Elohim of heaven, who has made the sea and the dry land.” 
+<sup>9&#160;</sup>He said to them, “I am a Hebrew, and I fear Yahuah, the Elohim of heaven, who has made the sea and the dry land.” 
 </p><p>
-<sup>10&#160;</sup>Then the men were exceedingly afraid, and said to him, “What have you done?” For the men knew that he was fleeing from the presence of Yahweh, because he had told them. 
+<sup>10&#160;</sup>Then the men were exceedingly afraid, and said to him, “What have you done?” For the men knew that he was fleeing from the presence of Yahuah, because he had told them. 
 <sup>11&#160;</sup>Then they said to him, “What shall we do to you, that the sea may be calm to us?” For the sea grew more and more stormy. 
 </p><p>
 <sup>12&#160;</sup>He said to them, “Take me up, and throw me into the sea. Then the sea will be calm for you; for I know that because of me this great storm is on you.” 
 </p><p>
 <sup>13&#160;</sup>Nevertheless the men rowed hard to get them back to the land; but they could not, for the sea grew more and more stormy against them. 
-<sup>14&#160;</sup>Therefore they cried to Yahweh, and said, “We beg you, Yahweh, we beg you, don’t let us die for this man’s life, and don’t lay on us innocent blood; for you, Yahweh, have done as it pleased you.” 
+<sup>14&#160;</sup>Therefore they cried to Yahuah, and said, “We beg you, Yahuah, we beg you, don’t let us die for this man’s life, and don’t lay on us innocent blood; for you, Yahuah, have done as it pleased you.” 
 <sup>15&#160;</sup>So they took up Jonah and threw him into the sea; and the sea ceased its raging. 
-<sup>16&#160;</sup>Then the men feared Yahweh exceedingly; and they offered a sacrifice to Yahweh and made vows. 
+<sup>16&#160;</sup>Then the men feared Yahuah exceedingly; and they offered a sacrifice to Yahuah and made vows. 
 </p><p>
-<sup>17&#160;</sup>Yahweh prepared a huge fish to swallow up Jonah, and Jonah was in the belly of the fish three days and three nights. 
+<sup>17&#160;</sup>Yahuah prepared a huge fish to swallow up Jonah, and Jonah was in the belly of the fish three days and three nights. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>Then Jonah prayed to Yahweh, his Elohim, out of the fish’s belly. 
+<sup>1&#160;</sup>Then Jonah prayed to Yahuah, his Elohim, out of the fish’s belly. 
 <sup>2&#160;</sup>He said, 
-</p><p class="q1">“I called because of my affliction to Yahweh. 
+</p><p class="q1">“I called because of my affliction to Yahuah. 
 </p><p class="q2">He answered me. 
 </p><p class="q1">Out of the belly of Sheol I cried. 
 </p><p class="q2">You heard my voice. 
@@ -112,25 +112,25 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>6&#160;</sup>I went down to the bottoms of the mountains. 
 </p><p class="q2">The earth barred me in forever; 
-</p><p class="q2">yet you have brought my life up from the pit, Yahweh my Elohim. 
+</p><p class="q2">yet you have brought my life up from the pit, Yahuah my Elohim. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>7&#160;</sup>“When my soul fainted within me, I remembered Yahweh. 
+<sup>7&#160;</sup>“When my soul fainted within me, I remembered Yahuah. 
 </p><p class="q2">My prayer came in to you, into your set-apart temple. 
 </p><p class="q1">
 <sup>8&#160;</sup>Those who regard vain idols forsake their own mercy. 
 </p><p class="q2">
 <sup>9&#160;</sup>But I will sacrifice to you with the voice of thanksgiving. 
 </p><p class="q2">I will pay that which I have vowed. 
-</p><p class="q1">Salvation belongs to Yahweh.” 
+</p><p class="q1">Salvation belongs to Yahuah.” 
 </p><p>
-<sup>10&#160;</sup>Then Yahweh spoke to the fish, and it vomited out Jonah on the dry land. 
+<sup>10&#160;</sup>Then Yahuah spoke to the fish, and it vomited out Jonah on the dry land. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s word came to Jonah the second time, saying, 
+<sup>1&#160;</sup>Yahuah’s word came to Jonah the second time, saying, 
 <sup>2&#160;</sup>“Arise, go to Nineveh, that great city, and preach to it the message that I give you.” 
 </p><p>
-<sup>3&#160;</sup>So Jonah arose, and went to Nineveh, according to Yahweh’s word. Now Nineveh was an exceedingly great city, three days’ journey across. 
+<sup>3&#160;</sup>So Jonah arose, and went to Nineveh, according to Yahuah’s word. Now Nineveh was an exceedingly great city, three days’ journey across. 
 <sup>4&#160;</sup>Jonah began to enter into the city a day’s journey, and he cried out, and said, “In forty days, Nineveh will be overthrown!” 
 </p><p>
 <sup>5&#160;</sup>The people of Nineveh believed Elohim; and they proclaimed a fast and put on sackcloth, from their greatest even to their least. 
@@ -143,18 +143,18 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
 <sup>1&#160;</sup>But it displeased Jonah exceedingly, and he was angry. 
-<sup>2&#160;</sup>He prayed to Yahweh, and said, “Please, Yahweh, wasn’t this what I said when I was still in my own country? Therefore I hurried to flee to Tarshish, for I knew that you are a gracious Elohim and merciful, slow to anger, and abundant in loving kindness, and you relent of doing harm. 
-<sup>3&#160;</sup>Therefore now, Yahweh, take, I beg you, my life from me, for it is better for me to die than to live.” 
+<sup>2&#160;</sup>He prayed to Yahuah, and said, “Please, Yahuah, wasn’t this what I said when I was still in my own country? Therefore I hurried to flee to Tarshish, for I knew that you are a gracious Elohim and merciful, slow to anger, and abundant in loving kindness, and you relent of doing harm. 
+<sup>3&#160;</sup>Therefore now, Yahuah, take, I beg you, my life from me, for it is better for me to die than to live.” 
 </p><p>
-<sup>4&#160;</sup>Yahweh said, “Is it right for you to be angry?” 
+<sup>4&#160;</sup>Yahuah said, “Is it right for you to be angry?” 
 </p><p>
 <sup>5&#160;</sup>Then Jonah went out of the city and sat on the east side of the city, and there made himself a booth and sat under it in the shade, until he might see what would become of the city. 
-<sup>6&#160;</sup>Yahweh Elohim prepared a vine and made it to come up over Jonah, that it might be a shade over his head to deliver him from his discomfort. So Jonah was exceedingly glad because of the vine. 
+<sup>6&#160;</sup>Yahuah Elohim prepared a vine and made it to come up over Jonah, that it might be a shade over his head to deliver him from his discomfort. So Jonah was exceedingly glad because of the vine. 
 <sup>7&#160;</sup>But Elohim prepared a worm at dawn the next day, and it chewed on the vine so that it withered. 
 <sup>8&#160;</sup>When the sun arose, Elohim prepared a sultry east wind; and the sun beat on Jonah’s head, so that he was faint and requested for himself that he might die. He said, “It is better for me to die than to live.” 
 </p><p>
 <sup>9&#160;</sup>Elohim said to Jonah, “Is it right for you to be angry about the vine?” 
 </p><p>He said, “I am right to be angry, even to death.” 
 </p><p>
-<sup>10&#160;</sup>Yahweh said, “You have been concerned for the vine, for which you have not labored, neither made it grow; which came up in a night and perished in a night. 
+<sup>10&#160;</sup>Yahuah said, “You have been concerned for the vine, for which you have not labored, neither made it grow; which came up in a night and perished in a night. 
 <sup>11&#160;</sup>Shouldn’t I be concerned for Nineveh, that great city, in which are more than one hundred twenty thousand persons who can’t discern between their right hand and their left hand, and also many animals?” </p></div><script src="../main.js"></script></body></html>

--- a/book/joshua.html
+++ b/book/joshua.html
@@ -83,7 +83,7 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>Now after the death of Moses the servant of Yahweh, Yahweh spoke to Joshua the son of Nun, Moses’ servant, saying, 
+<sup>1&#160;</sup>Now after the death of Moses the servant of Yahuah, Yahuah spoke to Joshua the son of Nun, Moses’ servant, saying, 
 <sup>2&#160;</sup>“Moses my servant is dead. Now therefore arise, go across this Jordan, you and all these people, to the land which I am giving to them, even to the children of Israel. 
 <sup>3&#160;</sup>I have given you every place that the sole of your foot will tread on, as I told Moses. 
 <sup>4&#160;</sup>From the wilderness and this Lebanon even to the great river, the river Euphrates, all the land of the Hittites, and to the great sea toward the going down of the sun, shall be your border. 
@@ -92,18 +92,18 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>“Be strong and courageous; for you shall cause this people to inherit the land which I swore to their fathers to give them. 
 <sup>7&#160;</sup>Only be strong and very courageous. Be careful to observe to do according to all the law which Moses my servant commanded you. Don’t turn from it to the right hand or to the left, that you may have good success wherever you go. 
 <sup>8&#160;</sup>This book of the law shall not depart from your mouth, but you shall meditate on it day and night, that you may observe to do according to all that is written in it; for then you shall make your way prosperous, and then you shall have good success. 
-<sup>9&#160;</sup>Haven’t I commanded you? Be strong and courageous. Don’t be afraid. Don’t be dismayed, for Yahweh your Elohim is with you wherever you go.” 
+<sup>9&#160;</sup>Haven’t I commanded you? Be strong and courageous. Don’t be afraid. Don’t be dismayed, for Yahuah your Elohim is with you wherever you go.” 
 </p><p>
 <sup>10&#160;</sup>Then Joshua commanded the officers of the people, saying, 
-<sup>11&#160;</sup>“Pass through the middle of the camp, and command the people, saying, ‘Prepare food; for within three days you are to pass over this Jordan, to go in to possess the land which Yahweh your Elohim gives you to possess.’&#160;” 
+<sup>11&#160;</sup>“Pass through the middle of the camp, and command the people, saying, ‘Prepare food; for within three days you are to pass over this Jordan, to go in to possess the land which Yahuah your Elohim gives you to possess.’&#160;” 
 </p><p>
 <sup>12&#160;</sup>Joshua spoke to the Reubenites, and to the Gadites, and to the half-tribe of Manasseh, saying, 
-<sup>13&#160;</sup>“Remember the word which Moses the servant of Yahweh commanded you, saying, ‘Yahweh your Elohim gives you rest, and will give you this land. 
+<sup>13&#160;</sup>“Remember the word which Moses the servant of Yahuah commanded you, saying, ‘Yahuah your Elohim gives you rest, and will give you this land. 
 <sup>14&#160;</sup>Your women, your little ones, and your livestock shall live in the land which Moses gave you beyond the Jordan; but you shall pass over before your brothers armed, all the mighty men of valor, and shall help them 
-<sup>15&#160;</sup>until Yahweh has given your brothers rest, as he has given you, and they have also possessed the land which Yahweh your Elohim gives them. Then you shall return to the land of your possession and possess it, which Moses the servant of Yahweh gave you beyond the Jordan toward the sunrise.’&#160;” 
+<sup>15&#160;</sup>until Yahuah has given your brothers rest, as he has given you, and they have also possessed the land which Yahuah your Elohim gives them. Then you shall return to the land of your possession and possess it, which Moses the servant of Yahuah gave you beyond the Jordan toward the sunrise.’&#160;” 
 </p><p>
 <sup>16&#160;</sup>They answered Joshua, saying, “All that you have commanded us we will do, and wherever you send us we will go. 
-<sup>17&#160;</sup>Just as we listened to Moses in all things, so will we listen to you. Only may Yahweh your Elohim be with you, as he was with Moses. 
+<sup>17&#160;</sup>Just as we listened to Moses in all things, so will we listen to you. Only may Yahuah your Elohim be with you, as he was with Moses. 
 <sup>18&#160;</sup>Whoever rebels against your commandment, and doesn’t listen to your words in all that you command him shall himself be put to death. Only be strong and courageous.” 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
@@ -118,13 +118,13 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>But she had brought them up to the roof, and hidden them under the stalks of flax which she had laid in order on the roof. 
 <sup>7&#160;</sup>The men pursued them along the way to the fords of the Jordan River. As soon as those who pursued them had gone out, they shut the gate. 
 <sup>8&#160;</sup>Before they had lain down, she came up to them on the roof. 
-<sup>9&#160;</sup>She said to the men, “I know that Yahweh has given you the land, and that the fear of you has fallen upon us, and that all the inhabitants of the land melt away before you. 
-<sup>10&#160;</sup>For we have heard how Yahweh dried up the water of the Red Sea before you, when you came out of Egypt; and what you did to the two kings of the Amorites, who were beyond the Jordan, to Sihon and to Og, whom you utterly destroyed. 
-<sup>11&#160;</sup>As soon as we had heard it, our hearts melted, and there wasn’t any more spirit in any man, because of you: for Yahweh your Elohim, he is Elohim in heaven above, and on earth beneath. 
-<sup>12&#160;</sup>Now therefore, please swear to me by Yahweh, since I have dealt kindly with you, that you also will deal kindly with my father’s house, and give me a true sign; 
+<sup>9&#160;</sup>She said to the men, “I know that Yahuah has given you the land, and that the fear of you has fallen upon us, and that all the inhabitants of the land melt away before you. 
+<sup>10&#160;</sup>For we have heard how Yahuah dried up the water of the Red Sea before you, when you came out of Egypt; and what you did to the two kings of the Amorites, who were beyond the Jordan, to Sihon and to Og, whom you utterly destroyed. 
+<sup>11&#160;</sup>As soon as we had heard it, our hearts melted, and there wasn’t any more spirit in any man, because of you: for Yahuah your Elohim, he is Elohim in heaven above, and on earth beneath. 
+<sup>12&#160;</sup>Now therefore, please swear to me by Yahuah, since I have dealt kindly with you, that you also will deal kindly with my father’s house, and give me a true sign; 
 <sup>13&#160;</sup>and that you will save alive my father, my mother, my brothers, and my sisters, and all that they have, and will deliver our lives from death.” 
 </p><p>
-<sup>14&#160;</sup>The men said to her, “Our life for yours, if you don’t talk about this business of ours; and it shall be, when Yahweh gives us the land, that we will deal kindly and truly with you.” 
+<sup>14&#160;</sup>The men said to her, “Our life for yours, if you don’t talk about this business of ours; and it shall be, when Yahuah gives us the land, that we will deal kindly and truly with you.” 
 </p><p>
 <sup>15&#160;</sup>Then she let them down by a cord through the window; for her house was on the side of the wall, and she lived on the wall. 
 <sup>16&#160;</sup>She said to them, “Go to the mountain, lest the pursuers find you. Hide yourselves there three days, until the pursuers have returned. Afterward, you may go your way.” 
@@ -138,165 +138,165 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>22&#160;</sup>They went and came to the mountain, and stayed there three days, until the pursuers had returned. The pursuers sought them all along the way, but didn’t find them. 
 <sup>23&#160;</sup>Then the two men returned, descended from the mountain, crossed the river, and came to Joshua the son of Nun. They told him all that had happened to them. 
-<sup>24&#160;</sup>They said to Joshua, “Truly Yahweh has delivered all the land into our hands. Moreover, all the inhabitants of the land melt away before us.” 
+<sup>24&#160;</sup>They said to Joshua, “Truly Yahuah has delivered all the land into our hands. Moreover, all the inhabitants of the land melt away before us.” 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
 <sup>1&#160;</sup>Joshua got up early in the morning; and they moved from Shittim and came to the Jordan, he and all the children of Israel. They camped there before they crossed over. 
 <sup>2&#160;</sup>After three days, the officers went through the middle of the camp; 
-<sup>3&#160;</sup>and they commanded the people, saying, “When you see the ark of Yahweh your Elohim’s covenant, and the Levitical priests bearing it, then leave your place and follow it. 
+<sup>3&#160;</sup>and they commanded the people, saying, “When you see the ark of Yahuah your Elohim’s covenant, and the Levitical priests bearing it, then leave your place and follow it. 
 <sup>4&#160;</sup>Yet there shall be a space between you and it of about two thousand cubits by measure—don’t come closer to it—that you may know the way by which you must go; for you have not passed this way before.” 
 </p><p>
-<sup>5&#160;</sup>Joshua said to the people, “Sanctify yourselves; for tomorrow Yahweh will do wonders among you.” 
+<sup>5&#160;</sup>Joshua said to the people, “Sanctify yourselves; for tomorrow Yahuah will do wonders among you.” 
 </p><p>
 <sup>6&#160;</sup>Joshua spoke to the priests, saying, “Take up the ark of the covenant, and cross over before the people.” They took up the ark of the covenant, and went before the people. 
 </p><p>
-<sup>7&#160;</sup>Yahweh said to Joshua, “Today I will begin to magnify you in the sight of all Israel, that they may know that as I was with Moses, so I will be with you. 
+<sup>7&#160;</sup>Yahuah said to Joshua, “Today I will begin to magnify you in the sight of all Israel, that they may know that as I was with Moses, so I will be with you. 
 <sup>8&#160;</sup>You shall command the priests who bear the ark of the covenant, saying, ‘When you come to the brink of the waters of the Jordan, you shall stand still in the Jordan.’&#160;” 
 </p><p>
-<sup>9&#160;</sup>Joshua said to the children of Israel, “Come here, and hear the words of Yahweh your Elohim.” 
+<sup>9&#160;</sup>Joshua said to the children of Israel, “Come here, and hear the words of Yahuah your Elohim.” 
 <sup>10&#160;</sup>Joshua said, “By this you shall know that the living Elohim is among you, and that he will without fail drive the Canaanite, the Hittite, the Hivite, the Perizzite, the Girgashite, the Amorite, and the Jebusite out from before you. 
 <sup>11&#160;</sup>Behold, the ark of the covenant of the Lord of all the earth passes over before you into the Jordan. 
 <sup>12&#160;</sup>Now therefore take twelve men out of the tribes of Israel, for every tribe a man. 
-<sup>13&#160;</sup>It shall be that when the soles of the feet of the priests who bear the ark of Yahweh, the Lord of all the earth, rest in the waters of the Jordan, that the waters of the Jordan will be cut off. The waters that come down from above shall stand in one heap.” 
+<sup>13&#160;</sup>It shall be that when the soles of the feet of the priests who bear the ark of Yahuah, the Lord of all the earth, rest in the waters of the Jordan, that the waters of the Jordan will be cut off. The waters that come down from above shall stand in one heap.” 
 </p><p>
 <sup>14&#160;</sup>When the people moved from their tents to pass over the Jordan, the priests who bore the ark of the covenant being before the people, 
 <sup>15&#160;</sup>and when those who bore the ark had come to the Jordan, and the feet of the priests who bore the ark had dipped in the edge of the water (for the Jordan overflows all its banks all the time of harvest), 
 <sup>16&#160;</sup>the waters which came down from above stood, and rose up in one heap a great way off, at Adam, the city that is beside Zarethan; and those that went down toward the sea of the Arabah, even the Salt Sea, were wholly cut off. Then the people passed over near Jericho. 
-<sup>17&#160;</sup>The priests who bore the ark of Yahweh’s covenant stood firm on dry ground in the middle of the Jordan; and all Israel crossed over on dry ground, until all the nation had passed completely over the Jordan. 
+<sup>17&#160;</sup>The priests who bore the ark of Yahuah’s covenant stood firm on dry ground in the middle of the Jordan; and all Israel crossed over on dry ground, until all the nation had passed completely over the Jordan. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>When all the nation had completely crossed over the Jordan, Yahweh spoke to Joshua, saying, 
+<sup>1&#160;</sup>When all the nation had completely crossed over the Jordan, Yahuah spoke to Joshua, saying, 
 <sup>2&#160;</sup>“Take twelve men out of the people, a man out of every tribe, 
 <sup>3&#160;</sup>and command them, saying, ‘Take from out of the middle of the Jordan, out of the place where the priests’ feet stood firm, twelve stones, carry them over with you, and lay them down in the place where you’ll camp tonight.’&#160;” 
 </p><p>
 <sup>4&#160;</sup>Then Joshua called the twelve men whom he had prepared of the children of Israel, a man out of every tribe. 
-<sup>5&#160;</sup>Joshua said to them, “Cross before the ark of Yahweh your Elohim into the middle of the Jordan, and each of you pick up a stone and put it on your shoulder, according to the number of the tribes of the children of Israel; 
+<sup>5&#160;</sup>Joshua said to them, “Cross before the ark of Yahuah your Elohim into the middle of the Jordan, and each of you pick up a stone and put it on your shoulder, according to the number of the tribes of the children of Israel; 
 <sup>6&#160;</sup>that this may be a sign among you, that when your children ask in the future, saying, ‘What do you mean by these stones?’ 
-<sup>7&#160;</sup>then you shall tell them, ‘Because the waters of the Jordan were cut off before the ark of Yahweh’s covenant. When it crossed over the Jordan, the waters of the Jordan were cut off. These stones shall be for a memorial to the children of Israel forever.’&#160;” 
+<sup>7&#160;</sup>then you shall tell them, ‘Because the waters of the Jordan were cut off before the ark of Yahuah’s covenant. When it crossed over the Jordan, the waters of the Jordan were cut off. These stones shall be for a memorial to the children of Israel forever.’&#160;” 
 </p><p>
-<sup>8&#160;</sup>The children of Israel did as Joshua commanded, and took up twelve stones out of the middle of the Jordan, as Yahweh spoke to Joshua, according to the number of the tribes of the children of Israel. They carried them over with them to the place where they camped, and laid them down there. 
+<sup>8&#160;</sup>The children of Israel did as Joshua commanded, and took up twelve stones out of the middle of the Jordan, as Yahuah spoke to Joshua, according to the number of the tribes of the children of Israel. They carried them over with them to the place where they camped, and laid them down there. 
 <sup>9&#160;</sup>Joshua set up twelve stones in the middle of the Jordan, in the place where the feet of the priests who bore the ark of the covenant stood; and they are there to this day. 
-<sup>10&#160;</sup>For the priests who bore the ark stood in the middle of the Jordan until everything was finished that Yahweh commanded Joshua to speak to the people, according to all that Moses commanded Joshua; and the people hurried and passed over. 
-<sup>11&#160;</sup>When all the people had completely crossed over, Yahweh’s ark crossed over with the priests in the presence of the people. 
+<sup>10&#160;</sup>For the priests who bore the ark stood in the middle of the Jordan until everything was finished that Yahuah commanded Joshua to speak to the people, according to all that Moses commanded Joshua; and the people hurried and passed over. 
+<sup>11&#160;</sup>When all the people had completely crossed over, Yahuah’s ark crossed over with the priests in the presence of the people. 
 </p><p>
 <sup>12&#160;</sup>The children of Reuben, and the children of Gad, and the half-tribe of Manasseh crossed over armed before the children of Israel, as Moses spoke to them. 
-<sup>13&#160;</sup>About forty thousand men, ready and armed for war, passed over before Yahweh to battle, to the plains of Jericho. 
-<sup>14&#160;</sup>On that day, Yahweh magnified Joshua in the sight of all Israel; and they feared him, as they feared Moses, all the days of his life. 
+<sup>13&#160;</sup>About forty thousand men, ready and armed for war, passed over before Yahuah to battle, to the plains of Jericho. 
+<sup>14&#160;</sup>On that day, Yahuah magnified Joshua in the sight of all Israel; and they feared him, as they feared Moses, all the days of his life. 
 </p><p>
-<sup>15&#160;</sup>Yahweh spoke to Joshua, saying, 
+<sup>15&#160;</sup>Yahuah spoke to Joshua, saying, 
 <sup>16&#160;</sup>“Command the priests who bear the ark of the covenant, that they come up out of the Jordan.” 
 </p><p>
 <sup>17&#160;</sup>Joshua therefore commanded the priests, saying, “Come up out of the Jordan!” 
-<sup>18&#160;</sup>When the priests who bore the ark of Yahweh’s covenant had come up out of the middle of the Jordan, and the soles of the priests’ feet had been lifted up to the dry ground, the waters of the Jordan returned to their place, and went over all its banks, as before. 
+<sup>18&#160;</sup>When the priests who bore the ark of Yahuah’s covenant had come up out of the middle of the Jordan, and the soles of the priests’ feet had been lifted up to the dry ground, the waters of the Jordan returned to their place, and went over all its banks, as before. 
 <sup>19&#160;</sup>The people came up out of the Jordan on the tenth day of the first month, and encamped in Gilgal, on the east border of Jericho. 
 </p><p>
 <sup>20&#160;</sup>Joshua set up those twelve stones, which they took out of the Jordan, in Gilgal. 
 <sup>21&#160;</sup>He spoke to the children of Israel, saying, “When your children ask their fathers in time to come, saying, ‘What do these stones mean?’ 
 <sup>22&#160;</sup>Then you shall let your children know, saying, ‘Israel came over this Jordan on dry land. 
-<sup>23&#160;</sup>For Yahweh your Elohim dried up the waters of the Jordan from before you until you had crossed over, as Yahweh your Elohim did to the Red Sea, which he dried up from before us, until we had crossed over, 
-<sup>24&#160;</sup>that all the peoples of the earth may know that Yahweh’s hand is mighty, and that you may fear Yahweh your Elohim forever.’&#160;” 
+<sup>23&#160;</sup>For Yahuah your Elohim dried up the waters of the Jordan from before you until you had crossed over, as Yahuah your Elohim did to the Red Sea, which he dried up from before us, until we had crossed over, 
+<sup>24&#160;</sup>that all the peoples of the earth may know that Yahuah’s hand is mighty, and that you may fear Yahuah your Elohim forever.’&#160;” 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
-<sup>1&#160;</sup>When all the kings of the Amorites, who were beyond the Jordan westward, and all the kings of the Canaanites, who were by the sea, heard how Yahweh had dried up the waters of the Jordan from before the children of Israel until we had crossed over, their heart melted, and there was no more spirit in them, because of the children of Israel. 
-<sup>2&#160;</sup>At that time, Yahweh said to Joshua, “Make flint knives, and circumcise again the sons of Israel the second time.” 
+<sup>1&#160;</sup>When all the kings of the Amorites, who were beyond the Jordan westward, and all the kings of the Canaanites, who were by the sea, heard how Yahuah had dried up the waters of the Jordan from before the children of Israel until we had crossed over, their heart melted, and there was no more spirit in them, because of the children of Israel. 
+<sup>2&#160;</sup>At that time, Yahuah said to Joshua, “Make flint knives, and circumcise again the sons of Israel the second time.” 
 <sup>3&#160;</sup>Joshua made himself flint knives, and circumcised the sons of Israel at the hill of the foreskins. 
 <sup>4&#160;</sup>This is the reason Joshua circumcised them: all the people who came out of Egypt, who were males, even all the men of war, died in the wilderness along the way, after they came out of Egypt. 
 <sup>5&#160;</sup>For all the people who came out were circumcised; but all the people who were born in the wilderness along the way as they came out of Egypt had not been circumcised. 
-<sup>6&#160;</sup>For the children of Israel walked forty years in the wilderness until all the nation, even the men of war who came out of Egypt, were consumed, because they didn’t listen to Yahweh’s voice. Yahweh swore to them that he wouldn’t let them see the land which Yahweh swore to their fathers that he would give us, a land flowing with milk and honey. 
+<sup>6&#160;</sup>For the children of Israel walked forty years in the wilderness until all the nation, even the men of war who came out of Egypt, were consumed, because they didn’t listen to Yahuah’s voice. Yahuah swore to them that he wouldn’t let them see the land which Yahuah swore to their fathers that he would give us, a land flowing with milk and honey. 
 <sup>7&#160;</sup>Their children, whom he raised up in their place, were circumcised by Joshua, for they were uncircumcised, because they had not circumcised them on the way. 
 <sup>8&#160;</sup>When they were done circumcising the whole nation, they stayed in their places in the camp until they were healed. 
 </p><p>
-<sup>9&#160;</sup>Yahweh said to Joshua, “Today I have rolled away the reproach of Egypt from you.” Therefore the name of that place was called Gilgal to this day. 
+<sup>9&#160;</sup>Yahuah said to Joshua, “Today I have rolled away the reproach of Egypt from you.” Therefore the name of that place was called Gilgal to this day. 
 <sup>10&#160;</sup>The children of Israel encamped in Gilgal. They kept the Passover on the fourteenth day of the month at evening in the plains of Jericho. 
 <sup>11&#160;</sup>They ate unleavened cakes and parched grain of the produce of the land on the next day after the Passover, in the same day. 
 <sup>12&#160;</sup>The manna ceased on the next day, after they had eaten of the produce of the land. The children of Israel didn’t have manna any more, but they ate of the fruit of the land of Canaan that year. 
 </p><p>
 <sup>13&#160;</sup>When Joshua was by Jericho, he lifted up his eyes and looked, and behold, a man stood in front of him with his sword drawn in his hand. Joshua went to him and said to him, “Are you for us, or for our enemies?” 
 </p><p>
-<sup>14&#160;</sup>He said, “No; but I have come now as commander of Yahweh’s army.” 
+<sup>14&#160;</sup>He said, “No; but I have come now as commander of Yahuah’s army.” 
 </p><p>Joshua fell on his face to the earth, and worshiped, and asked him, “What does my lord say to his servant?” 
 </p><p>
-<sup>15&#160;</sup>The prince of Yahweh’s army said to Joshua, “Take off your sandals, for the place on which you stand is set-apart.” Joshua did so. 
+<sup>15&#160;</sup>The prince of Yahuah’s army said to Joshua, “Take off your sandals, for the place on which you stand is set-apart.” Joshua did so. 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
 <sup>1&#160;</sup>Now Jericho was tightly shut up because of the children of Israel. No one went out, and no one came in. 
-<sup>2&#160;</sup>Yahweh said to Joshua, “Behold, I have given Jericho into your hand, with its king and the mighty men of valor. 
+<sup>2&#160;</sup>Yahuah said to Joshua, “Behold, I have given Jericho into your hand, with its king and the mighty men of valor. 
 <sup>3&#160;</sup>All of your men of war shall march around the city, going around the city once. You shall do this six days. 
 <sup>4&#160;</sup>Seven priests shall bear seven trumpets of rams’ horns before the ark. On the seventh day, you shall march around the city seven times, and the priests shall blow the trumpets. 
 <sup>5&#160;</sup>It shall be that when they make a long blast with the ram’s horn, and when you hear the sound of the trumpet, all the people shall shout with a great shout; then the city wall will fall down flat, and the people shall go up, every man straight in front of him.” 
 </p><p>
-<sup>6&#160;</sup>Joshua the son of Nun called the priests, and said to them, “Take up the ark of the covenant, and let seven priests bear seven trumpets of rams’ horns before Yahweh’s ark.” 
+<sup>6&#160;</sup>Joshua the son of Nun called the priests, and said to them, “Take up the ark of the covenant, and let seven priests bear seven trumpets of rams’ horns before Yahuah’s ark.” 
 </p><p>
-<sup>7&#160;</sup>They said to the people, “Advance! March around the city, and let the armed men pass on before Yahweh’s ark.” 
+<sup>7&#160;</sup>They said to the people, “Advance! March around the city, and let the armed men pass on before Yahuah’s ark.” 
 </p><p>
-<sup>8&#160;</sup>It was so, that when Joshua had spoken to the people, the seven priests bearing the seven trumpets of rams’ horns before Yahweh advanced and blew the trumpets, and the ark of Yahweh’s covenant followed them. 
+<sup>8&#160;</sup>It was so, that when Joshua had spoken to the people, the seven priests bearing the seven trumpets of rams’ horns before Yahuah advanced and blew the trumpets, and the ark of Yahuah’s covenant followed them. 
 <sup>9&#160;</sup>The armed men went before the priests who blew the trumpets, and the ark went after them. The trumpets sounded as they went. 
 </p><p>
 <sup>10&#160;</sup>Joshua commanded the people, saying, “You shall not shout nor let your voice be heard, neither shall any word proceed out of your mouth until the day I tell you to shout. Then you shall shout.” 
-<sup>11&#160;</sup>So he caused Yahweh’s ark to go around the city, circling it once. Then they came into the camp, and stayed in the camp. 
-<sup>12&#160;</sup>Joshua rose early in the morning, and the priests took up Yahweh’s ark. 
-<sup>13&#160;</sup>The seven priests bearing the seven trumpets of rams’ horns in front of Yahweh’s ark went on continually, and blew the trumpets. The armed men went in front of them. The rear guard came after Yahweh’s ark. The trumpets sounded as they went. 
+<sup>11&#160;</sup>So he caused Yahuah’s ark to go around the city, circling it once. Then they came into the camp, and stayed in the camp. 
+<sup>12&#160;</sup>Joshua rose early in the morning, and the priests took up Yahuah’s ark. 
+<sup>13&#160;</sup>The seven priests bearing the seven trumpets of rams’ horns in front of Yahuah’s ark went on continually, and blew the trumpets. The armed men went in front of them. The rear guard came after Yahuah’s ark. The trumpets sounded as they went. 
 <sup>14&#160;</sup>The second day they marched around the city once, and returned into the camp. They did this six days. 
 </p><p>
 <sup>15&#160;</sup>On the seventh day, they rose early at the dawning of the day, and marched around the city in the same way seven times. On this day only they marched around the city seven times. 
-<sup>16&#160;</sup>At the seventh time, when the priests blew the trumpets, Joshua said to the people, “Shout, for Yahweh has given you the city! 
-<sup>17&#160;</sup>The city shall be devoted, even it and all that is in it, to Yahweh. Only Rahab the prostitute shall live, she and all who are with her in the house, because she hid the messengers that we sent. 
+<sup>16&#160;</sup>At the seventh time, when the priests blew the trumpets, Joshua said to the people, “Shout, for Yahuah has given you the city! 
+<sup>17&#160;</sup>The city shall be devoted, even it and all that is in it, to Yahuah. Only Rahab the prostitute shall live, she and all who are with her in the house, because she hid the messengers that we sent. 
 <sup>18&#160;</sup>But as for you, only keep yourselves from what is devoted to destruction, lest when you have devoted it, you take of the devoted thing; so you would make the camp of Israel accursed and trouble it. 
-<sup>19&#160;</sup>But all the silver, gold, and vessels of bronze and iron are set-apart to Yahweh. They shall come into Yahweh’s treasury.” 
+<sup>19&#160;</sup>But all the silver, gold, and vessels of bronze and iron are set-apart to Yahuah. They shall come into Yahuah’s treasury.” 
 </p><p>
 <sup>20&#160;</sup>So the people shouted and the priests blew the trumpets. When the people heard the sound of the trumpet, the people shouted with a great shout, and the wall fell down flat, so that the people went up into the city, every man straight in front of him, and they took the city. 
 <sup>21&#160;</sup>They utterly destroyed all that was in the city, both man and woman, both young and old, and ox, sheep, and donkey, with the edge of the sword. 
 <sup>22&#160;</sup>Joshua said to the two men who had spied out the land, “Go into the prostitute’s house, and bring the woman and all that she has out from there, as you swore to her.” 
 <sup>23&#160;</sup>The young men who were spies went in, and brought out Rahab with her father, her mother, her brothers, and all that she had. They also brought out all of her relatives, and they set them outside of the camp of Israel. 
-<sup>24&#160;</sup>They burned the city with fire, and all that was in it. Only they put the silver, the gold, and the vessels of bronze and of iron into the treasury of Yahweh’s house. 
+<sup>24&#160;</sup>They burned the city with fire, and all that was in it. Only they put the silver, the gold, and the vessels of bronze and of iron into the treasury of Yahuah’s house. 
 <sup>25&#160;</sup>But Rahab the prostitute, her father’s household, and all that she had, Joshua saved alive. She lives in the middle of Israel to this day, because she hid the messengers whom Joshua sent to spy out Jericho. 
 </p><p>
-<sup>26&#160;</sup>Joshua commanded them with an oath at that time, saying, “Cursed is the man before Yahweh who rises up and builds this city Jericho. With the loss of his firstborn he will lay its foundation, and with the loss of his youngest son he will set up its gates.” 
-<sup>27&#160;</sup>So Yahweh was with Joshua; and his fame was in all the land. 
+<sup>26&#160;</sup>Joshua commanded them with an oath at that time, saying, “Cursed is the man before Yahuah who rises up and builds this city Jericho. With the loss of his firstborn he will lay its foundation, and with the loss of his youngest son he will set up its gates.” 
+<sup>27&#160;</sup>So Yahuah was with Joshua; and his fame was in all the land. 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>But the children of Israel committed a trespass in the devoted things; for Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, took some of the devoted things. Therefore Yahweh’s anger burned against the children of Israel. 
+<sup>1&#160;</sup>But the children of Israel committed a trespass in the devoted things; for Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, took some of the devoted things. Therefore Yahuah’s anger burned against the children of Israel. 
 <sup>2&#160;</sup>Joshua sent men from Jericho to Ai, which is beside Beth Aven, on the east side of Bethel, and spoke to them, saying, “Go up and spy out the land.” 
 </p><p>The men went up and spied out Ai. 
 <sup>3&#160;</sup>They returned to Joshua, and said to him, “Don’t let all the people go up, but let about two or three thousand men go up and strike Ai. Don’t make all the people to toil there, for there are only a few of them.” 
 <sup>4&#160;</sup>So about three thousand men of the people went up there, and they fled before the men of Ai. 
 <sup>5&#160;</sup>The men of Ai struck about thirty-six men of them. They chased them from before the gate even to Shebarim, and struck them at the descent. The hearts of the people melted, and became like water. 
-<sup>6&#160;</sup>Joshua tore his clothes, and fell to the earth on his face before Yahweh’s ark until the evening, he and the elders of Israel; and they put dust on their heads. 
-<sup>7&#160;</sup>Joshua said, “Alas, Lord Yahweh, why have you brought this people over the Jordan at all, to deliver us into the hand of the Amorites, to cause us to perish? I wish that we had been content and lived beyond the Jordan! 
+<sup>6&#160;</sup>Joshua tore his clothes, and fell to the earth on his face before Yahuah’s ark until the evening, he and the elders of Israel; and they put dust on their heads. 
+<sup>7&#160;</sup>Joshua said, “Alas, Lord Yahuah, why have you brought this people over the Jordan at all, to deliver us into the hand of the Amorites, to cause us to perish? I wish that we had been content and lived beyond the Jordan! 
 <sup>8&#160;</sup>Oh, Lord, what shall I say, after Israel has turned their backs before their enemies? 
 <sup>9&#160;</sup>For the Canaanites and all the inhabitants of the land will hear of it, and will surround us, and cut off our name from the earth. What will you do for your great name?” 
 </p><p>
-<sup>10&#160;</sup>Yahweh said to Joshua, “Get up! Why have you fallen on your face like that? 
+<sup>10&#160;</sup>Yahuah said to Joshua, “Get up! Why have you fallen on your face like that? 
 <sup>11&#160;</sup>Israel has sinned. Yes, they have even transgressed my covenant which I commanded them. Yes, they have even taken some of the devoted things, and have also stolen, and also deceived. They have even put it among their own stuff. 
 <sup>12&#160;</sup>Therefore the children of Israel can’t stand before their enemies. They turn their backs before their enemies, because they have become devoted for destruction. I will not be with you any more, unless you destroy the devoted things from among you. 
-<sup>13&#160;</sup>Get up! Sanctify the people, and say, ‘Sanctify yourselves for tomorrow, for Yahweh, the Elohim of Israel, says, “There is a devoted thing among you, Israel. You cannot stand before your enemies until you take away the devoted thing from among you.” 
-<sup>14&#160;</sup>In the morning therefore you shall be brought near by your tribes. It shall be that the tribe which Yahweh selects shall come near by families. The family which Yahweh selects shall come near by households. The household which Yahweh selects shall come near man by man. 
-<sup>15&#160;</sup>It shall be, that he who is taken with the devoted thing shall be burned with fire, he and all that he has, because he has transgressed Yahweh’s covenant, and because he has done a disgraceful thing in Israel.’&#160;” 
+<sup>13&#160;</sup>Get up! Sanctify the people, and say, ‘Sanctify yourselves for tomorrow, for Yahuah, the Elohim of Israel, says, “There is a devoted thing among you, Israel. You cannot stand before your enemies until you take away the devoted thing from among you.” 
+<sup>14&#160;</sup>In the morning therefore you shall be brought near by your tribes. It shall be that the tribe which Yahuah selects shall come near by families. The family which Yahuah selects shall come near by households. The household which Yahuah selects shall come near man by man. 
+<sup>15&#160;</sup>It shall be, that he who is taken with the devoted thing shall be burned with fire, he and all that he has, because he has transgressed Yahuah’s covenant, and because he has done a disgraceful thing in Israel.’&#160;” 
 </p><p>
 <sup>16&#160;</sup>So Joshua rose up early in the morning and brought Israel near by their tribes. The tribe of Judah was selected. 
 <sup>17&#160;</sup>He brought near the family of Judah, and he selected the family of the Zerahites. He brought near the family of the Zerahites man by man, and Zabdi was selected. 
 <sup>18&#160;</sup>He brought near his household man by man, and Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, was selected. 
-<sup>19&#160;</sup>Joshua said to Achan, “My son, please give glory to Yahweh, the Elohim of Israel, and make confession to him. Tell me now what you have done! Don’t hide it from me!” 
+<sup>19&#160;</sup>Joshua said to Achan, “My son, please give glory to Yahuah, the Elohim of Israel, and make confession to him. Tell me now what you have done! Don’t hide it from me!” 
 </p><p>
-<sup>20&#160;</sup>Achan answered Joshua, and said, “I have truly sinned against Yahweh, the Elohim of Israel, and this is what I have done. 
+<sup>20&#160;</sup>Achan answered Joshua, and said, “I have truly sinned against Yahuah, the Elohim of Israel, and this is what I have done. 
 <sup>21&#160;</sup>When I saw among the plunder a beautiful Babylonian robe, two hundred shekels of silver, and a wedge of gold weighing fifty shekels, then I desired them and took them. Behold, they are hidden in the ground in the middle of my tent, with the silver under it.” 
 </p><p>
 <sup>22&#160;</sup>So Joshua sent messengers, and they ran to the tent. Behold, it was hidden in his tent, with the silver under it. 
-<sup>23&#160;</sup>They took them from the middle of the tent, and brought them to Joshua and to all the children of Israel. They laid them down before Yahweh. 
+<sup>23&#160;</sup>They took them from the middle of the tent, and brought them to Joshua and to all the children of Israel. They laid them down before Yahuah. 
 <sup>24&#160;</sup>Joshua, and all Israel with him, took Achan the son of Zerah, the silver, the robe, the wedge of gold, his sons, his daughters, his cattle, his donkeys, his sheep, his tent, and all that he had; and they brought them up to the valley of Achor. 
-<sup>25&#160;</sup>Joshua said, “Why have you troubled us? Yahweh will trouble you today.” All Israel stoned him with stones, and they burned them with fire and stoned them with stones. 
-<sup>26&#160;</sup>They raised over him a great heap of stones that remains to this day. Yahweh turned from the fierceness of his anger. Therefore the name of that place was called “The valley of Achor” to this day. 
+<sup>25&#160;</sup>Joshua said, “Why have you troubled us? Yahuah will trouble you today.” All Israel stoned him with stones, and they burned them with fire and stoned them with stones. 
+<sup>26&#160;</sup>They raised over him a great heap of stones that remains to this day. Yahuah turned from the fierceness of his anger. Therefore the name of that place was called “The valley of Achor” to this day. 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Joshua, “Don’t be afraid, and don’t be dismayed. Take all the warriors with you, and arise, go up to Ai. Behold, I have given into your hand the king of Ai, with his people, his city, and his land. 
+<sup>1&#160;</sup>Yahuah said to Joshua, “Don’t be afraid, and don’t be dismayed. Take all the warriors with you, and arise, go up to Ai. Behold, I have given into your hand the king of Ai, with his people, his city, and his land. 
 <sup>2&#160;</sup>You shall do to Ai and her king as you did to Jericho and her king, except you shall take its goods and its livestock for yourselves. Set an ambush for the city behind it.” 
 </p><p>
 <sup>3&#160;</sup>So Joshua arose, with all the warriors, to go up to Ai. Joshua chose thirty thousand men, the mighty men of valor, and sent them out by night. 
 <sup>4&#160;</sup>He commanded them, saying, “Behold, you shall lie in ambush against the city, behind the city. Don’t go very far from the city, but all of you be ready. 
 <sup>5&#160;</sup>I and all the people who are with me will approach the city. It shall happen, when they come out against us, as at the first, that we will flee before them. 
 <sup>6&#160;</sup>They will come out after us until we have drawn them away from the city; for they will say, ‘They flee before us, like the first time.’ So we will flee before them, 
-<sup>7&#160;</sup>and you shall rise up from the ambush, and take possession of the city; for Yahweh your Elohim will deliver it into your hand. 
-<sup>8&#160;</sup>It shall be, when you have seized the city, that you shall set the city on fire. You shall do this according to Yahweh’s word. Behold, I have commanded you.” 
+<sup>7&#160;</sup>and you shall rise up from the ambush, and take possession of the city; for Yahuah your Elohim will deliver it into your hand. 
+<sup>8&#160;</sup>It shall be, when you have seized the city, that you shall set the city on fire. You shall do this according to Yahuah’s word. Behold, I have commanded you.” 
 </p><p>
 <sup>9&#160;</sup>Joshua sent them out; and they went to set up the ambush, and stayed between Bethel and Ai on the west side of Ai; but Joshua stayed among the people that night. 
 <sup>10&#160;</sup>Joshua rose up early in the morning, mustered the people, and went up, he and the elders of Israel, before the people to Ai. 
@@ -308,7 +308,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>All the people who were in the city were called together to pursue after them. They pursued Joshua, and were drawn away from the city. 
 <sup>17&#160;</sup>There was not a man left in Ai or Bethel who didn’t go out after Israel. They left the city open, and pursued Israel. 
 </p><p>
-<sup>18&#160;</sup>Yahweh said to Joshua, “Stretch out the javelin that is in your hand toward Ai, for I will give it into your hand.” 
+<sup>18&#160;</sup>Yahuah said to Joshua, “Stretch out the javelin that is in your hand toward Ai, for I will give it into your hand.” 
 </p><p>Joshua stretched out the javelin that was in his hand toward the city. 
 <sup>19&#160;</sup>The ambush arose quickly out of their place, and they ran as soon as he had stretched out his hand and entered into the city and took it. They hurried and set the city on fire. 
 <sup>20&#160;</sup>When the men of Ai looked behind them, they saw, and behold, the smoke of the city ascended up to heaven, and they had no power to flee this way or that way. The people who fled to the wilderness turned back on the pursuers. 
@@ -319,14 +319,14 @@ html[dir=ltr] .q2 {
 <sup>24&#160;</sup>When Israel had finished killing all the inhabitants of Ai in the field, in the wilderness in which they pursued them, and they had all fallen by the edge of the sword until they were consumed, all Israel returned to Ai and struck it with the edge of the sword. 
 <sup>25&#160;</sup>All that fell that day, both of men and women, were twelve thousand, even all the people of Ai. 
 <sup>26&#160;</sup>For Joshua didn’t draw back his hand, with which he stretched out the javelin, until he had utterly destroyed all the inhabitants of Ai. 
-<sup>27&#160;</sup>Israel took for themselves only the livestock and the goods of that city, according to Yahweh’s word which he commanded Joshua. 
+<sup>27&#160;</sup>Israel took for themselves only the livestock and the goods of that city, according to Yahuah’s word which he commanded Joshua. 
 <sup>28&#160;</sup>So Joshua burned Ai and made it a heap forever, even a desolation, to this day. 
 <sup>29&#160;</sup>He hanged the king of Ai on a tree until the evening. At sundown, Joshua commanded, and they took his body down from the tree and threw it at the entrance of the gate of the city, and raised a great heap of stones on it that remains to this day. 
 </p><p>
-<sup>30&#160;</sup>Then Joshua built an altar to Yahweh, the Elohim of Israel, on Mount Ebal, 
-<sup>31&#160;</sup>as Moses the servant of Yahweh commanded the children of Israel, as it is written in the book of the law of Moses: an altar of uncut stones, on which no one had lifted up any iron. They offered burnt offerings on it to Yahweh and sacrificed peace offerings. 
+<sup>30&#160;</sup>Then Joshua built an altar to Yahuah, the Elohim of Israel, on Mount Ebal, 
+<sup>31&#160;</sup>as Moses the servant of Yahuah commanded the children of Israel, as it is written in the book of the law of Moses: an altar of uncut stones, on which no one had lifted up any iron. They offered burnt offerings on it to Yahuah and sacrificed peace offerings. 
 <sup>32&#160;</sup>He wrote there on the stones a copy of Moses’ law, which he wrote in the presence of the children of Israel. 
-<sup>33&#160;</sup>All Israel, with their elders, officers, and judges, stood on both sides of the ark before the Levitical priests, who carried the ark of Yahweh’s covenant, the foreigner as well as the native; half of them in front of Mount Gerizim, and half of them in front of Mount Ebal, as Moses the servant of Yahweh had commanded at the first, that they should bless the people of Israel. 
+<sup>33&#160;</sup>All Israel, with their elders, officers, and judges, stood on both sides of the ark before the Levitical priests, who carried the ark of Yahuah’s covenant, the foreigner as well as the native; half of them in front of Mount Gerizim, and half of them in front of Mount Ebal, as Moses the servant of Yahuah had commanded at the first, that they should bless the people of Israel. 
 <sup>34&#160;</sup>Afterward he read all the words of the law, the blessing and the curse, according to all that is written in the book of the law. 
 <sup>35&#160;</sup>There was not a word of all that Moses commanded which Joshua didn’t read before all the assembly of Israel, with the women, the little ones, and the foreigners who were among them. 
 </p><h2 class="chapterlabel" id="9">9</h2>
@@ -343,29 +343,29 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>They said to Joshua, “We are your servants.” 
 </p><p>Joshua said to them, “Who are you? Where do you come from?” 
 </p><p>
-<sup>9&#160;</sup>They said to him, “Your servants have come from a very far country because of the name of Yahweh your Elohim; for we have heard of his fame, all that he did in Egypt, 
+<sup>9&#160;</sup>They said to him, “Your servants have come from a very far country because of the name of Yahuah your Elohim; for we have heard of his fame, all that he did in Egypt, 
 <sup>10&#160;</sup>and all that he did to the two kings of the Amorites who were beyond the Jordan, to Sihon king of Heshbon and to Og king of Bashan, who was at Ashtaroth. 
 <sup>11&#160;</sup>Our elders and all the inhabitants of our country spoke to us, saying, ‘Take supplies in your hand for the journey, and go to meet them. Tell them, “We are your servants. Now make a covenant with us.”&#160;’ 
 <sup>12&#160;</sup>This our bread we took hot for our supplies out of our houses on the day we went out to go to you; but now, behold, it is dry, and has become moldy. 
 <sup>13&#160;</sup>These wine skins, which we filled, were new; and behold, they are torn. These our garments and our sandals have become old because of the very long journey.” 
 </p><p>
-<sup>14&#160;</sup>The men sampled their provisions, and didn’t ask counsel from Yahweh’s mouth. 
+<sup>14&#160;</sup>The men sampled their provisions, and didn’t ask counsel from Yahuah’s mouth. 
 <sup>15&#160;</sup>Joshua made peace with them, and made a covenant with them, to let them live. The princes of the congregation swore to them. 
 <sup>16&#160;</sup>At the end of three days after they had made a covenant with them, they heard that they were their neighbors, and that they lived among them. 
 <sup>17&#160;</sup>The children of Israel traveled and came to their cities on the third day. Now their cities were Gibeon, Chephirah, Beeroth, and Kiriath Jearim. 
-<sup>18&#160;</sup>The children of Israel didn’t strike them, because the princes of the congregation had sworn to them by Yahweh, the Elohim of Israel. All the congregation murmured against the princes. 
-<sup>19&#160;</sup>But all the princes said to all the congregation, “We have sworn to them by Yahweh, the Elohim of Israel. Now therefore we may not touch them. 
+<sup>18&#160;</sup>The children of Israel didn’t strike them, because the princes of the congregation had sworn to them by Yahuah, the Elohim of Israel. All the congregation murmured against the princes. 
+<sup>19&#160;</sup>But all the princes said to all the congregation, “We have sworn to them by Yahuah, the Elohim of Israel. Now therefore we may not touch them. 
 <sup>20&#160;</sup>We will do this to them, and let them live; lest wrath be on us, because of the oath which we swore to them.” 
 <sup>21&#160;</sup>The princes said to them, “Let them live.” So they became wood cutters and drawers of water for all the congregation, as the princes had spoken to them. 
 </p><p>
 <sup>22&#160;</sup>Joshua called for them, and he spoke to them, saying, “Why have you deceived us, saying, ‘We are very far from you,’ when you live among us? 
 <sup>23&#160;</sup>Now therefore you are cursed, and some of you will never fail to be slaves, both wood cutters and drawers of water for the house of my Elohim.” 
 </p><p>
-<sup>24&#160;</sup>They answered Joshua, and said, “Because your servants were certainly told how Yahweh your Elohim commanded his servant Moses to give you all the land, and to destroy all the inhabitants of the land from before you. Therefore we were very afraid for our lives because of you, and have done this thing. 
+<sup>24&#160;</sup>They answered Joshua, and said, “Because your servants were certainly told how Yahuah your Elohim commanded his servant Moses to give you all the land, and to destroy all the inhabitants of the land from before you. Therefore we were very afraid for our lives because of you, and have done this thing. 
 <sup>25&#160;</sup>Now, behold, we are in your hand. Do to us as it seems good and right to you to do.” 
 </p><p>
 <sup>26&#160;</sup>He did so to them, and delivered them out of the hand of the children of Israel, so that they didn’t kill them. 
-<sup>27&#160;</sup>That day Joshua made them wood cutters and drawers of water for the congregation and for Yahweh’s altar to this day, in the place which he should choose. 
+<sup>27&#160;</sup>That day Joshua made them wood cutters and drawers of water for the congregation and for Yahuah’s altar to this day, in the place which he should choose. 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p>
 <sup>1&#160;</sup>Now when Adoni-Zedek king of Jerusalem heard how Joshua had taken Ai, and had utterly destroyed it; as he had done to Jericho and her king, so he had done to Ai and her king; and how the inhabitants of Gibeon had made peace with Israel, and were among them, 
@@ -376,23 +376,23 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>The men of Gibeon sent to Joshua at the camp at Gilgal, saying, “Don’t abandon your servants! Come up to us quickly and save us! Help us; for all the kings of the Amorites that dwell in the hill country have gathered together against us.” 
 </p><p>
 <sup>7&#160;</sup>So Joshua went up from Gilgal, he and the whole army with him, including all the mighty men of valor. 
-<sup>8&#160;</sup>Yahweh said to Joshua, “Don’t fear them, for I have delivered them into your hands. Not a man of them will stand before you.” 
+<sup>8&#160;</sup>Yahuah said to Joshua, “Don’t fear them, for I have delivered them into your hands. Not a man of them will stand before you.” 
 </p><p>
 <sup>9&#160;</sup>Joshua therefore came to them suddenly. He marched from Gilgal all night. 
-<sup>10&#160;</sup>Yahweh confused them before Israel. He killed them with a great slaughter at Gibeon, and chased them by the way of the ascent of Beth Horon, and struck them to Azekah and to Makkedah. 
-<sup>11&#160;</sup>As they fled from before Israel, while they were at the descent of Beth Horon, Yahweh hurled down great stones from the sky on them to Azekah, and they died. There were more who died from the hailstones than those whom the children of Israel killed with the sword. 
+<sup>10&#160;</sup>Yahuah confused them before Israel. He killed them with a great slaughter at Gibeon, and chased them by the way of the ascent of Beth Horon, and struck them to Azekah and to Makkedah. 
+<sup>11&#160;</sup>As they fled from before Israel, while they were at the descent of Beth Horon, Yahuah hurled down great stones from the sky on them to Azekah, and they died. There were more who died from the hailstones than those whom the children of Israel killed with the sword. 
 </p><p>
-<sup>12&#160;</sup>Then Joshua spoke to Yahweh in the day when Yahweh delivered up the Amorites before the children of Israel. He said in the sight of Israel, “Sun, stand still on Gibeon! You, moon, stop in the valley of Aijalon!” 
+<sup>12&#160;</sup>Then Joshua spoke to Yahuah in the day when Yahuah delivered up the Amorites before the children of Israel. He said in the sight of Israel, “Sun, stand still on Gibeon! You, moon, stop in the valley of Aijalon!” 
 </p><p>
 <sup>13&#160;</sup>The sun stood still, and the moon stayed, until the nation had avenged themselves of their enemies. Isn’t this written in the book of Jashar? The sun stayed in the middle of the sky, and didn’t hurry to go down about a whole day. 
-<sup>14&#160;</sup>There was no day like that before it or after it, that Yahweh listened to the voice of a man; for Yahweh fought for Israel. 
+<sup>14&#160;</sup>There was no day like that before it or after it, that Yahuah listened to the voice of a man; for Yahuah fought for Israel. 
 </p><p>
 <sup>15&#160;</sup>Joshua returned, and all Israel with him, to the camp to Gilgal. 
 <sup>16&#160;</sup>These five kings fled, and hid themselves in the cave at Makkedah. 
 <sup>17&#160;</sup>Joshua was told, saying, “The five kings have been found, hidden in the cave at Makkedah.” 
 </p><p>
 <sup>18&#160;</sup>Joshua said, “Roll large stones to cover the cave’s entrance, and set men by it to guard them; 
-<sup>19&#160;</sup>but don’t stay there. Pursue your enemies, and attack them from the rear. Don’t allow them to enter into their cities; for Yahweh your Elohim has delivered them into your hand.” 
+<sup>19&#160;</sup>but don’t stay there. Pursue your enemies, and attack them from the rear. Don’t allow them to enter into their cities; for Yahuah your Elohim has delivered them into your hand.” 
 </p><p>
 <sup>20&#160;</sup>When Joshua and the children of Israel had finished killing them with a very great slaughter until they were consumed, and the remnant which remained of them had entered into the fortified cities, 
 <sup>21&#160;</sup>all the people returned to the camp to Joshua at Makkedah in peace. None moved his tongue against any of the children of Israel. 
@@ -402,7 +402,7 @@ html[dir=ltr] .q2 {
 <sup>24&#160;</sup>When they brought those kings out to Joshua, Joshua called for all the men of Israel, and said to the chiefs of the men of war who went with him, “Come near. Put your feet on the necks of these kings.” 
 </p><p>They came near, and put their feet on their necks. 
 </p><p>
-<sup>25&#160;</sup>Joshua said to them, “Don’t be afraid, nor be dismayed. Be strong and courageous, for Yahweh will do this to all your enemies against whom you fight.” 
+<sup>25&#160;</sup>Joshua said to them, “Don’t be afraid, nor be dismayed. Be strong and courageous, for Yahuah will do this to all your enemies against whom you fight.” 
 </p><p>
 <sup>26&#160;</sup>Afterward Joshua struck them, put them to death, and hanged them on five trees. They were hanging on the trees until the evening. 
 <sup>27&#160;</sup>At the time of the going down of the sun, Joshua commanded, and they took them down off the trees, and threw them into the cave in which they had hidden themselves, and laid great stones on the mouth of the cave, which remain to this very day. 
@@ -410,10 +410,10 @@ html[dir=ltr] .q2 {
 <sup>28&#160;</sup>Joshua took Makkedah on that day, and struck it with the edge of the sword, with its king. He utterly destroyed it and all the souls who were in it. He left no one remaining. He did to the king of Makkedah as he had done to the king of Jericho. 
 </p><p>
 <sup>29&#160;</sup>Joshua passed from Makkedah, and all Israel with him, to Libnah, and fought against Libnah. 
-<sup>30&#160;</sup>Yahweh delivered it also, with its king, into the hand of Israel. He struck it with the edge of the sword, and all the souls who were in it. He left no one remaining in it. He did to its king as he had done to the king of Jericho. 
+<sup>30&#160;</sup>Yahuah delivered it also, with its king, into the hand of Israel. He struck it with the edge of the sword, and all the souls who were in it. He left no one remaining in it. He did to its king as he had done to the king of Jericho. 
 </p><p>
 <sup>31&#160;</sup>Joshua passed from Libnah, and all Israel with him, to Lachish, and encamped against it, and fought against it. 
-<sup>32&#160;</sup>Yahweh delivered Lachish into the hand of Israel. He took it on the second day, and struck it with the edge of the sword, with all the souls who were in it, according to all that he had done to Libnah. 
+<sup>32&#160;</sup>Yahuah delivered Lachish into the hand of Israel. He took it on the second day, and struck it with the edge of the sword, with all the souls who were in it, according to all that he had done to Libnah. 
 <sup>33&#160;</sup>Then Horam king of Gezer came up to help Lachish; and Joshua struck him and his people, until he had left him no one remaining. 
 </p><p>
 <sup>34&#160;</sup>Joshua passed from Lachish, and all Israel with him, to Eglon; and they encamped against it and fought against it. 
@@ -424,9 +424,9 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>38&#160;</sup>Joshua returned, and all Israel with him, to Debir, and fought against it. 
 <sup>39&#160;</sup>He took it, with its king and all its cities. They struck them with the edge of the sword, and utterly destroyed all the souls who were in it. He left no one remaining. As he had done to Hebron, so he did to Debir, and to its king; as he had done also to Libnah, and to its king. 
-<sup>40&#160;</sup>So Joshua struck all the land, the hill country, the South, the lowland, the slopes, and all their kings. He left no one remaining, but he utterly destroyed all that breathed, as Yahweh, the Elohim of Israel, commanded. 
+<sup>40&#160;</sup>So Joshua struck all the land, the hill country, the South, the lowland, the slopes, and all their kings. He left no one remaining, but he utterly destroyed all that breathed, as Yahuah, the Elohim of Israel, commanded. 
 <sup>41&#160;</sup>Joshua struck them from Kadesh Barnea even to Gaza, and all the country of Goshen, even to Gibeon. 
-<sup>42&#160;</sup>Joshua took all these kings and their land at one time because Yahweh, the Elohim of Israel, fought for Israel. 
+<sup>42&#160;</sup>Joshua took all these kings and their land at one time because Yahuah, the Elohim of Israel, fought for Israel. 
 <sup>43&#160;</sup>Joshua returned, and all Israel with him, to the camp to Gilgal. 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p>
@@ -436,26 +436,26 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>They went out, they and all their armies with them, many people, even as the sand that is on the seashore in multitude, with very many horses and chariots. 
 <sup>5&#160;</sup>All these kings met together; and they came and encamped together at the waters of Merom, to fight with Israel. 
 </p><p>
-<sup>6&#160;</sup>Yahweh said to Joshua, “Don’t be afraid because of them; for tomorrow at this time, I will deliver them up all slain before Israel. You shall hamstring their horses and burn their chariots with fire.” 
+<sup>6&#160;</sup>Yahuah said to Joshua, “Don’t be afraid because of them; for tomorrow at this time, I will deliver them up all slain before Israel. You shall hamstring their horses and burn their chariots with fire.” 
 </p><p>
 <sup>7&#160;</sup>So Joshua came suddenly, with all the warriors, against them by the waters of Merom, and attacked them. 
-<sup>8&#160;</sup>Yahweh delivered them into the hand of Israel, and they struck them, and chased them to great Sidon, and to Misrephoth Maim, and to the valley of Mizpah eastward. They struck them until they left them no one remaining. 
-<sup>9&#160;</sup>Joshua did to them as Yahweh told him. He hamstrung their horses and burned their chariots with fire. 
+<sup>8&#160;</sup>Yahuah delivered them into the hand of Israel, and they struck them, and chased them to great Sidon, and to Misrephoth Maim, and to the valley of Mizpah eastward. They struck them until they left them no one remaining. 
+<sup>9&#160;</sup>Joshua did to them as Yahuah told him. He hamstrung their horses and burned their chariots with fire. 
 <sup>10&#160;</sup>Joshua turned back at that time, and took Hazor, and struck its king with the sword; for Hazor used to be the head of all those kingdoms. 
 <sup>11&#160;</sup>They struck all the souls who were in it with the edge of the sword, utterly destroying them. There was no one left who breathed. He burned Hazor with fire. 
-<sup>12&#160;</sup>Joshua captured all the cities of those kings, with their kings, and he struck them with the edge of the sword, and utterly destroyed them, as Moses the servant of Yahweh commanded. 
+<sup>12&#160;</sup>Joshua captured all the cities of those kings, with their kings, and he struck them with the edge of the sword, and utterly destroyed them, as Moses the servant of Yahuah commanded. 
 <sup>13&#160;</sup>But as for the cities that stood on their mounds, Israel burned none of them, except Hazor only. Joshua burned that. 
 <sup>14&#160;</sup>The children of Israel took all the plunder of these cities, with the livestock, as plunder for themselves; but every man they struck with the edge of the sword, until they had destroyed them. They didn’t leave any who breathed. 
 </p><p>
-<sup>15&#160;</sup>As Yahweh commanded Moses his servant, so Moses commanded Joshua. Joshua did so. He left nothing undone of all that Yahweh commanded Moses. 
+<sup>15&#160;</sup>As Yahuah commanded Moses his servant, so Moses commanded Joshua. Joshua did so. He left nothing undone of all that Yahuah commanded Moses. 
 <sup>16&#160;</sup>So Joshua captured all that land, the hill country, all the South, all the land of Goshen, the lowland, the Arabah, the hill country of Israel, and the lowland of the same, 
 <sup>17&#160;</sup>from Mount Halak, that goes up to Seir, even to Baal Gad in the valley of Lebanon under Mount Hermon. He took all their kings, struck them, and put them to death. 
 <sup>18&#160;</sup>Joshua made war a long time with all those kings. 
 <sup>19&#160;</sup>There was not a city that made peace with the children of Israel, except the Hivites, the inhabitants of Gibeon. They took all in battle. 
-<sup>20&#160;</sup>For it was of Yahweh to harden their hearts, to come against Israel in battle, that he might utterly destroy them, that they might have no favor, but that he might destroy them, as Yahweh commanded Moses. 
+<sup>20&#160;</sup>For it was of Yahuah to harden their hearts, to come against Israel in battle, that he might utterly destroy them, that they might have no favor, but that he might destroy them, as Yahuah commanded Moses. 
 <sup>21&#160;</sup>Joshua came at that time, and cut off the Anakim from the hill country, from Hebron, from Debir, from Anab, and from all the hill country of Judah, and from all the hill country of Israel. Joshua utterly destroyed them with their cities. 
 <sup>22&#160;</sup>There were none of the Anakim left in the land of the children of Israel. Only in Gaza, in Gath, and in Ashdod, did some remain. 
-<sup>23&#160;</sup>So Joshua took the whole land, according to all that Yahweh spoke to Moses; and Joshua gave it for an inheritance to Israel according to their divisions by their tribes. Then the land had rest from war. 
+<sup>23&#160;</sup>So Joshua took the whole land, according to all that Yahuah spoke to Moses; and Joshua gave it for an inheritance to Israel according to their divisions by their tribes. Then the land had rest from war. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
 <sup>1&#160;</sup>Now these are the kings of the land, whom the children of Israel struck, and possessed their land beyond the Jordan toward the sunrise, from the valley of the Arnon to Mount Hermon, and all the Arabah eastward: 
@@ -463,7 +463,7 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>and the Arabah to the sea of Chinneroth, eastward, and to the sea of the Arabah, even the Salt Sea, eastward, the way to Beth Jeshimoth; and on the south, under the slopes of Pisgah: 
 <sup>4&#160;</sup>and the border of Og king of Bashan, of the remnant of the Rephaim, who lived at Ashtaroth and at Edrei, 
 <sup>5&#160;</sup>and ruled in Mount Hermon, and in Salecah, and in all Bashan, to the border of the Geshurites and the Maacathites, and half Gilead, the border of Sihon king of Heshbon. 
-<sup>6&#160;</sup>Moses the servant of Yahweh and the children of Israel struck them. Moses the servant of Yahweh gave it for a possession to the Reubenites, and the Gadites, and the half-tribe of Manasseh. 
+<sup>6&#160;</sup>Moses the servant of Yahuah and the children of Israel struck them. Moses the servant of Yahuah gave it for a possession to the Reubenites, and the Gadites, and the half-tribe of Manasseh. 
 </p><p>
 <sup>7&#160;</sup>These are the kings of the land whom Joshua and the children of Israel struck beyond the Jordan westward, from Baal Gad in the valley of Lebanon even to Mount Halak, that goes up to Seir. Joshua gave it to the tribes of Israel for a possession according to their divisions; 
 <sup>8&#160;</sup>in the hill country, and in the lowland, and in the Arabah, and in the slopes, and in the wilderness, and in the South; the Hittite, the Amorite, and the Canaanite, the Perizzite, the Hivite, and the Jebusite: 
@@ -517,7 +517,7 @@ html[dir=ltr] .q2 {
 </p><p class="m">all the kings thirty-one. 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
-<sup>1&#160;</sup>Now Joshua was old and well advanced in years. Yahweh said to him, “You are old and advanced in years, and there remains yet very much land to be possessed. 
+<sup>1&#160;</sup>Now Joshua was old and well advanced in years. Yahuah said to him, “You are old and advanced in years, and there remains yet very much land to be possessed. 
 </p><p>
 <sup>2&#160;</sup>“This is the land that still remains: all the regions of the Philistines, and all the Geshurites; 
 <sup>3&#160;</sup>from the Shihor, which is before Egypt, even to the border of Ekron northward, which is counted as Canaanite; the five lords of the Philistines; the Gazites, and the Ashdodites, the Ashkelonites, the Gittites, and the Ekronites; also the Avvim, 
@@ -525,13 +525,13 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>and the land of the Gebalites, and all Lebanon, toward the sunrise, from Baal Gad under Mount Hermon to the entrance of Hamath; 
 <sup>6&#160;</sup>all the inhabitants of the hill country from Lebanon to Misrephoth Maim, even all the Sidonians. I will drive them out from before the children of Israel. Just allocate it to Israel for an inheritance, as I have commanded you. 
 <sup>7&#160;</sup>Now therefore divide this land for an inheritance to the nine tribes and the half-tribe of Manasseh.” 
-<sup>8&#160;</sup>With him the Reubenites and the Gadites received their inheritance, which Moses gave them, beyond the Jordan eastward, even as Moses the servant of Yahweh gave them: 
+<sup>8&#160;</sup>With him the Reubenites and the Gadites received their inheritance, which Moses gave them, beyond the Jordan eastward, even as Moses the servant of Yahuah gave them: 
 <sup>9&#160;</sup>from Aroer, that is on the edge of the valley of the Arnon, and the city that is in the middle of the valley, and all the plain of Medeba to Dibon; 
 <sup>10&#160;</sup>and all the cities of Sihon king of the Amorites, who reigned in Heshbon, to the border of the children of Ammon; 
 <sup>11&#160;</sup>and Gilead, and the border of the Geshurites and Maacathites, and all Mount Hermon, and all Bashan to Salecah; 
 <sup>12&#160;</sup>all the kingdom of Og in Bashan, who reigned in Ashtaroth and in Edrei (who was left of the remnant of the Rephaim); for Moses attacked these, and drove them out. 
 <sup>13&#160;</sup>Nevertheless the children of Israel didn’t drive out the Geshurites, nor the Maacathites: but Geshur and Maacath live within Israel to this day. 
-<sup>14&#160;</sup>Only he gave no inheritance to the tribe of Levi. The offerings of Yahweh, the Elohim of Israel, made by fire are his inheritance, as he spoke to him. 
+<sup>14&#160;</sup>Only he gave no inheritance to the tribe of Levi. The offerings of Yahuah, the Elohim of Israel, made by fire are his inheritance, as he spoke to him. 
 <sup>15&#160;</sup>Moses gave to the tribe of the children of Reuben according to their families. 
 <sup>16&#160;</sup>Their border was from Aroer, that is on the edge of the valley of the Arnon, and the city that is in the middle of the valley, and all the plain by Medeba; 
 <sup>17&#160;</sup>Heshbon, and all its cities that are in the plain; Dibon, Bamoth Baal, Beth Baal Meon, 
@@ -554,26 +554,26 @@ html[dir=ltr] .q2 {
 <sup>31&#160;</sup>Half Gilead, Ashtaroth, and Edrei, the cities of the kingdom of Og in Bashan, were for the children of Machir the son of Manasseh, even for the half of the children of Machir according to their families. 
 </p><p>
 <sup>32&#160;</sup>These are the inheritances which Moses distributed in the plains of Moab, beyond the Jordan at Jericho, eastward. 
-<sup>33&#160;</sup>But Moses gave no inheritance to the tribe of Levi. Yahweh, the Elohim of Israel, is their inheritance, as he spoke to them. 
+<sup>33&#160;</sup>But Moses gave no inheritance to the tribe of Levi. Yahuah, the Elohim of Israel, is their inheritance, as he spoke to them. 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
 <sup>1&#160;</sup>These are the inheritances which the children of Israel took in the land of Canaan, which Eleazar the priest, Joshua the son of Nun, and the heads of the fathers’ houses of the tribes of the children of Israel, distributed to them, 
-<sup>2&#160;</sup>by the lot of their inheritance, as Yahweh commanded by Moses, for the nine tribes, and for the half-tribe. 
+<sup>2&#160;</sup>by the lot of their inheritance, as Yahuah commanded by Moses, for the nine tribes, and for the half-tribe. 
 <sup>3&#160;</sup>For Moses had given the inheritance of the two tribes and the half-tribe beyond the Jordan; but to the Levites he gave no inheritance among them. 
 <sup>4&#160;</sup>For the children of Joseph were two tribes, Manasseh and Ephraim. They gave no portion to the Levites in the land, except cities to dwell in, with their pasture lands for their livestock and for their property. 
-<sup>5&#160;</sup>The children of Israel did as Yahweh commanded Moses, and they divided the land. 
+<sup>5&#160;</sup>The children of Israel did as Yahuah commanded Moses, and they divided the land. 
 </p><p>
-<sup>6&#160;</sup>Then the children of Judah came near to Joshua in Gilgal. Caleb the son of Jephunneh the Kenizzite said to him, “You know the thing that Yahweh spoke to Moses the man of Elohim concerning me and concerning you in Kadesh Barnea. 
-<sup>7&#160;</sup>I was forty years old when Moses the servant of Yahweh sent me from Kadesh Barnea to spy out the land. I brought him word again as it was in my heart. 
-<sup>8&#160;</sup>Nevertheless, my brothers who went up with me made the heart of the people melt; but I wholly followed Yahweh my Elohim. 
-<sup>9&#160;</sup>Moses swore on that day, saying, ‘Surely the land where you walked shall be an inheritance to you and to your children forever, because you have wholly followed Yahweh my Elohim.’ 
+<sup>6&#160;</sup>Then the children of Judah came near to Joshua in Gilgal. Caleb the son of Jephunneh the Kenizzite said to him, “You know the thing that Yahuah spoke to Moses the man of Elohim concerning me and concerning you in Kadesh Barnea. 
+<sup>7&#160;</sup>I was forty years old when Moses the servant of Yahuah sent me from Kadesh Barnea to spy out the land. I brought him word again as it was in my heart. 
+<sup>8&#160;</sup>Nevertheless, my brothers who went up with me made the heart of the people melt; but I wholly followed Yahuah my Elohim. 
+<sup>9&#160;</sup>Moses swore on that day, saying, ‘Surely the land where you walked shall be an inheritance to you and to your children forever, because you have wholly followed Yahuah my Elohim.’ 
 </p><p>
-<sup>10&#160;</sup>“Now, behold, Yahweh has kept me alive, as he spoke, these forty-five years, from the time that Yahweh spoke this word to Moses, while Israel walked in the wilderness. Now, behold, I am eighty-five years old, today. 
+<sup>10&#160;</sup>“Now, behold, Yahuah has kept me alive, as he spoke, these forty-five years, from the time that Yahuah spoke this word to Moses, while Israel walked in the wilderness. Now, behold, I am eighty-five years old, today. 
 <sup>11&#160;</sup>As yet I am as strong today as I was in the day that Moses sent me. As my strength was then, even so is my strength now for war, to go out and to come in. 
-<sup>12&#160;</sup>Now therefore give me this hill country, of which Yahweh spoke in that day; for you heard in that day how the Anakim were there, and great and fortified cities. It may be that Yahweh will be with me, and I shall drive them out, as Yahweh said.” 
+<sup>12&#160;</sup>Now therefore give me this hill country, of which Yahuah spoke in that day; for you heard in that day how the Anakim were there, and great and fortified cities. It may be that Yahuah will be with me, and I shall drive them out, as Yahuah said.” 
 </p><p>
 <sup>13&#160;</sup>Joshua blessed him; and he gave Hebron to Caleb the son of Jephunneh for an inheritance. 
-<sup>14&#160;</sup>Therefore Hebron became the inheritance of Caleb the son of Jephunneh the Kenizzite to this day, because he followed Yahweh, the Elohim of Israel wholeheartedly. 
+<sup>14&#160;</sup>Therefore Hebron became the inheritance of Caleb the son of Jephunneh the Kenizzite to this day, because he followed Yahuah, the Elohim of Israel wholeheartedly. 
 <sup>15&#160;</sup>Now the name of Hebron before was Kiriath Arba, after the greatest man among the Anakim. Then the land had rest from war. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
@@ -590,7 +590,7 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>and the border went out to the side of Ekron northward; and the border extended to Shikkeron, and passed along to Mount Baalah, and went out at Jabneel; and the goings out of the border were at the sea. 
 <sup>12&#160;</sup>The west border was to the shore of the great sea. This is the border of the children of Judah according to their families. 
 </p><p>
-<sup>13&#160;</sup>He gave to Caleb the son of Jephunneh a portion among the children of Judah, according to the commandment of Yahweh to Joshua, even Kiriath Arba, named after the father of Anak (also called Hebron). 
+<sup>13&#160;</sup>He gave to Caleb the son of Jephunneh a portion among the children of Judah, according to the commandment of Yahuah to Joshua, even Kiriath Arba, named after the father of Anak (also called Hebron). 
 <sup>14&#160;</sup>Caleb drove out the three sons of Anak: Sheshai, and Ahiman, and Talmai, the children of Anak. 
 <sup>15&#160;</sup>He went up against the inhabitants of Debir: now the name of Debir before was Kiriath Sepher. 
 <sup>16&#160;</sup>Caleb said, “He who strikes Kiriath Sepher, and takes it, to him I will give Achsah my daughter as woman.” 
@@ -672,7 +672,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>This was the lot for the tribe of Manasseh, for he was the firstborn of Joseph. As for Machir the firstborn of Manasseh, the father of Gilead, because he was a man of war, therefore he had Gilead and Bashan. 
 <sup>2&#160;</sup>So this was for the rest of the children of Manasseh according to their families: for the children of Abiezer, for the children of Helek, for the children of Asriel, for the children of Shechem, for the children of Hepher, and for the children of Shemida. These were the male children of Manasseh the son of Joseph according to their families. 
 <sup>3&#160;</sup>But Zelophehad, the son of Hepher, the son of Gilead, the son of Machir, the son of Manasseh, had no sons, but daughters. These are the names of his daughters: Mahlah, Noah, Hoglah, Milcah, and Tirzah. 
-<sup>4&#160;</sup>They came to Eleazar the priest, and to Joshua the son of Nun, and to the princes, saying, “Yahweh commanded Moses to give us an inheritance among our brothers.” Therefore according to the commandment of Yahweh he gave them an inheritance among the brothers of their father. 
+<sup>4&#160;</sup>They came to Eleazar the priest, and to Joshua the son of Nun, and to the princes, saying, “Yahuah commanded Moses to give us an inheritance among our brothers.” Therefore according to the commandment of Yahuah he gave them an inheritance among the brothers of their father. 
 <sup>5&#160;</sup>Ten parts fell to Manasseh, in addition to the land of Gilead and Bashan, which is beyond the Jordan; 
 <sup>6&#160;</sup>because the daughters of Manasseh had an inheritance among his sons. The land of Gilead belonged to the rest of the sons of Manasseh. 
 <sup>7&#160;</sup>The border of Manasseh was from Asher to Michmethath, which is before Shechem. The border went along to the right hand, to the inhabitants of En Tappuah. 
@@ -683,7 +683,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Yet the children of Manasseh couldn’t drive out the inhabitants of those cities; but the Canaanites would dwell in that land. 
 </p><p>
 <sup>13&#160;</sup>When the children of Israel had grown strong, they put the Canaanites to forced labor, and didn’t utterly drive them out. 
-<sup>14&#160;</sup>The children of Joseph spoke to Joshua, saying, “Why have you given me just one lot and one part for an inheritance, since we are a numerous people, because Yahweh has blessed us so far?” 
+<sup>14&#160;</sup>The children of Joseph spoke to Joshua, saying, “Why have you given me just one lot and one part for an inheritance, since we are a numerous people, because Yahuah has blessed us so far?” 
 </p><p>
 <sup>15&#160;</sup>Joshua said to them, “If you are a numerous people, go up to the forest, and clear land for yourself there in the land of the Perizzites and of the Rephaim, since the hill country of Ephraim is too narrow for you.” 
 </p><p>
@@ -695,16 +695,16 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>The whole congregation of the children of Israel assembled themselves together at Shiloh, and set up the Tent of Meeting there. The land was subdued before them. 
 <sup>2&#160;</sup>Seven tribes remained among the children of Israel, which had not yet divided their inheritance. 
-<sup>3&#160;</sup>Joshua said to the children of Israel, “How long will you neglect to go in to possess the land, which Yahweh, the Elohim of your fathers, has given you? 
+<sup>3&#160;</sup>Joshua said to the children of Israel, “How long will you neglect to go in to possess the land, which Yahuah, the Elohim of your fathers, has given you? 
 <sup>4&#160;</sup>Appoint for yourselves three men from each tribe. I will send them, and they shall arise, walk through the land, and describe it according to their inheritance; then they shall come to me. 
 <sup>5&#160;</sup>They shall divide it into seven portions. Judah shall live in his borders on the south, and the house of Joseph shall live in their borders on the north. 
-<sup>6&#160;</sup>You shall survey the land into seven parts, and bring the description here to me; and I will cast lots for you here before Yahweh our Elohim. 
-<sup>7&#160;</sup>However, the Levites have no portion among you; for the priesthood of Yahweh is their inheritance. Gad, Reuben, and the half-tribe of Manasseh have received their inheritance east of the Jordan, which Moses the servant of Yahweh gave them.” 
+<sup>6&#160;</sup>You shall survey the land into seven parts, and bring the description here to me; and I will cast lots for you here before Yahuah our Elohim. 
+<sup>7&#160;</sup>However, the Levites have no portion among you; for the priesthood of Yahuah is their inheritance. Gad, Reuben, and the half-tribe of Manasseh have received their inheritance east of the Jordan, which Moses the servant of Yahuah gave them.” 
 </p><p>
-<sup>8&#160;</sup>The men arose and went. Joshua commanded those who went to survey the land, saying, “Go walk through the land, survey it, and come again to me. I will cast lots for you here before Yahweh in Shiloh.” 
+<sup>8&#160;</sup>The men arose and went. Joshua commanded those who went to survey the land, saying, “Go walk through the land, survey it, and come again to me. I will cast lots for you here before Yahuah in Shiloh.” 
 </p><p>
 <sup>9&#160;</sup>The men went and passed through the land, and surveyed it by cities into seven portions in a book. They came to Joshua to the camp at Shiloh. 
-<sup>10&#160;</sup>Joshua cast lots for them in Shiloh before Yahweh. There Joshua divided the land to the children of Israel according to their divisions. 
+<sup>10&#160;</sup>Joshua cast lots for them in Shiloh before Yahuah. There Joshua divided the land to the children of Israel according to their divisions. 
 </p><p>
 <sup>11&#160;</sup>The lot of the tribe of the children of Benjamin came up according to their families. The border of their lot went out between the children of Judah and the children of Joseph. 
 <sup>12&#160;</sup>Their border on the north quarter was from the Jordan. The border went up to the side of Jericho on the north, and went up through the hill country westward. It ended at the wilderness of Beth Aven. 
@@ -781,11 +781,11 @@ html[dir=ltr] .q2 {
 <sup>48&#160;</sup>This is the inheritance of the tribe of the children of Dan according to their families, these cities with their villages. 
 </p><p>
 <sup>49&#160;</sup>So they finished distributing the land for inheritance by its borders. The children of Israel gave an inheritance to Joshua the son of Nun among them. 
-<sup>50&#160;</sup>According to Yahweh’s commandment, they gave him the city which he asked, even Timnathserah in the hill country of Ephraim; and he built the city, and lived there. 
-<sup>51&#160;</sup>These are the inheritances, which Eleazar the priest, Joshua the son of Nun, and the heads of the fathers’ houses of the tribes of the children of Israel, distributed for inheritance by lot in Shiloh before Yahweh, at the door of the Tent of Meeting. So they finished dividing the land. 
+<sup>50&#160;</sup>According to Yahuah’s commandment, they gave him the city which he asked, even Timnathserah in the hill country of Ephraim; and he built the city, and lived there. 
+<sup>51&#160;</sup>These are the inheritances, which Eleazar the priest, Joshua the son of Nun, and the heads of the fathers’ houses of the tribes of the children of Israel, distributed for inheritance by lot in Shiloh before Yahuah, at the door of the Tent of Meeting. So they finished dividing the land. 
 </p><h2 class="chapterlabel" id="20">20</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Joshua, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Joshua, saying, 
 <sup>2&#160;</sup>“Speak to the children of Israel, saying, ‘Assign the cities of refuge, of which I spoke to you by Moses, 
 <sup>3&#160;</sup>that the man slayer who kills any person accidentally or unintentionally may flee there. They shall be to you for a refuge from the avenger of blood. 
 <sup>4&#160;</sup>He shall flee to one of those cities, and shall stand at the entrance of the gate of the city, and declare his case in the ears of the elders of that city. They shall take him into the city with them, and give him a place, that he may live among them. 
@@ -798,14 +798,14 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
 <sup>1&#160;</sup>Then the heads of fathers’ houses of the Levites came near to Eleazar the priest, and to Joshua the son of Nun, and to the heads of fathers’ houses of the tribes of the children of Israel. 
-<sup>2&#160;</sup>They spoke to them at Shiloh in the land of Canaan, saying, “Yahweh commanded through Moses to give us cities to dwell in, with their pasture lands for our livestock.” 
+<sup>2&#160;</sup>They spoke to them at Shiloh in the land of Canaan, saying, “Yahuah commanded through Moses to give us cities to dwell in, with their pasture lands for our livestock.” 
 </p><p>
-<sup>3&#160;</sup>The children of Israel gave to the Levites out of their inheritance, according to the commandment of Yahweh, these cities with their pasture lands. 
+<sup>3&#160;</sup>The children of Israel gave to the Levites out of their inheritance, according to the commandment of Yahuah, these cities with their pasture lands. 
 <sup>4&#160;</sup>The lot came out for the families of the Kohathites. The children of Aaron the priest, who were of the Levites, had thirteen cities by lot out of the tribe of Judah, out of the tribe of the Simeonites, and out of the tribe of Benjamin. 
 <sup>5&#160;</sup>The rest of the children of Kohath had ten cities by lot out of the families of the tribe of Ephraim, out of the tribe of Dan, and out of the half-tribe of Manasseh. 
 <sup>6&#160;</sup>The children of Gershon had thirteen cities by lot out of the families of the tribe of Issachar, out of the tribe of Asher, out of the tribe of Naphtali, and out of the half-tribe of Manasseh in Bashan. 
 <sup>7&#160;</sup>The children of Merari according to their families had twelve cities out of the tribe of Reuben, out of the tribe of Gad, and out of the tribe of Zebulun. 
-<sup>8&#160;</sup>The children of Israel gave these cities with their pasture lands by lot to the Levites, as Yahweh commanded by Moses. 
+<sup>8&#160;</sup>The children of Israel gave these cities with their pasture lands by lot to the Levites, as Yahuah commanded by Moses. 
 <sup>9&#160;</sup>They gave out of the tribe of the children of Judah, and out of the tribe of the children of Simeon, these cities which are mentioned by name: 
 <sup>10&#160;</sup>and they were for the children of Aaron, of the families of the Kohathites, who were of the children of Levi; for theirs was the first lot. 
 <sup>11&#160;</sup>They gave them Kiriath Arba, named after the father of Anak (also called Hebron), in the hill country of Judah, with its pasture lands around it. 
@@ -845,85 +845,85 @@ html[dir=ltr] .q2 {
 <sup>41&#160;</sup>All the cities of the Levites among the possessions of the children of Israel were forty-eight cities with their pasture lands. 
 <sup>42&#160;</sup>Each of these cities included their pasture lands around them. It was this way with all these cities. 
 </p><p>
-<sup>43&#160;</sup>So Yahweh gave to Israel all the land which he swore to give to their fathers. They possessed it, and lived in it. 
-<sup>44&#160;</sup>Yahweh gave them rest all around, according to all that he swore to their fathers. Not a man of all their enemies stood before them. Yahweh delivered all their enemies into their hand. 
-<sup>45&#160;</sup>Nothing failed of any good thing which Yahweh had spoken to the house of Israel. All came to pass. 
+<sup>43&#160;</sup>So Yahuah gave to Israel all the land which he swore to give to their fathers. They possessed it, and lived in it. 
+<sup>44&#160;</sup>Yahuah gave them rest all around, according to all that he swore to their fathers. Not a man of all their enemies stood before them. Yahuah delivered all their enemies into their hand. 
+<sup>45&#160;</sup>Nothing failed of any good thing which Yahuah had spoken to the house of Israel. All came to pass. 
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
 <sup>1&#160;</sup>Then Joshua called the Reubenites, the Gadites, and the half-tribe of Manasseh, 
-<sup>2&#160;</sup>and said to them, “You have kept all that Moses the servant of Yahweh commanded you, and have listened to my voice in all that I commanded you. 
-<sup>3&#160;</sup>You have not left your brothers these many days to this day, but have performed the duty of the commandment of Yahweh your Elohim. 
-<sup>4&#160;</sup>Now Yahweh your Elohim has given rest to your brothers, as he spoke to them. Therefore now return and go to your tents, to the land of your possession, which Moses the servant of Yahweh gave you beyond the Jordan. 
-<sup>5&#160;</sup>Only take diligent heed to do the commandment and the law which Moses the servant of Yahweh commanded you, to love Yahweh your Elohim, to walk in all his ways, to keep his commandments, to hold fast to him, and to serve him with all your heart and with all your soul.” 
+<sup>2&#160;</sup>and said to them, “You have kept all that Moses the servant of Yahuah commanded you, and have listened to my voice in all that I commanded you. 
+<sup>3&#160;</sup>You have not left your brothers these many days to this day, but have performed the duty of the commandment of Yahuah your Elohim. 
+<sup>4&#160;</sup>Now Yahuah your Elohim has given rest to your brothers, as he spoke to them. Therefore now return and go to your tents, to the land of your possession, which Moses the servant of Yahuah gave you beyond the Jordan. 
+<sup>5&#160;</sup>Only take diligent heed to do the commandment and the law which Moses the servant of Yahuah commanded you, to love Yahuah your Elohim, to walk in all his ways, to keep his commandments, to hold fast to him, and to serve him with all your heart and with all your soul.” 
 </p><p>
 <sup>6&#160;</sup>So Joshua blessed them, and sent them away; and they went to their tents. 
 <sup>7&#160;</sup>Now to the one half-tribe of Manasseh Moses had given inheritance in Bashan; but Joshua gave to the other half among their brothers beyond the Jordan westward. Moreover when Joshua sent them away to their tents, he blessed them, 
 <sup>8&#160;</sup>and spoke to them, saying, “Return with much wealth to your tents, with very much livestock, with silver, with gold, with bronze, with iron, and with very much clothing. Divide the plunder of your enemies with your brothers.” 
 </p><p>
-<sup>9&#160;</sup>The children of Reuben and the children of Gad and the half-tribe of Manasseh returned, and departed from the children of Israel out of Shiloh, which is in the land of Canaan, to go to the land of Gilead, to the land of their possession, which they owned, according to the commandment of Yahweh by Moses. 
+<sup>9&#160;</sup>The children of Reuben and the children of Gad and the half-tribe of Manasseh returned, and departed from the children of Israel out of Shiloh, which is in the land of Canaan, to go to the land of Gilead, to the land of their possession, which they owned, according to the commandment of Yahuah by Moses. 
 <sup>10&#160;</sup>When they came to the region near the Jordan, that is in the land of Canaan, the children of Reuben and the children of Gad and the half-tribe of Manasseh built an altar there by the Jordan, a great altar to look at. 
 <sup>11&#160;</sup>The children of Israel heard this, “Behold, the children of Reuben and the children of Gad and the half-tribe of Manasseh have built an altar along the border of the land of Canaan, in the region around the Jordan, on the side that belongs to the children of Israel.” 
 <sup>12&#160;</sup>When the children of Israel heard of it, the whole congregation of the children of Israel gathered themselves together at Shiloh, to go up against them to war. 
 <sup>13&#160;</sup>The children of Israel sent to the children of Reuben, and to the children of Gad, and to the half-tribe of Manasseh, into the land of Gilead, Phinehas the son of Eleazar the priest. 
 <sup>14&#160;</sup>With him were ten princes, one prince of a fathers’ house for each of the tribes of Israel; and they were each head of their fathers’ houses among the thousands of Israel. 
 <sup>15&#160;</sup>They came to the children of Reuben, and to the children of Gad, and to the half-tribe of Manasseh, to the land of Gilead, and they spoke with them, saying, 
-<sup>16&#160;</sup>“The whole congregation of Yahweh says, ‘What trespass is this that you have committed against the Elohim of Israel, to turn away today from following Yahweh, in that you have built yourselves an altar, to rebel today against Yahweh? 
-<sup>17&#160;</sup>Is the iniquity of Peor too little for us, from which we have not cleansed ourselves to this day, although there came a plague on the congregation of Yahweh, 
-<sup>18&#160;</sup>that you must turn away today from following Yahweh? It will be, since you rebel today against Yahweh, that tomorrow he will be angry with the whole congregation of Israel. 
-<sup>19&#160;</sup>However, if the land of your possession is unclean, then pass over to the land of the possession of Yahweh, in which Yahweh’s tabernacle dwells, and take possession among us; but don’t rebel against Yahweh, nor rebel against us, in building an altar other than Yahweh our Elohim’s altar. 
+<sup>16&#160;</sup>“The whole congregation of Yahuah says, ‘What trespass is this that you have committed against the Elohim of Israel, to turn away today from following Yahuah, in that you have built yourselves an altar, to rebel today against Yahuah? 
+<sup>17&#160;</sup>Is the iniquity of Peor too little for us, from which we have not cleansed ourselves to this day, although there came a plague on the congregation of Yahuah, 
+<sup>18&#160;</sup>that you must turn away today from following Yahuah? It will be, since you rebel today against Yahuah, that tomorrow he will be angry with the whole congregation of Israel. 
+<sup>19&#160;</sup>However, if the land of your possession is unclean, then pass over to the land of the possession of Yahuah, in which Yahuah’s tabernacle dwells, and take possession among us; but don’t rebel against Yahuah, nor rebel against us, in building an altar other than Yahuah our Elohim’s altar. 
 <sup>20&#160;</sup>Didn’t Achan the son of Zerah commit a trespass in the devoted thing, and wrath fell on all the congregation of Israel? That man didn’t perish alone in his iniquity.’&#160;” 
 </p><p>
 <sup>21&#160;</sup>Then the children of Reuben and the children of Gad and the half-tribe of Manasseh answered, and spoke to the heads of the thousands of Israel, 
-<sup>22&#160;</sup>“The Mighty One, Elohim, Yahweh, the Mighty One, Elohim, Yahweh, he knows; and Israel shall know: if it was in rebellion, or if in trespass against Yahweh (don’t save us today), 
-<sup>23&#160;</sup>that we have built us an altar to turn away from following Yahweh; or if to offer burnt offering or meal offering, or if to offer sacrifices of peace offerings, let Yahweh himself require it. 
+<sup>22&#160;</sup>“The Mighty One, Elohim, Yahuah, the Mighty One, Elohim, Yahuah, he knows; and Israel shall know: if it was in rebellion, or if in trespass against Yahuah (don’t save us today), 
+<sup>23&#160;</sup>that we have built us an altar to turn away from following Yahuah; or if to offer burnt offering or meal offering, or if to offer sacrifices of peace offerings, let Yahuah himself require it. 
 </p><p>
-<sup>24&#160;</sup>“If we have not out of concern done this, and for a reason, saying, ‘In time to come your children might speak to our children, saying, “What have you to do with Yahweh, the Elohim of Israel? 
-<sup>25&#160;</sup>For Yahweh has made the Jordan a border between us and you, you children of Reuben and children of Gad. You have no portion in Yahweh.”&#160;’ So your children might make our children cease from fearing Yahweh. 
+<sup>24&#160;</sup>“If we have not out of concern done this, and for a reason, saying, ‘In time to come your children might speak to our children, saying, “What have you to do with Yahuah, the Elohim of Israel? 
+<sup>25&#160;</sup>For Yahuah has made the Jordan a border between us and you, you children of Reuben and children of Gad. You have no portion in Yahuah.”&#160;’ So your children might make our children cease from fearing Yahuah. 
 </p><p>
 <sup>26&#160;</sup>“Therefore we said, ‘Let’s now prepare to build ourselves an altar, not for burnt offering, nor for sacrifice; 
-<sup>27&#160;</sup>but it will be a witness between us and you, and between our generations after us, that we may perform the service of Yahweh before him with our burnt offerings, with our sacrifices, and with our peace offerings;’ that your children may not tell our children in time to come, ‘You have no portion in Yahweh.’ 
+<sup>27&#160;</sup>but it will be a witness between us and you, and between our generations after us, that we may perform the service of Yahuah before him with our burnt offerings, with our sacrifices, and with our peace offerings;’ that your children may not tell our children in time to come, ‘You have no portion in Yahuah.’ 
 </p><p>
-<sup>28&#160;</sup>“Therefore we said, ‘It shall be, when they tell us or our generations this in time to come, that we shall say, “Behold the pattern of Yahweh’s altar, which our fathers made, not for burnt offering, nor for sacrifice; but it is a witness between us and you.”&#160;’ 
+<sup>28&#160;</sup>“Therefore we said, ‘It shall be, when they tell us or our generations this in time to come, that we shall say, “Behold the pattern of Yahuah’s altar, which our fathers made, not for burnt offering, nor for sacrifice; but it is a witness between us and you.”&#160;’ 
 </p><p>
-<sup>29&#160;</sup>“Far be it from us that we should rebel against Yahweh, and turn away today from following Yahweh, to build an altar for burnt offering, for meal offering, or for sacrifice, besides Yahweh our Elohim’s altar that is before his tabernacle!” 
+<sup>29&#160;</sup>“Far be it from us that we should rebel against Yahuah, and turn away today from following Yahuah, to build an altar for burnt offering, for meal offering, or for sacrifice, besides Yahuah our Elohim’s altar that is before his tabernacle!” 
 </p><p>
 <sup>30&#160;</sup>When Phinehas the priest, and the princes of the congregation, even the heads of the thousands of Israel that were with him, heard the words that the children of Reuben and the children of Gad and the children of Manasseh spoke, it pleased them well. 
-<sup>31&#160;</sup>Phinehas the son of Eleazar the priest said to the children of Reuben, to the children of Gad, and to the children of Manasseh, “Today we know that Yahweh is among us, because you have not committed this trespass against Yahweh. Now you have delivered the children of Israel out of Yahweh’s hand.” 
+<sup>31&#160;</sup>Phinehas the son of Eleazar the priest said to the children of Reuben, to the children of Gad, and to the children of Manasseh, “Today we know that Yahuah is among us, because you have not committed this trespass against Yahuah. Now you have delivered the children of Israel out of Yahuah’s hand.” 
 <sup>32&#160;</sup>Phinehas the son of Eleazar the priest, and the princes, returned from the children of Reuben, and from the children of Gad, out of the land of Gilead, to the land of Canaan, to the children of Israel, and brought them word again. 
 <sup>33&#160;</sup>The thing pleased the children of Israel; and the children of Israel blessed Elohim, and spoke no more of going up against them to war, to destroy the land in which the children of Reuben and the children of Gad lived. 
-<sup>34&#160;</sup>The children of Reuben and the children of Gad named the altar “A Witness Between Us that Yahweh is Elohim.” 
+<sup>34&#160;</sup>The children of Reuben and the children of Gad named the altar “A Witness Between Us that Yahuah is Elohim.” 
 </p><h2 class="chapterlabel" id="23">23</h2>
 <p>
-<sup>1&#160;</sup>After many days, when Yahweh had given rest to Israel from their enemies all around, and Joshua was old and well advanced in years, 
+<sup>1&#160;</sup>After many days, when Yahuah had given rest to Israel from their enemies all around, and Joshua was old and well advanced in years, 
 <sup>2&#160;</sup>Joshua called for all Israel, for their elders and for their heads, and for their judges and for their officers, and said to them, “I am old and well advanced in years. 
-<sup>3&#160;</sup>You have seen all that Yahweh your Elohim has done to all these nations because of you; for it is Yahweh your Elohim who has fought for you. 
+<sup>3&#160;</sup>You have seen all that Yahuah your Elohim has done to all these nations because of you; for it is Yahuah your Elohim who has fought for you. 
 <sup>4&#160;</sup>Behold, I have allotted to you these nations that remain, to be an inheritance for your tribes, from the Jordan, with all the nations that I have cut off, even to the great sea toward the going down of the sun. 
-<sup>5&#160;</sup>Yahweh your Elohim will thrust them out from before you, and drive them from out of your sight. You shall possess their land, as Yahweh your Elohim spoke to you. 
+<sup>5&#160;</sup>Yahuah your Elohim will thrust them out from before you, and drive them from out of your sight. You shall possess their land, as Yahuah your Elohim spoke to you. 
 </p><p>
 <sup>6&#160;</sup>“Therefore be very courageous to keep and to do all that is written in the book of the law of Moses, that you not turn away from it to the right hand or to the left; 
 <sup>7&#160;</sup>that you not come among these nations, these that remain among you; neither make mention of the name of their elohims, nor cause to swear by them, neither serve them, nor bow down yourselves to them; 
-<sup>8&#160;</sup>but hold fast to Yahweh your Elohim, as you have done to this day. 
+<sup>8&#160;</sup>but hold fast to Yahuah your Elohim, as you have done to this day. 
 </p><p>
-<sup>9&#160;</sup>“For Yahweh has driven great and strong nations out from before you. But as for you, no man has stood before you to this day. 
-<sup>10&#160;</sup>One man of you shall chase a thousand; for it is Yahweh your Elohim who fights for you, as he spoke to you. 
-<sup>11&#160;</sup>Take good heed therefore to yourselves, that you love Yahweh your Elohim. 
+<sup>9&#160;</sup>“For Yahuah has driven great and strong nations out from before you. But as for you, no man has stood before you to this day. 
+<sup>10&#160;</sup>One man of you shall chase a thousand; for it is Yahuah your Elohim who fights for you, as he spoke to you. 
+<sup>11&#160;</sup>Take good heed therefore to yourselves, that you love Yahuah your Elohim. 
 </p><p>
 <sup>12&#160;</sup>“But if you do at all go back, and hold fast to the remnant of these nations, even these who remain among you, and you make yourselves relatives of them, and go in to them, and they to you; 
-<sup>13&#160;</sup>know for a certainty that Yahweh your Elohim will no longer drive these nations from out of your sight; but they shall be a snare and a trap to you, a scourge in your sides, and thorns in your eyes, until you perish from off this good land which Yahweh your Elohim has given you. 
+<sup>13&#160;</sup>know for a certainty that Yahuah your Elohim will no longer drive these nations from out of your sight; but they shall be a snare and a trap to you, a scourge in your sides, and thorns in your eyes, until you perish from off this good land which Yahuah your Elohim has given you. 
 </p><p>
-<sup>14&#160;</sup>“Behold, today I am going the way of all the earth. You know in all your hearts and in all your souls that not one thing has failed of all the good things which Yahweh your Elohim spoke concerning you. All have happened to you. Not one thing has failed of it. 
-<sup>15&#160;</sup>It shall happen that as all the good things have come on you of which Yahweh your Elohim spoke to you, so Yahweh will bring on you all the evil things, until he has destroyed you from off this good land which Yahweh your Elohim has given you, 
-<sup>16&#160;</sup>when you disobey the covenant of Yahweh your Elohim, which he commanded you, and go and serve other elohims, and bow down yourselves to them. Then Yahweh’s anger will be kindled against you, and you will perish quickly from off the good land which he has given to you.” 
+<sup>14&#160;</sup>“Behold, today I am going the way of all the earth. You know in all your hearts and in all your souls that not one thing has failed of all the good things which Yahuah your Elohim spoke concerning you. All have happened to you. Not one thing has failed of it. 
+<sup>15&#160;</sup>It shall happen that as all the good things have come on you of which Yahuah your Elohim spoke to you, so Yahuah will bring on you all the evil things, until he has destroyed you from off this good land which Yahuah your Elohim has given you, 
+<sup>16&#160;</sup>when you disobey the covenant of Yahuah your Elohim, which he commanded you, and go and serve other elohims, and bow down yourselves to them. Then Yahuah’s anger will be kindled against you, and you will perish quickly from off the good land which he has given to you.” 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
 <sup>1&#160;</sup>Joshua gathered all the tribes of Israel to Shechem, and called for the elders of Israel, for their heads, for their judges, and for their officers; and they presented themselves before Elohim. 
-<sup>2&#160;</sup>Joshua said to all the people, “Yahweh, the Elohim of Israel, says, ‘Your fathers lived of old time beyond the River, even Terah, the father of Abraham, and the father of Nahor. They served other elohims. 
+<sup>2&#160;</sup>Joshua said to all the people, “Yahuah, the Elohim of Israel, says, ‘Your fathers lived of old time beyond the River, even Terah, the father of Abraham, and the father of Nahor. They served other elohims. 
 <sup>3&#160;</sup>I took your father Abraham from beyond the River, and led him throughout all the land of Canaan, and multiplied his offspring, and gave him Isaac. 
 <sup>4&#160;</sup>I gave to Isaac Jacob and Esau: and I gave to Esau Mount Seir, to possess it. Jacob and his children went down into Egypt. 
 </p><p>
 <sup>5&#160;</sup>“&#160;‘I sent Moses and Aaron, and I plagued Egypt, according to that which I did among them: and afterward I brought you out. 
 <sup>6&#160;</sup>I brought your fathers out of Egypt: and you came to the sea. The Egyptians pursued your fathers with chariots and with horsemen to the Red Sea. 
-<sup>7&#160;</sup>When they cried out to Yahweh, he put darkness between you and the Egyptians, and brought the sea on them, and covered them; and your eyes saw what I did in Egypt. You lived in the wilderness many days. 
+<sup>7&#160;</sup>When they cried out to Yahuah, he put darkness between you and the Egyptians, and brought the sea on them, and covered them; and your eyes saw what I did in Egypt. You lived in the wilderness many days. 
 </p><p>
 <sup>8&#160;</sup>“&#160;‘I brought you into the land of the Amorites, that lived beyond the Jordan. They fought with you, and I gave them into your hand. You possessed their land, and I destroyed them from before you. 
 <sup>9&#160;</sup>Then Balak the son of Zippor, king of Moab, arose and fought against Israel. He sent and called Balaam the son of Beor to curse you, 
@@ -933,31 +933,31 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>I sent the hornet before you, which drove them out from before you, even the two kings of the Amorites; not with your sword, nor with your bow. 
 <sup>13&#160;</sup>I gave you a land on which you had not labored, and cities which you didn’t build, and you live in them. You eat of vineyards and olive groves which you didn’t plant.’ 
 </p><p>
-<sup>14&#160;</sup>“Now therefore fear Yahweh, and serve him in sincerity and in truth. Put away the elohims which your fathers served beyond the River, in Egypt; and serve Yahweh. 
-<sup>15&#160;</sup>If it seems evil to you to serve Yahweh, choose today whom you will serve; whether the elohims which your fathers served that were beyond the River, or the elohims of the Amorites, in whose land you dwell; but as for me and my house, we will serve Yahweh.” 
+<sup>14&#160;</sup>“Now therefore fear Yahuah, and serve him in sincerity and in truth. Put away the elohims which your fathers served beyond the River, in Egypt; and serve Yahuah. 
+<sup>15&#160;</sup>If it seems evil to you to serve Yahuah, choose today whom you will serve; whether the elohims which your fathers served that were beyond the River, or the elohims of the Amorites, in whose land you dwell; but as for me and my house, we will serve Yahuah.” 
 </p><p>
-<sup>16&#160;</sup>The people answered, “Far be it from us that we should forsake Yahweh, to serve other elohims; 
-<sup>17&#160;</sup>for it is Yahweh our Elohim who brought us and our fathers up out of the land of Egypt, from the house of bondage, and who did those great signs in our sight, and preserved us in all the way in which we went, and among all the peoples through the middle of whom we passed. 
-<sup>18&#160;</sup>Yahweh drove out from before us all the peoples, even the Amorites who lived in the land. Therefore we also will serve Yahweh; for he is our Elohim.” 
+<sup>16&#160;</sup>The people answered, “Far be it from us that we should forsake Yahuah, to serve other elohims; 
+<sup>17&#160;</sup>for it is Yahuah our Elohim who brought us and our fathers up out of the land of Egypt, from the house of bondage, and who did those great signs in our sight, and preserved us in all the way in which we went, and among all the peoples through the middle of whom we passed. 
+<sup>18&#160;</sup>Yahuah drove out from before us all the peoples, even the Amorites who lived in the land. Therefore we also will serve Yahuah; for he is our Elohim.” 
 </p><p>
-<sup>19&#160;</sup>Joshua said to the people, “You can’t serve Yahweh, for he is a set-apart Elohim. He is a jealous Elohim. He will not forgive your disobedience nor your sins. 
-<sup>20&#160;</sup>If you forsake Yahweh, and serve foreign elohims, then he will turn and do you evil, and consume you, after he has done you good.” 
+<sup>19&#160;</sup>Joshua said to the people, “You can’t serve Yahuah, for he is a set-apart Elohim. He is a jealous Elohim. He will not forgive your disobedience nor your sins. 
+<sup>20&#160;</sup>If you forsake Yahuah, and serve foreign elohims, then he will turn and do you evil, and consume you, after he has done you good.” 
 </p><p>
-<sup>21&#160;</sup>The people said to Joshua, “No, but we will serve Yahweh.” 
-<sup>22&#160;</sup>Joshua said to the people, “You are witnesses against yourselves that you have chosen Yahweh yourselves, to serve him.” 
+<sup>21&#160;</sup>The people said to Joshua, “No, but we will serve Yahuah.” 
+<sup>22&#160;</sup>Joshua said to the people, “You are witnesses against yourselves that you have chosen Yahuah yourselves, to serve him.” 
 </p><p>They said, “We are witnesses.” 
 </p><p>
-<sup>23&#160;</sup>“Now therefore put away the foreign elohims which are among you, and incline your heart to Yahweh, the Elohim of Israel.” 
+<sup>23&#160;</sup>“Now therefore put away the foreign elohims which are among you, and incline your heart to Yahuah, the Elohim of Israel.” 
 </p><p>
-<sup>24&#160;</sup>The people said to Joshua, “We will serve Yahweh our Elohim, and we will listen to his voice.” 
+<sup>24&#160;</sup>The people said to Joshua, “We will serve Yahuah our Elohim, and we will listen to his voice.” 
 </p><p>
 <sup>25&#160;</sup>So Joshua made a covenant with the people that day, and made for them a statute and an ordinance in Shechem. 
-<sup>26&#160;</sup>Joshua wrote these words in the book of the law of Elohim; and he took a great stone, and set it up there under the oak that was by the sanctuary of Yahweh. 
-<sup>27&#160;</sup>Joshua said to all the people, “Behold, this stone shall be a witness against us, for it has heard all Yahweh’s words which he spoke to us. It shall be therefore a witness against you, lest you deny your Elohim.” 
+<sup>26&#160;</sup>Joshua wrote these words in the book of the law of Elohim; and he took a great stone, and set it up there under the oak that was by the sanctuary of Yahuah. 
+<sup>27&#160;</sup>Joshua said to all the people, “Behold, this stone shall be a witness against us, for it has heard all Yahuah’s words which he spoke to us. It shall be therefore a witness against you, lest you deny your Elohim.” 
 <sup>28&#160;</sup>So Joshua sent the people away, each to his own inheritance. 
 </p><p>
-<sup>29&#160;</sup>After these things, Joshua the son of Nun, the servant of Yahweh, died, being one hundred ten years old. 
+<sup>29&#160;</sup>After these things, Joshua the son of Nun, the servant of Yahuah, died, being one hundred ten years old. 
 <sup>30&#160;</sup>They buried him in the border of his inheritance in Timnathserah, which is in the hill country of Ephraim, on the north of the mountain of Gaash. 
-<sup>31&#160;</sup>Israel served Yahweh all the days of Joshua, and all the days of the elders who outlived Joshua, and had known all the work of Yahweh, that he had worked for Israel. 
+<sup>31&#160;</sup>Israel served Yahuah all the days of Joshua, and all the days of the elders who outlived Joshua, and had known all the work of Yahuah, that he had worked for Israel. 
 <sup>32&#160;</sup>They buried the bones of Joseph, which the children of Israel brought up out of Egypt, in Shechem, in the parcel of ground which Jacob bought from the sons of Hamor the father of Shechem for a hundred pieces of silver. They became the inheritance of the children of Joseph. 
 <sup>33&#160;</sup>Eleazar the son of Aaron died. They buried him in the hill of Phinehas his son, which was given him in the hill country of Ephraim. </p></div><script src="../main.js"></script></body></html>

--- a/book/judges.html
+++ b/book/judges.html
@@ -80,12 +80,12 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>After the death of Joshua, the children of Israel asked of Yahweh, saying, “Who should go up for us first against the Canaanites, to fight against them?” 
+<sup>1&#160;</sup>After the death of Joshua, the children of Israel asked of Yahuah, saying, “Who should go up for us first against the Canaanites, to fight against them?” 
 </p><p>
-<sup>2&#160;</sup>Yahweh said, “Judah shall go up. Behold, I have delivered the land into his hand.” 
+<sup>2&#160;</sup>Yahuah said, “Judah shall go up. Behold, I have delivered the land into his hand.” 
 </p><p>
 <sup>3&#160;</sup>Judah said to Simeon his brother, “Come up with me into my lot, that we may fight against the Canaanites; and I likewise will go with you into your lot.” So Simeon went with him. 
-<sup>4&#160;</sup>Judah went up, and Yahweh delivered the Canaanites and the Perizzites into their hand. They struck ten thousand men in Bezek. 
+<sup>4&#160;</sup>Judah went up, and Yahuah delivered the Canaanites and the Perizzites into their hand. They struck ten thousand men in Bezek. 
 <sup>5&#160;</sup>They found Adoni-Bezek in Bezek, and they fought against him. They struck the Canaanites and the Perizzites. 
 <sup>6&#160;</sup>But Adoni-Bezek fled. They pursued him, caught him, and cut off his thumbs and his big toes. 
 <sup>7&#160;</sup>Adoni-Bezek said, “Seventy kings, having their thumbs and their big toes cut off, scavenged under my table. As I have done, so Elohim has done to me.” They brought him to Jerusalem, and he died there. 
@@ -104,11 +104,11 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>The children of the Kenite, Moses’ brother-in-law, went up out of the city of palm trees with the children of Judah into the wilderness of Judah, which is in the south of Arad; and they went and lived with the people. 
 <sup>17&#160;</sup>Judah went with Simeon his brother, and they struck the Canaanites who inhabited Zephath, and utterly destroyed it. The name of the city was called Hormah. 
 <sup>18&#160;</sup>Also Judah took Gaza with its border, and Ashkelon with its border, and Ekron with its border. 
-<sup>19&#160;</sup>Yahweh was with Judah, and drove out the inhabitants of the hill country; for he could not drive out the inhabitants of the valley, because they had chariots of iron. 
+<sup>19&#160;</sup>Yahuah was with Judah, and drove out the inhabitants of the hill country; for he could not drive out the inhabitants of the valley, because they had chariots of iron. 
 <sup>20&#160;</sup>They gave Hebron to Caleb, as Moses had said, and he drove the three sons of Anak out of there. 
 <sup>21&#160;</sup>The children of Benjamin didn’t drive out the Jebusites who inhabited Jerusalem, but the Jebusites dwell with the children of Benjamin in Jerusalem to this day. 
 </p><p>
-<sup>22&#160;</sup>The house of Joseph also went up against Bethel, and Yahweh was with them. 
+<sup>22&#160;</sup>The house of Joseph also went up against Bethel, and Yahuah was with them. 
 <sup>23&#160;</sup>The house of Joseph sent to spy out Bethel. (The name of the city before that was Luz.) 
 <sup>24&#160;</sup>The watchers saw a man come out of the city, and they said to him, “Please show us the entrance into the city, and we will deal kindly with you.” 
 <sup>25&#160;</sup>He showed them the entrance into the city, and they struck the city with the edge of the sword; but they let the man and all his family go. 
@@ -126,48 +126,48 @@ html[dir=ltr] .q2 {
 <sup>36&#160;</sup>The border of the Amorites was from the ascent of Akrabbim, from the rock, and upward. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>Yahweh’s angel came up from Gilgal to Bochim. He said, “I brought you out of Egypt, and have brought you to the land which I swore to give your fathers. I said, ‘I will never break my covenant with you. 
+<sup>1&#160;</sup>Yahuah’s angel came up from Gilgal to Bochim. He said, “I brought you out of Egypt, and have brought you to the land which I swore to give your fathers. I said, ‘I will never break my covenant with you. 
 <sup>2&#160;</sup>You shall make no covenant with the inhabitants of this land. You shall break down their altars.’ But you have not listened to my voice. Why have you done this? 
 <sup>3&#160;</sup>Therefore I also said, ‘I will not drive them out from before you; but they shall be in your sides, and their elohims will be a snare to you.’&#160;” 
 </p><p>
-<sup>4&#160;</sup>When Yahweh’s angel spoke these words to all the children of Israel, the people lifted up their voice and wept. 
-<sup>5&#160;</sup>They called the name of that place Bochim, and they sacrificed there to Yahweh. 
+<sup>4&#160;</sup>When Yahuah’s angel spoke these words to all the children of Israel, the people lifted up their voice and wept. 
+<sup>5&#160;</sup>They called the name of that place Bochim, and they sacrificed there to Yahuah. 
 <sup>6&#160;</sup>Now when Joshua had sent the people away, the children of Israel each went to his inheritance to possess the land. 
-<sup>7&#160;</sup>The people served Yahweh all the days of Joshua, and all the days of the elders who outlived Joshua, who had seen all the great work of Yahweh that he had worked for Israel. 
-<sup>8&#160;</sup>Joshua the son of Nun, the servant of Yahweh, died, being one hundred ten years old. 
+<sup>7&#160;</sup>The people served Yahuah all the days of Joshua, and all the days of the elders who outlived Joshua, who had seen all the great work of Yahuah that he had worked for Israel. 
+<sup>8&#160;</sup>Joshua the son of Nun, the servant of Yahuah, died, being one hundred ten years old. 
 <sup>9&#160;</sup>They buried him in the border of his inheritance in Timnath Heres, in the hill country of Ephraim, on the north of the mountain of Gaash. 
-<sup>10&#160;</sup>After all that generation were gathered to their fathers, another generation arose after them who didn’t know Yahweh, nor the work which he had done for Israel. 
-<sup>11&#160;</sup>The children of Israel did that which was evil in Yahweh’s sight, and served the Baals. 
-<sup>12&#160;</sup>They abandoned Yahweh, the Elohim of their fathers, who brought them out of the land of Egypt, and followed other elohims, of the elohims of the peoples who were around them, and bowed themselves down to them; and they provoked Yahweh to anger. 
-<sup>13&#160;</sup>They abandoned Yahweh, and served Baal and the Ashtaroth. 
-<sup>14&#160;</sup>Yahweh’s anger burned against Israel, and he delivered them into the hands of raiders who plundered them. He sold them into the hands of their enemies all around, so that they could no longer stand before their enemies. 
-<sup>15&#160;</sup>Wherever they went out, Yahweh’s hand was against them for evil, as Yahweh had spoken, and as Yahweh had sworn to them; and they were very distressed. 
-<sup>16&#160;</sup>Yahweh raised up judges, who saved them out of the hand of those who plundered them. 
-<sup>17&#160;</sup>Yet they didn’t listen to their judges; for they prostituted themselves to other elohims, and bowed themselves down to them. They quickly turned away from the way in which their fathers walked, obeying Yahweh’s commandments. They didn’t do so. 
-<sup>18&#160;</sup>When Yahweh raised up judges for them, then Yahweh was with the judge, and saved them out of the hand of their enemies all the days of the judge; for it grieved Yahweh because of their groaning by reason of those who oppressed them and troubled them. 
+<sup>10&#160;</sup>After all that generation were gathered to their fathers, another generation arose after them who didn’t know Yahuah, nor the work which he had done for Israel. 
+<sup>11&#160;</sup>The children of Israel did that which was evil in Yahuah’s sight, and served the Baals. 
+<sup>12&#160;</sup>They abandoned Yahuah, the Elohim of their fathers, who brought them out of the land of Egypt, and followed other elohims, of the elohims of the peoples who were around them, and bowed themselves down to them; and they provoked Yahuah to anger. 
+<sup>13&#160;</sup>They abandoned Yahuah, and served Baal and the Ashtaroth. 
+<sup>14&#160;</sup>Yahuah’s anger burned against Israel, and he delivered them into the hands of raiders who plundered them. He sold them into the hands of their enemies all around, so that they could no longer stand before their enemies. 
+<sup>15&#160;</sup>Wherever they went out, Yahuah’s hand was against them for evil, as Yahuah had spoken, and as Yahuah had sworn to them; and they were very distressed. 
+<sup>16&#160;</sup>Yahuah raised up judges, who saved them out of the hand of those who plundered them. 
+<sup>17&#160;</sup>Yet they didn’t listen to their judges; for they prostituted themselves to other elohims, and bowed themselves down to them. They quickly turned away from the way in which their fathers walked, obeying Yahuah’s commandments. They didn’t do so. 
+<sup>18&#160;</sup>When Yahuah raised up judges for them, then Yahuah was with the judge, and saved them out of the hand of their enemies all the days of the judge; for it grieved Yahuah because of their groaning by reason of those who oppressed them and troubled them. 
 <sup>19&#160;</sup>But when the judge was dead, they turned back, and dealt more corruptly than their fathers in following other elohims to serve them and to bow down to them. They didn’t cease what they were doing, or give up their stubborn ways. 
-<sup>20&#160;</sup>Yahweh’s anger burned against Israel; and he said, “Because this nation transgressed my covenant which I commanded their fathers, and has not listened to my voice, 
+<sup>20&#160;</sup>Yahuah’s anger burned against Israel; and he said, “Because this nation transgressed my covenant which I commanded their fathers, and has not listened to my voice, 
 <sup>21&#160;</sup>I also will no longer drive out any of the nations that Joshua left when he died from before them; 
-<sup>22&#160;</sup>that by them I may test Israel, to see if they will keep Yahweh’s way to walk therein, as their fathers kept it, or not.” 
-<sup>23&#160;</sup>So Yahweh left those nations, without driving them out hastily. He didn’t deliver them into Joshua’s hand. 
+<sup>22&#160;</sup>that by them I may test Israel, to see if they will keep Yahuah’s way to walk therein, as their fathers kept it, or not.” 
+<sup>23&#160;</sup>So Yahuah left those nations, without driving them out hastily. He didn’t deliver them into Joshua’s hand. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>Now these are the nations which Yahweh left, to test Israel by them, even as many as had not known all the wars of Canaan; 
+<sup>1&#160;</sup>Now these are the nations which Yahuah left, to test Israel by them, even as many as had not known all the wars of Canaan; 
 <sup>2&#160;</sup>only that the generations of the children of Israel might know, to teach them war, at least those who knew nothing of it before: 
 <sup>3&#160;</sup>the five lords of the Philistines, all the Canaanites, the Sidonians, and the Hivites who lived on Mount Lebanon, from Mount Baal Hermon to the entrance of Hamath. 
-<sup>4&#160;</sup>They were left to test Israel by them, to know whether they would listen to Yahweh’s commandments, which he commanded their fathers by Moses. 
+<sup>4&#160;</sup>They were left to test Israel by them, to know whether they would listen to Yahuah’s commandments, which he commanded their fathers by Moses. 
 <sup>5&#160;</sup>The children of Israel lived among the Canaanites, the Hittites, the Amorites, the Perizzites, the Hivites, and the Jebusites. 
 <sup>6&#160;</sup>They took their daughters to be their women, and gave their own daughters to their sons and served their elohims. 
-<sup>7&#160;</sup>The children of Israel did that which was evil in Yahweh’s sight, and forgot Yahweh their Elohim, and served the Baals and the Asheroth. 
-<sup>8&#160;</sup>Therefore Yahweh’s anger burned against Israel, and he sold them into the hand of Cushan Rishathaim king of Mesopotamia; and the children of Israel served Cushan Rishathaim eight years. 
-<sup>9&#160;</sup>When the children of Israel cried to Yahweh, Yahweh raised up a savior to the children of Israel, who saved them, even Othniel the son of Kenaz, Caleb’s younger brother. 
-<sup>10&#160;</sup>Yahweh’s Spirit came on him, and he judged Israel; and he went out to war, and Yahweh delivered Cushan Rishathaim king of Mesopotamia into his hand. His hand prevailed against Cushan Rishathaim. 
+<sup>7&#160;</sup>The children of Israel did that which was evil in Yahuah’s sight, and forgot Yahuah their Elohim, and served the Baals and the Asheroth. 
+<sup>8&#160;</sup>Therefore Yahuah’s anger burned against Israel, and he sold them into the hand of Cushan Rishathaim king of Mesopotamia; and the children of Israel served Cushan Rishathaim eight years. 
+<sup>9&#160;</sup>When the children of Israel cried to Yahuah, Yahuah raised up a savior to the children of Israel, who saved them, even Othniel the son of Kenaz, Caleb’s younger brother. 
+<sup>10&#160;</sup>Yahuah’s Spirit came on him, and he judged Israel; and he went out to war, and Yahuah delivered Cushan Rishathaim king of Mesopotamia into his hand. His hand prevailed against Cushan Rishathaim. 
 <sup>11&#160;</sup>The land had rest forty years, then Othniel the son of Kenaz died. 
 </p><p>
-<sup>12&#160;</sup>The children of Israel again did that which was evil in Yahweh’s sight, and Yahweh strengthened Eglon the king of Moab against Israel, because they had done that which was evil in Yahweh’s sight. 
+<sup>12&#160;</sup>The children of Israel again did that which was evil in Yahuah’s sight, and Yahuah strengthened Eglon the king of Moab against Israel, because they had done that which was evil in Yahuah’s sight. 
 <sup>13&#160;</sup>He gathered the children of Ammon and Amalek to himself; and he went and struck Israel, and they possessed the city of palm trees. 
 <sup>14&#160;</sup>The children of Israel served Eglon the king of Moab eighteen years. 
-<sup>15&#160;</sup>But when the children of Israel cried to Yahweh, Yahweh raised up a savior for them: Ehud the son of Gera, the Benjamite, a left-handed man. The children of Israel sent tribute by him to Eglon the king of Moab. 
+<sup>15&#160;</sup>But when the children of Israel cried to Yahuah, Yahuah raised up a savior for them: Ehud the son of Gera, the Benjamite, a left-handed man. The children of Israel sent tribute by him to Eglon the king of Moab. 
 <sup>16&#160;</sup>Ehud made himself a sword which had two edges, a cubit in length; and he wore it under his clothing on his right thigh. 
 <sup>17&#160;</sup>He offered the tribute to Eglon king of Moab. Now Eglon was a very fat man. 
 <sup>18&#160;</sup>When Ehud had finished offering the tribute, he sent away the people who carried the tribute. 
@@ -185,32 +185,32 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>Ehud escaped while they waited, passed beyond the stone idols, and escaped to Seirah. 
 <sup>27&#160;</sup>When he had come, he blew a trumpet in the hill country of Ephraim; and the children of Israel went down with him from the hill country, and he led them. 
 </p><p>
-<sup>28&#160;</sup>He said to them, “Follow me; for Yahweh has delivered your enemies the Moabites into your hand.” They followed him, and took the fords of the Jordan against the Moabites, and didn’t allow any man to pass over. 
+<sup>28&#160;</sup>He said to them, “Follow me; for Yahuah has delivered your enemies the Moabites into your hand.” They followed him, and took the fords of the Jordan against the Moabites, and didn’t allow any man to pass over. 
 <sup>29&#160;</sup>They struck at that time about ten thousand men of Moab, every strong man and every man of valor. No man escaped. 
 <sup>30&#160;</sup>So Moab was subdued that day under the hand of Israel. Then the land had rest eighty years. 
 </p><p>
 <sup>31&#160;</sup>After him was Shamgar the son of Anath, who struck six hundred men of the Philistines with an ox goad. He also saved Israel. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>The children of Israel again did that which was evil in Yahweh’s sight, when Ehud was dead. 
-<sup>2&#160;</sup>Yahweh sold them into the hand of Jabin king of Canaan, who reigned in Hazor; the captain of whose army was Sisera, who lived in Harosheth of the Gentiles. 
-<sup>3&#160;</sup>The children of Israel cried to Yahweh, for he had nine hundred chariots of iron; and he mightily oppressed the children of Israel for twenty years. 
+<sup>1&#160;</sup>The children of Israel again did that which was evil in Yahuah’s sight, when Ehud was dead. 
+<sup>2&#160;</sup>Yahuah sold them into the hand of Jabin king of Canaan, who reigned in Hazor; the captain of whose army was Sisera, who lived in Harosheth of the Gentiles. 
+<sup>3&#160;</sup>The children of Israel cried to Yahuah, for he had nine hundred chariots of iron; and he mightily oppressed the children of Israel for twenty years. 
 <sup>4&#160;</sup>Now Deborah, a prophetess, the woman of Lappidoth, judged Israel at that time. 
 <sup>5&#160;</sup>She lived under Deborah’s palm tree between Ramah and Bethel in the hill country of Ephraim; and the children of Israel came up to her for judgment. 
-<sup>6&#160;</sup>She sent and called Barak the son of Abinoam out of Kedesh Naphtali, and said to him, “Hasn’t Yahweh, the Elohim of Israel, commanded, ‘Go and lead the way to Mount Tabor, and take with you ten thousand men of the children of Naphtali and of the children of Zebulun? 
+<sup>6&#160;</sup>She sent and called Barak the son of Abinoam out of Kedesh Naphtali, and said to him, “Hasn’t Yahuah, the Elohim of Israel, commanded, ‘Go and lead the way to Mount Tabor, and take with you ten thousand men of the children of Naphtali and of the children of Zebulun? 
 <sup>7&#160;</sup>I will draw to you, to the river Kishon, Sisera, the captain of Jabin’s army, with his chariots and his multitude; and I will deliver him into your hand.’&#160;” 
 </p><p>
 <sup>8&#160;</sup>Barak said to her, “If you will go with me, then I will go; but if you will not go with me, I will not go.” 
 </p><p>
-<sup>9&#160;</sup>She said, “I will surely go with you. Nevertheless, the journey that you take won’t be for your honor; for Yahweh will sell Sisera into a woman’s hand.” Deborah arose, and went with Barak to Kedesh. 
+<sup>9&#160;</sup>She said, “I will surely go with you. Nevertheless, the journey that you take won’t be for your honor; for Yahuah will sell Sisera into a woman’s hand.” Deborah arose, and went with Barak to Kedesh. 
 </p><p>
 <sup>10&#160;</sup>Barak called Zebulun and Naphtali together to Kedesh. Ten thousand men followed him; and Deborah went up with him. 
 <sup>11&#160;</sup>Now Heber the Kenite had separated himself from the Kenites, even from the children of Hobab, Moses’ brother-in-law, and had pitched his tent as far as the oak in Zaanannim, which is by Kedesh. 
 <sup>12&#160;</sup>They told Sisera that Barak the son of Abinoam had gone up to Mount Tabor. 
 <sup>13&#160;</sup>Sisera gathered together all his chariots, even nine hundred chariots of iron, and all the people who were with him, from Harosheth of the Gentiles, to the river Kishon. 
 </p><p>
-<sup>14&#160;</sup>Deborah said to Barak, “Go; for this is the day in which Yahweh has delivered Sisera into your hand. Hasn’t Yahweh gone out before you?” So Barak went down from Mount Tabor, and ten thousand men after him. 
-<sup>15&#160;</sup>Yahweh confused Sisera, all his chariots, and all his army, with the edge of the sword before Barak. Sisera abandoned his chariot and fled away on his feet. 
+<sup>14&#160;</sup>Deborah said to Barak, “Go; for this is the day in which Yahuah has delivered Sisera into your hand. Hasn’t Yahuah gone out before you?” So Barak went down from Mount Tabor, and ten thousand men after him. 
+<sup>15&#160;</sup>Yahuah confused Sisera, all his chariots, and all his army, with the edge of the sword before Barak. Sisera abandoned his chariot and fled away on his feet. 
 <sup>16&#160;</sup>But Barak pursued the chariots and the army to Harosheth of the Gentiles; and all the army of Sisera fell by the edge of the sword. There was not a man left. 
 </p><p>
 <sup>17&#160;</sup>However Sisera fled away on his feet to the tent of Jael the woman of Heber the Kenite; for there was peace between Jabin the king of Hazor and the house of Heber the Kenite. 
@@ -231,22 +231,22 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>2&#160;</sup>“Because the leaders took the lead in Israel, 
 </p><p class="q2">because the people offered themselves willingly, 
-</p><p class="q1">be blessed, Yahweh! 
+</p><p class="q1">be blessed, Yahuah! 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>3&#160;</sup>“Hear, you kings! 
 </p><p class="q2">Give ear, you princes! 
-</p><p class="q1">I, even I, will sing to Yahweh. 
-</p><p class="q2">I will sing praise to Yahweh, the Elohim of Israel. 
+</p><p class="q1">I, even I, will sing to Yahuah. 
+</p><p class="q2">I will sing praise to Yahuah, the Elohim of Israel. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>4&#160;</sup>“Yahweh, when you went out of Seir, 
+<sup>4&#160;</sup>“Yahuah, when you went out of Seir, 
 </p><p class="q2">when you marched out of the field of Edom, 
 </p><p class="q1">the earth trembled, the sky also dropped. 
 </p><p class="q2">Yes, the clouds dropped water. 
 </p><p class="q1">
-<sup>5&#160;</sup>The mountains quaked at Yahweh’s presence, 
-</p><p class="q2">even Sinai at the presence of Yahweh, the Elohim of Israel. 
+<sup>5&#160;</sup>The mountains quaked at Yahuah’s presence, 
+</p><p class="q2">even Sinai at the presence of Yahuah, the Elohim of Israel. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>6&#160;</sup>“In the days of Shamgar the son of Anath, 
@@ -263,7 +263,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>9&#160;</sup>My heart is toward the governors of Israel, 
 </p><p class="q2">who offered themselves willingly among the people. 
-</p><p class="q2">Bless Yahweh! 
+</p><p class="q2">Bless Yahuah! 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>10&#160;</sup>“Speak, you who ride on white donkeys, 
@@ -271,10 +271,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and you who walk by the way. 
 </p><p class="q1">
 <sup>11&#160;</sup>Far from the noise of archers, in the places of drawing water, 
-</p><p class="q2">there they will rehearse Yahweh’s righteous acts, 
+</p><p class="q2">there they will rehearse Yahuah’s righteous acts, 
 </p><p class="q2">the righteous acts of his rule in Israel. 
 </p><p class="b"> &#160; </p>
-<p class="q1">“Then Yahweh’s people went down to the gates. 
+<p class="q1">“Then Yahuah’s people went down to the gates. 
 </p><p class="q2">
 <sup>12&#160;</sup>‘Awake, awake, Deborah! 
 </p><p class="q2">Awake, awake, utter a song! 
@@ -282,7 +282,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>13&#160;</sup>“Then a remnant of the nobles and the people came down. 
-</p><p class="q2">Yahweh came down for me against the mighty. 
+</p><p class="q2">Yahuah came down for me against the mighty. 
 </p><p class="q1">
 <sup>14&#160;</sup>Those whose root is in Amalek came out of Ephraim, 
 </p><p class="q2">after you, Benjamin, among your peoples. 
@@ -323,10 +323,10 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>Then the horse hoofs stamped because of the prancing, 
 </p><p class="q2">the prancing of their strong ones. 
 </p><p class="q1">
-<sup>23&#160;</sup>‘Curse Meroz,’ said Yahweh’s angel. 
+<sup>23&#160;</sup>‘Curse Meroz,’ said Yahuah’s angel. 
 </p><p class="q2">‘Curse bitterly its inhabitants, 
-</p><p class="q2">because they didn’t come to help Yahweh, 
-</p><p class="q2">to help Yahweh against the mighty.’ 
+</p><p class="q2">because they didn’t come to help Yahuah, 
+</p><p class="q2">to help Yahuah against the mighty.’ 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>24&#160;</sup>“Jael shall be blessed above women, 
@@ -363,34 +363,34 @@ html[dir=ltr] .q2 {
 </p><p class="q2">of dyed garments embroidered on both sides, on the necks of the plunder?’ 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>31&#160;</sup>“So let all your enemies perish, Yahweh, 
+<sup>31&#160;</sup>“So let all your enemies perish, Yahuah, 
 </p><p class="q2">but let those who love him be as the sun when it rises in its strength.” 
 </p><p class="b"> &#160; </p>
 <p>Then the land had rest forty years. 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>The children of Israel did that which was evil in Yahweh’s sight, so Yahweh delivered them into the hand of Midian seven years. 
+<sup>1&#160;</sup>The children of Israel did that which was evil in Yahuah’s sight, so Yahuah delivered them into the hand of Midian seven years. 
 <sup>2&#160;</sup>The hand of Midian prevailed against Israel; and because of Midian the children of Israel made themselves the dens which are in the mountains, the caves, and the strongholds. 
 <sup>3&#160;</sup>So it was, when Israel had sown, that the Midianites, the Amalekites, and the children of the east came up against them. 
 <sup>4&#160;</sup>They encamped against them, and destroyed the increase of the earth, until you come to Gaza. They left no sustenance in Israel, and no sheep, ox, or donkey. 
 <sup>5&#160;</sup>For they came up with their livestock and their tents. They came in as locusts for multitude. Both they and their camels were without number; and they came into the land to destroy it. 
-<sup>6&#160;</sup>Israel was brought very low because of Midian; and the children of Israel cried to Yahweh. 
+<sup>6&#160;</sup>Israel was brought very low because of Midian; and the children of Israel cried to Yahuah. 
 </p><p>
-<sup>7&#160;</sup>When the children of Israel cried to Yahweh because of Midian, 
-<sup>8&#160;</sup>Yahweh sent a prophet to the children of Israel; and he said to them, “Yahweh, the Elohim of Israel, says, ‘I brought you up from Egypt, and brought you out of the house of bondage. 
+<sup>7&#160;</sup>When the children of Israel cried to Yahuah because of Midian, 
+<sup>8&#160;</sup>Yahuah sent a prophet to the children of Israel; and he said to them, “Yahuah, the Elohim of Israel, says, ‘I brought you up from Egypt, and brought you out of the house of bondage. 
 <sup>9&#160;</sup>I delivered you out of the hand of the Egyptians and out of the hand of all who oppressed you, and drove them out from before you, and gave you their land. 
-<sup>10&#160;</sup>I said to you, “I am Yahweh your Elohim. You shall not fear the elohims of the Amorites, in whose land you dwell.” But you have not listened to my voice.’&#160;” 
+<sup>10&#160;</sup>I said to you, “I am Yahuah your Elohim. You shall not fear the elohims of the Amorites, in whose land you dwell.” But you have not listened to my voice.’&#160;” 
 </p><p>
-<sup>11&#160;</sup>Yahweh’s angel came and sat under the oak which was in Ophrah, that belonged to Joash the Abiezrite. His son Gideon was beating out wheat in the wine press, to hide it from the Midianites. 
-<sup>12&#160;</sup>Yahweh’s angel appeared to him, and said to him, “Yahweh is with you, you mighty man of valor!” 
+<sup>11&#160;</sup>Yahuah’s angel came and sat under the oak which was in Ophrah, that belonged to Joash the Abiezrite. His son Gideon was beating out wheat in the wine press, to hide it from the Midianites. 
+<sup>12&#160;</sup>Yahuah’s angel appeared to him, and said to him, “Yahuah is with you, you mighty man of valor!” 
 </p><p>
-<sup>13&#160;</sup>Gideon said to him, “Oh, my lord, if Yahweh is with us, why then has all this happened to us? Where are all his wondrous works which our fathers told us of, saying, ‘Didn’t Yahweh bring us up from Egypt?’ But now Yahweh has cast us off, and delivered us into the hand of Midian.” 
+<sup>13&#160;</sup>Gideon said to him, “Oh, my lord, if Yahuah is with us, why then has all this happened to us? Where are all his wondrous works which our fathers told us of, saying, ‘Didn’t Yahuah bring us up from Egypt?’ But now Yahuah has cast us off, and delivered us into the hand of Midian.” 
 </p><p>
-<sup>14&#160;</sup>Yahweh looked at him, and said, “Go in this your might, and save Israel from the hand of Midian. Haven’t I sent you?” 
+<sup>14&#160;</sup>Yahuah looked at him, and said, “Go in this your might, and save Israel from the hand of Midian. Haven’t I sent you?” 
 </p><p>
 <sup>15&#160;</sup>He said to him, “O Lord, how shall I save Israel? Behold, my family is the poorest in Manasseh, and I am the least in my father’s house.” 
 </p><p>
-<sup>16&#160;</sup>Yahweh said to him, “Surely I will be with you, and you shall strike the Midianites as one man.” 
+<sup>16&#160;</sup>Yahuah said to him, “Surely I will be with you, and you shall strike the Midianites as one man.” 
 </p><p>
 <sup>17&#160;</sup>He said to him, “If now I have found favor in your sight, then show me a sign that it is you who talk with me. 
 <sup>18&#160;</sup>Please don’t go away until I come to you, and bring out my present, and lay it before you.” 
@@ -400,18 +400,18 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>20&#160;</sup>The angel of Elohim said to him, “Take the meat and the unleavened cakes, and lay them on this rock, and pour out the broth.” 
 </p><p>He did so. 
-<sup>21&#160;</sup>Then Yahweh’s angel stretched out the end of the staff that was in his hand, and touched the meat and the unleavened cakes; and fire went up out of the rock and consumed the meat and the unleavened cakes. Then Yahweh’s angel departed out of his sight. 
+<sup>21&#160;</sup>Then Yahuah’s angel stretched out the end of the staff that was in his hand, and touched the meat and the unleavened cakes; and fire went up out of the rock and consumed the meat and the unleavened cakes. Then Yahuah’s angel departed out of his sight. 
 </p><p>
-<sup>22&#160;</sup>Gideon saw that he was Yahweh’s angel; and Gideon said, “Alas, Lord Yahweh! Because I have seen Yahweh’s angel face to face!” 
+<sup>22&#160;</sup>Gideon saw that he was Yahuah’s angel; and Gideon said, “Alas, Lord Yahuah! Because I have seen Yahuah’s angel face to face!” 
 </p><p>
-<sup>23&#160;</sup>Yahweh said to him, “Peace be to you! Don’t be afraid. You shall not die.” 
+<sup>23&#160;</sup>Yahuah said to him, “Peace be to you! Don’t be afraid. You shall not die.” 
 </p><p>
-<sup>24&#160;</sup>Then Gideon built an altar there to Yahweh, and called it “Yahweh is Peace.” To this day it is still in Ophrah of the Abiezrites. 
+<sup>24&#160;</sup>Then Gideon built an altar there to Yahuah, and called it “Yahuah is Peace.” To this day it is still in Ophrah of the Abiezrites. 
 </p><p>
-<sup>25&#160;</sup>That same night, Yahweh said to him, “Take your father’s bull, even the second bull seven years old, and throw down the altar of Baal that your father has, and cut down the Asherah that is by it. 
-<sup>26&#160;</sup>Then build an altar to Yahweh your Elohim on the top of this stronghold, in an orderly way, and take the second bull, and offer a burnt offering with the wood of the Asherah which you shall cut down.” 
+<sup>25&#160;</sup>That same night, Yahuah said to him, “Take your father’s bull, even the second bull seven years old, and throw down the altar of Baal that your father has, and cut down the Asherah that is by it. 
+<sup>26&#160;</sup>Then build an altar to Yahuah your Elohim on the top of this stronghold, in an orderly way, and take the second bull, and offer a burnt offering with the wood of the Asherah which you shall cut down.” 
 </p><p>
-<sup>27&#160;</sup>Then Gideon took ten men of his servants, and did as Yahweh had spoken to him. Because he feared his father’s household and the men of the city, he could not do it by day, but he did it by night. 
+<sup>27&#160;</sup>Then Gideon took ten men of his servants, and did as Yahuah had spoken to him. Because he feared his father’s household and the men of the city, he could not do it by day, but he did it by night. 
 </p><p>
 <sup>28&#160;</sup>When the men of the city arose early in the morning, behold, the altar of Baal was broken down, and the Asherah was cut down that was by it, and the second bull was offered on the altar that was built. 
 <sup>29&#160;</sup>They said to one another, “Who has done this thing?” 
@@ -422,7 +422,7 @@ html[dir=ltr] .q2 {
 <sup>32&#160;</sup>Therefore on that day he named him Jerub-Baal, saying, “Let Baal contend against him, because he has broken down his altar.” 
 </p><p>
 <sup>33&#160;</sup>Then all the Midianites and the Amalekites and the children of the east assembled themselves together; and they passed over, and encamped in the valley of Jezreel. 
-<sup>34&#160;</sup>But Yahweh’s Spirit came on Gideon, and he blew a trumpet; and Abiezer was gathered together to follow him. 
+<sup>34&#160;</sup>But Yahuah’s Spirit came on Gideon, and he blew a trumpet; and Abiezer was gathered together to follow him. 
 <sup>35&#160;</sup>He sent messengers throughout all Manasseh, and they also were gathered together to follow him. He sent messengers to Asher, to Zebulun, and to Naphtali; and they came up to meet them. 
 </p><p>
 <sup>36&#160;</sup>Gideon said to Elohim, “If you will save Israel by my hand, as you have spoken, 
@@ -436,16 +436,16 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
 <sup>1&#160;</sup>Then Jerubbaal, who is Gideon, and all the people who were with him, rose up early and encamped beside the spring of Harod. Midian’s camp was on the north side of them, by the hill of Moreh, in the valley. 
-<sup>2&#160;</sup>Yahweh said to Gideon, “The people who are with you are too many for me to give the Midianites into their hand, lest Israel brag against me, saying, ‘My own hand has saved me.’ 
+<sup>2&#160;</sup>Yahuah said to Gideon, “The people who are with you are too many for me to give the Midianites into their hand, lest Israel brag against me, saying, ‘My own hand has saved me.’ 
 <sup>3&#160;</sup>Now therefore proclaim in the ears of the people, saying, ‘Whoever is fearful and trembling, let him return and depart from Mount Gilead.’&#160;” So twenty-two thousand of the people returned, and ten thousand remained. 
 </p><p>
-<sup>4&#160;</sup>Yahweh said to Gideon, “There are still too many people. Bring them down to the water, and I will test them for you there. It shall be, that those whom I tell you, ‘This shall go with you,’ shall go with you; and whoever I tell you, ‘This shall not go with you,’ shall not go.” 
-<sup>5&#160;</sup>So he brought down the people to the water; and Yahweh said to Gideon, “Everyone who laps of the water with his tongue, like a dog laps, you shall set him by himself; likewise everyone who bows down on his knees to drink.” 
+<sup>4&#160;</sup>Yahuah said to Gideon, “There are still too many people. Bring them down to the water, and I will test them for you there. It shall be, that those whom I tell you, ‘This shall go with you,’ shall go with you; and whoever I tell you, ‘This shall not go with you,’ shall not go.” 
+<sup>5&#160;</sup>So he brought down the people to the water; and Yahuah said to Gideon, “Everyone who laps of the water with his tongue, like a dog laps, you shall set him by himself; likewise everyone who bows down on his knees to drink.” 
 <sup>6&#160;</sup>The number of those who lapped, putting their hand to their mouth, was three hundred men; but all the rest of the people bowed down on their knees to drink water. 
-<sup>7&#160;</sup>Yahweh said to Gideon, “I will save you by the three hundred men who lapped, and deliver the Midianites into your hand. Let all the other people go, each to his own place.” 
+<sup>7&#160;</sup>Yahuah said to Gideon, “I will save you by the three hundred men who lapped, and deliver the Midianites into your hand. Let all the other people go, each to his own place.” 
 </p><p>
 <sup>8&#160;</sup>So the people took food in their hand, and their trumpets; and he sent all the rest of the men of Israel to their own tents, but retained the three hundred men; and the camp of Midian was beneath him in the valley. 
-<sup>9&#160;</sup>That same night, Yahweh said to him, “Arise, go down into the camp, for I have delivered it into your hand. 
+<sup>9&#160;</sup>That same night, Yahuah said to him, “Arise, go down into the camp, for I have delivered it into your hand. 
 <sup>10&#160;</sup>But if you are afraid to go down, go with Purah your servant down to the camp. 
 <sup>11&#160;</sup>You will hear what they say; and afterward your hands will be strengthened to go down into the camp.” Then went he down with Purah his servant to the outermost part of the armed men who were in the camp. 
 </p><p>
@@ -455,17 +455,17 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>14&#160;</sup>His fellow answered, “This is nothing other than the sword of Gideon the son of Joash, a man of Israel. Elohim has delivered Midian into his hand, with all the army.” 
 </p><p>
-<sup>15&#160;</sup>It was so, when Gideon heard the telling of the dream and its interpretation, that he worshiped. Then he returned into the camp of Israel and said, “Arise, for Yahweh has delivered the army of Midian into your hand!” 
+<sup>15&#160;</sup>It was so, when Gideon heard the telling of the dream and its interpretation, that he worshiped. Then he returned into the camp of Israel and said, “Arise, for Yahuah has delivered the army of Midian into your hand!” 
 </p><p>
 <sup>16&#160;</sup>He divided the three hundred men into three companies, and he put into the hands of all of them trumpets and empty pitchers, with torches within the pitchers. 
 </p><p>
 <sup>17&#160;</sup>He said to them, “Watch me, and do likewise. Behold, when I come to the outermost part of the camp, it shall be that, as I do, so you shall do. 
-<sup>18&#160;</sup>When I blow the trumpet, I and all who are with me, then blow the trumpets also on every side of all the camp, and shout, ‘For Yahweh and for Gideon!’&#160;” 
+<sup>18&#160;</sup>When I blow the trumpet, I and all who are with me, then blow the trumpets also on every side of all the camp, and shout, ‘For Yahuah and for Gideon!’&#160;” 
 </p><p>
 <sup>19&#160;</sup>So Gideon and the hundred men who were with him came to the outermost part of the camp in the beginning of the middle watch, when they had but newly set the watch. Then they blew the trumpets and broke in pieces the pitchers that were in their hands. 
-<sup>20&#160;</sup>The three companies blew the trumpets, broke the pitchers, and held the torches in their left hands and the trumpets in their right hands with which to blow; and they shouted, “The sword of Yahweh and of Gideon!” 
+<sup>20&#160;</sup>The three companies blew the trumpets, broke the pitchers, and held the torches in their left hands and the trumpets in their right hands with which to blow; and they shouted, “The sword of Yahuah and of Gideon!” 
 <sup>21&#160;</sup>They each stood in his place around the camp, and all the army ran; and they shouted, and put them to flight. 
-<sup>22&#160;</sup>They blew the three hundred trumpets, and Yahweh set every man’s sword against his fellow and against all the army; and the army fled as far as Beth Shittah toward Zererah, as far as the border of Abel Meholah, by Tabbath. 
+<sup>22&#160;</sup>They blew the three hundred trumpets, and Yahuah set every man’s sword against his fellow and against all the army; and the army fled as far as Beth Shittah toward Zererah, as far as the border of Abel Meholah, by Tabbath. 
 <sup>23&#160;</sup>The men of Israel were gathered together out of Naphtali, out of Asher, and out of all Manasseh, and pursued Midian. 
 <sup>24&#160;</sup>Gideon sent messengers throughout all the hill country of Ephraim, saying, “Come down against Midian and take the waters before them as far as Beth Barah, even the Jordan!” So all the men of Ephraim were gathered together and took the waters as far as Beth Barah, even the Jordan. 
 <sup>25&#160;</sup>They took the two princes of Midian, Oreb and Zeeb. They killed Oreb at Oreb’s rock, and Zeeb they killed at Zeeb’s wine press, as they pursued Midian. Then they brought the heads of Oreb and Zeeb to Gideon beyond the Jordan. 
@@ -480,7 +480,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>6&#160;</sup>The princes of Succoth said, “Are the hands of Zebah and Zalmunna now in your hand, that we should give bread to your army?” 
 </p><p>
-<sup>7&#160;</sup>Gideon said, “Therefore when Yahweh has delivered Zebah and Zalmunna into my hand, then I will tear your flesh with the thorns of the wilderness and with briers.” 
+<sup>7&#160;</sup>Gideon said, “Therefore when Yahuah has delivered Zebah and Zalmunna into my hand, then I will tear your flesh with the thorns of the wilderness and with briers.” 
 </p><p>
 <sup>8&#160;</sup>He went up there to Penuel, and spoke to them in the same way; and the men of Penuel answered him as the men of Succoth had answered. 
 <sup>9&#160;</sup>He spoke also to the men of Penuel, saying, “When I come again in peace, I will break down this tower.” 
@@ -497,7 +497,7 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>Then he said to Zebah and Zalmunna, “What kind of men were they whom you killed at Tabor?” 
 </p><p>They answered, “They were like you. They all resembled the children of a king.” 
 </p><p>
-<sup>19&#160;</sup>He said, “They were my brothers, the sons of my mother. As Yahweh lives, if you had saved them alive, I would not kill you.” 
+<sup>19&#160;</sup>He said, “They were my brothers, the sons of my mother. As Yahuah lives, if you had saved them alive, I would not kill you.” 
 </p><p>
 <sup>20&#160;</sup>He said to Jether his firstborn, “Get up and kill them!” But the youth didn’t draw his sword; for he was afraid, because he was yet a youth. 
 </p><p>
@@ -505,7 +505,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>22&#160;</sup>Then the men of Israel said to Gideon, “Rule over us, both you, your son, and your son’s son also; for you have saved us out of the hand of Midian.” 
 </p><p>
-<sup>23&#160;</sup>Gideon said to them, “I will not rule over you, neither shall my son rule over you. Yahweh shall rule over you.” 
+<sup>23&#160;</sup>Gideon said to them, “I will not rule over you, neither shall my son rule over you. Yahuah shall rule over you.” 
 <sup>24&#160;</sup>Gideon said to them, “I do have a request: that you would each give me the earrings of his plunder.” (For they had golden earrings, because they were Ishmaelites.) 
 </p><p>
 <sup>25&#160;</sup>They answered, “We will willingly give them.” They spread a garment, and every man threw the earrings of his plunder into it. 
@@ -519,7 +519,7 @@ html[dir=ltr] .q2 {
 <sup>32&#160;</sup>Gideon the son of Joash died in a good old age, and was buried in the tomb of Joash his father, in Ophrah of the Abiezrites. 
 </p><p>
 <sup>33&#160;</sup>As soon as Gideon was dead, the children of Israel turned again and played the prostitute following the Baals, and made Baal Berith their elohim. 
-<sup>34&#160;</sup>The children of Israel didn’t remember Yahweh their Elohim, who had delivered them out of the hand of all their enemies on every side; 
+<sup>34&#160;</sup>The children of Israel didn’t remember Yahuah their Elohim, who had delivered them out of the hand of all their enemies on every side; 
 <sup>35&#160;</sup>neither did they show kindness to the house of Jerubbaal, that is, Gideon, according to all the goodness which he had shown to Israel. 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
@@ -611,19 +611,19 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>He had thirty sons who rode on thirty donkey colts. They had thirty cities, which are called Havvoth Jair to this day, which are in the land of Gilead. 
 <sup>5&#160;</sup>Jair died, and was buried in Kamon. 
 </p><p>
-<sup>6&#160;</sup>The children of Israel again did that which was evil in Yahweh’s sight, and served the Baals, the Ashtaroth, the elohims of Syria, the elohims of Sidon, the elohims of Moab, the elohims of the children of Ammon, and the elohims of the Philistines. They abandoned Yahweh, and didn’t serve him. 
-<sup>7&#160;</sup>Yahweh’s anger burned against Israel, and he sold them into the hand of the Philistines and into the hand of the children of Ammon. 
+<sup>6&#160;</sup>The children of Israel again did that which was evil in Yahuah’s sight, and served the Baals, the Ashtaroth, the elohims of Syria, the elohims of Sidon, the elohims of Moab, the elohims of the children of Ammon, and the elohims of the Philistines. They abandoned Yahuah, and didn’t serve him. 
+<sup>7&#160;</sup>Yahuah’s anger burned against Israel, and he sold them into the hand of the Philistines and into the hand of the children of Ammon. 
 <sup>8&#160;</sup>They troubled and oppressed the children of Israel that year. For eighteen years they oppressed all the children of Israel that were beyond the Jordan in the land of the Amorites, which is in Gilead. 
 <sup>9&#160;</sup>The children of Ammon passed over the Jordan to fight also against Judah, and against Benjamin, and against the house of Ephraim, so that Israel was very distressed. 
-<sup>10&#160;</sup>The children of Israel cried to Yahweh, saying, “We have sinned against you, even because we have forsaken our Elohim, and have served the Baals.” 
+<sup>10&#160;</sup>The children of Israel cried to Yahuah, saying, “We have sinned against you, even because we have forsaken our Elohim, and have served the Baals.” 
 </p><p>
-<sup>11&#160;</sup>Yahweh said to the children of Israel, “Didn’t I save you from the Egyptians, and from the Amorites, from the children of Ammon, and from the Philistines? 
+<sup>11&#160;</sup>Yahuah said to the children of Israel, “Didn’t I save you from the Egyptians, and from the Amorites, from the children of Ammon, and from the Philistines? 
 <sup>12&#160;</sup>The Sidonians also, and the Amalekites, and the Maonites, oppressed you; and you cried to me, and I saved you out of their hand. 
 <sup>13&#160;</sup>Yet you have forsaken me and served other elohims. Therefore I will save you no more. 
 <sup>14&#160;</sup>Go and cry to the elohims which you have chosen. Let them save you in the time of your distress!” 
 </p><p>
-<sup>15&#160;</sup>The children of Israel said to Yahweh, “We have sinned! Do to us whatever seems good to you; only deliver us, please, today.” 
-<sup>16&#160;</sup>They put away the foreign elohims from among them and served Yahweh; and his soul was grieved for the misery of Israel. 
+<sup>15&#160;</sup>The children of Israel said to Yahuah, “We have sinned! Do to us whatever seems good to you; only deliver us, please, today.” 
+<sup>16&#160;</sup>They put away the foreign elohims from among them and served Yahuah; and his soul was grieved for the misery of Israel. 
 </p><p>
 <sup>17&#160;</sup>Then the children of Ammon were gathered together and encamped in Gilead. The children of Israel assembled themselves together and encamped in Mizpah. 
 <sup>18&#160;</sup>The people, the princes of Gilead, said to one another, “Who is the man who will begin to fight against the children of Ammon? He shall be head over all the inhabitants of Gilead.” 
@@ -641,11 +641,11 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>8&#160;</sup>The elders of Gilead said to Jephthah, “Therefore we have turned again to you now, that you may go with us and fight with the children of Ammon. You will be our head over all the inhabitants of Gilead.” 
 </p><p>
-<sup>9&#160;</sup>Jephthah said to the elders of Gilead, “If you bring me home again to fight with the children of Ammon, and Yahweh delivers them before me, will I be your head?” 
+<sup>9&#160;</sup>Jephthah said to the elders of Gilead, “If you bring me home again to fight with the children of Ammon, and Yahuah delivers them before me, will I be your head?” 
 </p><p>
-<sup>10&#160;</sup>The elders of Gilead said to Jephthah, “Yahweh will be witness between us. Surely we will do what you say.” 
+<sup>10&#160;</sup>The elders of Gilead said to Jephthah, “Yahuah will be witness between us. Surely we will do what you say.” 
 </p><p>
-<sup>11&#160;</sup>Then Jephthah went with the elders of Gilead, and the people made him head and chief over them. Jephthah spoke all his words before Yahweh in Mizpah. 
+<sup>11&#160;</sup>Then Jephthah went with the elders of Gilead, and the people made him head and chief over them. Jephthah spoke all his words before Yahuah in Mizpah. 
 </p><p>
 <sup>12&#160;</sup>Jephthah sent messengers to the king of the children of Ammon, saying, “What do you have to do with me, that you have come to me to fight against my land?” 
 </p><p>
@@ -658,27 +658,27 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>Then they went through the wilderness, and went around the land of Edom, and the land of Moab, and came by the east side of the land of Moab, and they encamped on the other side of the Arnon; but they didn’t come within the border of Moab, for the Arnon was the border of Moab. 
 <sup>19&#160;</sup>Israel sent messengers to Sihon king of the Amorites, the king of Heshbon; and Israel said to him, ‘Please let us pass through your land to my place.’ 
 <sup>20&#160;</sup>But Sihon didn’t trust Israel to pass through his border; but Sihon gathered all his people together, and encamped in Jahaz, and fought against Israel. 
-<sup>21&#160;</sup>Yahweh, the Elohim of Israel, delivered Sihon and all his people into the hand of Israel, and they struck them. So Israel possessed all the land of the Amorites, the inhabitants of that country. 
+<sup>21&#160;</sup>Yahuah, the Elohim of Israel, delivered Sihon and all his people into the hand of Israel, and they struck them. So Israel possessed all the land of the Amorites, the inhabitants of that country. 
 <sup>22&#160;</sup>They possessed all the border of the Amorites, from the Arnon even to the Jabbok, and from the wilderness even to the Jordan. 
-<sup>23&#160;</sup>So now Yahweh, the Elohim of Israel, has dispossessed the Amorites from before his people Israel, and should you possess them? 
-<sup>24&#160;</sup>Won’t you possess that which Chemosh your elohim gives you to possess? So whoever Yahweh our Elohim has dispossessed from before us, them will we possess. 
+<sup>23&#160;</sup>So now Yahuah, the Elohim of Israel, has dispossessed the Amorites from before his people Israel, and should you possess them? 
+<sup>24&#160;</sup>Won’t you possess that which Chemosh your elohim gives you to possess? So whoever Yahuah our Elohim has dispossessed from before us, them will we possess. 
 <sup>25&#160;</sup>Now are you anything better than Balak the son of Zippor, king of Moab? Did he ever strive against Israel, or did he ever fight against them? 
 <sup>26&#160;</sup>Israel lived in Heshbon and its towns, and in Aroer and its towns, and in all the cities that are along the side of the Arnon for three hundred years! Why didn’t you recover them within that time? 
-<sup>27&#160;</sup>Therefore I have not sinned against you, but you do me wrong to war against me. May Yahweh the Judge be judge today between the children of Israel and the children of Ammon.” 
+<sup>27&#160;</sup>Therefore I have not sinned against you, but you do me wrong to war against me. May Yahuah the Judge be judge today between the children of Israel and the children of Ammon.” 
 </p><p>
 <sup>28&#160;</sup>However, the king of the children of Ammon didn’t listen to the words of Jephthah which he sent him. 
-<sup>29&#160;</sup>Then Yahweh’s Spirit came on Jephthah, and he passed over Gilead and Manasseh, and passed over Mizpah of Gilead, and from Mizpah of Gilead he passed over to the children of Ammon. 
+<sup>29&#160;</sup>Then Yahuah’s Spirit came on Jephthah, and he passed over Gilead and Manasseh, and passed over Mizpah of Gilead, and from Mizpah of Gilead he passed over to the children of Ammon. 
 </p><p>
-<sup>30&#160;</sup>Jephthah vowed a vow to Yahweh, and said, “If you will indeed deliver the children of Ammon into my hand, 
-<sup>31&#160;</sup>then it shall be, that whatever comes out of the doors of my house to meet me when I return in peace from the children of Ammon, it shall be Yahweh’s, and I will offer it up for a burnt offering.” 
+<sup>30&#160;</sup>Jephthah vowed a vow to Yahuah, and said, “If you will indeed deliver the children of Ammon into my hand, 
+<sup>31&#160;</sup>then it shall be, that whatever comes out of the doors of my house to meet me when I return in peace from the children of Ammon, it shall be Yahuah’s, and I will offer it up for a burnt offering.” 
 </p><p>
-<sup>32&#160;</sup>So Jephthah passed over to the children of Ammon to fight against them; and Yahweh delivered them into his hand. 
+<sup>32&#160;</sup>So Jephthah passed over to the children of Ammon to fight against them; and Yahuah delivered them into his hand. 
 <sup>33&#160;</sup>He struck them from Aroer until you come to Minnith, even twenty cities, and to Abelcheramim, with a very great slaughter. So the children of Ammon were subdued before the children of Israel. 
 </p><p>
 <sup>34&#160;</sup>Jephthah came to Mizpah to his house; and behold, his daughter came out to meet him with tambourines and with dances. She was his only child. Besides her he had neither son nor daughter. 
-<sup>35&#160;</sup>When he saw her, he tore his clothes, and said, “Alas, my daughter! You have brought me very low, and you are one of those who trouble me; for I have opened my mouth to Yahweh, and I can’t go back.” 
+<sup>35&#160;</sup>When he saw her, he tore his clothes, and said, “Alas, my daughter! You have brought me very low, and you are one of those who trouble me; for I have opened my mouth to Yahuah, and I can’t go back.” 
 </p><p>
-<sup>36&#160;</sup>She said to him, “My father, you have opened your mouth to Yahweh; do to me according to that which has proceeded out of your mouth, because Yahweh has taken vengeance for you on your enemies, even on the children of Ammon.” 
+<sup>36&#160;</sup>She said to him, “My father, you have opened your mouth to Yahuah; do to me according to that which has proceeded out of your mouth, because Yahuah has taken vengeance for you on your enemies, even on the children of Ammon.” 
 <sup>37&#160;</sup>Then she said to her father, “Let this thing be done for me. Leave me alone two months, that I may depart and go down on the mountains, and bewail my virginity, I and my companions.” 
 </p><p>
 <sup>38&#160;</sup>He said, “Go.” He sent her away for two months; and she departed, she and her companions, and mourned her virginity on the mountains. 
@@ -689,7 +689,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>The men of Ephraim were gathered together, and passed northward; and they said to Jephthah, “Why did you pass over to fight against the children of Ammon, and didn’t call us to go with you? We will burn your house around you with fire!” 
 </p><p>
 <sup>2&#160;</sup>Jephthah said to them, “I and my people were at great strife with the children of Ammon; and when I called you, you didn’t save me out of their hand. 
-<sup>3&#160;</sup>When I saw that you didn’t save me, I put my life in my hand, and passed over against the children of Ammon, and Yahweh delivered them into my hand. Why then have you come up to me today, to fight against me?” 
+<sup>3&#160;</sup>When I saw that you didn’t save me, I put my life in my hand, and passed over against the children of Ammon, and Yahuah delivered them into my hand. Why then have you come up to me today, to fight against me?” 
 </p><p>
 <sup>4&#160;</sup>Then Jephthah gathered together all the men of Gilead, and fought with Ephraim. The men of Gilead struck Ephraim, because they said, “You are fugitives of Ephraim, you Gileadites, in the middle of Ephraim, and in the middle of Manasseh.” 
 <sup>5&#160;</sup>The Gileadites took the fords of the Jordan against the Ephraimites. Whenever a fugitive of Ephraim said, “Let me go over,” the men of Gilead said to him, “Are you an Ephraimite?” If he said, “No;” 
@@ -709,17 +709,17 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Abdon the son of Hillel the Pirathonite died, and was buried in Pirathon in the land of Ephraim, in the hill country of the Amalekites. 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
-<sup>1&#160;</sup>The children of Israel again did that which was evil in Yahweh’s sight; and Yahweh delivered them into the hand of the Philistines forty years. 
+<sup>1&#160;</sup>The children of Israel again did that which was evil in Yahuah’s sight; and Yahuah delivered them into the hand of the Philistines forty years. 
 </p><p>
 <sup>2&#160;</sup>There was a certain man of Zorah, of the family of the Danites, whose name was Manoah; and his woman was barren, and childless. 
-<sup>3&#160;</sup>Yahweh’s angel appeared to the woman, and said to her, “See now, you are barren and childless; but you shall conceive and bear a son. 
+<sup>3&#160;</sup>Yahuah’s angel appeared to the woman, and said to her, “See now, you are barren and childless; but you shall conceive and bear a son. 
 <sup>4&#160;</sup>Now therefore please beware and drink no wine nor strong drink, and don’t eat any unclean thing; 
 <sup>5&#160;</sup>for, behold, you shall conceive and give birth to a son. No razor shall come on his head, for the child shall be a Nazirite to Elohim from the womb. He shall begin to save Israel out of the hand of the Philistines.” 
 </p><p>
 <sup>6&#160;</sup>Then the woman came and told her man, saying, “A man of Elohim came to me, and his face was like the face of the angel of Elohim, very awesome. I didn’t ask him where he was from, neither did he tell me his name; 
 <sup>7&#160;</sup>but he said to me, ‘Behold, you shall conceive and bear a son; and now drink no wine nor strong drink. Don’t eat any unclean thing, for the child shall be a Nazirite to Elohim from the womb to the day of his death.’&#160;” 
 </p><p>
-<sup>8&#160;</sup>Then Manoah entreated Yahweh, and said, “Oh, Lord, please let the man of Elohim whom you sent come again to us, and teach us what we should do to the child who shall be born.” 
+<sup>8&#160;</sup>Then Manoah entreated Yahuah, and said, “Oh, Lord, please let the man of Elohim whom you sent come again to us, and teach us what we should do to the child who shall be born.” 
 </p><p>
 <sup>9&#160;</sup>Elohim listened to the voice of Manoah, and the angel of Elohim came again to the woman as she sat in the field; but Manoah, her man, wasn’t with her. 
 <sup>10&#160;</sup>The woman hurried and ran, and told her man, saying to him, “Behold, the man who came to me that day has appeared to me.” 
@@ -729,25 +729,25 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>12&#160;</sup>Manoah said, “Now let your words happen. What shall the child’s way of life and mission be?” 
 </p><p>
-<sup>13&#160;</sup>Yahweh’s angel said to Manoah, “Of all that I said to the woman let her beware. 
+<sup>13&#160;</sup>Yahuah’s angel said to Manoah, “Of all that I said to the woman let her beware. 
 <sup>14&#160;</sup>She may not eat of anything that comes of the vine, neither let her drink wine or strong drink, nor eat any unclean thing. Let her observe all that I commanded her.” 
 </p><p>
-<sup>15&#160;</sup>Manoah said to Yahweh’s angel, “Please stay with us, that we may make a young goat ready for you.” 
+<sup>15&#160;</sup>Manoah said to Yahuah’s angel, “Please stay with us, that we may make a young goat ready for you.” 
 </p><p>
-<sup>16&#160;</sup>Yahweh’s angel said to Manoah, “Though you detain me, I won’t eat your bread. If you will prepare a burnt offering, you must offer it to Yahweh.” For Manoah didn’t know that he was Yahweh’s angel. 
+<sup>16&#160;</sup>Yahuah’s angel said to Manoah, “Though you detain me, I won’t eat your bread. If you will prepare a burnt offering, you must offer it to Yahuah.” For Manoah didn’t know that he was Yahuah’s angel. 
 </p><p>
-<sup>17&#160;</sup>Manoah said to Yahweh’s angel, “What is your name, that when your words happen, we may honor you?” 
+<sup>17&#160;</sup>Manoah said to Yahuah’s angel, “What is your name, that when your words happen, we may honor you?” 
 </p><p>
-<sup>18&#160;</sup>Yahweh’s angel said to him, “Why do you ask about my name, since it is incomprehensible?” 
+<sup>18&#160;</sup>Yahuah’s angel said to him, “Why do you ask about my name, since it is incomprehensible?” 
 </p><p>
-<sup>19&#160;</sup>So Manoah took the young goat with the meal offering, and offered it on the rock to Yahweh. Then the angel did an amazing thing as Manoah and his woman watched. 
-<sup>20&#160;</sup>For when the flame went up toward the sky from off the altar, Yahweh’s angel ascended in the flame of the altar. Manoah and his woman watched; and they fell on their faces to the ground. 
-<sup>21&#160;</sup>But Yahweh’s angel didn’t appear to Manoah or to his woman any more. Then Manoah knew that he was Yahweh’s angel. 
+<sup>19&#160;</sup>So Manoah took the young goat with the meal offering, and offered it on the rock to Yahuah. Then the angel did an amazing thing as Manoah and his woman watched. 
+<sup>20&#160;</sup>For when the flame went up toward the sky from off the altar, Yahuah’s angel ascended in the flame of the altar. Manoah and his woman watched; and they fell on their faces to the ground. 
+<sup>21&#160;</sup>But Yahuah’s angel didn’t appear to Manoah or to his woman any more. Then Manoah knew that he was Yahuah’s angel. 
 <sup>22&#160;</sup>Manoah said to his woman, “We shall surely die, because we have seen Elohim.” 
 </p><p>
-<sup>23&#160;</sup>But his woman said to him, “If Yahweh were pleased to kill us, he wouldn’t have received a burnt offering and a meal offering at our hand, and he wouldn’t have shown us all these things, nor would he have told us such things as these at this time.” 
-<sup>24&#160;</sup>The woman bore a son and named him Samson. The child grew, and Yahweh blessed him. 
-<sup>25&#160;</sup>Yahweh’s Spirit began to move him in Mahaneh Dan, between Zorah and Eshtaol. 
+<sup>23&#160;</sup>But his woman said to him, “If Yahuah were pleased to kill us, he wouldn’t have received a burnt offering and a meal offering at our hand, and he wouldn’t have shown us all these things, nor would he have told us such things as these at this time.” 
+<sup>24&#160;</sup>The woman bore a son and named him Samson. The child grew, and Yahuah blessed him. 
+<sup>25&#160;</sup>Yahuah’s Spirit began to move him in Mahaneh Dan, between Zorah and Eshtaol. 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
 <sup>1&#160;</sup>Samson went down to Timnah, and saw a woman in Timnah of the daughters of the Philistines. 
@@ -756,10 +756,10 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>Then his father and his mother said to him, “Isn’t there a woman among your brothers’ daughters, or among all my people, that you go to take a woman of the uncircumcised Philistines?” 
 </p><p>Samson said to his father, “Get her for me, for she pleases me well.” 
 </p><p>
-<sup>4&#160;</sup>But his father and his mother didn’t know that it was of Yahweh; for he sought an occasion against the Philistines. Now at that time the Philistines ruled over Israel. 
+<sup>4&#160;</sup>But his father and his mother didn’t know that it was of Yahuah; for he sought an occasion against the Philistines. Now at that time the Philistines ruled over Israel. 
 </p><p>
 <sup>5&#160;</sup>Then Samson went down to Timnah with his father and his mother, and came to the vineyards of Timnah; and behold, a young lion roared at him. 
-<sup>6&#160;</sup>Yahweh’s Spirit came mightily on him, and he tore him as he would have torn a young goat with his bare hands, but he didn’t tell his father or his mother what he had done. 
+<sup>6&#160;</sup>Yahuah’s Spirit came mightily on him, and he tore him as he would have torn a young goat with his bare hands, but he didn’t tell his father or his mother what he had done. 
 <sup>7&#160;</sup>He went down and talked with the woman, and she pleased Samson well. 
 <sup>8&#160;</sup>After a while he returned to take her, and he went over to see the carcass of the lion; and behold, there was a swarm of bees in the body of the lion, and honey. 
 <sup>9&#160;</sup>He took it into his hands, and went on, eating as he went. He came to his father and mother and gave to them, and they ate, but he didn’t tell them that he had taken the honey out of the lion’s body. 
@@ -785,7 +785,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">“If you hadn’t plowed with my heifer, 
 </p><p class="q2">you wouldn’t have found out my riddle.” 
 </p><p>
-<sup>19&#160;</sup>Yahweh’s Spirit came mightily on him, and he went down to Ashkelon and struck thirty men of them. He took their plunder, then gave the changes of clothing to those who declared the riddle. His anger burned, and he went up to his father’s house. 
+<sup>19&#160;</sup>Yahuah’s Spirit came mightily on him, and he went down to Ashkelon and struck thirty men of them. He took their plunder, then gave the changes of clothing to those who declared the riddle. His anger burned, and he went up to his father’s house. 
 <sup>20&#160;</sup>But Samson’s woman was given to his companion, who had been his friend. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
@@ -815,12 +815,12 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>13&#160;</sup>They spoke to him, saying, “No, but we will bind you securely and deliver you into their hands; but surely we will not kill you.” They bound him with two new ropes, and brought him up from the rock. 
 </p><p>
-<sup>14&#160;</sup>When he came to Lehi, the Philistines shouted as they met him. Then Yahweh’s Spirit came mightily on him, and the ropes that were on his arms became as flax that was burned with fire; and his bands dropped from off his hands. 
+<sup>14&#160;</sup>When he came to Lehi, the Philistines shouted as they met him. Then Yahuah’s Spirit came mightily on him, and the ropes that were on his arms became as flax that was burned with fire; and his bands dropped from off his hands. 
 <sup>15&#160;</sup>He found a fresh jawbone of a donkey, put out his hand, took it, and struck a thousand men with it. 
 <sup>16&#160;</sup>Samson said, “With the jawbone of a donkey, heaps on heaps; with the jawbone of a donkey I have struck a thousand men.” 
 <sup>17&#160;</sup>When he had finished speaking, he threw the jawbone out of his hand; and that place was called Ramath Lehi. 
 </p><p>
-<sup>18&#160;</sup>He was very thirsty, and called on Yahweh and said, “You have given this great deliverance by the hand of your servant; and now shall I die of thirst, and fall into the hands of the uncircumcised?” 
+<sup>18&#160;</sup>He was very thirsty, and called on Yahuah and said, “You have given this great deliverance by the hand of your servant; and now shall I die of thirst, and fall into the hands of the uncircumcised?” 
 </p><p>
 <sup>19&#160;</sup>But Elohim split the hollow place that is in Lehi, and water came out of it. When he had drunk, his spirit came again, and he revived. Therefore its name was called En Hakkore, which is in Lehi, to this day. 
 <sup>20&#160;</sup>He judged Israel twenty years in the days of the Philistines. 
@@ -859,7 +859,7 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>When Delilah saw that he had told her all his heart, she sent and called for the lords of the Philistines, saying, “Come up this once, for he has told me all his heart.” Then the lords of the Philistines came up to her and brought the money in their hand. 
 <sup>19&#160;</sup>She made him sleep on her knees; and she called for a man and shaved off the seven locks of his head; and she began to afflict him, and his strength went from him. 
 <sup>20&#160;</sup>She said, “The Philistines are upon you, Samson!” 
-</p><p>He awoke out of his sleep, and said, “I will go out as at other times, and shake myself free.” But he didn’t know that Yahweh had departed from him. 
+</p><p>He awoke out of his sleep, and said, “I will go out as at other times, and shake myself free.” But he didn’t know that Yahuah had departed from him. 
 <sup>21&#160;</sup>The Philistines laid hold on him and put out his eyes; and they brought him down to Gaza and bound him with fetters of bronze; and he ground at the mill in the prison. 
 <sup>22&#160;</sup>However, the hair of his head began to grow again after he was shaved. 
 </p><p>
@@ -869,7 +869,7 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>When their hearts were merry, they said, “Call for Samson, that he may entertain us.” They called for Samson out of the prison; and he performed before them. They set him between the pillars; 
 <sup>26&#160;</sup>and Samson said to the boy who held him by the hand, “Allow me to feel the pillars on which the house rests, that I may lean on them.” 
 <sup>27&#160;</sup>Now the house was full of men and women; and all the lords of the Philistines were there; and there were on the roof about three thousand men and women, who saw while Samson performed. 
-<sup>28&#160;</sup>Samson called to Yahweh, and said, “Lord Yahweh, remember me, please, and strengthen me, please, only this once, Elohim, that I may be at once avenged of the Philistines for my two eyes.” 
+<sup>28&#160;</sup>Samson called to Yahuah, and said, “Lord Yahuah, remember me, please, and strengthen me, please, only this once, Elohim, that I may be at once avenged of the Philistines for my two eyes.” 
 <sup>29&#160;</sup>Samson took hold of the two middle pillars on which the house rested and leaned on them, the one with his right hand and the other with his left. 
 <sup>30&#160;</sup>Samson said, “Let me die with the Philistines!” He bowed himself with all his might; and the house fell on the lords, and on all the people who were in it. So the dead that he killed at his death were more than those who he killed in his life. 
 </p><p>
@@ -878,9 +878,9 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>There was a man of the hill country of Ephraim, whose name was Micah. 
 <sup>2&#160;</sup>He said to his mother, “The eleven hundred pieces of silver that were taken from you, about which you uttered a curse, and also spoke it in my ears—behold, the silver is with me. I took it.” 
-</p><p>His mother said, “May Yahweh bless my son!” 
+</p><p>His mother said, “May Yahuah bless my son!” 
 </p><p>
-<sup>3&#160;</sup>He restored the eleven hundred pieces of silver to his mother, then his mother said, “I most certainly dedicate the silver to Yahweh from my hand for my son, to make a carved image and a molten image. Now therefore I will restore it to you.” 
+<sup>3&#160;</sup>He restored the eleven hundred pieces of silver to his mother, then his mother said, “I most certainly dedicate the silver to Yahuah from my hand for my son, to make a carved image and a molten image. Now therefore I will restore it to you.” 
 </p><p>
 <sup>4&#160;</sup>When he restored the money to his mother, his mother took two hundred pieces of silver, and gave them to a silversmith, who made a carved image and a molten image out of it. It was in the house of Micah. 
 </p><p>
@@ -894,7 +894,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>Micah said to him, “Dwell with me, and be to me a father and a priest, and I will give you ten pieces of silver per year, a suit of clothing, and your food.” So the Levite went in. 
 <sup>11&#160;</sup>The Levite was content to dwell with the man; and the young man was to him as one of his sons. 
 <sup>12&#160;</sup>Micah consecrated the Levite, and the young man became his priest, and was in the house of Micah. 
-<sup>13&#160;</sup>Then Micah said, “Now I know that Yahweh will do good to me, since I have a Levite as my priest.” 
+<sup>13&#160;</sup>Then Micah said, “Now I know that Yahuah will do good to me, since I have a Levite as my priest.” 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
 <sup>1&#160;</sup>In those days there was no king in Israel. In those days the tribe of the Danites sought an inheritance to dwell in; for to that day, their inheritance had not fallen to them among the tribes of Israel. 
@@ -906,7 +906,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>5&#160;</sup>They said to him, “Please ask counsel of Elohim, that we may know whether our way which we go shall be prosperous.” 
 </p><p>
-<sup>6&#160;</sup>The priest said to them, “Go in peace. Your way in which you go is before Yahweh.” 
+<sup>6&#160;</sup>The priest said to them, “Go in peace. Your way in which you go is before Yahuah.” 
 </p><p>
 <sup>7&#160;</sup>Then the five men departed and came to Laish and saw the people who were there, how they lived in safety, in the way of the Sidonians, quiet and secure; for there was no one in the land possessing authority, that might put them to shame in anything, and they were far from the Sidonians, and had no dealings with anyone else. 
 <sup>8&#160;</sup>They came to their brothers at Zorah and Eshtaol; and their brothers asked them, “What do you say?” 
@@ -967,7 +967,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>Behold, an old man came from his work out of the field at evening. Now the man was from the hill country of Ephraim, and he lived in Gibeah; but the men of the place were Benjamites. 
 <sup>17&#160;</sup>He lifted up his eyes, and saw the wayfaring man in the street of the city; and the old man said, “Where are you going? Where did you come from?” 
 </p><p>
-<sup>18&#160;</sup>He said to him, “We are passing from Bethlehem Judah to the farther side of the hill country of Ephraim. I am from there, and I went to Bethlehem Judah. I am going to Yahweh’s house; and there is no one who has taken me into his house. 
+<sup>18&#160;</sup>He said to him, “We are passing from Bethlehem Judah to the farther side of the hill country of Ephraim. I am from there, and I went to Bethlehem Judah. I am going to Yahuah’s house; and there is no one who has taken me into his house. 
 <sup>19&#160;</sup>Yet there is both straw and feed for our donkeys; and there is bread and wine also for me, and for your servant, and for the young man who is with your servants. There is no lack of anything.” 
 </p><p>
 <sup>20&#160;</sup>The old man said, “Peace be to you! Just let me supply all your needs, but don’t sleep in the street.” 
@@ -987,7 +987,7 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>It was so, that all who saw it said, “Such a deed has not been done or seen from the day that the children of Israel came up out of the land of Egypt to this day! Consider it, take counsel, and speak.” 
 </p><h2 class="chapterlabel" id="20">20</h2>
 <p>
-<sup>1&#160;</sup>Then all the children of Israel went out, and the congregation was assembled as one man, from Dan even to Beersheba, with the land of Gilead, to Yahweh at Mizpah. 
+<sup>1&#160;</sup>Then all the children of Israel went out, and the congregation was assembled as one man, from Dan even to Beersheba, with the land of Gilead, to Yahuah at Mizpah. 
 <sup>2&#160;</sup>The chiefs of all the people, even of all the tribes of Israel, presented themselves in the assembly of the people of Elohim, four hundred thousand footmen who drew sword. 
 <sup>3&#160;</sup>(Now the children of Benjamin heard that the children of Israel had gone up to Mizpah.) The children of Israel said, “Tell us, how did this wickedness happen?” 
 </p><p>
@@ -1010,22 +1010,22 @@ html[dir=ltr] .q2 {
 <sup>17&#160;</sup>The men of Israel, besides Benjamin, were counted four hundred thousand men who drew sword. All these were men of war. 
 </p><p>
 <sup>18&#160;</sup>The children of Israel arose, went up to Bethel, and asked counsel of Elohim. They asked, “Who shall go up for us first to battle against the children of Benjamin?” 
-</p><p>Yahweh said, “Judah first.” 
+</p><p>Yahuah said, “Judah first.” 
 </p><p>
 <sup>19&#160;</sup>The children of Israel rose up in the morning and encamped against Gibeah. 
 <sup>20&#160;</sup>The men of Israel went out to battle against Benjamin; and the men of Israel set the battle in array against them at Gibeah. 
 <sup>21&#160;</sup>The children of Benjamin came out of Gibeah, and on that day destroyed twenty-two thousand of the Israelite men down to the ground. 
 <sup>22&#160;</sup>The people, the men of Israel, encouraged themselves, and set the battle again in array in the place where they set themselves in array the first day. 
-<sup>23&#160;</sup>The children of Israel went up and wept before Yahweh until evening; and they asked of Yahweh, saying, “Shall I again draw near to battle against the children of Benjamin my brother?” 
-</p><p>Yahweh said, “Go up against him.” 
+<sup>23&#160;</sup>The children of Israel went up and wept before Yahuah until evening; and they asked of Yahuah, saying, “Shall I again draw near to battle against the children of Benjamin my brother?” 
+</p><p>Yahuah said, “Go up against him.” 
 </p><p>
 <sup>24&#160;</sup>The children of Israel came near against the children of Benjamin the second day. 
 <sup>25&#160;</sup>Benjamin went out against them out of Gibeah the second day, and destroyed down to the ground of the children of Israel again eighteen thousand men. All these drew the sword. 
 </p><p>
-<sup>26&#160;</sup>Then all the children of Israel and all the people went up, and came to Bethel, and wept, and sat there before Yahweh, and fasted that day until evening; then they offered burnt offerings and peace offerings before Yahweh. 
-<sup>27&#160;</sup>The children of Israel asked Yahweh (for the ark of the covenant of Elohim was there in those days, 
+<sup>26&#160;</sup>Then all the children of Israel and all the people went up, and came to Bethel, and wept, and sat there before Yahuah, and fasted that day until evening; then they offered burnt offerings and peace offerings before Yahuah. 
+<sup>27&#160;</sup>The children of Israel asked Yahuah (for the ark of the covenant of Elohim was there in those days, 
 <sup>28&#160;</sup>and Phinehas, the son of Eleazar, the son of Aaron, stood before it in those days), saying, “Shall I yet again go out to battle against the children of Benjamin my brother, or shall I cease?” 
-</p><p>Yahweh said, “Go up; for tomorrow I will deliver him into your hand.” 
+</p><p>Yahuah said, “Go up; for tomorrow I will deliver him into your hand.” 
 </p><p>
 <sup>29&#160;</sup>Israel set ambushes all around Gibeah. 
 <sup>30&#160;</sup>The children of Israel went up against the children of Benjamin on the third day, and set themselves in array against Gibeah, as at other times. 
@@ -1035,7 +1035,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>33&#160;</sup>All the men of Israel rose up out of their place and set themselves in array at Baal Tamar. Then the ambushers of Israel broke out of their place, even out of Maareh Geba. 
 <sup>34&#160;</sup>Ten thousand chosen men out of all Israel came over against Gibeah, and the battle was severe; but they didn’t know that disaster was close to them. 
-<sup>35&#160;</sup>Yahweh struck Benjamin before Israel; and the children of Israel destroyed of Benjamin that day twenty-five thousand one hundred men. All these drew the sword. 
+<sup>35&#160;</sup>Yahuah struck Benjamin before Israel; and the children of Israel destroyed of Benjamin that day twenty-five thousand one hundred men. All these drew the sword. 
 <sup>36&#160;</sup>So the children of Benjamin saw that they were struck, for the men of Israel yielded to Benjamin because they trusted the ambushers whom they had set against Gibeah. 
 <sup>37&#160;</sup>The ambushers hurried, and rushed on Gibeah; then the ambushers spread out, and struck all the city with the edge of the sword. 
 <sup>38&#160;</sup>Now the appointed sign between the men of Israel and the ambushers was that they should make a great cloud of smoke rise up out of the city. 
@@ -1053,13 +1053,13 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Now the men of Israel had sworn in Mizpah, saying, “None of us will give his daughter to Benjamin as a woman.” 
 <sup>2&#160;</sup>The people came to Bethel and sat there until evening before Elohim, and lifted up their voices, and wept severely. 
-<sup>3&#160;</sup>They said, “Yahweh, the Elohim of Israel, why has this happened in Israel, that there should be one tribe lacking in Israel today?” 
+<sup>3&#160;</sup>They said, “Yahuah, the Elohim of Israel, why has this happened in Israel, that there should be one tribe lacking in Israel today?” 
 </p><p>
 <sup>4&#160;</sup>On the next day, the people rose early and built an altar there, and offered burnt offerings and peace offerings. 
-<sup>5&#160;</sup>The children of Israel said, “Who is there among all the tribes of Israel who didn’t come up in the assembly to Yahweh?” For they had made a great oath concerning him who didn’t come up to Yahweh to Mizpah, saying, “He shall surely be put to death.” 
+<sup>5&#160;</sup>The children of Israel said, “Who is there among all the tribes of Israel who didn’t come up in the assembly to Yahuah?” For they had made a great oath concerning him who didn’t come up to Yahuah to Mizpah, saying, “He shall surely be put to death.” 
 <sup>6&#160;</sup>The children of Israel grieved for Benjamin their brother, and said, “There is one tribe cut off from Israel today. 
-<sup>7&#160;</sup>How shall we provide women for those who remain, since we have sworn by Yahweh that we will not give them of our daughters to women?” 
-<sup>8&#160;</sup>They said, “What one is there of the tribes of Israel who didn’t come up to Yahweh to Mizpah?” Behold, no one came from Jabesh Gilead to the camp to the assembly. 
+<sup>7&#160;</sup>How shall we provide women for those who remain, since we have sworn by Yahuah that we will not give them of our daughters to women?” 
+<sup>8&#160;</sup>They said, “What one is there of the tribes of Israel who didn’t come up to Yahuah to Mizpah?” Behold, no one came from Jabesh Gilead to the camp to the assembly. 
 <sup>9&#160;</sup>For when the people were counted, behold, there were none of the inhabitants of Jabesh Gilead there. 
 <sup>10&#160;</sup>The congregation sent twelve thousand of the most valiant men there, and commanded them, saying, “Go and strike the inhabitants of Jabesh Gilead with the edge of the sword, with the women and the little ones. 
 <sup>11&#160;</sup>This is the thing that you shall do: you shall utterly destroy every male, and every woman who has lain with a man.” 
@@ -1067,11 +1067,11 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>13&#160;</sup>The whole congregation sent and spoke to the children of Benjamin who were in the rock of Rimmon, and proclaimed peace to them. 
 <sup>14&#160;</sup>Benjamin returned at that time; and they gave them the women whom they had saved alive of the women of Jabesh Gilead. There still weren’t enough for them. 
-<sup>15&#160;</sup>The people grieved for Benjamin, because Yahweh had made a breach in the tribes of Israel. 
+<sup>15&#160;</sup>The people grieved for Benjamin, because Yahuah had made a breach in the tribes of Israel. 
 <sup>16&#160;</sup>Then the elders of the congregation said, “How shall we provide women for those who remain, since the women are destroyed out of Benjamin?” 
 <sup>17&#160;</sup>They said, “There must be an inheritance for those who are escaped of Benjamin, that a tribe not be blotted out from Israel. 
 <sup>18&#160;</sup>However, we may not give them women of our daughters, for the children of Israel had sworn, saying, ‘Cursed is he who gives a woman to Benjamin.’&#160;” 
-<sup>19&#160;</sup>They said, “Behold, there is a feast of Yahweh from year to year in Shiloh, which is on the north of Bethel, on the east side of the highway that goes up from Bethel to Shechem, and on the south of Lebonah.” 
+<sup>19&#160;</sup>They said, “Behold, there is a feast of Yahuah from year to year in Shiloh, which is on the north of Bethel, on the east side of the highway that goes up from Bethel to Shechem, and on the south of Lebonah.” 
 <sup>20&#160;</sup>They commanded the children of Benjamin, saying, “Go and lie in wait in the vineyards, 
 <sup>21&#160;</sup>and see, and behold, if the daughters of Shiloh come out to dance in the dances, then come out of the vineyards, and each man catch his woman of the daughters of Shiloh, and go to the land of Benjamin. 
 <sup>22&#160;</sup>It shall be, when their fathers or their brothers come to complain to us, that we will say to them, ‘Grant them graciously to us, because we didn’t take for each man his woman in battle, neither did you give them to them; otherwise you would now be guilty.’&#160;” 

--- a/book/lamentations.html
+++ b/book/lamentations.html
@@ -97,7 +97,7 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>5&#160;</sup>Her adversaries have become the head. 
 </p><p class="q2">Her enemies prosper; 
-</p><p class="q1">for Yahweh has afflicted her for the multitude of her transgressions. 
+</p><p class="q1">for Yahuah has afflicted her for the multitude of her transgressions. 
 </p><p class="q2">Her young children have gone into captivity before the adversary. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -125,7 +125,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">She didn’t remember her latter end. 
 </p><p class="q1">Therefore she has come down astoundingly. 
 </p><p class="q2">She has no comforter. 
-</p><p class="q1">“See, Yahweh, my affliction; 
+</p><p class="q1">“See, Yahuah, my affliction; 
 </p><p class="q2">for the enemy has magnified himself.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -137,14 +137,14 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>All her people sigh. 
 </p><p class="q2">They seek bread. 
 </p><p class="q2">They have given their pleasant things for food to refresh their soul. 
-</p><p class="q1">“Look, Yahweh, and see, 
+</p><p class="q1">“Look, Yahuah, and see, 
 </p><p class="q2">for I have become despised.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>12&#160;</sup>“Is it nothing to you, all you who pass by? 
 </p><p class="q2">Look, and see if there is any sorrow like my sorrow, 
 </p><p class="q2">which is brought on me, 
-</p><p class="q2">with which Yahweh has afflicted me in the day of his fierce anger. 
+</p><p class="q2">with which Yahuah has afflicted me in the day of his fierce anger. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>13&#160;</sup>“From on high has he sent fire into my bones, 
@@ -176,12 +176,12 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>17&#160;</sup>Zion spreads out her hands. 
 </p><p class="q2">There is no one to comfort her. 
-</p><p class="q1">Yahweh has commanded concerning Jacob, 
+</p><p class="q1">Yahuah has commanded concerning Jacob, 
 </p><p class="q2">that those who are around him should be his adversaries. 
 </p><p class="q2">Jerusalem is among them as an unclean thing. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>18&#160;</sup>“Yahweh is righteous, 
+<sup>18&#160;</sup>“Yahuah is righteous, 
 </p><p class="q2">for I have rebelled against his commandment. 
 </p><p class="q1">Please hear all you peoples, 
 </p><p class="q2">and see my sorrow. 
@@ -194,7 +194,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">while they sought food for themselves to refresh their souls. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>20&#160;</sup>“Look, Yahweh; for I am in distress. 
+<sup>20&#160;</sup>“Look, Yahuah; for I am in distress. 
 </p><p class="q2">My heart is troubled. 
 </p><p class="q1">My heart turns over within me, 
 </p><p class="q2">for I have grievously rebelled. 
@@ -250,18 +250,18 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>He has violently taken away his tabernacle, 
 </p><p class="q2">as if it were a garden. 
 </p><p class="q1">He has destroyed his place of assembly. 
-</p><p class="q2">Yahweh has caused solemn assembly and Sabbath to be forgotten in Zion. 
+</p><p class="q2">Yahuah has caused solemn assembly and Sabbath to be forgotten in Zion. 
 </p><p class="q2">In the indignation of his anger, he has despised the king and the priest. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>7&#160;</sup>The Lord has cast off his altar. 
 </p><p class="q2">He has abhorred his sanctuary. 
 </p><p class="q1">He has given the walls of her palaces into the hand of the enemy. 
-</p><p class="q2">They have made a noise in Yahweh’s house, 
+</p><p class="q2">They have made a noise in Yahuah’s house, 
 </p><p class="q2">as in the day of a solemn assembly. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>8&#160;</sup>Yahweh has purposed to destroy the wall of the daughter of Zion. 
+<sup>8&#160;</sup>Yahuah has purposed to destroy the wall of the daughter of Zion. 
 </p><p class="q2">He has stretched out the line. 
 </p><p class="q2">He has not withdrawn his hand from destroying; 
 </p><p class="q1">He has made the rampart and wall lament. 
@@ -271,7 +271,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Her gates have sunk into the ground. 
 </p><p class="q2">He has destroyed and broken her bars. 
 </p><p class="q1">Her king and her princes are among the nations where the law is not. 
-</p><p class="q2">Yes, her prophets find no vision from Yahweh. 
+</p><p class="q2">Yes, her prophets find no vision from Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>10&#160;</sup>The elders of the daughter of Zion sit on the ground. 
@@ -322,7 +322,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">We have seen it.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>17&#160;</sup>Yahweh has done that which he planned. 
+<sup>17&#160;</sup>Yahuah has done that which he planned. 
 </p><p class="q2">He has fulfilled his word that he commanded in the days of old. 
 </p><p class="q1">He has thrown down, 
 </p><p class="q2">and has not pitied. 
@@ -344,7 +344,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">who faint for hunger at the head of every street. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>20&#160;</sup>“Look, Yahweh, and see to whom you have done thus! 
+<sup>20&#160;</sup>“Look, Yahuah, and see to whom you have done thus! 
 </p><p class="q2">Should the women eat their offspring, 
 </p><p class="q2">the children that they held and bounced on their knees? 
 </p><p class="q2">Should the priest and the prophet be killed in the sanctuary of the Lord? 
@@ -357,7 +357,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>22&#160;</sup>“You have called, as in the day of a solemn assembly, my terrors on every side. 
-</p><p class="q2">There was no one that escaped or remained in the day of Yahweh’s anger. 
+</p><p class="q2">There was no one that escaped or remained in the day of Yahuah’s anger. 
 </p><p class="q2">My enemy has consumed those whom I have cared for and brought up. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p class="q1">
@@ -418,7 +418,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I forgot prosperity. 
 </p><p class="q1">
 <sup>18&#160;</sup>I said, “My strength has perished, 
-</p><p class="q2">along with my expectation from Yahweh.” 
+</p><p class="q2">along with my expectation from Yahuah.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>19&#160;</sup>Remember my affliction and my misery, 
@@ -431,21 +431,21 @@ html[dir=ltr] .q2 {
 </p><p class="q2">therefore I have hope. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>22&#160;</sup>It is because of Yahweh’s loving kindnesses that we are not consumed, 
+<sup>22&#160;</sup>It is because of Yahuah’s loving kindnesses that we are not consumed, 
 </p><p class="q2">because his mercies don’t fail. 
 </p><p class="q1">
 <sup>23&#160;</sup>They are new every morning. 
 </p><p class="q2">Great is your faithfulness. 
 </p><p class="q1">
-<sup>24&#160;</sup>“Yahweh is my portion,” says my soul. 
+<sup>24&#160;</sup>“Yahuah is my portion,” says my soul. 
 </p><p class="q2">“Therefore I will hope in him.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>25&#160;</sup>Yahweh is good to those who wait for him, 
+<sup>25&#160;</sup>Yahuah is good to those who wait for him, 
 </p><p class="q2">to the soul who seeks him. 
 </p><p class="q1">
 <sup>26&#160;</sup>It is good that a man should hope 
-</p><p class="q2">and quietly wait for the salvation of Yahweh. 
+</p><p class="q2">and quietly wait for the salvation of Yahuah. 
 </p><p class="q2">
 <sup>27&#160;</sup>It is good for a man that he bear the yoke in his youth. 
 </p><p class="b"> &#160; </p>
@@ -486,7 +486,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>40&#160;</sup>Let us search and try our ways, 
-</p><p class="q2">and turn again to Yahweh. 
+</p><p class="q2">and turn again to Yahuah. 
 </p><p class="q1">
 <sup>41&#160;</sup>Let’s lift up our heart with our hands to Elohim in the heavens. 
 </p><p class="q2">
@@ -518,7 +518,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and doesn’t cease, 
 </p><p class="q2">without any intermission, 
 </p><p class="q1">
-<sup>50&#160;</sup>until Yahweh looks down, 
+<sup>50&#160;</sup>until Yahuah looks down, 
 </p><p class="q2">and sees from heaven. 
 </p><p class="q1">
 <sup>51&#160;</sup>My eye affects my soul, 
@@ -535,7 +535,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I said, “I am cut off.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>55&#160;</sup>I called on your name, Yahweh, 
+<sup>55&#160;</sup>I called on your name, Yahuah, 
 </p><p class="q2">out of the lowest dungeon. 
 </p><p class="q1">
 <sup>56&#160;</sup>You heard my voice: 
@@ -550,14 +550,14 @@ html[dir=ltr] .q2 {
 <sup>58&#160;</sup>Lord, you have pleaded the causes of my soul. 
 </p><p class="q2">You have redeemed my life. 
 </p><p class="q1">
-<sup>59&#160;</sup>Yahweh, you have seen my wrong. 
+<sup>59&#160;</sup>Yahuah, you have seen my wrong. 
 </p><p class="q2">Judge my cause. 
 </p><p class="q1">
 <sup>60&#160;</sup>You have seen all their vengeance 
 </p><p class="q2">and all their plans against me. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>61&#160;</sup>You have heard their reproach, Yahweh, 
+<sup>61&#160;</sup>You have heard their reproach, Yahuah, 
 </p><p class="q2">and all their plans against me, 
 </p><p class="q1">
 <sup>62&#160;</sup>the lips of those that rose up against me, 
@@ -567,14 +567,14 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I am their song. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>64&#160;</sup>You will pay them back, Yahweh, 
+<sup>64&#160;</sup>You will pay them back, Yahuah, 
 </p><p class="q2">according to the work of their hands. 
 </p><p class="q1">
 <sup>65&#160;</sup>You will give them hardness of heart, 
 </p><p class="q2">your curse to them. 
 </p><p class="q1">
 <sup>66&#160;</sup>You will pursue them in anger, 
-</p><p class="q2">and destroy them from under the heavens of Yahweh. 
+</p><p class="q2">and destroy them from under the heavens of Yahuah. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p class="q1">
 <sup>1&#160;</sup>How the gold has become dim! 
@@ -631,7 +631,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They were their food in the destruction of the daughter of my people. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>11&#160;</sup>Yahweh has accomplished his wrath. 
+<sup>11&#160;</sup>Yahuah has accomplished his wrath. 
 </p><p class="q2">He has poured out his fierce anger. 
 </p><p class="q1">He has kindled a fire in Zion, 
 </p><p class="q2">which has devoured its foundations. 
@@ -658,7 +658,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">“They can’t live here any more.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>16&#160;</sup>Yahweh’s anger has scattered them. 
+<sup>16&#160;</sup>Yahuah’s anger has scattered them. 
 </p><p class="q2">He will not pay attention to them any more. 
 </p><p class="q1">They didn’t respect the persons of the priests. 
 </p><p class="q2">They didn’t favor the elders. 
@@ -682,7 +682,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>20&#160;</sup>The breath of our nostrils, 
-</p><p class="q2">the anointed of Yahweh, 
+</p><p class="q2">the anointed of Yahuah, 
 </p><p class="q2">was taken in their pits; 
 </p><p class="q1">of whom we said, 
 </p><p class="q2">under his shadow we will live among the nations. 
@@ -701,7 +701,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He will uncover your sins. 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p class="q1">
-<sup>1&#160;</sup>Remember, Yahweh, what has come on us. 
+<sup>1&#160;</sup>Remember, Yahuah, what has come on us. 
 </p><p class="q2">Look, and see our reproach. 
 </p><p class="q1">
 <sup>2&#160;</sup>Our inheritance has been turned over to strangers, 
@@ -756,13 +756,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">The foxes walk on it. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>19&#160;</sup>You, Yahweh, remain forever. 
+<sup>19&#160;</sup>You, Yahuah, remain forever. 
 </p><p class="q2">Your throne is from generation to generation. 
 </p><p class="q1">
 <sup>20&#160;</sup>Why do you forget us forever, 
 </p><p class="q2">and forsake us for so long a time? 
 </p><p class="q1">
-<sup>21&#160;</sup>Turn us to yourself, Yahweh, and we will be turned. 
+<sup>21&#160;</sup>Turn us to yourself, Yahuah, and we will be turned. 
 </p><p class="q2">Renew our days as of old. 
 </p><p class="q1">
 <sup>22&#160;</sup>But you have utterly rejected us. 

--- a/book/leviticus.html
+++ b/book/leviticus.html
@@ -86,109 +86,109 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>Yahweh called to Moses, and spoke to him from the Tent of Meeting, saying, 
-<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘When anyone of you offers an offering to Yahweh, you shall offer your offering of the livestock, from the herd and from the flock. 
+<sup>1&#160;</sup>Yahuah called to Moses, and spoke to him from the Tent of Meeting, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘When anyone of you offers an offering to Yahuah, you shall offer your offering of the livestock, from the herd and from the flock. 
 </p><p>
-<sup>3&#160;</sup>“&#160;‘If his offering is a burnt offering from the herd, he shall offer a male without defect. He shall offer it at the door of the Tent of Meeting, that he may be accepted before Yahweh. 
+<sup>3&#160;</sup>“&#160;‘If his offering is a burnt offering from the herd, he shall offer a male without defect. He shall offer it at the door of the Tent of Meeting, that he may be accepted before Yahuah. 
 <sup>4&#160;</sup>He shall lay his hand on the head of the burnt offering, and it shall be accepted for him to make atonement for him. 
-<sup>5&#160;</sup>He shall kill the bull before Yahweh. Aaron’s sons, the priests, shall present the blood and sprinkle the blood around on the altar that is at the door of the Tent of Meeting. 
+<sup>5&#160;</sup>He shall kill the bull before Yahuah. Aaron’s sons, the priests, shall present the blood and sprinkle the blood around on the altar that is at the door of the Tent of Meeting. 
 <sup>6&#160;</sup>He shall skin the burnt offering and cut it into pieces. 
 <sup>7&#160;</sup>The sons of Aaron the priest shall put fire on the altar, and lay wood in order on the fire; 
 <sup>8&#160;</sup>and Aaron’s sons, the priests, shall lay the pieces, the head, and the fat in order on the wood that is on the fire which is on the altar; 
-<sup>9&#160;</sup>but he shall wash its innards and its legs with water. The priest shall burn all of it on the altar, for a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
+<sup>9&#160;</sup>but he shall wash its innards and its legs with water. The priest shall burn all of it on the altar, for a burnt offering, an offering made by fire, of a pleasant aroma to Yahuah. 
 </p><p>
 <sup>10&#160;</sup>“&#160;‘If his offering is from the flock, from the sheep or from the goats, for a burnt offering, he shall offer a male without defect. 
-<sup>11&#160;</sup>He shall kill it on the north side of the altar before Yahweh. Aaron’s sons, the priests, shall sprinkle its blood around on the altar. 
+<sup>11&#160;</sup>He shall kill it on the north side of the altar before Yahuah. Aaron’s sons, the priests, shall sprinkle its blood around on the altar. 
 <sup>12&#160;</sup>He shall cut it into its pieces, with its head and its fat. The priest shall lay them in order on the wood that is on the fire which is on the altar, 
-<sup>13&#160;</sup>but the innards and the legs he shall wash with water. The priest shall offer the whole, and burn it on the altar. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
+<sup>13&#160;</sup>but the innards and the legs he shall wash with water. The priest shall offer the whole, and burn it on the altar. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahuah. 
 </p><p>
-<sup>14&#160;</sup>“&#160;‘If his offering to Yahweh is a burnt offering of birds, then he shall offer his offering from turtledoves or of young pigeons. 
+<sup>14&#160;</sup>“&#160;‘If his offering to Yahuah is a burnt offering of birds, then he shall offer his offering from turtledoves or of young pigeons. 
 <sup>15&#160;</sup>The priest shall bring it to the altar, and wring off its head, and burn it on the altar; and its blood shall be drained out on the side of the altar; 
 <sup>16&#160;</sup>and he shall take away its crop and its feathers, and cast it beside the altar on the east part, in the place of the ashes. 
-<sup>17&#160;</sup>He shall tear it by its wings, but shall not divide it apart. The priest shall burn it on the altar, on the wood that is on the fire. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
+<sup>17&#160;</sup>He shall tear it by its wings, but shall not divide it apart. The priest shall burn it on the altar, on the wood that is on the fire. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahuah. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>“&#160;‘When anyone offers an offering of a meal offering to Yahweh, his offering shall be of fine flour. He shall pour oil on it, and put frankincense on it. 
-<sup>2&#160;</sup>He shall bring it to Aaron’s sons, the priests. He shall take his handful of its fine flour, and of its oil, with all its frankincense, and the priest shall burn its memorial on the altar, an offering made by fire, of a pleasant aroma to Yahweh. 
-<sup>3&#160;</sup>That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahweh made by fire. 
+<sup>1&#160;</sup>“&#160;‘When anyone offers an offering of a meal offering to Yahuah, his offering shall be of fine flour. He shall pour oil on it, and put frankincense on it. 
+<sup>2&#160;</sup>He shall bring it to Aaron’s sons, the priests. He shall take his handful of its fine flour, and of its oil, with all its frankincense, and the priest shall burn its memorial on the altar, an offering made by fire, of a pleasant aroma to Yahuah. 
+<sup>3&#160;</sup>That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahuah made by fire. 
 </p><p>
 <sup>4&#160;</sup>“&#160;‘When you offer an offering of a meal offering baked in the oven, it shall be unleavened cakes of fine flour mixed with oil, or unleavened wafers anointed with oil. 
 <sup>5&#160;</sup>If your offering is a meal offering made on a griddle, it shall be of unleavened fine flour, mixed with oil. 
 <sup>6&#160;</sup>You shall cut it in pieces, and pour oil on it. It is a meal offering. 
 <sup>7&#160;</sup>If your offering is a meal offering of the pan, it shall be made of fine flour with oil. 
-<sup>8&#160;</sup>You shall bring the meal offering that is made of these things to Yahweh. It shall be presented to the priest, and he shall bring it to the altar. 
-<sup>9&#160;</sup>The priest shall take from the meal offering its memorial, and shall burn it on the altar, an offering made by fire, of a pleasant aroma to Yahweh. 
-<sup>10&#160;</sup>That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahweh made by fire. 
+<sup>8&#160;</sup>You shall bring the meal offering that is made of these things to Yahuah. It shall be presented to the priest, and he shall bring it to the altar. 
+<sup>9&#160;</sup>The priest shall take from the meal offering its memorial, and shall burn it on the altar, an offering made by fire, of a pleasant aroma to Yahuah. 
+<sup>10&#160;</sup>That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahuah made by fire. 
 </p><p>
-<sup>11&#160;</sup>“&#160;‘No meal offering which you shall offer to Yahweh shall be made with yeast; for you shall burn no yeast, nor any honey, as an offering made by fire to Yahweh. 
-<sup>12&#160;</sup>As an offering of first fruits you shall offer them to Yahweh, but they shall not rise up as a pleasant aroma on the altar. 
+<sup>11&#160;</sup>“&#160;‘No meal offering which you shall offer to Yahuah shall be made with yeast; for you shall burn no yeast, nor any honey, as an offering made by fire to Yahuah. 
+<sup>12&#160;</sup>As an offering of first fruits you shall offer them to Yahuah, but they shall not rise up as a pleasant aroma on the altar. 
 <sup>13&#160;</sup>Every offering of your meal offering you shall season with salt. You shall not allow the salt of the covenant of your Elohim to be lacking from your meal offering. With all your offerings you shall offer salt. 
 </p><p>
-<sup>14&#160;</sup>“&#160;‘If you offer a meal offering of first fruits to Yahweh, you shall offer for the meal offering of your first fruits fresh heads of grain parched with fire and crushed. 
+<sup>14&#160;</sup>“&#160;‘If you offer a meal offering of first fruits to Yahuah, you shall offer for the meal offering of your first fruits fresh heads of grain parched with fire and crushed. 
 <sup>15&#160;</sup>You shall put oil on it and lay frankincense on it. It is a meal offering. 
-<sup>16&#160;</sup>The priest shall burn as its memorial part of its crushed grain and part of its oil, along with all its frankincense. It is an offering made by fire to Yahweh. 
+<sup>16&#160;</sup>The priest shall burn as its memorial part of its crushed grain and part of its oil, along with all its frankincense. It is an offering made by fire to Yahuah. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>“&#160;‘If his offering is a sacrifice of peace offerings, if he offers it from the herd, whether male or female, he shall offer it without defect before Yahweh. 
+<sup>1&#160;</sup>“&#160;‘If his offering is a sacrifice of peace offerings, if he offers it from the herd, whether male or female, he shall offer it without defect before Yahuah. 
 <sup>2&#160;</sup>He shall lay his hand on the head of his offering, and kill it at the door of the Tent of Meeting. Aaron’s sons, the priests, shall sprinkle the blood around on the altar. 
-<sup>3&#160;</sup>He shall offer of the sacrifice of peace offerings an offering made by fire to Yahweh. The fat that covers the innards, and all the fat that is on the innards, 
+<sup>3&#160;</sup>He shall offer of the sacrifice of peace offerings an offering made by fire to Yahuah. The fat that covers the innards, and all the fat that is on the innards, 
 <sup>4&#160;</sup>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
-<sup>5&#160;</sup>Aaron’s sons shall burn it on the altar on the burnt offering, which is on the wood that is on the fire: it is an offering made by fire, of a pleasant aroma to Yahweh. 
+<sup>5&#160;</sup>Aaron’s sons shall burn it on the altar on the burnt offering, which is on the wood that is on the fire: it is an offering made by fire, of a pleasant aroma to Yahuah. 
 </p><p>
-<sup>6&#160;</sup>“&#160;‘If his offering for a sacrifice of peace offerings to Yahweh is from the flock, either male or female, he shall offer it without defect. 
-<sup>7&#160;</sup>If he offers a lamb for his offering, then he shall offer it before Yahweh; 
+<sup>6&#160;</sup>“&#160;‘If his offering for a sacrifice of peace offerings to Yahuah is from the flock, either male or female, he shall offer it without defect. 
+<sup>7&#160;</sup>If he offers a lamb for his offering, then he shall offer it before Yahuah; 
 <sup>8&#160;</sup>and he shall lay his hand on the head of his offering, and kill it before the Tent of Meeting. Aaron’s sons shall sprinkle its blood around on the altar. 
-<sup>9&#160;</sup>He shall offer from the sacrifice of peace offerings an offering made by fire to Yahweh; its fat, the entire tail fat, he shall take away close to the backbone; and the fat that covers the entrails, and all the fat that is on the entrails, 
+<sup>9&#160;</sup>He shall offer from the sacrifice of peace offerings an offering made by fire to Yahuah; its fat, the entire tail fat, he shall take away close to the backbone; and the fat that covers the entrails, and all the fat that is on the entrails, 
 <sup>10&#160;</sup>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
-<sup>11&#160;</sup>The priest shall burn it on the altar: it is the food of the offering made by fire to Yahweh. 
+<sup>11&#160;</sup>The priest shall burn it on the altar: it is the food of the offering made by fire to Yahuah. 
 </p><p>
-<sup>12&#160;</sup>“&#160;‘If his offering is a goat, then he shall offer it before Yahweh. 
+<sup>12&#160;</sup>“&#160;‘If his offering is a goat, then he shall offer it before Yahuah. 
 <sup>13&#160;</sup>He shall lay his hand on its head, and kill it before the Tent of Meeting; and the sons of Aaron shall sprinkle its blood around on the altar. 
-<sup>14&#160;</sup>He shall offer from it as his offering, an offering made by fire to Yahweh; the fat that covers the innards, and all the fat that is on the innards, 
+<sup>14&#160;</sup>He shall offer from it as his offering, an offering made by fire to Yahuah; the fat that covers the innards, and all the fat that is on the innards, 
 <sup>15&#160;</sup>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
-<sup>16&#160;</sup>The priest shall burn them on the altar: it is the food of the offering made by fire, for a pleasant aroma; all the fat is Yahweh’s. 
+<sup>16&#160;</sup>The priest shall burn them on the altar: it is the food of the offering made by fire, for a pleasant aroma; all the fat is Yahuah’s. 
 </p><p>
 <sup>17&#160;</sup>“&#160;‘It shall be a perpetual statute throughout your generations in all your dwellings, that you shall eat neither fat nor blood.’&#160;” 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>2&#160;</sup>“Speak to the children of Israel, saying, ‘If anyone sins unintentionally, in any of the things which Yahweh has commanded not to be done, and does any one of them, 
-<sup>3&#160;</sup>if the anointed priest sins so as to bring guilt on the people, then let him offer for his sin which he has sinned a young bull without defect to Yahweh for a sin offering. 
-<sup>4&#160;</sup>He shall bring the bull to the door of the Tent of Meeting before Yahweh; and he shall lay his hand on the head of the bull, and kill the bull before Yahweh. 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, saying, ‘If anyone sins unintentionally, in any of the things which Yahuah has commanded not to be done, and does any one of them, 
+<sup>3&#160;</sup>if the anointed priest sins so as to bring guilt on the people, then let him offer for his sin which he has sinned a young bull without defect to Yahuah for a sin offering. 
+<sup>4&#160;</sup>He shall bring the bull to the door of the Tent of Meeting before Yahuah; and he shall lay his hand on the head of the bull, and kill the bull before Yahuah. 
 <sup>5&#160;</sup>The anointed priest shall take some of the blood of the bull, and bring it to the Tent of Meeting. 
-<sup>6&#160;</sup>The priest shall dip his finger in the blood, and sprinkle some of the blood seven times before Yahweh, before the veil of the sanctuary. 
-<sup>7&#160;</sup>The priest shall put some of the blood on the horns of the altar of sweet incense before Yahweh, which is in the Tent of Meeting; and he shall pour out the rest of the blood of the bull at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
+<sup>6&#160;</sup>The priest shall dip his finger in the blood, and sprinkle some of the blood seven times before Yahuah, before the veil of the sanctuary. 
+<sup>7&#160;</sup>The priest shall put some of the blood on the horns of the altar of sweet incense before Yahuah, which is in the Tent of Meeting; and he shall pour out the rest of the blood of the bull at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
 <sup>8&#160;</sup>He shall take all the fat of the bull of the sin offering from it: the fat that covers the innards, and all the fat that is on the innards, 
 <sup>9&#160;</sup>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall remove, 
 <sup>10&#160;</sup>as it is removed from the bull of the sacrifice of peace offerings. The priest shall burn them on the altar of burnt offering. 
 <sup>11&#160;</sup>He shall carry the bull’s skin, all its meat, with its head, and with its legs, its innards, and its dung<sup>12&#160;</sup>—all the rest of the bull—outside of the camp to a clean place where the ashes are poured out, and burn it on wood with fire. It shall be burned where the ashes are poured out. 
 </p><p>
-<sup>13&#160;</sup>“&#160;‘If the whole congregation of Israel sins, and the thing is hidden from the eyes of the assembly, and they have done any of the things which Yahweh has commanded not to be done, and are guilty; 
+<sup>13&#160;</sup>“&#160;‘If the whole congregation of Israel sins, and the thing is hidden from the eyes of the assembly, and they have done any of the things which Yahuah has commanded not to be done, and are guilty; 
 <sup>14&#160;</sup>when the sin in which they have sinned is known, then the assembly shall offer a young bull for a sin offering, and bring it before the Tent of Meeting. 
-<sup>15&#160;</sup>The elders of the congregation shall lay their hands on the head of the bull before Yahweh; and the bull shall be killed before Yahweh. 
+<sup>15&#160;</sup>The elders of the congregation shall lay their hands on the head of the bull before Yahuah; and the bull shall be killed before Yahuah. 
 <sup>16&#160;</sup>The anointed priest shall bring some of the blood of the bull to the Tent of Meeting. 
-<sup>17&#160;</sup>The priest shall dip his finger in the blood and sprinkle it seven times before Yahweh, before the veil. 
-<sup>18&#160;</sup>He shall put some of the blood on the horns of the altar which is before Yahweh, that is in the Tent of Meeting; and the rest of the blood he shall pour out at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
+<sup>17&#160;</sup>The priest shall dip his finger in the blood and sprinkle it seven times before Yahuah, before the veil. 
+<sup>18&#160;</sup>He shall put some of the blood on the horns of the altar which is before Yahuah, that is in the Tent of Meeting; and the rest of the blood he shall pour out at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
 <sup>19&#160;</sup>All its fat he shall take from it, and burn it on the altar. 
 <sup>20&#160;</sup>He shall do this with the bull; as he did with the bull of the sin offering, so he shall do with this; and the priest shall make atonement for them, and they shall be forgiven. 
 <sup>21&#160;</sup>He shall carry the bull outside the camp, and burn it as he burned the first bull. It is the sin offering for the assembly. 
 </p><p>
-<sup>22&#160;</sup>“&#160;‘When a ruler sins, and unwittingly does any one of all the things which Yahweh his Elohim has commanded not to be done, and is guilty, 
+<sup>22&#160;</sup>“&#160;‘When a ruler sins, and unwittingly does any one of all the things which Yahuah his Elohim has commanded not to be done, and is guilty, 
 <sup>23&#160;</sup>if his sin in which he has sinned is made known to him, he shall bring as his offering a goat, a male without defect. 
-<sup>24&#160;</sup>He shall lay his hand on the head of the goat, and kill it in the place where they kill the burnt offering before Yahweh. It is a sin offering. 
+<sup>24&#160;</sup>He shall lay his hand on the head of the goat, and kill it in the place where they kill the burnt offering before Yahuah. It is a sin offering. 
 <sup>25&#160;</sup>The priest shall take some of the blood of the sin offering with his finger, and put it on the horns of the altar of burnt offering. He shall pour out the rest of its blood at the base of the altar of burnt offering. 
 <sup>26&#160;</sup>All its fat he shall burn on the altar, like the fat of the sacrifice of peace offerings; and the priest shall make atonement for him concerning his sin, and he will be forgiven. 
 </p><p>
-<sup>27&#160;</sup>“&#160;‘If anyone of the common people sins unwittingly, in doing any of the things which Yahweh has commanded not to be done, and is guilty, 
+<sup>27&#160;</sup>“&#160;‘If anyone of the common people sins unwittingly, in doing any of the things which Yahuah has commanded not to be done, and is guilty, 
 <sup>28&#160;</sup>if his sin which he has sinned is made known to him, then he shall bring for his offering a goat, a female without defect, for his sin which he has sinned. 
 <sup>29&#160;</sup>He shall lay his hand on the head of the sin offering, and kill the sin offering in the place of burnt offering. 
 <sup>30&#160;</sup>The priest shall take some of its blood with his finger, and put it on the horns of the altar of burnt offering; and the rest of its blood he shall pour out at the base of the altar. 
-<sup>31&#160;</sup>All its fat he shall take away, like the fat is taken away from the sacrifice of peace offerings; and the priest shall burn it on the altar for a pleasant aroma to Yahweh; and the priest shall make atonement for him, and he will be forgiven. 
+<sup>31&#160;</sup>All its fat he shall take away, like the fat is taken away from the sacrifice of peace offerings; and the priest shall burn it on the altar for a pleasant aroma to Yahuah; and the priest shall make atonement for him, and he will be forgiven. 
 </p><p>
 <sup>32&#160;</sup>“&#160;‘If he brings a lamb as his offering for a sin offering, he shall bring a female without defect. 
 <sup>33&#160;</sup>He shall lay his hand on the head of the sin offering, and kill it for a sin offering in the place where they kill the burnt offering. 
 <sup>34&#160;</sup>The priest shall take some of the blood of the sin offering with his finger, and put it on the horns of the altar of burnt offering; and all the rest of its blood he shall pour out at the base of the altar. 
-<sup>35&#160;</sup>He shall remove all its fat, like the fat of the lamb is removed from the sacrifice of peace offerings. The priest shall burn them on the altar, on the offerings of Yahweh made by fire. The priest shall make atonement for him concerning his sin that he has sinned, and he will be forgiven. 
+<sup>35&#160;</sup>He shall remove all its fat, like the fat of the lamb is removed from the sacrifice of peace offerings. The priest shall burn them on the altar, on the offerings of Yahuah made by fire. The priest shall make atonement for him concerning his sin that he has sinned, and he will be forgiven. 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
 <sup>1&#160;</sup>“&#160;‘If anyone sins, in that he hears a public adjuration to testify, he being a witness, whether he has seen or known, if he doesn’t report it, then he shall bear his iniquity. 
@@ -199,54 +199,54 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>4&#160;</sup>“&#160;‘Or if anyone swears rashly with his lips to do evil or to do good—whatever it is that a man might utter rashly with an oath, and it is hidden from him—when he knows of it, then he will be guilty of one of these. 
 <sup>5&#160;</sup>It shall be, when he is guilty of one of these, he shall confess that in which he has sinned; 
-<sup>6&#160;</sup>and he shall bring his trespass offering to Yahweh for his sin which he has sinned: a female from the flock, a lamb or a goat, for a sin offering; and the priest shall make atonement for him concerning his sin. 
+<sup>6&#160;</sup>and he shall bring his trespass offering to Yahuah for his sin which he has sinned: a female from the flock, a lamb or a goat, for a sin offering; and the priest shall make atonement for him concerning his sin. 
 </p><p>
-<sup>7&#160;</sup>“&#160;‘If he can’t afford a lamb, then he shall bring his trespass offering for that in which he has sinned, two turtledoves, or two young pigeons, to Yahweh; one for a sin offering, and the other for a burnt offering. 
+<sup>7&#160;</sup>“&#160;‘If he can’t afford a lamb, then he shall bring his trespass offering for that in which he has sinned, two turtledoves, or two young pigeons, to Yahuah; one for a sin offering, and the other for a burnt offering. 
 <sup>8&#160;</sup>He shall bring them to the priest, who shall first offer the one which is for the sin offering. He shall wring off its head from its neck, but shall not sever it completely. 
 <sup>9&#160;</sup>He shall sprinkle some of the blood of the sin offering on the side of the altar; and the rest of the blood shall be drained out at the base of the altar. It is a sin offering. 
 <sup>10&#160;</sup>He shall offer the second for a burnt offering, according to the ordinance; and the priest shall make atonement for him concerning his sin which he has sinned, and he shall be forgiven. 
 </p><p>
 <sup>11&#160;</sup>“&#160;‘But if he can’t afford two turtledoves or two young pigeons, then he shall bring as his offering for that in which he has sinned, one tenth of an ephah of fine flour for a sin offering. He shall put no oil on it, and he shall not put any frankincense on it, for it is a sin offering. 
-<sup>12&#160;</sup>He shall bring it to the priest, and the priest shall take his handful of it as the memorial portion, and burn it on the altar, on the offerings of Yahweh made by fire. It is a sin offering. 
+<sup>12&#160;</sup>He shall bring it to the priest, and the priest shall take his handful of it as the memorial portion, and burn it on the altar, on the offerings of Yahuah made by fire. It is a sin offering. 
 <sup>13&#160;</sup>The priest shall make atonement for him concerning his sin that he has sinned in any of these things, and he will be forgiven; and the rest shall be the priest’s, as the meal offering.’&#160;” 
 </p><p>
-<sup>14&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>15&#160;</sup>“If anyone commits a trespass, and sins unwittingly regarding Yahweh’s set-apart things, then he shall bring his trespass offering to Yahweh: a ram without defect from the flock, according to your estimation in silver by shekels, according to the shekel of the sanctuary, for a trespass offering. 
+<sup>14&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>15&#160;</sup>“If anyone commits a trespass, and sins unwittingly regarding Yahuah’s set-apart things, then he shall bring his trespass offering to Yahuah: a ram without defect from the flock, according to your estimation in silver by shekels, according to the shekel of the sanctuary, for a trespass offering. 
 <sup>16&#160;</sup>He shall make restitution for that which he has done wrong regarding the set-apart thing, and shall add a fifth part to it, and give it to the priest; and the priest shall make atonement for him with the ram of the trespass offering, and he will be forgiven. 
 </p><p>
-<sup>17&#160;</sup>“If anyone sins, doing any of the things which Yahweh has commanded not to be done, though he didn’t know it, he is still guilty, and shall bear his iniquity. 
+<sup>17&#160;</sup>“If anyone sins, doing any of the things which Yahuah has commanded not to be done, though he didn’t know it, he is still guilty, and shall bear his iniquity. 
 <sup>18&#160;</sup>He shall bring a ram without defect from of the flock, according to your estimation, for a trespass offering, to the priest; and the priest shall make atonement for him concerning the thing in which he sinned and didn’t know it, and he will be forgiven. 
-<sup>19&#160;</sup>It is a trespass offering. He is certainly guilty before Yahweh.” 
+<sup>19&#160;</sup>It is a trespass offering. He is certainly guilty before Yahuah.” 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>2&#160;</sup>“If anyone sins, and commits a trespass against Yahweh, and deals falsely with his neighbor in a matter of deposit, or of bargain, or of robbery, or has oppressed his neighbor, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>2&#160;</sup>“If anyone sins, and commits a trespass against Yahuah, and deals falsely with his neighbor in a matter of deposit, or of bargain, or of robbery, or has oppressed his neighbor, 
 <sup>3&#160;</sup>or has found that which was lost, and lied about it, and swearing to a lie—in any of these things that a man sins in his actions—<sup>4&#160;</sup>then it shall be, if he has sinned, and is guilty, he shall restore that which he took by robbery, or the thing which he has gotten by oppression, or the deposit which was committed to him, or the lost thing which he found, 
 <sup>5&#160;</sup>or any thing about which he has sworn falsely: he shall restore it in full, and shall add a fifth part more to it. He shall return it to him to whom it belongs in the day of his being found guilty. 
-<sup>6&#160;</sup>He shall bring his trespass offering to Yahweh: a ram without defect from the flock, according to your estimation, for a trespass offering, to the priest. 
-<sup>7&#160;</sup>The priest shall make atonement for him before Yahweh, and he will be forgiven concerning whatever he does to become guilty.” 
+<sup>6&#160;</sup>He shall bring his trespass offering to Yahuah: a ram without defect from the flock, according to your estimation, for a trespass offering, to the priest. 
+<sup>7&#160;</sup>The priest shall make atonement for him before Yahuah, and he will be forgiven concerning whatever he does to become guilty.” 
 </p><p>
-<sup>8&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>8&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>9&#160;</sup>“Command Aaron and his sons, saying, ‘This is the law of the burnt offering: the burnt offering shall be on the hearth on the altar all night until the morning; and the fire of the altar shall be kept burning on it. 
 <sup>10&#160;</sup>The priest shall put on his linen garment, and he shall put on his linen trousers upon his body; and he shall remove the ashes from where the fire has consumed the burnt offering on the altar, and he shall put them beside the altar. 
 <sup>11&#160;</sup>He shall take off his garments, and put on other garments, and carry the ashes outside the camp to a clean place. 
 <sup>12&#160;</sup>The fire on the altar shall be kept burning on it, it shall not go out; and the priest shall burn wood on it every morning. He shall lay the burnt offering in order upon it, and shall burn on it the fat of the peace offerings. 
 <sup>13&#160;</sup>Fire shall be kept burning on the altar continually; it shall not go out. 
 </p><p>
-<sup>14&#160;</sup>“&#160;‘This is the law of the meal offering: the sons of Aaron shall offer it before Yahweh, before the altar. 
-<sup>15&#160;</sup>He shall take from there his handful of the fine flour of the meal offering, and of its oil, and all the frankincense which is on the meal offering, and shall burn it on the altar for a pleasant aroma, as its memorial portion, to Yahweh. 
+<sup>14&#160;</sup>“&#160;‘This is the law of the meal offering: the sons of Aaron shall offer it before Yahuah, before the altar. 
+<sup>15&#160;</sup>He shall take from there his handful of the fine flour of the meal offering, and of its oil, and all the frankincense which is on the meal offering, and shall burn it on the altar for a pleasant aroma, as its memorial portion, to Yahuah. 
 <sup>16&#160;</sup>That which is left of it Aaron and his sons shall eat. It shall be eaten without yeast in a set-apart place. They shall eat it in the court of the Tent of Meeting. 
 <sup>17&#160;</sup>It shall not be baked with yeast. I have given it as their portion of my offerings made by fire. It is most set-apart, as are the sin offering and the trespass offering. 
-<sup>18&#160;</sup>Every male among the children of Aaron shall eat of it, as their portion forever throughout your generations, from the offerings of Yahweh made by fire. Whoever touches them shall be set-apart.’&#160;” 
+<sup>18&#160;</sup>Every male among the children of Aaron shall eat of it, as their portion forever throughout your generations, from the offerings of Yahuah made by fire. Whoever touches them shall be set-apart.’&#160;” 
 </p><p>
-<sup>19&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>20&#160;</sup>“This is the offering of Aaron and of his sons, which they shall offer to Yahweh in the day when he is anointed: one tenth of an ephah of fine flour for a meal offering perpetually, half of it in the morning, and half of it in the evening. 
-<sup>21&#160;</sup>It shall be made with oil in a griddle. When it is soaked, you shall bring it in. You shall offer the meal offering in baked pieces for a pleasant aroma to Yahweh. 
-<sup>22&#160;</sup>The anointed priest that will be in his place from among his sons shall offer it. By a statute forever, it shall be wholly burned to Yahweh. 
+<sup>19&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>20&#160;</sup>“This is the offering of Aaron and of his sons, which they shall offer to Yahuah in the day when he is anointed: one tenth of an ephah of fine flour for a meal offering perpetually, half of it in the morning, and half of it in the evening. 
+<sup>21&#160;</sup>It shall be made with oil in a griddle. When it is soaked, you shall bring it in. You shall offer the meal offering in baked pieces for a pleasant aroma to Yahuah. 
+<sup>22&#160;</sup>The anointed priest that will be in his place from among his sons shall offer it. By a statute forever, it shall be wholly burned to Yahuah. 
 <sup>23&#160;</sup>Every meal offering of a priest shall be wholly burned. It shall not be eaten.” 
 </p><p>
-<sup>24&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>25&#160;</sup>“Speak to Aaron and to his sons, saying, ‘This is the law of the sin offering: in the place where the burnt offering is killed, the sin offering shall be killed before Yahweh. It is most set-apart. 
+<sup>24&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>25&#160;</sup>“Speak to Aaron and to his sons, saying, ‘This is the law of the sin offering: in the place where the burnt offering is killed, the sin offering shall be killed before Yahuah. It is most set-apart. 
 <sup>26&#160;</sup>The priest who offers it for sin shall eat it. It shall be eaten in a set-apart place, in the court of the Tent of Meeting. 
 <sup>27&#160;</sup>Whatever shall touch its flesh shall be set-apart. When there is any of its blood sprinkled on a garment, you shall wash that on which it was sprinkled in a set-apart place. 
 <sup>28&#160;</sup>But the earthen vessel in which it is boiled shall be broken; and if it is boiled in a bronze vessel, it shall be scoured, and rinsed in water. 
@@ -258,7 +258,7 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>In the place where they kill the burnt offering, he shall kill the trespass offering; and its blood he shall sprinkle around on the altar. 
 <sup>3&#160;</sup>He shall offer all of its fat: the fat tail, and the fat that covers the innards, 
 <sup>4&#160;</sup>and he shall take away the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys; 
-<sup>5&#160;</sup>and the priest shall burn them on the altar for an offering made by fire to Yahweh: it is a trespass offering. 
+<sup>5&#160;</sup>and the priest shall burn them on the altar for an offering made by fire to Yahuah: it is a trespass offering. 
 <sup>6&#160;</sup>Every male among the priests may eat of it. It shall be eaten in a set-apart place. It is most set-apart. 
 </p><p>
 <sup>7&#160;</sup>“&#160;‘As is the sin offering, so is the trespass offering; there is one law for them. The priest who makes atonement with them shall have it. 
@@ -266,10 +266,10 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Every meal offering that is baked in the oven, and all that is prepared in the pan and on the griddle, shall be the priest’s who offers it. 
 <sup>10&#160;</sup>Every meal offering, mixed with oil or dry, belongs to all the sons of Aaron, one as well as another. 
 </p><p>
-<sup>11&#160;</sup>“&#160;‘This is the law of the sacrifice of peace offerings, which one shall offer to Yahweh: 
+<sup>11&#160;</sup>“&#160;‘This is the law of the sacrifice of peace offerings, which one shall offer to Yahuah: 
 <sup>12&#160;</sup>If he offers it for a thanksgiving, then he shall offer with the sacrifice of thanksgiving unleavened cakes mixed with oil, and unleavened wafers anointed with oil, and cakes mixed with oil. 
 <sup>13&#160;</sup>He shall offer his offering with the sacrifice of his peace offerings for thanksgiving with cakes of leavened bread. 
-<sup>14&#160;</sup>Of it he shall offer one out of each offering for a heave offering to Yahweh. It shall be the priest’s who sprinkles the blood of the peace offerings. 
+<sup>14&#160;</sup>Of it he shall offer one out of each offering for a heave offering to Yahuah. It shall be the priest’s who sprinkles the blood of the peace offerings. 
 <sup>15&#160;</sup>The flesh of the sacrifice of his peace offerings for thanksgiving shall be eaten on the day of his offering. He shall not leave any of it until the morning. 
 </p><p>
 <sup>16&#160;</sup>“&#160;‘But if the sacrifice of his offering is a vow, or a free will offering, it shall be eaten on the day that he offers his sacrifice. On the next day what remains of it shall be eaten, 
@@ -277,83 +277,83 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>If any of the meat of the sacrifice of his peace offerings is eaten on the third day, it will not be accepted, and it shall not be credited to him who offers it. It will be an abomination, and the soul who eats any of it will bear his iniquity. 
 </p><p>
 <sup>19&#160;</sup>“&#160;‘The meat that touches any unclean thing shall not be eaten. It shall be burned with fire. As for the meat, everyone who is clean may eat it; 
-<sup>20&#160;</sup>but the soul who eats of the meat of the sacrifice of peace offerings that belongs to Yahweh, having his uncleanness on him, that soul shall be cut off from his people. 
-<sup>21&#160;</sup>When anyone touches any unclean thing, the uncleanness of man, or an unclean animal, or any unclean abomination, and eats some of the meat of the sacrifice of peace offerings which belong to Yahweh, that soul shall be cut off from his people.’&#160;” 
+<sup>20&#160;</sup>but the soul who eats of the meat of the sacrifice of peace offerings that belongs to Yahuah, having his uncleanness on him, that soul shall be cut off from his people. 
+<sup>21&#160;</sup>When anyone touches any unclean thing, the uncleanness of man, or an unclean animal, or any unclean abomination, and eats some of the meat of the sacrifice of peace offerings which belong to Yahuah, that soul shall be cut off from his people.’&#160;” 
 </p><p>
-<sup>22&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>22&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>23&#160;</sup>“Speak to the children of Israel, saying, ‘You shall eat no fat, of bull, or sheep, or goat. 
 <sup>24&#160;</sup>The fat of that which dies of itself, and the fat of that which is torn of animals, may be used for any other service, but you shall in no way eat of it. 
-<sup>25&#160;</sup>For whoever eats the fat of the animal which men offer as an offering made by fire to Yahweh, even the soul who eats it shall be cut off from his people. 
+<sup>25&#160;</sup>For whoever eats the fat of the animal which men offer as an offering made by fire to Yahuah, even the soul who eats it shall be cut off from his people. 
 <sup>26&#160;</sup>You shall not eat any blood, whether it is of bird or of animal, in any of your dwellings. 
 <sup>27&#160;</sup>Whoever it is who eats any blood, that soul shall be cut off from his people.’&#160;” 
 </p><p>
-<sup>28&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>29&#160;</sup>“Speak to the children of Israel, saying, ‘He who offers the sacrifice of his peace offerings to Yahweh shall bring his offering to Yahweh out of the sacrifice of his peace offerings. 
-<sup>30&#160;</sup>With his own hands he shall bring the offerings of Yahweh made by fire. He shall bring the fat with the breast, that the breast may be waved for a wave offering before Yahweh. 
+<sup>28&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>29&#160;</sup>“Speak to the children of Israel, saying, ‘He who offers the sacrifice of his peace offerings to Yahuah shall bring his offering to Yahuah out of the sacrifice of his peace offerings. 
+<sup>30&#160;</sup>With his own hands he shall bring the offerings of Yahuah made by fire. He shall bring the fat with the breast, that the breast may be waved for a wave offering before Yahuah. 
 <sup>31&#160;</sup>The priest shall burn the fat on the altar, but the breast shall be Aaron’s and his sons’. 
 <sup>32&#160;</sup>The right thigh you shall give to the priest for a heave offering out of the sacrifices of your peace offerings. 
 <sup>33&#160;</sup>He among the sons of Aaron who offers the blood of the peace offerings, and the fat, shall have the right thigh for a portion. 
 <sup>34&#160;</sup>For the waved breast and the heaved thigh I have taken from the children of Israel out of the sacrifices of their peace offerings, and have given them to Aaron the priest and to his sons as their portion forever from the children of Israel.’&#160;” 
 </p><p>
-<sup>35&#160;</sup>This is the consecrated portion of Aaron, and the consecrated portion of his sons, out of the offerings of Yahweh made by fire, in the day when he presented them to minister to Yahweh in the priest’s office; 
-<sup>36&#160;</sup>which Yahweh commanded to be given them of the children of Israel, in the day that he anointed them. It is their portion forever throughout their generations. 
+<sup>35&#160;</sup>This is the consecrated portion of Aaron, and the consecrated portion of his sons, out of the offerings of Yahuah made by fire, in the day when he presented them to minister to Yahuah in the priest’s office; 
+<sup>36&#160;</sup>which Yahuah commanded to be given them of the children of Israel, in the day that he anointed them. It is their portion forever throughout their generations. 
 <sup>37&#160;</sup>This is the law of the burnt offering, the meal offering, the sin offering, the trespass offering, the consecration, and the sacrifice of peace offerings 
-<sup>38&#160;</sup>which Yahweh commanded Moses in Mount Sinai in the day that he commanded the children of Israel to offer their offerings to Yahweh, in the wilderness of Sinai. 
+<sup>38&#160;</sup>which Yahuah commanded Moses in Mount Sinai in the day that he commanded the children of Israel to offer their offerings to Yahuah, in the wilderness of Sinai. 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Take Aaron and his sons with him, and the garments, and the anointing oil, and the bull of the sin offering, and the two rams, and the basket of unleavened bread; 
 <sup>3&#160;</sup>and assemble all the congregation at the door of the Tent of Meeting.” 
 </p><p>
-<sup>4&#160;</sup>Moses did as Yahweh commanded him; and the congregation was assembled at the door of the Tent of Meeting. 
-<sup>5&#160;</sup>Moses said to the congregation, “This is the thing which Yahweh has commanded to be done.” 
+<sup>4&#160;</sup>Moses did as Yahuah commanded him; and the congregation was assembled at the door of the Tent of Meeting. 
+<sup>5&#160;</sup>Moses said to the congregation, “This is the thing which Yahuah has commanded to be done.” 
 <sup>6&#160;</sup>Moses brought Aaron and his sons, and washed them with water. 
 <sup>7&#160;</sup>He put the tunic on him, tied the sash on him, clothed him with the robe, put the ephod on him, and he tied the skillfully woven band of the ephod on him and fastened it to him with it. 
 <sup>8&#160;</sup>He placed the breastplate on him. He put the Urim and Thummim in the breastplate. 
-<sup>9&#160;</sup>He set the turban on his head. He set the golden plate, the set-apart crown, on the front of the turban, as Yahweh commanded Moses. 
+<sup>9&#160;</sup>He set the turban on his head. He set the golden plate, the set-apart crown, on the front of the turban, as Yahuah commanded Moses. 
 <sup>10&#160;</sup>Moses took the anointing oil, and anointed the tabernacle and all that was in it, and sanctified them. 
 <sup>11&#160;</sup>He sprinkled it on the altar seven times, and anointed the altar and all its vessels, and the basin and its base, to sanctify them. 
 <sup>12&#160;</sup>He poured some of the anointing oil on Aaron’s head, and anointed him, to sanctify him. 
-<sup>13&#160;</sup>Moses brought Aaron’s sons, and clothed them with tunics, and tied sashes on them, and put headbands on them, as Yahweh commanded Moses. 
+<sup>13&#160;</sup>Moses brought Aaron’s sons, and clothed them with tunics, and tied sashes on them, and put headbands on them, as Yahuah commanded Moses. 
 </p><p>
 <sup>14&#160;</sup>He brought the bull of the sin offering, and Aaron and his sons laid their hands on the head of the bull of the sin offering. 
 <sup>15&#160;</sup>He killed it; and Moses took the blood, and put it around on the horns of the altar with his finger, and purified the altar, and poured out the blood at the base of the altar, and sanctified it, to make atonement for it. 
 <sup>16&#160;</sup>He took all the fat that was on the innards, and the cover of the liver, and the two kidneys, and their fat; and Moses burned it on the altar. 
-<sup>17&#160;</sup>But the bull, and its skin, and its meat, and its dung, he burned with fire outside the camp, as Yahweh commanded Moses. 
+<sup>17&#160;</sup>But the bull, and its skin, and its meat, and its dung, he burned with fire outside the camp, as Yahuah commanded Moses. 
 <sup>18&#160;</sup>He presented the ram of the burnt offering. Aaron and his sons laid their hands on the head of the ram. 
 <sup>19&#160;</sup>He killed it; and Moses sprinkled the blood around on the altar. 
 <sup>20&#160;</sup>He cut the ram into its pieces; and Moses burned the head, and the pieces, and the fat. 
-<sup>21&#160;</sup>He washed the innards and the legs with water; and Moses burned the whole ram on the altar. It was a burnt offering for a pleasant aroma. It was an offering made by fire to Yahweh, as Yahweh commanded Moses. 
+<sup>21&#160;</sup>He washed the innards and the legs with water; and Moses burned the whole ram on the altar. It was a burnt offering for a pleasant aroma. It was an offering made by fire to Yahuah, as Yahuah commanded Moses. 
 <sup>22&#160;</sup>He presented the other ram, the ram of consecration. Aaron and his sons laid their hands on the head of the ram. 
 <sup>23&#160;</sup>He killed it; and Moses took some of its blood, and put it on the tip of Aaron’s right ear, and on the thumb of his right hand, and on the great toe of his right foot. 
 <sup>24&#160;</sup>He brought Aaron’s sons; and Moses put some of the blood on the tip of their right ear, and on the thumb of their right hand, and on the great toe of their right foot; and Moses sprinkled the blood around on the altar. 
 <sup>25&#160;</sup>He took the fat, the fat tail, all the fat that was on the innards, the cover of the liver, the two kidneys and their fat, and the right thigh; 
-<sup>26&#160;</sup>and out of the basket of unleavened bread that was before Yahweh, he took one unleavened cake, one cake of oiled bread, and one wafer, and placed them on the fat and on the right thigh. 
-<sup>27&#160;</sup>He put all these in Aaron’s hands and in his sons’ hands, and waved them for a wave offering before Yahweh. 
-<sup>28&#160;</sup>Moses took them from their hands, and burned them on the altar on the burnt offering. They were a consecration offering for a pleasant aroma. It was an offering made by fire to Yahweh. 
-<sup>29&#160;</sup>Moses took the breast, and waved it for a wave offering before Yahweh. It was Moses’ portion of the ram of consecration, as Yahweh commanded Moses. 
+<sup>26&#160;</sup>and out of the basket of unleavened bread that was before Yahuah, he took one unleavened cake, one cake of oiled bread, and one wafer, and placed them on the fat and on the right thigh. 
+<sup>27&#160;</sup>He put all these in Aaron’s hands and in his sons’ hands, and waved them for a wave offering before Yahuah. 
+<sup>28&#160;</sup>Moses took them from their hands, and burned them on the altar on the burnt offering. They were a consecration offering for a pleasant aroma. It was an offering made by fire to Yahuah. 
+<sup>29&#160;</sup>Moses took the breast, and waved it for a wave offering before Yahuah. It was Moses’ portion of the ram of consecration, as Yahuah commanded Moses. 
 <sup>30&#160;</sup>Moses took some of the anointing oil, and some of the blood which was on the altar, and sprinkled it on Aaron, on his garments, and on his sons, and on his sons’ garments with him, and sanctified Aaron, his garments, and his sons, and his sons’ garments with him. 
 </p><p>
 <sup>31&#160;</sup>Moses said to Aaron and to his sons, “Boil the meat at the door of the Tent of Meeting, and there eat it and the bread that is in the basket of consecration, as I commanded, saying, ‘Aaron and his sons shall eat it.’ 
 <sup>32&#160;</sup>What remains of the meat and of the bread you shall burn with fire. 
 <sup>33&#160;</sup>You shall not go out from the door of the Tent of Meeting for seven days, until the days of your consecration are fulfilled: for he shall consecrate you seven days. 
-<sup>34&#160;</sup>What has been done today, so Yahweh has commanded to do, to make atonement for you. 
-<sup>35&#160;</sup>You shall stay at the door of the Tent of Meeting day and night seven days, and keep Yahweh’s command, that you don’t die: for so I am commanded.” 
-<sup>36&#160;</sup>Aaron and his sons did all the things which Yahweh commanded by Moses. 
+<sup>34&#160;</sup>What has been done today, so Yahuah has commanded to do, to make atonement for you. 
+<sup>35&#160;</sup>You shall stay at the door of the Tent of Meeting day and night seven days, and keep Yahuah’s command, that you don’t die: for so I am commanded.” 
+<sup>36&#160;</sup>Aaron and his sons did all the things which Yahuah commanded by Moses. 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
 <sup>1&#160;</sup>On the eighth day, Moses called Aaron and his sons, and the elders of Israel; 
-<sup>2&#160;</sup>and he said to Aaron, “Take a calf from the herd for a sin offering, and a ram for a burnt offering, without defect, and offer them before Yahweh. 
+<sup>2&#160;</sup>and he said to Aaron, “Take a calf from the herd for a sin offering, and a ram for a burnt offering, without defect, and offer them before Yahuah. 
 <sup>3&#160;</sup>You shall speak to the children of Israel, saying, ‘Take a male goat for a sin offering; and a calf and a lamb, both a year old, without defect, for a burnt offering; 
-<sup>4&#160;</sup>and a bull and a ram for peace offerings, to sacrifice before Yahweh; and a meal offering mixed with oil: for today Yahweh appears to you.’&#160;” 
+<sup>4&#160;</sup>and a bull and a ram for peace offerings, to sacrifice before Yahuah; and a meal offering mixed with oil: for today Yahuah appears to you.’&#160;” 
 </p><p>
-<sup>5&#160;</sup>They brought what Moses commanded before the Tent of Meeting. All the congregation came near and stood before Yahweh. 
-<sup>6&#160;</sup>Moses said, “This is the thing which Yahweh commanded that you should do; and Yahweh’s glory shall appear to you.” 
-<sup>7&#160;</sup>Moses said to Aaron, “Draw near to the altar, and offer your sin offering, and your burnt offering, and make atonement for yourself, and for the people; and offer the offering of the people, and make atonement for them, as Yahweh commanded.” 
+<sup>5&#160;</sup>They brought what Moses commanded before the Tent of Meeting. All the congregation came near and stood before Yahuah. 
+<sup>6&#160;</sup>Moses said, “This is the thing which Yahuah commanded that you should do; and Yahuah’s glory shall appear to you.” 
+<sup>7&#160;</sup>Moses said to Aaron, “Draw near to the altar, and offer your sin offering, and your burnt offering, and make atonement for yourself, and for the people; and offer the offering of the people, and make atonement for them, as Yahuah commanded.” 
 </p><p>
 <sup>8&#160;</sup>So Aaron came near to the altar, and killed the calf of the sin offering, which was for himself. 
 <sup>9&#160;</sup>The sons of Aaron presented the blood to him; and he dipped his finger in the blood, and put it on the horns of the altar, and poured out the blood at the base of the altar; 
-<sup>10&#160;</sup>but the fat, and the kidneys, and the cover from the liver of the sin offering, he burned upon the altar, as Yahweh commanded Moses. 
+<sup>10&#160;</sup>but the fat, and the kidneys, and the cover from the liver of the sin offering, he burned upon the altar, as Yahuah commanded Moses. 
 <sup>11&#160;</sup>The meat and the skin he burned with fire outside the camp. 
 <sup>12&#160;</sup>He killed the burnt offering; and Aaron’s sons delivered the blood to him, and he sprinkled it around on the altar. 
 <sup>13&#160;</sup>They delivered the burnt offering to him, piece by piece, and the head. He burned them upon the altar. 
@@ -364,45 +364,45 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>He also killed the bull and the ram, the sacrifice of peace offerings, which was for the people. Aaron’s sons delivered to him the blood, which he sprinkled around on the altar; 
 <sup>19&#160;</sup>and the fat of the bull and of the ram, the fat tail, and that which covers the innards, and the kidneys, and the cover of the liver; 
 <sup>20&#160;</sup>and they put the fat upon the breasts, and he burned the fat on the altar. 
-<sup>21&#160;</sup>Aaron waved the breasts and the right thigh for a wave offering before Yahweh, as Moses commanded. 
+<sup>21&#160;</sup>Aaron waved the breasts and the right thigh for a wave offering before Yahuah, as Moses commanded. 
 <sup>22&#160;</sup>Aaron lifted up his hands toward the people, and blessed them; and he came down from offering the sin offering, and the burnt offering, and the peace offerings. 
 </p><p>
-<sup>23&#160;</sup>Moses and Aaron went into the Tent of Meeting, and came out, and blessed the people; and Yahweh’s glory appeared to all the people. 
-<sup>24&#160;</sup>Fire came out from before Yahweh, and consumed the burnt offering and the fat upon the altar. When all the people saw it, they shouted, and fell on their faces. 
+<sup>23&#160;</sup>Moses and Aaron went into the Tent of Meeting, and came out, and blessed the people; and Yahuah’s glory appeared to all the people. 
+<sup>24&#160;</sup>Fire came out from before Yahuah, and consumed the burnt offering and the fat upon the altar. When all the people saw it, they shouted, and fell on their faces. 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p>
-<sup>1&#160;</sup>Nadab and Abihu, the sons of Aaron, each took his censer, and put fire in it, and laid incense on it, and offered strange fire before Yahweh, which he had not commanded them. 
-<sup>2&#160;</sup>Fire came out from before Yahweh, and devoured them, and they died before Yahweh. 
+<sup>1&#160;</sup>Nadab and Abihu, the sons of Aaron, each took his censer, and put fire in it, and laid incense on it, and offered strange fire before Yahuah, which he had not commanded them. 
+<sup>2&#160;</sup>Fire came out from before Yahuah, and devoured them, and they died before Yahuah. 
 </p><p>
-<sup>3&#160;</sup>Then Moses said to Aaron, “This is what Yahweh spoke of, saying, 
+<sup>3&#160;</sup>Then Moses said to Aaron, “This is what Yahuah spoke of, saying, 
 </p><p class="q1">‘I will show myself set-apart to those who come near me, 
 </p><p class="q2">and before all the people I will be glorified.’&#160;” 
 </p><p>Aaron held his peace. 
 <sup>4&#160;</sup>Moses called Mishael and Elzaphan, the sons of Uzziel the uncle of Aaron, and said to them, “Draw near, carry your brothers from before the sanctuary out of the camp.” 
 <sup>5&#160;</sup>So they came near, and carried them in their tunics out of the camp, as Moses had said. 
 </p><p>
-<sup>6&#160;</sup>Moses said to Aaron, and to Eleazar and to Ithamar, his sons, “Don’t let the hair of your heads go loose, and don’t tear your clothes, so that you don’t die, and so that he will not be angry with all the congregation; but let your brothers, the whole house of Israel, bewail the burning which Yahweh has kindled. 
-<sup>7&#160;</sup>You shall not go out from the door of the Tent of Meeting, lest you die; for the anointing oil of Yahweh is on you.” They did according to the word of Moses. 
-<sup>8&#160;</sup>Then Yahweh said to Aaron, 
+<sup>6&#160;</sup>Moses said to Aaron, and to Eleazar and to Ithamar, his sons, “Don’t let the hair of your heads go loose, and don’t tear your clothes, so that you don’t die, and so that he will not be angry with all the congregation; but let your brothers, the whole house of Israel, bewail the burning which Yahuah has kindled. 
+<sup>7&#160;</sup>You shall not go out from the door of the Tent of Meeting, lest you die; for the anointing oil of Yahuah is on you.” They did according to the word of Moses. 
+<sup>8&#160;</sup>Then Yahuah said to Aaron, 
 <sup>9&#160;</sup>“You and your sons are not to drink wine or strong drink whenever you go into the Tent of Meeting, or you will die. This shall be a statute forever throughout your generations. 
 <sup>10&#160;</sup>You are to make a distinction between the set-apart and the common, and between the unclean and the clean. 
-<sup>11&#160;</sup>You are to teach the children of Israel all the statutes which Yahweh has spoken to them by Moses.” 
+<sup>11&#160;</sup>You are to teach the children of Israel all the statutes which Yahuah has spoken to them by Moses.” 
 </p><p>
-<sup>12&#160;</sup>Moses spoke to Aaron, and to Eleazar and to Ithamar, his sons who were left, “Take the meal offering that remains of the offerings of Yahweh made by fire, and eat it without yeast beside the altar; for it is most set-apart; 
-<sup>13&#160;</sup>and you shall eat it in a set-apart place, because it is your portion, and your sons’ portion, of the offerings of Yahweh made by fire; for so I am commanded. 
+<sup>12&#160;</sup>Moses spoke to Aaron, and to Eleazar and to Ithamar, his sons who were left, “Take the meal offering that remains of the offerings of Yahuah made by fire, and eat it without yeast beside the altar; for it is most set-apart; 
+<sup>13&#160;</sup>and you shall eat it in a set-apart place, because it is your portion, and your sons’ portion, of the offerings of Yahuah made by fire; for so I am commanded. 
 <sup>14&#160;</sup>The waved breast and the heaved thigh you shall eat in a clean place, you, and your sons, and your daughters with you: for they are given as your portion, and your sons’ portion, out of the sacrifices of the peace offerings of the children of Israel. 
-<sup>15&#160;</sup>They shall bring the heaved thigh and the waved breast with the offerings made by fire of the fat, to wave it for a wave offering before Yahweh. It shall be yours, and your sons’ with you, as a portion forever, as Yahweh has commanded.” 
+<sup>15&#160;</sup>They shall bring the heaved thigh and the waved breast with the offerings made by fire of the fat, to wave it for a wave offering before Yahuah. It shall be yours, and your sons’ with you, as a portion forever, as Yahuah has commanded.” 
 </p><p>
 <sup>16&#160;</sup>Moses diligently inquired about the goat of the sin offering, and, behold, it was burned. He was angry with Eleazar and with Ithamar, the sons of Aaron who were left, saying, 
-<sup>17&#160;</sup>“Why haven’t you eaten the sin offering in the place of the sanctuary, since it is most set-apart, and he has given it to you to bear the iniquity of the congregation, to make atonement for them before Yahweh? 
+<sup>17&#160;</sup>“Why haven’t you eaten the sin offering in the place of the sanctuary, since it is most set-apart, and he has given it to you to bear the iniquity of the congregation, to make atonement for them before Yahuah? 
 <sup>18&#160;</sup>Behold, its blood was not brought into the inner part of the sanctuary. You certainly should have eaten it in the sanctuary, as I commanded.” 
 </p><p>
-<sup>19&#160;</sup>Aaron spoke to Moses, “Behold, today they have offered their sin offering and their burnt offering before Yahweh; and such things as these have happened to me. If I had eaten the sin offering today, would it have been pleasing in Yahweh’s sight?” 
+<sup>19&#160;</sup>Aaron spoke to Moses, “Behold, today they have offered their sin offering and their burnt offering before Yahuah; and such things as these have happened to me. If I had eaten the sin offering today, would it have been pleasing in Yahuah’s sight?” 
 </p><p>
 <sup>20&#160;</sup>When Moses heard that, it was pleasing in his sight. 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying to them, 
+<sup>1&#160;</sup>Yahuah spoke to Moses and to Aaron, saying to them, 
 <sup>2&#160;</sup>“Speak to the children of Israel, saying, ‘These are the living things which you may eat among all the animals that are on the earth. 
 <sup>3&#160;</sup>Whatever parts the hoof, and is cloven-footed, and chews the cud among the animals, that you may eat. 
 </p><p>
@@ -454,26 +454,26 @@ html[dir=ltr] .q2 {
 <sup>41&#160;</sup>“&#160;‘Every creeping thing that creeps on the earth is an abomination. It shall not be eaten. 
 <sup>42&#160;</sup>Whatever goes on its belly, and whatever goes on all fours, or whatever has many feet, even all creeping things that creep on the earth, them you shall not eat; for they are an abomination. 
 <sup>43&#160;</sup>You shall not make yourselves abominable with any creeping thing that creeps. You shall not make yourselves unclean with them, that you should be defiled by them. 
-<sup>44&#160;</sup>For I am Yahweh your Elohim. Sanctify yourselves therefore, and be set-apart; for I am set-apart. You shall not defile yourselves with any kind of creeping thing that moves on the earth. 
-<sup>45&#160;</sup>For I am Yahweh who brought you up out of the land of Egypt, to be your Elohim. You shall therefore be set-apart, for I am set-apart. 
+<sup>44&#160;</sup>For I am Yahuah your Elohim. Sanctify yourselves therefore, and be set-apart; for I am set-apart. You shall not defile yourselves with any kind of creeping thing that moves on the earth. 
+<sup>45&#160;</sup>For I am Yahuah who brought you up out of the land of Egypt, to be your Elohim. You shall therefore be set-apart, for I am set-apart. 
 </p><p>
 <sup>46&#160;</sup>“&#160;‘This is the law of the animal, and of the bird, and of every living creature that moves in the waters, and of every creature that creeps on the earth, 
 <sup>47&#160;</sup>to make a distinction between the unclean and the clean, and between the living thing that may be eaten and the living thing that may not be eaten.’&#160;” 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Speak to the children of Israel, saying, ‘If a woman conceives, and bears a male child, then she shall be unclean seven days; as in the days of her monthly period she shall be unclean. 
 <sup>3&#160;</sup>In the eighth day the flesh of his foreskin shall be circumcised. 
 <sup>4&#160;</sup>She shall continue in the blood of purification thirty-three days. She shall not touch any set-apart thing, nor come into the sanctuary, until the days of her purifying are completed. 
 <sup>5&#160;</sup>But if she bears a female child, then she shall be unclean two weeks, as in her period; and she shall continue in the blood of purification sixty-six days. 
 </p><p>
 <sup>6&#160;</sup>“&#160;‘When the days of her purification are completed for a son or for a daughter, she shall bring to the priest at the door of the Tent of Meeting, a year old lamb for a burnt offering, and a young pigeon or a turtledove, for a sin offering. 
-<sup>7&#160;</sup>He shall offer it before Yahweh, and make atonement for her; then she shall be cleansed from the fountain of her blood. 
+<sup>7&#160;</sup>He shall offer it before Yahuah, and make atonement for her; then she shall be cleansed from the fountain of her blood. 
 </p><p>“&#160;‘This is the law for her who bears, whether a male or a female. 
 <sup>8&#160;</sup>If she cannot afford a lamb, then she shall take two turtledoves or two young pigeons: the one for a burnt offering, and the other for a sin offering. The priest shall make atonement for her, and she shall be clean.’&#160;” 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses and to Aaron, saying, 
 <sup>2&#160;</sup>“When a man shall have a swelling in his body’s skin, or a scab, or a bright spot, and it becomes in the skin of his body the plague of leprosy, then he shall be brought to Aaron the priest or to one of his sons, the priests. 
 <sup>3&#160;</sup>The priest shall examine the plague in the skin of the body. If the hair in the plague has turned white, and the appearance of the plague is deeper than the body’s skin, it is the plague of leprosy; so the priest shall examine him and pronounce him unclean. 
 <sup>4&#160;</sup>If the bright spot is white in the skin of his body, and its appearance isn’t deeper than the skin, and its hair hasn’t turned white, then the priest shall isolate the infected person for seven days. 
@@ -545,7 +545,7 @@ html[dir=ltr] .q2 {
 <sup>59&#160;</sup>This is the law of the plague of mildew in a garment of wool or linen, either in the warp, or the woof, or in anything of skin, to pronounce it clean, or to pronounce it unclean. 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 </p><p>
 <sup>2&#160;</sup>“This shall be the law of the leper in the day of his cleansing: He shall be brought to the priest, 
 <sup>3&#160;</sup>and the priest shall go out of the camp. The priest shall examine him. Behold, if the plague of leprosy is healed in the leper, 
@@ -558,15 +558,15 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>It shall be on the seventh day, that he shall shave all his hair off his head and his beard and his eyebrows. He shall shave off all his hair. He shall wash his clothes, and he shall bathe his body in water. Then he shall be clean. 
 </p><p>
 <sup>10&#160;</sup>“On the eighth day he shall take two male lambs without defect, one ewe lamb a year old without defect, three tenths of an ephah of fine flour for a meal offering, mixed with oil, and one log of oil. 
-<sup>11&#160;</sup>The priest who cleanses him shall set the man who is to be cleansed, and those things, before Yahweh, at the door of the Tent of Meeting. 
+<sup>11&#160;</sup>The priest who cleanses him shall set the man who is to be cleansed, and those things, before Yahuah, at the door of the Tent of Meeting. 
 </p><p>
-<sup>12&#160;</sup>“The priest shall take one of the male lambs, and offer him for a trespass offering, with the log of oil, and wave them for a wave offering before Yahweh. 
+<sup>12&#160;</sup>“The priest shall take one of the male lambs, and offer him for a trespass offering, with the log of oil, and wave them for a wave offering before Yahuah. 
 <sup>13&#160;</sup>He shall kill the male lamb in the place where they kill the sin offering and the burnt offering, in the place of the sanctuary; for as the sin offering is the priest’s, so is the trespass offering. It is most set-apart. 
 <sup>14&#160;</sup>The priest shall take some of the blood of the trespass offering, and the priest shall put it on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot. 
 <sup>15&#160;</sup>The priest shall take some of the log of oil, and pour it into the palm of his own left hand. 
-<sup>16&#160;</sup>The priest shall dip his right finger in the oil that is in his left hand, and shall sprinkle some of the oil with his finger seven times before Yahweh. 
+<sup>16&#160;</sup>The priest shall dip his right finger in the oil that is in his left hand, and shall sprinkle some of the oil with his finger seven times before Yahuah. 
 <sup>17&#160;</sup>The priest shall put some of the rest of the oil that is in his hand on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot, upon the blood of the trespass offering. 
-<sup>18&#160;</sup>The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, and the priest shall make atonement for him before Yahweh. 
+<sup>18&#160;</sup>The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, and the priest shall make atonement for him before Yahuah. 
 </p><p>
 <sup>19&#160;</sup>“The priest shall offer the sin offering, and make atonement for him who is to be cleansed because of his uncleanness. Afterward he shall kill the burnt offering; 
 <sup>20&#160;</sup>then the priest shall offer the burnt offering and the meal offering on the altar. The priest shall make atonement for him, and he shall be clean. 
@@ -574,19 +574,19 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>“If he is poor, and can’t afford so much, then he shall take one male lamb for a trespass offering to be waved, to make atonement for him, and one tenth of an ephah of fine flour mixed with oil for a meal offering, and a log of oil; 
 <sup>22&#160;</sup>and two turtledoves, or two young pigeons, such as he is able to afford; and the one shall be a sin offering, and the other a burnt offering. 
 </p><p>
-<sup>23&#160;</sup>“On the eighth day he shall bring them for his cleansing to the priest, to the door of the Tent of Meeting, before Yahweh. 
-<sup>24&#160;</sup>The priest shall take the lamb of the trespass offering, and the log of oil, and the priest shall wave them for a wave offering before Yahweh. 
+<sup>23&#160;</sup>“On the eighth day he shall bring them for his cleansing to the priest, to the door of the Tent of Meeting, before Yahuah. 
+<sup>24&#160;</sup>The priest shall take the lamb of the trespass offering, and the log of oil, and the priest shall wave them for a wave offering before Yahuah. 
 <sup>25&#160;</sup>He shall kill the lamb of the trespass offering. The priest shall take some of the blood of the trespass offering and put it on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot. 
 <sup>26&#160;</sup>The priest shall pour some of the oil into the palm of his own left hand; 
-<sup>27&#160;</sup>and the priest shall sprinkle with his right finger some of the oil that is in his left hand seven times before Yahweh. 
+<sup>27&#160;</sup>and the priest shall sprinkle with his right finger some of the oil that is in his left hand seven times before Yahuah. 
 <sup>28&#160;</sup>Then the priest shall put some of the oil that is in his hand on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot, on the place of the blood of the trespass offering. 
-<sup>29&#160;</sup>The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, to make atonement for him before Yahweh. 
+<sup>29&#160;</sup>The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, to make atonement for him before Yahuah. 
 <sup>30&#160;</sup>He shall offer one of the turtledoves, or of the young pigeons, which ever he is able to afford, 
-<sup>31&#160;</sup>of the kind he is able to afford, the one for a sin offering, and the other for a burnt offering, with the meal offering. The priest shall make atonement for him who is to be cleansed before Yahweh.” 
+<sup>31&#160;</sup>of the kind he is able to afford, the one for a sin offering, and the other for a burnt offering, with the meal offering. The priest shall make atonement for him who is to be cleansed before Yahuah.” 
 </p><p>
 <sup>32&#160;</sup>This is the law for him in whom is the plague of leprosy, who is not able to afford the sacrifice for his cleansing. 
 </p><p>
-<sup>33&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>33&#160;</sup>Yahuah spoke to Moses and to Aaron, saying, 
 <sup>34&#160;</sup>“When you have come into the land of Canaan, which I give to you for a possession, and I put a spreading mildew in a house in the land of your possession, 
 <sup>35&#160;</sup>then he who owns the house shall come and tell the priest, saying, ‘There seems to me to be some sort of plague in the house.’ 
 <sup>36&#160;</sup>The priest shall command that they empty the house, before the priest goes in to examine the plague, that all that is in the house not be made unclean. Afterward the priest shall go in to inspect the house. 
@@ -618,7 +618,7 @@ html[dir=ltr] .q2 {
 </p><p>This is the law of leprosy. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses and to Aaron, saying, 
 <sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘When any man has a discharge from his body, because of his discharge he is unclean. 
 <sup>3&#160;</sup>This shall be his uncleanness in his discharge: whether his body runs with his discharge, or his body has stopped from his discharge, it is his uncleanness. 
 </p><p>
@@ -639,8 +639,8 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>13&#160;</sup>“&#160;‘When he who has a discharge is cleansed of his discharge, then he shall count to himself seven days for his cleansing, and wash his clothes; and he shall bathe his flesh in running water, and shall be clean. 
 </p><p>
-<sup>14&#160;</sup>“&#160;‘On the eighth day he shall take two turtledoves, or two young pigeons, and come before Yahweh to the door of the Tent of Meeting, and give them to the priest. 
-<sup>15&#160;</sup>The priest shall offer them, the one for a sin offering, and the other for a burnt offering. The priest shall make atonement for him before Yahweh for his discharge. 
+<sup>14&#160;</sup>“&#160;‘On the eighth day he shall take two turtledoves, or two young pigeons, and come before Yahuah to the door of the Tent of Meeting, and give them to the priest. 
+<sup>15&#160;</sup>The priest shall offer them, the one for a sin offering, and the other for a burnt offering. The priest shall make atonement for him before Yahuah for his discharge. 
 </p><p>
 <sup>16&#160;</sup>“&#160;‘If any man has an emission of semen, then he shall bathe all his flesh in water, and be unclean until the evening. 
 <sup>17&#160;</sup>Every garment and every skin which the semen is on shall be washed with water, and be unclean until the evening. 
@@ -661,7 +661,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>28&#160;</sup>“&#160;‘But if she is cleansed of her discharge, then she shall count to herself seven days, and after that she shall be clean. 
 <sup>29&#160;</sup>On the eighth day she shall take two turtledoves, or two young pigeons, and bring them to the priest, to the door of the Tent of Meeting. 
-<sup>30&#160;</sup>The priest shall offer the one for a sin offering, and the other for a burnt offering; and the priest shall make atonement for her before Yahweh for the uncleanness of her discharge. 
+<sup>30&#160;</sup>The priest shall offer the one for a sin offering, and the other for a burnt offering; and the priest shall make atonement for her before Yahuah for the uncleanness of her discharge. 
 </p><p>
 <sup>31&#160;</sup>“&#160;‘Thus you shall separate the children of Israel from their uncleanness, so they will not die in their uncleanness when they defile my tabernacle that is among them.’&#160;” 
 </p><p>
@@ -669,29 +669,29 @@ html[dir=ltr] .q2 {
 <sup>33&#160;</sup>and of her who has her period, and of a man or woman who has a discharge, and of him who lies with her who is unclean. 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses after the death of the two sons of Aaron, when they came near before Yahweh, and died; 
-<sup>2&#160;</sup>and Yahweh said to Moses, “Tell Aaron your brother not to come at just any time into the Most Set-Apart Place within the veil, before the mercy seat which is on the ark; lest he die; for I will appear in the cloud on the mercy seat. 
+<sup>1&#160;</sup>Yahuah spoke to Moses after the death of the two sons of Aaron, when they came near before Yahuah, and died; 
+<sup>2&#160;</sup>and Yahuah said to Moses, “Tell Aaron your brother not to come at just any time into the Most Set-Apart Place within the veil, before the mercy seat which is on the ark; lest he die; for I will appear in the cloud on the mercy seat. 
 </p><p>
 <sup>3&#160;</sup>“Aaron shall come into the sanctuary with a young bull for a sin offering, and a ram for a burnt offering. 
 <sup>4&#160;</sup>He shall put on the set-apart linen tunic. He shall have the linen trousers on his body, and shall put on the linen sash, and he shall be clothed with the linen turban. They are the set-apart garments. He shall bathe his body in water, and put them on. 
 <sup>5&#160;</sup>He shall take from the congregation of the children of Israel two male goats for a sin offering, and one ram for a burnt offering. 
 </p><p>
 <sup>6&#160;</sup>“Aaron shall offer the bull of the sin offering, which is for himself, and make atonement for himself and for his house. 
-<sup>7&#160;</sup>He shall take the two goats, and set them before Yahweh at the door of the Tent of Meeting. 
-<sup>8&#160;</sup>Aaron shall cast lots for the two goats: one lot for Yahweh, and the other lot for the scapegoat. 
-<sup>9&#160;</sup>Aaron shall present the goat on which the lot fell for Yahweh, and offer him for a sin offering. 
-<sup>10&#160;</sup>But the goat on which the lot fell for the scapegoat shall be presented alive before Yahweh, to make atonement for him, to send him away as the scapegoat into the wilderness. 
+<sup>7&#160;</sup>He shall take the two goats, and set them before Yahuah at the door of the Tent of Meeting. 
+<sup>8&#160;</sup>Aaron shall cast lots for the two goats: one lot for Yahuah, and the other lot for the scapegoat. 
+<sup>9&#160;</sup>Aaron shall present the goat on which the lot fell for Yahuah, and offer him for a sin offering. 
+<sup>10&#160;</sup>But the goat on which the lot fell for the scapegoat shall be presented alive before Yahuah, to make atonement for him, to send him away as the scapegoat into the wilderness. 
 </p><p>
 <sup>11&#160;</sup>“Aaron shall present the bull of the sin offering, which is for himself, and shall make atonement for himself and for his house, and shall kill the bull of the sin offering which is for himself. 
-<sup>12&#160;</sup>He shall take a censer full of coals of fire from off the altar before Yahweh, and two handfuls of sweet incense beaten small, and bring it within the veil. 
-<sup>13&#160;</sup>He shall put the incense on the fire before Yahweh, that the cloud of the incense may cover the mercy seat that is on the covenant, so that he will not die. 
+<sup>12&#160;</sup>He shall take a censer full of coals of fire from off the altar before Yahuah, and two handfuls of sweet incense beaten small, and bring it within the veil. 
+<sup>13&#160;</sup>He shall put the incense on the fire before Yahuah, that the cloud of the incense may cover the mercy seat that is on the covenant, so that he will not die. 
 <sup>14&#160;</sup>He shall take some of the blood of the bull, and sprinkle it with his finger on the mercy seat on the east; and before the mercy seat he shall sprinkle some of the blood with his finger seven times. 
 </p><p>
 <sup>15&#160;</sup>“Then he shall kill the goat of the sin offering that is for the people, and bring his blood within the veil, and do with his blood as he did with the blood of the bull, and sprinkle it on the mercy seat and before the mercy seat. 
 <sup>16&#160;</sup>He shall make atonement for the Set-Apart Place, because of the uncleanness of the children of Israel, and because of their transgressions, even all their sins; and so he shall do for the Tent of Meeting that dwells with them in the middle of their uncleanness. 
 <sup>17&#160;</sup>No one shall be in the Tent of Meeting when he enters to make atonement in the Set-Apart Place, until he comes out, and has made atonement for himself and for his household, and for all the assembly of Israel. 
 </p><p>
-<sup>18&#160;</sup>“He shall go out to the altar that is before Yahweh and make atonement for it, and shall take some of the bull’s blood, and some of the goat’s blood, and put it around on the horns of the altar. 
+<sup>18&#160;</sup>“He shall go out to the altar that is before Yahuah and make atonement for it, and shall take some of the bull’s blood, and some of the goat’s blood, and put it around on the horns of the altar. 
 <sup>19&#160;</sup>He shall sprinkle some of the blood on it with his finger seven times, and cleanse it, and make it set-apart from the uncleanness of the children of Israel. 
 </p><p>
 <sup>20&#160;</sup>“When he has finished atoning for the Set-Apart Place, the Tent of Meeting, and the altar, he shall present the live goat. 
@@ -707,25 +707,25 @@ html[dir=ltr] .q2 {
 <sup>28&#160;</sup>He who burns them shall wash his clothes, and bathe his flesh in water, and afterward he shall come into the camp. 
 </p><p>
 <sup>29&#160;</sup>“It shall be a statute to you forever: in the seventh month, on the tenth day of the month, you shall afflict your souls, and shall do no kind of work, whether native-born or a stranger who lives as a foreigner among you; 
-<sup>30&#160;</sup>for on this day shall atonement be made for you, to cleanse you. You shall be clean from all your sins before Yahweh. 
+<sup>30&#160;</sup>for on this day shall atonement be made for you, to cleanse you. You shall be clean from all your sins before Yahuah. 
 <sup>31&#160;</sup>It is a Sabbath of solemn rest to you, and you shall afflict your souls. It is a statute forever. 
 <sup>32&#160;</sup>The priest, who is anointed and who is consecrated to be priest in his father’s place, shall make the atonement, and shall put on the linen garments, even the set-apart garments. 
 <sup>33&#160;</sup>Then he shall make atonement for the Set-Apart Sanctuary; and he shall make atonement for the Tent of Meeting and for the altar; and he shall make atonement for the priests and for all the people of the assembly. 
 </p><p>
 <sup>34&#160;</sup>“This shall be an everlasting statute for you, to make atonement for the children of Israel once in the year because of all their sins.” 
-</p><p>It was done as Yahweh commanded Moses. 
+</p><p>It was done as Yahuah commanded Moses. 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>2&#160;</sup>“Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘This is the thing which Yahweh has commanded: 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘This is the thing which Yahuah has commanded: 
 <sup>3&#160;</sup>Whatever man there is of the house of Israel who kills a bull, or lamb, or goat in the camp, or who kills it outside the camp, 
-<sup>4&#160;</sup>and hasn’t brought it to the door of the Tent of Meeting to offer it as an offering to Yahweh before Yahweh’s tabernacle: blood shall be imputed to that man. He has shed blood. That man shall be cut off from among his people. 
-<sup>5&#160;</sup>This is to the end that the children of Israel may bring their sacrifices, which they sacrifice in the open field, that they may bring them to Yahweh, to the door of the Tent of Meeting, to the priest, and sacrifice them for sacrifices of peace offerings to Yahweh. 
-<sup>6&#160;</sup>The priest shall sprinkle the blood on Yahweh’s altar at the door of the Tent of Meeting, and burn the fat for a pleasant aroma to Yahweh. 
+<sup>4&#160;</sup>and hasn’t brought it to the door of the Tent of Meeting to offer it as an offering to Yahuah before Yahuah’s tabernacle: blood shall be imputed to that man. He has shed blood. That man shall be cut off from among his people. 
+<sup>5&#160;</sup>This is to the end that the children of Israel may bring their sacrifices, which they sacrifice in the open field, that they may bring them to Yahuah, to the door of the Tent of Meeting, to the priest, and sacrifice them for sacrifices of peace offerings to Yahuah. 
+<sup>6&#160;</sup>The priest shall sprinkle the blood on Yahuah’s altar at the door of the Tent of Meeting, and burn the fat for a pleasant aroma to Yahuah. 
 <sup>7&#160;</sup>They shall no more sacrifice their sacrifices to the goat idols, after which they play the prostitute. This shall be a statute forever to them throughout their generations.’ 
 </p><p>
 <sup>8&#160;</sup>“You shall say to them, ‘Any man there is of the house of Israel, or of the strangers who live as foreigners among them, who offers a burnt offering or sacrifice, 
-<sup>9&#160;</sup>and doesn’t bring it to the door of the Tent of Meeting to sacrifice it to Yahweh, that man shall be cut off from his people. 
+<sup>9&#160;</sup>and doesn’t bring it to the door of the Tent of Meeting to sacrifice it to Yahuah, that man shall be cut off from his people. 
 </p><p>
 <sup>10&#160;</sup>“&#160;‘Any man of the house of Israel, or of the strangers who live as foreigners among them, who eats any kind of blood, I will set my face against that soul who eats blood, and will cut him off from among his people. 
 <sup>11&#160;</sup>For the life of the flesh is in the blood. I have given it to you on the altar to make atonement for your souls; for it is the blood that makes atonement by reason of the life. 
@@ -738,13 +738,13 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>But if he doesn’t wash them, or bathe his flesh, then he shall bear his iniquity.’&#160;” 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Moses, 
-<sup>2&#160;</sup>“Speak to the children of Israel, and say to them, ‘I am Yahweh your Elohim. 
+<sup>1&#160;</sup>Yahuah said to Moses, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and say to them, ‘I am Yahuah your Elohim. 
 <sup>3&#160;</sup>You shall not do as they do in the land of Egypt, where you lived. You shall not do as they do in the land of Canaan, where I am bringing you. You shall not follow their statutes. 
-<sup>4&#160;</sup>You shall do my ordinances. You shall keep my statutes and walk in them. I am Yahweh your Elohim. 
-<sup>5&#160;</sup>You shall therefore keep my statutes and my ordinances, which if a man does, he shall live in them. I am Yahweh. 
+<sup>4&#160;</sup>You shall do my ordinances. You shall keep my statutes and walk in them. I am Yahuah your Elohim. 
+<sup>5&#160;</sup>You shall therefore keep my statutes and my ordinances, which if a man does, he shall live in them. I am Yahuah. 
 </p><p>
-<sup>6&#160;</sup>“&#160;‘None of you shall approach any close relatives, to uncover their nakedness: I am Yahweh. 
+<sup>6&#160;</sup>“&#160;‘None of you shall approach any close relatives, to uncover their nakedness: I am Yahuah. 
 </p><p>
 <sup>7&#160;</sup>“&#160;‘You shall not uncover the nakedness of your father, nor the nakedness of your mother: she is your mother. You shall not uncover her nakedness. 
 </p><p>
@@ -774,7 +774,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>20&#160;</sup>“&#160;‘You shall not lie carnally with your neighbor’s woman, and defile yourself with her. 
 </p><p>
-<sup>21&#160;</sup>“&#160;‘You shall not give any of your children as a sacrifice to Molech. You shall not profane the name of your Elohim. I am Yahweh. 
+<sup>21&#160;</sup>“&#160;‘You shall not give any of your children as a sacrifice to Molech. You shall not profane the name of your Elohim. I am Yahuah. 
 </p><p>
 <sup>22&#160;</sup>“&#160;‘You shall not lie with a man as with a woman. That is detestable. 
 </p><p>
@@ -787,43 +787,43 @@ html[dir=ltr] .q2 {
 <sup>28&#160;</sup>that the land not vomit you out also, when you defile it, as it vomited out the nation that was before you. 
 </p><p>
 <sup>29&#160;</sup>“&#160;‘For whoever shall do any of these abominations, even the souls that do them shall be cut off from among their people. 
-<sup>30&#160;</sup>Therefore you shall keep my requirements, that you do not practice any of these abominable customs which were practiced before you, and that you do not defile yourselves with them. I am Yahweh your Elohim.’&#160;” 
+<sup>30&#160;</sup>Therefore you shall keep my requirements, that you do not practice any of these abominable customs which were practiced before you, and that you do not defile yourselves with them. I am Yahuah your Elohim.’&#160;” 
 </p><h2 class="chapterlabel" id="19">19</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>2&#160;</sup>“Speak to all the congregation of the children of Israel, and tell them, ‘You shall be set-apart; for I, Yahweh your Elohim, am set-apart. 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to all the congregation of the children of Israel, and tell them, ‘You shall be set-apart; for I, Yahuah your Elohim, am set-apart. 
 </p><p>
-<sup>3&#160;</sup>“&#160;‘Each one of you shall respect his mother and his father. You shall keep my Sabbaths. I am Yahweh your Elohim. 
+<sup>3&#160;</sup>“&#160;‘Each one of you shall respect his mother and his father. You shall keep my Sabbaths. I am Yahuah your Elohim. 
 </p><p>
-<sup>4&#160;</sup>“&#160;‘Don’t turn to idols, nor make molten elohims for yourselves. I am Yahweh your Elohim. 
+<sup>4&#160;</sup>“&#160;‘Don’t turn to idols, nor make molten elohims for yourselves. I am Yahuah your Elohim. 
 </p><p>
-<sup>5&#160;</sup>“&#160;‘When you offer a sacrifice of peace offerings to Yahweh, you shall offer it so that you may be accepted. 
+<sup>5&#160;</sup>“&#160;‘When you offer a sacrifice of peace offerings to Yahuah, you shall offer it so that you may be accepted. 
 <sup>6&#160;</sup>It shall be eaten the same day you offer it, and on the next day. If anything remains until the third day, it shall be burned with fire. 
 <sup>7&#160;</sup>If it is eaten at all on the third day, it is an abomination. It will not be accepted; 
-<sup>8&#160;</sup>but everyone who eats it shall bear his iniquity, because he has profaned the set-apart thing of Yahweh, and that soul shall be cut off from his people. 
+<sup>8&#160;</sup>but everyone who eats it shall bear his iniquity, because he has profaned the set-apart thing of Yahuah, and that soul shall be cut off from his people. 
 </p><p>
 <sup>9&#160;</sup>“&#160;‘When you reap the harvest of your land, you shall not wholly reap the corners of your field, neither shall you gather the gleanings of your harvest. 
-<sup>10&#160;</sup>You shall not glean your vineyard, neither shall you gather the fallen grapes of your vineyard. You shall leave them for the poor and for the foreigner. I am Yahweh your Elohim. 
+<sup>10&#160;</sup>You shall not glean your vineyard, neither shall you gather the fallen grapes of your vineyard. You shall leave them for the poor and for the foreigner. I am Yahuah your Elohim. 
 </p><p>
 <sup>11&#160;</sup>“&#160;‘You shall not steal. 
 </p><p>“&#160;‘You shall not lie. 
 </p><p>“&#160;‘You shall not deceive one another. 
 </p><p>
-<sup>12&#160;</sup>“&#160;‘You shall not swear by my name falsely, and profane the name of your Elohim. I am Yahweh. 
+<sup>12&#160;</sup>“&#160;‘You shall not swear by my name falsely, and profane the name of your Elohim. I am Yahuah. 
 </p><p>
 <sup>13&#160;</sup>“&#160;‘You shall not oppress your neighbor, nor rob him. 
 </p><p>“&#160;‘The wages of a hired servant shall not remain with you all night until the morning. 
 </p><p>
-<sup>14&#160;</sup>“&#160;‘You shall not curse the deaf, nor put a stumbling block before the blind; but you shall fear your Elohim. I am Yahweh. 
+<sup>14&#160;</sup>“&#160;‘You shall not curse the deaf, nor put a stumbling block before the blind; but you shall fear your Elohim. I am Yahuah. 
 </p><p>
 <sup>15&#160;</sup>“&#160;‘You shall do no injustice in judgment. You shall not be partial to the poor, nor show favoritism to the great; but you shall judge your neighbor in righteousness. 
 </p><p>
 <sup>16&#160;</sup>“&#160;‘You shall not go around as a slanderer among your people. 
-</p><p>“&#160;‘You shall not endanger the life of your neighbor. I am Yahweh. 
+</p><p>“&#160;‘You shall not endanger the life of your neighbor. I am Yahuah. 
 </p><p>
 <sup>17&#160;</sup>“&#160;‘You shall not hate your brother in your heart. You shall surely rebuke your neighbor, and not bear sin because of him. 
 </p><p>
-<sup>18&#160;</sup>“&#160;‘You shall not take vengeance, nor bear any grudge against the children of your people; but you shall love your neighbor as yourself. I am Yahweh. 
+<sup>18&#160;</sup>“&#160;‘You shall not take vengeance, nor bear any grudge against the children of your people; but you shall love your neighbor as yourself. I am Yahuah. 
 </p><p>
 <sup>19&#160;</sup>“&#160;‘You shall keep my statutes. 
 </p><p>“&#160;‘You shall not cross-breed different kinds of animals. 
@@ -831,37 +831,37 @@ html[dir=ltr] .q2 {
 </p><p>“&#160;‘Don’t wear a garment made of two kinds of material. 
 </p><p>
 <sup>20&#160;</sup>“&#160;‘If a man lies carnally with a woman who is a slave girl, pierced to another man, and not ransomed or given her freedom; they shall be punished. They shall not be put to death, because she was not free. 
-<sup>21&#160;</sup>He shall bring his trespass offering to Yahweh, to the door of the Tent of Meeting, even a ram for a trespass offering. 
-<sup>22&#160;</sup>The priest shall make atonement for him with the ram of the trespass offering before Yahweh for his sin which he has committed; and the sin which he has committed shall be forgiven him. 
+<sup>21&#160;</sup>He shall bring his trespass offering to Yahuah, to the door of the Tent of Meeting, even a ram for a trespass offering. 
+<sup>22&#160;</sup>The priest shall make atonement for him with the ram of the trespass offering before Yahuah for his sin which he has committed; and the sin which he has committed shall be forgiven him. 
 </p><p>
 <sup>23&#160;</sup>“&#160;‘When you come into the land, and have planted all kinds of trees for food, then you shall count their fruit as forbidden. For three years it shall be forbidden to you. It shall not be eaten. 
-<sup>24&#160;</sup>But in the fourth year all its fruit shall be set-apart, for giving praise to Yahweh. 
-<sup>25&#160;</sup>In the fifth year you shall eat its fruit, that it may yield its increase to you. I am Yahweh your Elohim. 
+<sup>24&#160;</sup>But in the fourth year all its fruit shall be set-apart, for giving praise to Yahuah. 
+<sup>25&#160;</sup>In the fifth year you shall eat its fruit, that it may yield its increase to you. I am Yahuah your Elohim. 
 </p><p>
 <sup>26&#160;</sup>“&#160;‘You shall not eat any meat with the blood still in it. You shall not use enchantments, nor practice sorcery. 
 </p><p>
 <sup>27&#160;</sup>“&#160;‘You shall not cut the hair on the sides of your head or clip off the edge of your beard. 
 </p><p>
-<sup>28&#160;</sup>“&#160;‘You shall not make any cuttings in your flesh for the dead, nor tattoo any marks on you. I am Yahweh. 
+<sup>28&#160;</sup>“&#160;‘You shall not make any cuttings in your flesh for the dead, nor tattoo any marks on you. I am Yahuah. 
 </p><p>
 <sup>29&#160;</sup>“&#160;‘Don’t profane your daughter, to make her a prostitute; lest the land fall to prostitution, and the land become full of wickedness. 
 </p><p>
-<sup>30&#160;</sup>“&#160;‘You shall keep my Sabbaths, and reverence my sanctuary; I am Yahweh. 
+<sup>30&#160;</sup>“&#160;‘You shall keep my Sabbaths, and reverence my sanctuary; I am Yahuah. 
 </p><p>
-<sup>31&#160;</sup>“&#160;‘Don’t turn to those who are mediums, nor to the wizards. Don’t seek them out, to be defiled by them. I am Yahweh your Elohim. 
+<sup>31&#160;</sup>“&#160;‘Don’t turn to those who are mediums, nor to the wizards. Don’t seek them out, to be defiled by them. I am Yahuah your Elohim. 
 </p><p>
-<sup>32&#160;</sup>“&#160;‘You shall rise up before the gray head and honor the face of the elderly; and you shall fear your Elohim. I am Yahweh. 
+<sup>32&#160;</sup>“&#160;‘You shall rise up before the gray head and honor the face of the elderly; and you shall fear your Elohim. I am Yahuah. 
 </p><p>
 <sup>33&#160;</sup>“&#160;‘If a stranger lives as a foreigner with you in your land, you shall not do him wrong. 
-<sup>34&#160;</sup>The stranger who lives as a foreigner with you shall be to you as the native-born among you, and you shall love him as yourself; for you lived as foreigners in the land of Egypt. I am Yahweh your Elohim. 
+<sup>34&#160;</sup>The stranger who lives as a foreigner with you shall be to you as the native-born among you, and you shall love him as yourself; for you lived as foreigners in the land of Egypt. I am Yahuah your Elohim. 
 </p><p>
 <sup>35&#160;</sup>“&#160;‘You shall do no unrighteousness in judgment, in measures of length, of weight, or of quantity. 
-<sup>36&#160;</sup>You shall have just balances, just weights, a just ephah, and a just hin. I am Yahweh your Elohim, who brought you out of the land of Egypt. 
+<sup>36&#160;</sup>You shall have just balances, just weights, a just ephah, and a just hin. I am Yahuah your Elohim, who brought you out of the land of Egypt. 
 </p><p>
-<sup>37&#160;</sup>“&#160;‘You shall observe all my statutes and all my ordinances, and do them. I am Yahweh.’&#160;” 
+<sup>37&#160;</sup>“&#160;‘You shall observe all my statutes and all my ordinances, and do them. I am Yahuah.’&#160;” 
 </p><h2 class="chapterlabel" id="20">20</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Moreover, you shall tell the children of Israel, ‘Anyone of the children of Israel, or of the strangers who live as foreigners in Israel, who gives any of his offspring to Molech shall surely be put to death. The people of the land shall stone that person with stones. 
 <sup>3&#160;</sup>I also will set my face against that person, and will cut him off from among his people, because he has given of his offspring to Molech, to defile my sanctuary, and to profane my set-apart name. 
 <sup>4&#160;</sup>If the people of the land all hide their eyes from that person when he gives of his offspring to Molech, and don’t put him to death, 
@@ -869,8 +869,8 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>6&#160;</sup>“&#160;‘The person that turns to those who are mediums and wizards, to play the prostitute after them, I will even set my face against that person, and will cut him off from among his people. 
 </p><p>
-<sup>7&#160;</sup>“&#160;‘Sanctify yourselves therefore, and be set-apart; for I am Yahweh your Elohim. 
-<sup>8&#160;</sup>You shall keep my statutes, and do them. I am Yahweh who sanctifies you. 
+<sup>7&#160;</sup>“&#160;‘Sanctify yourselves therefore, and be set-apart; for I am Yahuah your Elohim. 
+<sup>8&#160;</sup>You shall keep my statutes, and do them. I am Yahuah who sanctifies you. 
 </p><p>
 <sup>9&#160;</sup>“&#160;‘For everyone who curses his father or his mother shall surely be put to death. He has cursed his father or his mother. His blood shall be upon himself. 
 </p><p>
@@ -899,58 +899,58 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>22&#160;</sup>“&#160;‘You shall therefore keep all my statutes and all my ordinances, and do them, that the land where I am bringing you to dwell may not vomit you out. 
 <sup>23&#160;</sup>You shall not walk in the customs of the nation which I am casting out before you; for they did all these things, and therefore I abhorred them. 
-<sup>24&#160;</sup>But I have said to you, “You shall inherit their land, and I will give it to you to possess it, a land flowing with milk and honey.” I am Yahweh your Elohim, who has separated you from the peoples. 
+<sup>24&#160;</sup>But I have said to you, “You shall inherit their land, and I will give it to you to possess it, a land flowing with milk and honey.” I am Yahuah your Elohim, who has separated you from the peoples. 
 </p><p>
 <sup>25&#160;</sup>“&#160;‘You shall therefore make a distinction between the clean animal and the unclean, and between the unclean fowl and the clean. You shall not make yourselves abominable by animal, or by bird, or by anything with which the ground teems, which I have separated from you as unclean for you. 
-<sup>26&#160;</sup>You shall be set-apart to me, for I, Yahweh, am set-apart, and have set you apart from the peoples, that you should be mine. 
+<sup>26&#160;</sup>You shall be set-apart to me, for I, Yahuah, am set-apart, and have set you apart from the peoples, that you should be mine. 
 </p><p>
 <sup>27&#160;</sup>“&#160;‘A man or a woman that is a medium or is a wizard shall surely be put to death. They shall be stoned with stones. Their blood shall be upon themselves.’&#160;” 
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Moses, “Speak to the priests, the sons of Aaron, and say to them, ‘A priest shall not defile himself for the dead among his people, 
+<sup>1&#160;</sup>Yahuah said to Moses, “Speak to the priests, the sons of Aaron, and say to them, ‘A priest shall not defile himself for the dead among his people, 
 <sup>2&#160;</sup>except for his relatives that are near to him: for his mother, for his father, for his son, for his daughter, for his brother, 
 <sup>3&#160;</sup>and for his virgin sister who is near to him, who has had no man; for her he may defile himself. 
 <sup>4&#160;</sup>He shall not defile himself, being an owner among his people, to profane himself. 
 </p><p>
 <sup>5&#160;</sup>“&#160;‘They shall not shave their heads or shave off the corners of their beards or make any cuttings in their flesh. 
-<sup>6&#160;</sup>They shall be set-apart to their Elohim, and not profane the name of their Elohim, for they offer the offerings of Yahweh made by fire, the bread of their Elohim. Therefore they shall be set-apart. 
+<sup>6&#160;</sup>They shall be set-apart to their Elohim, and not profane the name of their Elohim, for they offer the offerings of Yahuah made by fire, the bread of their Elohim. Therefore they shall be set-apart. 
 </p><p>
 <sup>7&#160;</sup>“&#160;‘They shall not take a woman who is a whore, or pierced. A priest shall not take a woman divorced from her man; for he is set-apart to his Elohim. 
-<sup>8&#160;</sup>Therefore you shall sanctify him, for he offers the bread of your Elohim. He shall be set-apart to you, for I Yahweh, who sanctify you, am set-apart. 
+<sup>8&#160;</sup>Therefore you shall sanctify him, for he offers the bread of your Elohim. He shall be set-apart to you, for I Yahuah, who sanctify you, am set-apart. 
 </p><p>
 <sup>9&#160;</sup>“&#160;‘The daughter of any priest, if she profanes herself by playing the prostitute, she profanes her father. She shall be burned with fire. 
 </p><p>
 <sup>10&#160;</sup>“&#160;‘He who is the high priest among his brothers, upon whose head the anointing oil is poured, and who is consecrated to put on the garments, shall not let the hair of his head hang loose, or tear his clothes. 
 <sup>11&#160;</sup>He must not go in to any dead body, or defile himself for his father or for his mother. 
-<sup>12&#160;</sup>He shall not go out of the sanctuary, nor profane the sanctuary of his Elohim; for the crown of the anointing oil of his Elohim is upon him. I am Yahweh. 
+<sup>12&#160;</sup>He shall not go out of the sanctuary, nor profane the sanctuary of his Elohim; for the crown of the anointing oil of his Elohim is upon him. I am Yahuah. 
 </p><p>
 <sup>13&#160;</sup>“&#160;‘He shall take a woman in her virginity. 
 <sup>14&#160;</sup>He shall not take a widow, or one divorced, or a woman who has been pierced, or a whore. He shall take a virgin of his own people as a woman. 
-<sup>15&#160;</sup>He shall not profane his offspring among his people, for I am Yahweh who sanctifies him.’&#160;” 
+<sup>15&#160;</sup>He shall not profane his offspring among his people, for I am Yahuah who sanctifies him.’&#160;” 
 </p><p>
-<sup>16&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>16&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>17&#160;</sup>“Say to Aaron, ‘None of your offspring throughout their generations who has a defect may approach to offer the bread of his Elohim. 
 <sup>18&#160;</sup>For whatever man he is that has a defect, he shall not draw near: a blind man, or a lame, or he who has a flat nose, or any deformity, 
 <sup>19&#160;</sup>or a man who has an injured foot, or an injured hand, 
 <sup>20&#160;</sup>or hunchbacked, or a dwarf, or one who has a defect in his eye, or an itching disease, or scabs, or who has damaged testicles. 
-<sup>21&#160;</sup>No man of the offspring of Aaron the priest who has a defect shall come near to offer the offerings of Yahweh made by fire. Since he has a defect, he shall not come near to offer the bread of his Elohim. 
+<sup>21&#160;</sup>No man of the offspring of Aaron the priest who has a defect shall come near to offer the offerings of Yahuah made by fire. Since he has a defect, he shall not come near to offer the bread of his Elohim. 
 <sup>22&#160;</sup>He shall eat the bread of his Elohim, both of the most set-apart, and of the set-apart. 
-<sup>23&#160;</sup>He shall not come near to the veil, nor come near to the altar, because he has a defect; that he may not profane my sanctuaries, for I am Yahweh who sanctifies them.’&#160;” 
+<sup>23&#160;</sup>He shall not come near to the veil, nor come near to the altar, because he has a defect; that he may not profane my sanctuaries, for I am Yahuah who sanctifies them.’&#160;” 
 </p><p>
 <sup>24&#160;</sup>So Moses spoke to Aaron, and to his sons, and to all the children of Israel. 
 </p><h2 class="chapterlabel" id="22">22</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>2&#160;</sup>“Tell Aaron and his sons to separate themselves from the set-apart things of the children of Israel, which they make set-apart to me, and that they not profane my set-apart name. I am Yahweh. 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>2&#160;</sup>“Tell Aaron and his sons to separate themselves from the set-apart things of the children of Israel, which they make set-apart to me, and that they not profane my set-apart name. I am Yahuah. 
 </p><p>
-<sup>3&#160;</sup>“Tell them, ‘If anyone of all your offspring throughout your generations approaches the set-apart things which the children of Israel make set-apart to Yahweh, having his uncleanness on him, that soul shall be cut off from before me. I am Yahweh. 
+<sup>3&#160;</sup>“Tell them, ‘If anyone of all your offspring throughout your generations approaches the set-apart things which the children of Israel make set-apart to Yahuah, having his uncleanness on him, that soul shall be cut off from before me. I am Yahuah. 
 </p><p>
 <sup>4&#160;</sup>“&#160;‘Whoever of the offspring of Aaron is a leper or has a discharge shall not eat of the set-apart things until he is clean. Whoever touches anything that is unclean by the dead, or a man who has a seminal emission, 
 <sup>5&#160;</sup>or whoever touches any creeping thing by which he may be made unclean, or a man from whom he may become unclean, whatever uncleanness he has—<sup>6&#160;</sup>the person that touches any such shall be unclean until the evening, and shall not eat of the set-apart things unless he bathes his body in water. 
 <sup>7&#160;</sup>When the sun is down, he shall be clean; and afterward he shall eat of the set-apart things, because it is his bread. 
-<sup>8&#160;</sup>He shall not eat that which dies of itself or is torn by animals, defiling himself by it. I am Yahweh. 
+<sup>8&#160;</sup>He shall not eat that which dies of itself or is torn by animals, defiling himself by it. I am Yahuah. 
 </p><p>
-<sup>9&#160;</sup>“&#160;‘They shall therefore follow my commandment, lest they bear sin for it and die in it, if they profane it. I am Yahweh who sanctifies them. 
+<sup>9&#160;</sup>“&#160;‘They shall therefore follow my commandment, lest they bear sin for it and die in it, if they profane it. I am Yahuah who sanctifies them. 
 </p><p>
 <sup>10&#160;</sup>“&#160;‘No stranger shall eat of the set-apart thing: a foreigner living with the priests, or a hired servant, shall not eat of the set-apart thing. 
 <sup>11&#160;</sup>But if a priest buys a slave, purchased by his money, he shall eat of it; and those who are born in his house shall eat of his bread. 
@@ -958,120 +958,120 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>But if a priest’s daughter is a widow, or divorced, and has no child, and has returned to her father’s house as in her youth, she may eat of her father’s bread; but no stranger shall eat any of it. 
 </p><p>
 <sup>14&#160;</sup>“&#160;‘If a man eats something set-apart unwittingly, then he shall add the fifth part of its value to it, and shall give the set-apart thing to the priest. 
-<sup>15&#160;</sup>The priests shall not profane the set-apart things of the children of Israel, which they offer to Yahweh, 
-<sup>16&#160;</sup>and so cause them to bear the iniquity that brings guilt when they eat their set-apart things; for I am Yahweh who sanctifies them.’&#160;” 
+<sup>15&#160;</sup>The priests shall not profane the set-apart things of the children of Israel, which they offer to Yahuah, 
+<sup>16&#160;</sup>and so cause them to bear the iniquity that brings guilt when they eat their set-apart things; for I am Yahuah who sanctifies them.’&#160;” 
 </p><p>
-<sup>17&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>18&#160;</sup>“Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘Whoever is of the house of Israel, or of the foreigners in Israel, who offers his offering, whether it is any of their vows or any of their free will offerings, which they offer to Yahweh for a burnt offering: 
+<sup>17&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>18&#160;</sup>“Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘Whoever is of the house of Israel, or of the foreigners in Israel, who offers his offering, whether it is any of their vows or any of their free will offerings, which they offer to Yahuah for a burnt offering: 
 <sup>19&#160;</sup>that you may be accepted, you shall offer a male without defect, of the bulls, of the sheep, or of the goats. 
 <sup>20&#160;</sup>But you shall not offer whatever has a defect, for it shall not be acceptable for you. 
-<sup>21&#160;</sup>Whoever offers a sacrifice of peace offerings to Yahweh to accomplish a vow, or for a free will offering of the herd or of the flock, it shall be perfect to be accepted. It shall have no defect. 
-<sup>22&#160;</sup>You shall not offer what is blind, is injured, is maimed, has a wart, is festering, or has a running sore to Yahweh, nor make an offering by fire of them on the altar to Yahweh. 
+<sup>21&#160;</sup>Whoever offers a sacrifice of peace offerings to Yahuah to accomplish a vow, or for a free will offering of the herd or of the flock, it shall be perfect to be accepted. It shall have no defect. 
+<sup>22&#160;</sup>You shall not offer what is blind, is injured, is maimed, has a wart, is festering, or has a running sore to Yahuah, nor make an offering by fire of them on the altar to Yahuah. 
 <sup>23&#160;</sup>Either a bull or a lamb that has any deformity or lacking in his parts, that you may offer for a free will offering; but for a vow it shall not be accepted. 
-<sup>24&#160;</sup>You must not offer to Yahweh that which has its testicles bruised, crushed, broken, or cut. You must not do this in your land. 
+<sup>24&#160;</sup>You must not offer to Yahuah that which has its testicles bruised, crushed, broken, or cut. You must not do this in your land. 
 <sup>25&#160;</sup>You must not offer any of these as the bread of your Elohim from the hand of a foreigner, because their corruption is in them. There is a defect in them. They shall not be accepted for you.’&#160;” 
 </p><p>
-<sup>26&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>27&#160;</sup>“When a bull, a sheep, or a goat is born, it shall remain seven days with its mother. From the eighth day on it shall be accepted for the offering of an offering made by fire to Yahweh. 
+<sup>26&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>27&#160;</sup>“When a bull, a sheep, or a goat is born, it shall remain seven days with its mother. From the eighth day on it shall be accepted for the offering of an offering made by fire to Yahuah. 
 <sup>28&#160;</sup>Whether it is a cow or ewe, you shall not kill it and its young both in one day. 
 </p><p>
-<sup>29&#160;</sup>“When you sacrifice a sacrifice of thanksgiving to Yahweh, you shall sacrifice it so that you may be accepted. 
-<sup>30&#160;</sup>It shall be eaten on the same day; you shall leave none of it until the morning. I am Yahweh. 
+<sup>29&#160;</sup>“When you sacrifice a sacrifice of thanksgiving to Yahuah, you shall sacrifice it so that you may be accepted. 
+<sup>30&#160;</sup>It shall be eaten on the same day; you shall leave none of it until the morning. I am Yahuah. 
 </p><p>
-<sup>31&#160;</sup>“Therefore you shall keep my commandments, and do them. I am Yahweh. 
-<sup>32&#160;</sup>You shall not profane my set-apart name, but I will be made set-apart among the children of Israel. I am Yahweh who makes you set-apart, 
-<sup>33&#160;</sup>who brought you out of the land of Egypt, to be your Elohim. I am Yahweh.” 
+<sup>31&#160;</sup>“Therefore you shall keep my commandments, and do them. I am Yahuah. 
+<sup>32&#160;</sup>You shall not profane my set-apart name, but I will be made set-apart among the children of Israel. I am Yahuah who makes you set-apart, 
+<sup>33&#160;</sup>who brought you out of the land of Egypt, to be your Elohim. I am Yahuah.” 
 </p><h2 class="chapterlabel" id="23">23</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘The set feasts of Yahweh, which you shall proclaim to be set-apart convocations, even these are my set feasts. 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘The set feasts of Yahuah, which you shall proclaim to be set-apart convocations, even these are my set feasts. 
 </p><p>
-<sup>3&#160;</sup>“&#160;‘Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, a set-apart convocation; you shall do no kind of work. It is a Sabbath to Yahweh in all your dwellings. 
+<sup>3&#160;</sup>“&#160;‘Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, a set-apart convocation; you shall do no kind of work. It is a Sabbath to Yahuah in all your dwellings. 
 </p><p>
-<sup>4&#160;</sup>“&#160;‘These are the set feasts of Yahweh, even set-apart convocations, which you shall proclaim in their appointed season. 
-<sup>5&#160;</sup>In the first month, on the fourteenth day of the month in the evening, is Yahweh’s Passover. 
-<sup>6&#160;</sup>On the fifteenth day of the same month is the feast of unleavened bread to Yahweh. Seven days you shall eat unleavened bread. 
+<sup>4&#160;</sup>“&#160;‘These are the set feasts of Yahuah, even set-apart convocations, which you shall proclaim in their appointed season. 
+<sup>5&#160;</sup>In the first month, on the fourteenth day of the month in the evening, is Yahuah’s Passover. 
+<sup>6&#160;</sup>On the fifteenth day of the same month is the feast of unleavened bread to Yahuah. Seven days you shall eat unleavened bread. 
 <sup>7&#160;</sup>In the first day you shall have a set-apart convocation. You shall do no regular work. 
-<sup>8&#160;</sup>But you shall offer an offering made by fire to Yahweh seven days. In the seventh day is a set-apart convocation. You shall do no regular work.’&#160;” 
+<sup>8&#160;</sup>But you shall offer an offering made by fire to Yahuah seven days. In the seventh day is a set-apart convocation. You shall do no regular work.’&#160;” 
 </p><p>
-<sup>9&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>9&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>10&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you have come into the land which I give to you, and shall reap its harvest, then you shall bring the sheaf of the first fruits of your harvest to the priest. 
-<sup>11&#160;</sup>He shall wave the sheaf before Yahweh, to be accepted for you. On the next day after the Sabbath the priest shall wave it. 
-<sup>12&#160;</sup>On the day when you wave the sheaf, you shall offer a male lamb without defect a year old for a burnt offering to Yahweh. 
-<sup>13&#160;</sup>The meal offering with it shall be two tenths of an ephah of fine flour mixed with oil, an offering made by fire to Yahweh for a pleasant aroma; and the drink offering with it shall be of wine, the fourth part of a hin. 
+<sup>11&#160;</sup>He shall wave the sheaf before Yahuah, to be accepted for you. On the next day after the Sabbath the priest shall wave it. 
+<sup>12&#160;</sup>On the day when you wave the sheaf, you shall offer a male lamb without defect a year old for a burnt offering to Yahuah. 
+<sup>13&#160;</sup>The meal offering with it shall be two tenths of an ephah of fine flour mixed with oil, an offering made by fire to Yahuah for a pleasant aroma; and the drink offering with it shall be of wine, the fourth part of a hin. 
 <sup>14&#160;</sup>You must not eat bread, or roasted grain, or fresh grain, until this same day, until you have brought the offering of your Elohim. This is a statute forever throughout your generations in all your dwellings. 
 </p><p>
 <sup>15&#160;</sup>“&#160;‘You shall count from the next day after the Sabbath, from the day that you brought the sheaf of the wave offering: seven Sabbaths shall be completed. 
-<sup>16&#160;</sup>The next day after the seventh Sabbath you shall count fifty days; and you shall offer a new meal offering to Yahweh. 
-<sup>17&#160;</sup>You shall bring out of your habitations two loaves of bread for a wave offering made of two tenths of an ephah of fine flour. They shall be baked with yeast, for first fruits to Yahweh. 
-<sup>18&#160;</sup>You shall present with the bread seven lambs without defect a year old, one young bull, and two rams. They shall be a burnt offering to Yahweh, with their meal offering and their drink offerings, even an offering made by fire, of a sweet aroma to Yahweh. 
+<sup>16&#160;</sup>The next day after the seventh Sabbath you shall count fifty days; and you shall offer a new meal offering to Yahuah. 
+<sup>17&#160;</sup>You shall bring out of your habitations two loaves of bread for a wave offering made of two tenths of an ephah of fine flour. They shall be baked with yeast, for first fruits to Yahuah. 
+<sup>18&#160;</sup>You shall present with the bread seven lambs without defect a year old, one young bull, and two rams. They shall be a burnt offering to Yahuah, with their meal offering and their drink offerings, even an offering made by fire, of a sweet aroma to Yahuah. 
 <sup>19&#160;</sup>You shall offer one male goat for a sin offering, and two male lambs a year old for a sacrifice of peace offerings. 
-<sup>20&#160;</sup>The priest shall wave them with the bread of the first fruits for a wave offering before Yahweh, with the two lambs. They shall be set-apart to Yahweh for the priest. 
+<sup>20&#160;</sup>The priest shall wave them with the bread of the first fruits for a wave offering before Yahuah, with the two lambs. They shall be set-apart to Yahuah for the priest. 
 <sup>21&#160;</sup>You shall make proclamation on the same day that there shall be a set-apart convocation to you. You shall do no regular work. This is a statute forever in all your dwellings throughout your generations. 
 </p><p>
-<sup>22&#160;</sup>“&#160;‘When you reap the harvest of your land, you must not wholly reap into the corners of your field. You must not gather the gleanings of your harvest. You must leave them for the poor and for the foreigner. I am Yahweh your Elohim.’&#160;” 
+<sup>22&#160;</sup>“&#160;‘When you reap the harvest of your land, you must not wholly reap into the corners of your field. You must not gather the gleanings of your harvest. You must leave them for the poor and for the foreigner. I am Yahuah your Elohim.’&#160;” 
 </p><p>
-<sup>23&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>23&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>24&#160;</sup>“Speak to the children of Israel, saying, ‘In the seventh month, on the first day of the month, there shall be a solemn rest for you, a memorial of blowing of trumpets, a set-apart convocation. 
-<sup>25&#160;</sup>You shall do no regular work. You shall offer an offering made by fire to Yahweh.’&#160;” 
+<sup>25&#160;</sup>You shall do no regular work. You shall offer an offering made by fire to Yahuah.’&#160;” 
 </p><p>
-<sup>26&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>27&#160;</sup>“However on the tenth day of this seventh month is the day of atonement. It shall be a set-apart convocation to you. You shall afflict yourselves and you shall offer an offering made by fire to Yahweh. 
-<sup>28&#160;</sup>You shall do no kind of work in that same day, for it is a day of atonement, to make atonement for you before Yahweh your Elohim. 
+<sup>26&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>27&#160;</sup>“However on the tenth day of this seventh month is the day of atonement. It shall be a set-apart convocation to you. You shall afflict yourselves and you shall offer an offering made by fire to Yahuah. 
+<sup>28&#160;</sup>You shall do no kind of work in that same day, for it is a day of atonement, to make atonement for you before Yahuah your Elohim. 
 <sup>29&#160;</sup>For whoever it is who shall not deny himself in that same day shall be cut off from his people. 
 <sup>30&#160;</sup>Whoever does any kind of work in that same day, I will destroy that person from among his people. 
 <sup>31&#160;</sup>You shall do no kind of work: it is a statute forever throughout your generations in all your dwellings. 
 <sup>32&#160;</sup>It shall be a Sabbath of solemn rest for you, and you shall deny yourselves. In the ninth day of the month at evening, from evening to evening, you shall keep your Sabbath.” 
 </p><p>
-<sup>33&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>34&#160;</sup>“Speak to the children of Israel, and say, ‘On the fifteenth day of this seventh month is the feast of booths for seven days to Yahweh. 
+<sup>33&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>34&#160;</sup>“Speak to the children of Israel, and say, ‘On the fifteenth day of this seventh month is the feast of booths for seven days to Yahuah. 
 <sup>35&#160;</sup>On the first day shall be a set-apart convocation. You shall do no regular work. 
-<sup>36&#160;</sup>Seven days you shall offer an offering made by fire to Yahweh. On the eighth day shall be a set-apart convocation to you. You shall offer an offering made by fire to Yahweh. It is a solemn assembly; you shall do no regular work. 
+<sup>36&#160;</sup>Seven days you shall offer an offering made by fire to Yahuah. On the eighth day shall be a set-apart convocation to you. You shall offer an offering made by fire to Yahuah. It is a solemn assembly; you shall do no regular work. 
 </p><p>
-<sup>37&#160;</sup>“&#160;‘These are the appointed feasts of Yahweh which you shall proclaim to be set-apart convocations, to offer an offering made by fire to Yahweh, a burnt offering, a meal offering, a sacrifice, and drink offerings, each on its own day—<sup>38&#160;</sup>in addition to the Sabbaths of Yahweh, and in addition to your gifts, and in addition to all your vows, and in addition to all your free will offerings, which you give to Yahweh. 
+<sup>37&#160;</sup>“&#160;‘These are the appointed feasts of Yahuah which you shall proclaim to be set-apart convocations, to offer an offering made by fire to Yahuah, a burnt offering, a meal offering, a sacrifice, and drink offerings, each on its own day—<sup>38&#160;</sup>in addition to the Sabbaths of Yahuah, and in addition to your gifts, and in addition to all your vows, and in addition to all your free will offerings, which you give to Yahuah. 
 </p><p>
-<sup>39&#160;</sup>“&#160;‘So on the fifteenth day of the seventh month, when you have gathered in the fruits of the land, you shall keep the feast of Yahweh seven days. On the first day shall be a solemn rest, and on the eighth day shall be a solemn rest. 
-<sup>40&#160;</sup>You shall take on the first day the fruit of majestic trees, branches of palm trees, and boughs of thick trees, and willows of the brook; and you shall rejoice before Yahweh your Elohim seven days. 
-<sup>41&#160;</sup>You shall keep it as a feast to Yahweh seven days in the year. It is a statute forever throughout your generations. You shall keep it in the seventh month. 
+<sup>39&#160;</sup>“&#160;‘So on the fifteenth day of the seventh month, when you have gathered in the fruits of the land, you shall keep the feast of Yahuah seven days. On the first day shall be a solemn rest, and on the eighth day shall be a solemn rest. 
+<sup>40&#160;</sup>You shall take on the first day the fruit of majestic trees, branches of palm trees, and boughs of thick trees, and willows of the brook; and you shall rejoice before Yahuah your Elohim seven days. 
+<sup>41&#160;</sup>You shall keep it as a feast to Yahuah seven days in the year. It is a statute forever throughout your generations. You shall keep it in the seventh month. 
 <sup>42&#160;</sup>You shall dwell in temporary shelters for seven days. All who are native-born in Israel shall dwell in temporary shelters, 
-<sup>43&#160;</sup>that your generations may know that I made the children of Israel to dwell in temporary shelters when I brought them out of the land of Egypt. I am Yahweh your Elohim.’&#160;” 
+<sup>43&#160;</sup>that your generations may know that I made the children of Israel to dwell in temporary shelters when I brought them out of the land of Egypt. I am Yahuah your Elohim.’&#160;” 
 </p><p>
-<sup>44&#160;</sup>So Moses declared to the children of Israel the appointed feasts of Yahweh. 
+<sup>44&#160;</sup>So Moses declared to the children of Israel the appointed feasts of Yahuah. 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Command the children of Israel, that they bring to you pure olive oil beaten for the light, to cause a lamp to burn continually. 
-<sup>3&#160;</sup>Outside of the veil of the Testimony, in the Tent of Meeting, Aaron shall keep it in order from evening to morning before Yahweh continually. It shall be a statute forever throughout your generations. 
-<sup>4&#160;</sup>He shall keep in order the lamps on the pure gold lamp stand before Yahweh continually. 
+<sup>3&#160;</sup>Outside of the veil of the Testimony, in the Tent of Meeting, Aaron shall keep it in order from evening to morning before Yahuah continually. It shall be a statute forever throughout your generations. 
+<sup>4&#160;</sup>He shall keep in order the lamps on the pure gold lamp stand before Yahuah continually. 
 </p><p>
 <sup>5&#160;</sup>“You shall take fine flour, and bake twelve cakes of it: two tenths of an ephah shall be in one cake. 
-<sup>6&#160;</sup>You shall set them in two rows, six on a row, on the pure gold table before Yahweh. 
-<sup>7&#160;</sup>You shall put pure frankincense on each row, that it may be to the bread for a memorial, even an offering made by fire to Yahweh. 
-<sup>8&#160;</sup>Every Sabbath day he shall set it in order before Yahweh continually. It is an everlasting covenant on the behalf of the children of Israel. 
-<sup>9&#160;</sup>It shall be for Aaron and his sons. They shall eat it in a set-apart place; for it is most set-apart to him of the offerings of Yahweh made by fire by a perpetual statute.” 
+<sup>6&#160;</sup>You shall set them in two rows, six on a row, on the pure gold table before Yahuah. 
+<sup>7&#160;</sup>You shall put pure frankincense on each row, that it may be to the bread for a memorial, even an offering made by fire to Yahuah. 
+<sup>8&#160;</sup>Every Sabbath day he shall set it in order before Yahuah continually. It is an everlasting covenant on the behalf of the children of Israel. 
+<sup>9&#160;</sup>It shall be for Aaron and his sons. They shall eat it in a set-apart place; for it is most set-apart to him of the offerings of Yahuah made by fire by a perpetual statute.” 
 </p><p>
 <sup>10&#160;</sup>The son of an Israelite woman, whose father was an Egyptian, went out among the children of Israel; and the son of the Israelite woman and a man of Israel strove together in the camp. 
 <sup>11&#160;</sup>The son of the Israelite woman blasphemed the Name, and cursed; and they brought him to Moses. His mother’s name was Shelomith, the daughter of Dibri, of the tribe of Dan. 
-<sup>12&#160;</sup>They put him in custody until Yahweh’s will should be declared to them. 
-<sup>13&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>12&#160;</sup>They put him in custody until Yahuah’s will should be declared to them. 
+<sup>13&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>14&#160;</sup>“Bring him who cursed out of the camp; and let all who heard him lay their hands on his head, and let all the congregation stone him. 
 <sup>15&#160;</sup>You shall speak to the children of Israel, saying, ‘Whoever curses his Elohim shall bear his sin. 
-<sup>16&#160;</sup>He who blasphemes Yahweh’s name, he shall surely be put to death. All the congregation shall certainly stone him. The foreigner as well as the native-born shall be put to death when he blasphemes the Name. 
+<sup>16&#160;</sup>He who blasphemes Yahuah’s name, he shall surely be put to death. All the congregation shall certainly stone him. The foreigner as well as the native-born shall be put to death when he blasphemes the Name. 
 </p><p>
 <sup>17&#160;</sup>“&#160;‘He who strikes any man mortally shall surely be put to death. 
 <sup>18&#160;</sup>He who strikes an animal mortally shall make it good, life for life. 
 <sup>19&#160;</sup>If anyone injures his neighbor, it shall be done to him as he has done: 
 <sup>20&#160;</sup>fracture for fracture, eye for eye, tooth for tooth. It shall be done to him as he has injured someone. 
 <sup>21&#160;</sup>He who kills an animal shall make it good; and he who kills a man shall be put to death. 
-<sup>22&#160;</sup>You shall have one kind of law for the foreigner as well as the native-born; for I am Yahweh your Elohim.’&#160;” 
+<sup>22&#160;</sup>You shall have one kind of law for the foreigner as well as the native-born; for I am Yahuah your Elohim.’&#160;” 
 </p><p>
-<sup>23&#160;</sup>Moses spoke to the children of Israel; and they brought him who had cursed out of the camp, and stoned him with stones. The children of Israel did as Yahweh commanded Moses. 
+<sup>23&#160;</sup>Moses spoke to the children of Israel; and they brought him who had cursed out of the camp, and stoned him with stones. The children of Israel did as Yahuah commanded Moses. 
 </p><h2 class="chapterlabel" id="25">25</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Moses on Mount Sinai, 
-<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you come into the land which I give you, then the land shall keep a Sabbath to Yahweh. 
+<sup>1&#160;</sup>Yahuah said to Moses on Mount Sinai, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you come into the land which I give you, then the land shall keep a Sabbath to Yahuah. 
 <sup>3&#160;</sup>You shall sow your field six years, and you shall prune your vineyard six years, and gather in its fruits; 
-<sup>4&#160;</sup>but in the seventh year there shall be a Sabbath of solemn rest for the land, a Sabbath to Yahweh. You shall not sow your field or prune your vineyard. 
+<sup>4&#160;</sup>but in the seventh year there shall be a Sabbath of solemn rest for the land, a Sabbath to Yahuah. You shall not sow your field or prune your vineyard. 
 <sup>5&#160;</sup>What grows of itself in your harvest you shall not reap, and you shall not gather the grapes of your undressed vine. It shall be a year of solemn rest for the land. 
 <sup>6&#160;</sup>The Sabbath of the land shall be for food for you; for yourself, for your servant, for your maid, for your hired servant, and for your stranger, who lives as a foreigner with you. 
 <sup>7&#160;</sup>For your livestock also, and for the animals that are in your land, shall all its increase be for food. 
@@ -1087,7 +1087,7 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>“&#160;‘If you sell anything to your neighbor, or buy from your neighbor, you shall not wrong one another. 
 <sup>15&#160;</sup>According to the number of years after the Jubilee you shall buy from your neighbor. According to the number of years of the crops he shall sell to you. 
 <sup>16&#160;</sup>According to the length of the years you shall increase its price, and according to the shortness of the years you shall diminish its price; for he is selling the number of the crops to you. 
-<sup>17&#160;</sup>You shall not wrong one another, but you shall fear your Elohim; for I am Yahweh your Elohim. 
+<sup>17&#160;</sup>You shall not wrong one another, but you shall fear your Elohim; for I am Yahuah your Elohim. 
 </p><p>
 <sup>18&#160;</sup>“&#160;‘Therefore you shall do my statutes, and keep my ordinances and do them; and you shall dwell in the land in safety. 
 <sup>19&#160;</sup>The land shall yield its fruit, and you shall eat your fill, and dwell therein in safety. 
@@ -1114,7 +1114,7 @@ html[dir=ltr] .q2 {
 <sup>35&#160;</sup>“&#160;‘If your brother has become poor, and his hand can’t support himself among you, then you shall uphold him. He shall live with you like an alien and a temporary resident. 
 <sup>36&#160;</sup>Take no interest from him or profit; but fear your Elohim, that your brother may live among you. 
 <sup>37&#160;</sup>You shall not lend him your money at interest, nor give him your food for profit. 
-<sup>38&#160;</sup>I am Yahweh your Elohim, who brought you out of the land of Egypt, to give you the land of Canaan, and to be your Elohim. 
+<sup>38&#160;</sup>I am Yahuah your Elohim, who brought you out of the land of Egypt, to give you the land of Canaan, and to be your Elohim. 
 </p><p>
 <sup>39&#160;</sup>“&#160;‘If your brother has grown poor among you, and sells himself to you, you shall not make him to serve as a slave. 
 <sup>40&#160;</sup>As a hired servant, and as a temporary resident, he shall be with you; he shall serve with you until the Year of Jubilee. 
@@ -1134,12 +1134,12 @@ html[dir=ltr] .q2 {
 <sup>52&#160;</sup>If there remain but a few years to the year of jubilee, then he shall reckon with him; according to his years of service he shall give back the price of his redemption. 
 <sup>53&#160;</sup>As a servant hired year by year shall he be with him. He shall not rule with harshness over him in your sight. 
 <sup>54&#160;</sup>If he isn’t redeemed by these means, then he shall be released in the Year of Jubilee: he and his children with him. 
-<sup>55&#160;</sup>For to me the children of Israel are servants; they are my servants whom I brought out of the land of Egypt. I am Yahweh your Elohim. 
+<sup>55&#160;</sup>For to me the children of Israel are servants; they are my servants whom I brought out of the land of Egypt. I am Yahuah your Elohim. 
 </p><h2 class="chapterlabel" id="26">26</h2>
 <p>
-<sup>1&#160;</sup>“&#160;‘You shall make for yourselves no idols, and you shall not raise up a carved image or a pillar, and you shall not place any figured stone in your land, to bow down to it; for I am Yahweh your Elohim. 
+<sup>1&#160;</sup>“&#160;‘You shall make for yourselves no idols, and you shall not raise up a carved image or a pillar, and you shall not place any figured stone in your land, to bow down to it; for I am Yahuah your Elohim. 
 </p><p>
-<sup>2&#160;</sup>“&#160;‘You shall keep my Sabbaths, and have reverence for my sanctuary. I am Yahweh. 
+<sup>2&#160;</sup>“&#160;‘You shall keep my Sabbaths, and have reverence for my sanctuary. I am Yahuah. 
 </p><p>
 <sup>3&#160;</sup>“&#160;‘If you walk in my statutes and keep my commandments, and do them, 
 <sup>4&#160;</sup>then I will give you your rains in their season, and the land shall yield its increase, and the trees of the field shall yield their fruit. 
@@ -1153,7 +1153,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>You shall eat old supplies long kept, and you shall move out the old because of the new. 
 <sup>11&#160;</sup>I will set my tent among you, and my soul won’t abhor you. 
 <sup>12&#160;</sup>I will walk among you, and will be your Elohim, and you will be my people. 
-<sup>13&#160;</sup>I am Yahweh your Elohim, who brought you out of the land of Egypt, that you should not be their slaves. I have broken the bars of your yoke, and made you walk upright. 
+<sup>13&#160;</sup>I am Yahuah your Elohim, who brought you out of the land of Egypt, that you should not be their slaves. I have broken the bars of your yoke, and made you walk upright. 
 </p><p>
 <sup>14&#160;</sup>“&#160;‘But if you will not listen to me, and will not do all these commandments, 
 <sup>15&#160;</sup>and if you shall reject my statutes, and if your soul abhors my ordinances, so that you will not do all my commandments, but break my covenant, 
@@ -1191,14 +1191,14 @@ html[dir=ltr] .q2 {
 <sup>41&#160;</sup>I also walked contrary to them, and brought them into the land of their enemies; if then their uncircumcised heart is humbled, and they then accept the punishment of their iniquity, 
 <sup>42&#160;</sup>then I will remember my covenant with Jacob, my covenant with Isaac, and also my covenant with Abraham; and I will remember the land. 
 <sup>43&#160;</sup>The land also will be left by them, and will enjoy its Sabbaths while it lies desolate without them; and they will accept the punishment of their iniquity because they rejected my ordinances, and their soul abhorred my statutes. 
-<sup>44&#160;</sup>Yet for all that, when they are in the land of their enemies, I will not reject them, neither will I abhor them, to destroy them utterly and to break my covenant with them; for I am Yahweh their Elohim. 
-<sup>45&#160;</sup>But I will for their sake remember the covenant of their ancestors, whom I brought out of the land of Egypt in the sight of the nations, that I might be their Elohim. I am Yahweh.’&#160;” 
+<sup>44&#160;</sup>Yet for all that, when they are in the land of their enemies, I will not reject them, neither will I abhor them, to destroy them utterly and to break my covenant with them; for I am Yahuah their Elohim. 
+<sup>45&#160;</sup>But I will for their sake remember the covenant of their ancestors, whom I brought out of the land of Egypt in the sight of the nations, that I might be their Elohim. I am Yahuah.’&#160;” 
 </p><p>
-<sup>46&#160;</sup>These are the statutes, ordinances, and laws, which Yahweh made between him and the children of Israel in Mount Sinai by Moses. 
+<sup>46&#160;</sup>These are the statutes, ordinances, and laws, which Yahuah made between him and the children of Israel in Mount Sinai by Moses. 
 </p><h2 class="chapterlabel" id="27">27</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>2&#160;</sup>“Speak to the children of Israel, and say to them, ‘When a man consecrates a person to Yahweh in a vow, according to your valuation, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and say to them, ‘When a man consecrates a person to Yahuah in a vow, according to your valuation, 
 <sup>3&#160;</sup>your valuation of a male from twenty years old to sixty years old shall be fifty shekels of silver, according to the shekel of the sanctuary. 
 <sup>4&#160;</sup>If she is a female, then your valuation shall be thirty shekels. 
 <sup>5&#160;</sup>If the person is from five years old to twenty years old, then your valuation shall be for a male twenty shekels, and for a female ten shekels. 
@@ -1206,37 +1206,37 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>If the person is from sixty years old and upward; if he is a male, then your valuation shall be fifteen shekels, and for a female ten shekels. 
 <sup>8&#160;</sup>But if he is poorer than your valuation, then he shall be set before the priest, and the priest shall assign a value to him. The priest shall assign a value according to his ability to pay. 
 </p><p>
-<sup>9&#160;</sup>“&#160;‘If it is an animal of which men offer an offering to Yahweh, all that any man gives of such to Yahweh becomes set-apart. 
+<sup>9&#160;</sup>“&#160;‘If it is an animal of which men offer an offering to Yahuah, all that any man gives of such to Yahuah becomes set-apart. 
 <sup>10&#160;</sup>He shall not alter it, nor exchange it, a good for a bad, or a bad for a good. If he shall at all exchange animal for animal, then both it and that for which it is exchanged shall be set-apart. 
-<sup>11&#160;</sup>If it is any unclean animal, of which they do not offer as an offering to Yahweh, then he shall set the animal before the priest; 
+<sup>11&#160;</sup>If it is any unclean animal, of which they do not offer as an offering to Yahuah, then he shall set the animal before the priest; 
 <sup>12&#160;</sup>and the priest shall evaluate it, whether it is good or bad. As the priest evaluates it, so it shall be. 
 <sup>13&#160;</sup>But if he will indeed redeem it, then he shall add the fifth part of it to its valuation. 
 </p><p>
-<sup>14&#160;</sup>“&#160;‘When a man dedicates his house to be set-apart to Yahweh, then the priest shall evaluate it, whether it is good or bad. As the priest evaluates it, so it shall stand. 
+<sup>14&#160;</sup>“&#160;‘When a man dedicates his house to be set-apart to Yahuah, then the priest shall evaluate it, whether it is good or bad. As the priest evaluates it, so it shall stand. 
 <sup>15&#160;</sup>If he who dedicates it will redeem his house, then he shall add the fifth part of the money of your valuation to it, and it shall be his. 
 </p><p>
-<sup>16&#160;</sup>“&#160;‘If a man dedicates to Yahweh part of the field of his possession, then your valuation shall be according to the seed for it. The sowing of a homer of barley shall be valued at fifty shekels of silver. 
+<sup>16&#160;</sup>“&#160;‘If a man dedicates to Yahuah part of the field of his possession, then your valuation shall be according to the seed for it. The sowing of a homer of barley shall be valued at fifty shekels of silver. 
 <sup>17&#160;</sup>If he dedicates his field from the Year of Jubilee, according to your valuation it shall stand. 
 <sup>18&#160;</sup>But if he dedicates his field after the Jubilee, then the priest shall reckon to him the money according to the years that remain to the Year of Jubilee; and an abatement shall be made from your valuation. 
 <sup>19&#160;</sup>If he who dedicated the field will indeed redeem it, then he shall add the fifth part of the money of your valuation to it, and it shall remain his. 
 <sup>20&#160;</sup>If he will not redeem the field, or if he has sold the field to another man, it shall not be redeemed any more; 
-<sup>21&#160;</sup>but the field, when it goes out in the Jubilee, shall be set-apart to Yahweh, as a devoted field. It shall be owned by the priests. 
+<sup>21&#160;</sup>but the field, when it goes out in the Jubilee, shall be set-apart to Yahuah, as a devoted field. It shall be owned by the priests. 
 </p><p>
-<sup>22&#160;</sup>“&#160;‘If he dedicates a field to Yahweh which he has bought, which is not of the field of his possession, 
-<sup>23&#160;</sup>then the priest shall reckon to him the worth of your valuation up to the Year of Jubilee; and he shall give your valuation on that day, as a set-apart thing to Yahweh. 
+<sup>22&#160;</sup>“&#160;‘If he dedicates a field to Yahuah which he has bought, which is not of the field of his possession, 
+<sup>23&#160;</sup>then the priest shall reckon to him the worth of your valuation up to the Year of Jubilee; and he shall give your valuation on that day, as a set-apart thing to Yahuah. 
 <sup>24&#160;</sup>In the Year of Jubilee the field shall return to him from whom it was bought, even to him to whom the possession of the land belongs. 
 <sup>25&#160;</sup>All your valuations shall be according to the shekel of the sanctuary: twenty gerahs to the shekel. 
 </p><p>
-<sup>26&#160;</sup>“&#160;‘However the firstborn among animals, which belongs to Yahweh as a firstborn, no man may dedicate, whether an ox or a sheep. It is Yahweh’s. 
+<sup>26&#160;</sup>“&#160;‘However the firstborn among animals, which belongs to Yahuah as a firstborn, no man may dedicate, whether an ox or a sheep. It is Yahuah’s. 
 <sup>27&#160;</sup>If it is an unclean animal, then he shall buy it back according to your valuation, and shall add to it the fifth part of it; or if it isn’t redeemed, then it shall be sold according to your valuation. 
 </p><p>
-<sup>28&#160;</sup>“&#160;‘Notwithstanding, no devoted thing that a man devotes to Yahweh of all that he has, whether of man or animal, or of the field of his possession, shall be sold or redeemed. Everything that is permanently devoted is most set-apart to Yahweh. 
+<sup>28&#160;</sup>“&#160;‘Notwithstanding, no devoted thing that a man devotes to Yahuah of all that he has, whether of man or animal, or of the field of his possession, shall be sold or redeemed. Everything that is permanently devoted is most set-apart to Yahuah. 
 </p><p>
 <sup>29&#160;</sup>“&#160;‘No one devoted to destruction, who shall be devoted from among men, shall be ransomed. He shall surely be put to death. 
 </p><p>
-<sup>30&#160;</sup>“&#160;‘All the tithe of the land, whether of the seed of the land or of the fruit of the trees, is Yahweh’s. It is set-apart to Yahweh. 
+<sup>30&#160;</sup>“&#160;‘All the tithe of the land, whether of the seed of the land or of the fruit of the trees, is Yahuah’s. It is set-apart to Yahuah. 
 <sup>31&#160;</sup>If a man redeems anything of his tithe, he shall add a fifth part to it. 
-<sup>32&#160;</sup>All the tithe of the herds or the flocks, whatever passes under the rod, the tenth shall be set-apart to Yahweh. 
+<sup>32&#160;</sup>All the tithe of the herds or the flocks, whatever passes under the rod, the tenth shall be set-apart to Yahuah. 
 <sup>33&#160;</sup>He shall not examine whether it is good or bad, neither shall he exchange it. If he exchanges it at all, then both it and that for which it is exchanged shall be set-apart. It shall not be redeemed.’&#160;” 
 </p><p>
-<sup>34&#160;</sup>These are the commandments which Yahweh commanded Moses for the children of Israel on Mount Sinai. </p></div><script src="../main.js"></script></body></html>
+<sup>34&#160;</sup>These are the commandments which Yahuah commanded Moses for the children of Israel on Mount Sinai. </p></div><script src="../main.js"></script></body></html>

--- a/book/malachi.html
+++ b/book/malachi.html
@@ -63,81 +63,81 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>A revelation, Yahweh’s word to Israel by Malachi. 
+<sup>1&#160;</sup>A revelation, Yahuah’s word to Israel by Malachi. 
 </p><p>
-<sup>2&#160;</sup>“I have loved you,” says Yahweh. 
+<sup>2&#160;</sup>“I have loved you,” says Yahuah. 
 </p><p>Yet you say, “How have you loved us?” 
-</p><p>“Wasn’t Esau Jacob’s brother?” says Yahweh, “Yet I loved Jacob; 
+</p><p>“Wasn’t Esau Jacob’s brother?” says Yahuah, “Yet I loved Jacob; 
 <sup>3&#160;</sup>but Esau I hated, and made his mountains a desolation, and gave his heritage to the jackals of the wilderness.” 
-<sup>4&#160;</sup>Whereas Edom says, “We are beaten down, but we will return and build the waste places,” Yahweh of Armies says, “They shall build, but I will throw down; and men will call them ‘The Wicked Land,’ even the people against whom Yahweh shows wrath forever.” 
+<sup>4&#160;</sup>Whereas Edom says, “We are beaten down, but we will return and build the waste places,” Yahuah of Armies says, “They shall build, but I will throw down; and men will call them ‘The Wicked Land,’ even the people against whom Yahuah shows wrath forever.” 
 </p><p>
-<sup>5&#160;</sup>Your eyes will see, and you will say, “Yahweh is great—even beyond the border of Israel!” 
+<sup>5&#160;</sup>Your eyes will see, and you will say, “Yahuah is great—even beyond the border of Israel!” 
 </p><p>
-<sup>6&#160;</sup>“A son honors his father, and a servant his master. If I am a father, then where is my honor? And if I am a master, where is the respect due me?” says Yahweh of Armies to you priests who despise my name. “You say, ‘How have we despised your name?’ 
-<sup>7&#160;</sup>You offer polluted bread on my altar. You say, ‘How have we polluted you?’ In that you say, ‘Yahweh’s table is contemptible.’ 
-<sup>8&#160;</sup>When you offer the blind for sacrifice, isn’t that evil? And when you offer the lame and sick, isn’t that evil? Present it now to your governor! Will he be pleased with you? Or will he accept your person?” says Yahweh of Armies. 
+<sup>6&#160;</sup>“A son honors his father, and a servant his master. If I am a father, then where is my honor? And if I am a master, where is the respect due me?” says Yahuah of Armies to you priests who despise my name. “You say, ‘How have we despised your name?’ 
+<sup>7&#160;</sup>You offer polluted bread on my altar. You say, ‘How have we polluted you?’ In that you say, ‘Yahuah’s table is contemptible.’ 
+<sup>8&#160;</sup>When you offer the blind for sacrifice, isn’t that evil? And when you offer the lame and sick, isn’t that evil? Present it now to your governor! Will he be pleased with you? Or will he accept your person?” says Yahuah of Armies. 
 </p><p>
-<sup>9&#160;</sup>“Now, please entreat the favor of Elohim, that he may be gracious to us. With this, will he accept any of you?” says Yahweh of Armies. 
+<sup>9&#160;</sup>“Now, please entreat the favor of Elohim, that he may be gracious to us. With this, will he accept any of you?” says Yahuah of Armies. 
 </p><p>
-<sup>10&#160;</sup>“Oh that there were one among you who would shut the doors, that you might not kindle fire on my altar in vain! I have no pleasure in you,” says Yahweh of Armies, “neither will I accept an offering at your hand. 
-<sup>11&#160;</sup>For from the rising of the sun even to its going down, my name is great among the nations, and in every place incense will be offered to my name, and a pure offering; for my name is great among the nations,” says Yahweh of Armies. 
-<sup>12&#160;</sup>“But you profane it when you say, ‘Yahweh’s table is polluted, and its fruit, even its food, is contemptible.’ 
-<sup>13&#160;</sup>You say also, ‘Behold, what a weariness it is!’ And you have sniffed at it”, says Yahweh of Armies; “and you have brought that which was taken by violence, the lame, and the sick; thus you bring the offering. Should I accept this at your hand?” says Yahweh. 
+<sup>10&#160;</sup>“Oh that there were one among you who would shut the doors, that you might not kindle fire on my altar in vain! I have no pleasure in you,” says Yahuah of Armies, “neither will I accept an offering at your hand. 
+<sup>11&#160;</sup>For from the rising of the sun even to its going down, my name is great among the nations, and in every place incense will be offered to my name, and a pure offering; for my name is great among the nations,” says Yahuah of Armies. 
+<sup>12&#160;</sup>“But you profane it when you say, ‘Yahuah’s table is polluted, and its fruit, even its food, is contemptible.’ 
+<sup>13&#160;</sup>You say also, ‘Behold, what a weariness it is!’ And you have sniffed at it”, says Yahuah of Armies; “and you have brought that which was taken by violence, the lame, and the sick; thus you bring the offering. Should I accept this at your hand?” says Yahuah. 
 </p><p>
-<sup>14&#160;</sup>“But the deceiver is cursed who has in his flock a male, and vows and sacrifices to the Lord a defective thing; for I am a great King,” says Yahweh of Armies, “and my name is awesome among the nations.” 
+<sup>14&#160;</sup>“But the deceiver is cursed who has in his flock a male, and vows and sacrifices to the Lord a defective thing; for I am a great King,” says Yahuah of Armies, “and my name is awesome among the nations.” 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
 <sup>1&#160;</sup>“Now, you priests, this commandment is for you. 
-<sup>2&#160;</sup>If you will not listen, and if you will not take it to heart, to give glory to my name,” says Yahweh of Armies, “then I will send the curse on you, and I will curse your blessings. Indeed, I have cursed them already, because you do not take it to heart. 
+<sup>2&#160;</sup>If you will not listen, and if you will not take it to heart, to give glory to my name,” says Yahuah of Armies, “then I will send the curse on you, and I will curse your blessings. Indeed, I have cursed them already, because you do not take it to heart. 
 <sup>3&#160;</sup>Behold, I will rebuke your offspring, and will spread dung on your faces, even the dung of your feasts; and you will be taken away with it. 
-<sup>4&#160;</sup>You will know that I have sent this commandment to you, that my covenant may be with Levi,” says Yahweh of Armies. 
+<sup>4&#160;</sup>You will know that I have sent this commandment to you, that my covenant may be with Levi,” says Yahuah of Armies. 
 <sup>5&#160;</sup>“My covenant was with him of life and peace; and I gave them to him that he might be reverent toward me; and he was reverent toward me, and stood in awe of my name. 
 <sup>6&#160;</sup>The law of truth was in his mouth, and unrighteousness was not found in his lips. He walked with me in peace and uprightness, and turned many away from iniquity. 
-<sup>7&#160;</sup>For the priest’s lips should keep knowledge, and they should seek the law at his mouth; for he is the messenger of Yahweh of Armies. 
-<sup>8&#160;</sup>But you have turned away from the path. You have caused many to stumble in the law. You have corrupted the covenant of Levi,” says Yahweh of Armies. 
+<sup>7&#160;</sup>For the priest’s lips should keep knowledge, and they should seek the law at his mouth; for he is the messenger of Yahuah of Armies. 
+<sup>8&#160;</sup>But you have turned away from the path. You have caused many to stumble in the law. You have corrupted the covenant of Levi,” says Yahuah of Armies. 
 <sup>9&#160;</sup>“Therefore I have also made you contemptible and wicked before all the people, according to the way you have not kept my ways, but have had respect for persons in the law. 
 <sup>10&#160;</sup>Don’t we all have one father? Hasn’t one Elohim created us? Why do we deal treacherously every man against his brother, profaning the covenant of our fathers? 
-<sup>11&#160;</sup>Judah has dealt treacherously, and an abomination is committed in Israel and in Jerusalem; for Judah has profaned the set-apartness of Yahweh which he loves, and has owned the daughter of a foreign elohim. 
-<sup>12&#160;</sup>Yahweh will cut off the man who does this, him who wakes and him who answers, out of the tents of Jacob and him who offers an offering to Yahweh of Armies. 
+<sup>11&#160;</sup>Judah has dealt treacherously, and an abomination is committed in Israel and in Jerusalem; for Judah has profaned the set-apartness of Yahuah which he loves, and has owned the daughter of a foreign elohim. 
+<sup>12&#160;</sup>Yahuah will cut off the man who does this, him who wakes and him who answers, out of the tents of Jacob and him who offers an offering to Yahuah of Armies. 
 </p><p>
-<sup>13&#160;</sup>“This again you do: you cover Yahweh’s altar with tears, with weeping, and with sighing, because he doesn’t regard the offering any more, neither receives it with good will at your hand. 
-<sup>14&#160;</sup>Yet you say, ‘Why?’ Because Yahweh has been witness between you and the woman of your youth, against whom you have dealt treacherously, though she is your companion and the woman of your covenant. 
+<sup>13&#160;</sup>“This again you do: you cover Yahuah’s altar with tears, with weeping, and with sighing, because he doesn’t regard the offering any more, neither receives it with good will at your hand. 
+<sup>14&#160;</sup>Yet you say, ‘Why?’ Because Yahuah has been witness between you and the woman of your youth, against whom you have dealt treacherously, though she is your companion and the woman of your covenant. 
 <sup>15&#160;</sup>Did he not make you one, although he had the residue of the Spirit? Why one? He sought elohimly offspring. Therefore take heed to your spirit, and let no one deal treacherously against the woman of his youth. 
-<sup>16&#160;</sup>One who hates and divorces”, says Yahweh, the Elohim of Israel, “covers his garment with violence!” says Yahweh of Armies. “Therefore pay attention to your spirit, that you don’t be unfaithful. 
+<sup>16&#160;</sup>One who hates and divorces”, says Yahuah, the Elohim of Israel, “covers his garment with violence!” says Yahuah of Armies. “Therefore pay attention to your spirit, that you don’t be unfaithful. 
 </p><p>
-<sup>17&#160;</sup>You have wearied Yahweh with your words. Yet you say, ‘How have we wearied him?’ In that you say, ‘Everyone who does evil is good in Yahweh’s sight, and he delights in them;’ or ‘Where is the Elohim of justice?’ 
+<sup>17&#160;</sup>You have wearied Yahuah with your words. Yet you say, ‘How have we wearied him?’ In that you say, ‘Everyone who does evil is good in Yahuah’s sight, and he delights in them;’ or ‘Where is the Elohim of justice?’ 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>“Behold, I send my messenger, and he will prepare the way before me! The Lord, whom you seek, will suddenly come to his temple. Behold, the messenger of the covenant, whom you desire, is coming!” says Yahweh of Armies. 
+<sup>1&#160;</sup>“Behold, I send my messenger, and he will prepare the way before me! The Lord, whom you seek, will suddenly come to his temple. Behold, the messenger of the covenant, whom you desire, is coming!” says Yahuah of Armies. 
 <sup>2&#160;</sup>“But who can endure the day of his coming? And who will stand when he appears? For he is like a refiner’s fire, and like launderers’ soap; 
-<sup>3&#160;</sup>and he will sit as a refiner and purifier of silver, and he will purify the sons of Levi, and refine them as gold and silver; and they shall offer to Yahweh offerings in righteousness. 
-<sup>4&#160;</sup>Then the offering of Judah and Jerusalem will be pleasant to Yahweh as in the days of old and as in ancient years. 
+<sup>3&#160;</sup>and he will sit as a refiner and purifier of silver, and he will purify the sons of Levi, and refine them as gold and silver; and they shall offer to Yahuah offerings in righteousness. 
+<sup>4&#160;</sup>Then the offering of Judah and Jerusalem will be pleasant to Yahuah as in the days of old and as in ancient years. 
 </p><p>
-<sup>5&#160;</sup>I will come near to you to judgment. I will be a swift witness against the sorcerers, against the adulterers, against the perjurers, and against those who oppress the hireling in his wages, the widow, and the fatherless, and who deprive the foreigner of justice, and don’t fear me,” says Yahweh of Armies. 
+<sup>5&#160;</sup>I will come near to you to judgment. I will be a swift witness against the sorcerers, against the adulterers, against the perjurers, and against those who oppress the hireling in his wages, the widow, and the fatherless, and who deprive the foreigner of justice, and don’t fear me,” says Yahuah of Armies. 
 </p><p>
-<sup>6&#160;</sup>“For I, Yahweh, don’t change; therefore you, sons of Jacob, are not consumed. 
-<sup>7&#160;</sup>From the days of your fathers you have turned away from my ordinances and have not kept them. Return to me, and I will return to you,” says Yahweh of Armies. “But you say, ‘How shall we return?’ 
+<sup>6&#160;</sup>“For I, Yahuah, don’t change; therefore you, sons of Jacob, are not consumed. 
+<sup>7&#160;</sup>From the days of your fathers you have turned away from my ordinances and have not kept them. Return to me, and I will return to you,” says Yahuah of Armies. “But you say, ‘How shall we return?’ 
 </p><p>
 <sup>8&#160;</sup>Will a man rob Elohim? Yet you rob me! But you say, ‘How have we robbed you?’ In tithes and offerings. 
 <sup>9&#160;</sup>You are cursed with the curse; for you rob me, even this whole nation. 
-<sup>10&#160;</sup>Bring the whole tithe into the storehouse, that there may be food in my house, and test me now in this,” says Yahweh of Armies, “if I will not open you the windows of heaven, and pour you out a blessing, that there will not be enough room for. 
-<sup>11&#160;</sup>I will rebuke the devourer for your sakes, and he shall not destroy the fruits of your ground; neither shall your vine cast its fruit before its time in the field,” says Yahweh of Armies. 
-<sup>12&#160;</sup>“All nations shall call you blessed, for you will be a delightful land,” says Yahweh of Armies. 
+<sup>10&#160;</sup>Bring the whole tithe into the storehouse, that there may be food in my house, and test me now in this,” says Yahuah of Armies, “if I will not open you the windows of heaven, and pour you out a blessing, that there will not be enough room for. 
+<sup>11&#160;</sup>I will rebuke the devourer for your sakes, and he shall not destroy the fruits of your ground; neither shall your vine cast its fruit before its time in the field,” says Yahuah of Armies. 
+<sup>12&#160;</sup>“All nations shall call you blessed, for you will be a delightful land,” says Yahuah of Armies. 
 </p><p>
-<sup>13&#160;</sup>“Your words have been harsh against me,” says Yahweh. “Yet you say, ‘What have we spoken against you?’ 
-<sup>14&#160;</sup>You have said, ‘It is vain to serve Elohim,’ and ‘What profit is it that we have followed his instructions and that we have walked mournfully before Yahweh of Armies? 
+<sup>13&#160;</sup>“Your words have been harsh against me,” says Yahuah. “Yet you say, ‘What have we spoken against you?’ 
+<sup>14&#160;</sup>You have said, ‘It is vain to serve Elohim,’ and ‘What profit is it that we have followed his instructions and that we have walked mournfully before Yahuah of Armies? 
 <sup>15&#160;</sup>Now we call the proud happy; yes, those who work wickedness are built up; yes, they tempt Elohim, and escape.’ 
 </p><p>
-<sup>16&#160;</sup>Then those who feared Yahweh spoke one with another; and Yahweh listened and heard, and a book of memory was written before him for those who feared Yahweh and who honored his name. 
-<sup>17&#160;</sup>They shall be mine,” says Yahweh of Armies, “my own possession in the day that I make. I will spare them, as a man spares his own son who serves him. 
+<sup>16&#160;</sup>Then those who feared Yahuah spoke one with another; and Yahuah listened and heard, and a book of memory was written before him for those who feared Yahuah and who honored his name. 
+<sup>17&#160;</sup>They shall be mine,” says Yahuah of Armies, “my own possession in the day that I make. I will spare them, as a man spares his own son who serves him. 
 <sup>18&#160;</sup>Then you shall return and discern between the righteous and the wicked, between him who serves Elohim and him who doesn’t serve him. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>“For behold, the day comes, burning like a furnace, when all the proud and all who work wickedness will be stubble. The day that comes will burn them up,” says Yahweh of Armies, “so that it will leave them neither root nor branch. 
+<sup>1&#160;</sup>“For behold, the day comes, burning like a furnace, when all the proud and all who work wickedness will be stubble. The day that comes will burn them up,” says Yahuah of Armies, “so that it will leave them neither root nor branch. 
 <sup>2&#160;</sup>But to you who fear my name shall the sun of righteousness arise with healing in its wings. You will go out and leap like calves of the stall. 
-<sup>3&#160;</sup>You shall tread down the wicked; for they will be ashes under the soles of your feet in the day that I make,” says Yahweh of Armies. 
+<sup>3&#160;</sup>You shall tread down the wicked; for they will be ashes under the soles of your feet in the day that I make,” says Yahuah of Armies. 
 </p><p>
 <sup>4&#160;</sup>“Remember the law of Moses my servant, which I commanded to him in Horeb for all Israel, even statutes and ordinances. 
 </p><p>
-<sup>5&#160;</sup>Behold, I will send you Elijah the prophet before the great and terrible day of Yahweh comes. 
+<sup>5&#160;</sup>Behold, I will send you Elijah the prophet before the great and terrible day of Yahuah comes. 
 <sup>6&#160;</sup>He will turn the hearts of the fathers to the children and the hearts of the children to their fathers, lest I come and strike the earth with a curse.” </p></div><script src="../main.js"></script></body></html>

--- a/book/matthew.html
+++ b/book/matthew.html
@@ -1531,7 +1531,7 @@ html[dir=ltr] .q2 {
 <sup>62&#160;</sup>The high priest stood up and said to him, “Have you no answer? What is this that these testify against you?” 
 <sup>63&#160;</sup>But Yahushua stayed silent. The high priest answered him, “I adjure you by the living Elohim that you tell us whether you are the Christ, the Son of Elohim.” 
 </p><p>
-<sup>64&#160;</sup>Yahushua said to him, “You have said so. Nevertheless, I tell you, after this you will see the Son of Man sitting at the right hand of Yahweh, and coming on the clouds of the sky.” 
+<sup>64&#160;</sup>Yahushua said to him, “You have said so. Nevertheless, I tell you, after this you will see the Son of Man sitting at the right hand of Yahuah, and coming on the clouds of the sky.” 
 </p><p>
 <sup>65&#160;</sup>Then the high priest tore his clothing, saying, “He has spoken blasphemy! Why do we need any more witnesses? Behold, now you have heard his blasphemy. 
 <sup>66&#160;</sup>What do you think?” 

--- a/book/micah.html
+++ b/book/micah.html
@@ -66,14 +66,14 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>Yahweh’s word that came to Micah of Morasheth in the days of Jotham, Ahaz, and Hezekiah, kings of Judah, which he saw concerning Samaria and Jerusalem. 
+<sup>1&#160;</sup>Yahuah’s word that came to Micah of Morasheth in the days of Jotham, Ahaz, and Hezekiah, kings of Judah, which he saw concerning Samaria and Jerusalem. 
 </p><p class="q1">
 <sup>2&#160;</sup>Hear, you peoples, all of you! 
 </p><p class="q2">Listen, O earth, and all that is therein. 
-</p><p class="q1">Let the Lord Yahweh be witness against you, 
+</p><p class="q1">Let the Lord Yahuah be witness against you, 
 </p><p class="q2">the Lord from his set-apart temple. 
 </p><p class="q1">
-<sup>3&#160;</sup>For behold, Yahweh comes out of his place, 
+<sup>3&#160;</sup>For behold, Yahuah comes out of his place, 
 </p><p class="q2">and will come down and tread on the high places of the earth. 
 </p><p class="q1">
 <sup>4&#160;</sup>The mountains melt under him, 
@@ -119,7 +119,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">The wailing of Beth Ezel will take from you his protection. 
 </p><p class="q1">
 <sup>12&#160;</sup>For the inhabitant of Maroth waits anxiously for good, 
-</p><p class="q2">because evil has come down from Yahweh to the gate of Jerusalem. 
+</p><p class="q2">because evil has come down from Yahuah to the gate of Jerusalem. 
 </p><p class="q1">
 <sup>13&#160;</sup>Harness the chariot to the swift steed, inhabitant of Lachish. 
 </p><p class="q2">She was the beginning of sin to the daughter of Zion; 
@@ -148,7 +148,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">They oppress a man and his house, 
 </p><p class="q2">even a man and his heritage. 
 </p><p class="q1">
-<sup>3&#160;</sup>Therefore Yahweh says: 
+<sup>3&#160;</sup>Therefore Yahuah says: 
 </p><p class="q1">“Behold, I am planning against these people a disaster, 
 </p><p class="q2">from which you will not remove your necks, 
 </p><p class="q2">neither will you walk haughtily, 
@@ -160,13 +160,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">My people’s possession is divided up. 
 </p><p class="q2">Indeed he takes it from me and assigns our fields to traitors!’&#160;” 
 </p><p class="q1">
-<sup>5&#160;</sup>Therefore you will have no one who divides the land by lot in Yahweh’s assembly. 
+<sup>5&#160;</sup>Therefore you will have no one who divides the land by lot in Yahuah’s assembly. 
 </p><p class="q1">
 <sup>6&#160;</sup>“Don’t prophesy!”—they prophesy—</p><p class="q2">“Don’t prophesy about these things. 
 </p><p class="q2">Disgrace won’t overtake us.” 
 </p><p class="q1">
 <sup>7&#160;</sup>Shall it be said, O house of Jacob, 
-</p><p class="q2">“Is Yahweh’s Spirit angry? 
+</p><p class="q2">“Is Yahuah’s Spirit angry? 
 </p><p class="q2">Are these his doings? 
 </p><p class="q2">Don’t my words do good to him who walks blamelessly?” 
 </p><p class="q1">
@@ -194,7 +194,7 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>He who breaks open the way goes up before them. 
 </p><p class="q2">They break through the gate, and go out. 
 </p><p class="q2">Their king passes on before them, 
-</p><p class="q2">with Yahweh at their head. 
+</p><p class="q2">with Yahuah at their head. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
 <sup>1&#160;</sup>I said, 
@@ -213,12 +213,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and chop them in pieces, as for the pot, 
 </p><p class="q2">and as meat within the cauldron. 
 </p><p class="q1">
-<sup>4&#160;</sup>Then they will cry to Yahweh, 
+<sup>4&#160;</sup>Then they will cry to Yahuah, 
 </p><p class="q2">but he will not answer them. 
 </p><p class="q1">Yes, he will hide his face from them at that time, 
 </p><p class="q2">because they made their deeds evil.” 
 </p><p>
-<sup>5&#160;</sup>Yahweh says concerning the prophets who lead my people astray—for those who feed their teeth, they proclaim, “Peace!” and whoever doesn’t provide for their mouths, they prepare war against him: 
+<sup>5&#160;</sup>Yahuah says concerning the prophets who lead my people astray—for those who feed their teeth, they proclaim, “Peace!” and whoever doesn’t provide for their mouths, they prepare war against him: 
 </p><p class="q1">
 <sup>6&#160;</sup>“Therefore night is over you, with no vision, 
 </p><p class="q2">and it is dark to you, that you may not divine; 
@@ -230,7 +230,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Yes, they shall all cover their lips, 
 </p><p class="q2">for there is no answer from Elohim.” 
 </p><p class="q1">
-<sup>8&#160;</sup>But as for me, I am full of power by Yahweh’s Spirit, 
+<sup>8&#160;</sup>But as for me, I am full of power by Yahuah’s Spirit, 
 </p><p class="q2">and of judgment, and of might, 
 </p><p class="q2">to declare to Jacob his disobedience, 
 </p><p class="q2">and to Israel his sin. 
@@ -246,8 +246,8 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>Her leaders judge for bribes, 
 </p><p class="q2">and her priests teach for a price, 
 </p><p class="q2">and her prophets of it tell fortunes for money; 
-</p><p class="q1">yet they lean on Yahweh, and say, 
-</p><p class="q2">“Isn’t Yahweh among us? 
+</p><p class="q1">yet they lean on Yahuah, and say, 
+</p><p class="q2">“Isn’t Yahuah among us? 
 </p><p class="q2">No disaster will come on us.” 
 </p><p class="q1">
 <sup>12&#160;</sup>Therefore Zion for your sake will be plowed like a field, 
@@ -257,17 +257,17 @@ html[dir=ltr] .q2 {
 <h2 class="chapterlabel" id="4">4</h2>
 <p class="q1">
 <sup>1&#160;</sup>But in the latter days, 
-</p><p class="q2">it will happen that the mountain of Yahweh’s temple will be established on the top of the mountains, 
+</p><p class="q2">it will happen that the mountain of Yahuah’s temple will be established on the top of the mountains, 
 </p><p class="q2">and it will be exalted above the hills; 
 </p><p class="q2">and peoples will stream to it. 
 </p><p class="q1">
 <sup>2&#160;</sup>Many nations will go and say, 
-</p><p class="q2">“Come! Let’s go up to the mountain of Yahweh, 
+</p><p class="q2">“Come! Let’s go up to the mountain of Yahuah, 
 </p><p class="q2">and to the house of the Elohim of Jacob; 
 </p><p class="q2">and he will teach us of his ways, 
 </p><p class="q2">and we will walk in his paths.” 
 </p><p class="q1">For the law will go out of Zion, 
-</p><p class="q2">and Yahweh’s word from Jerusalem; 
+</p><p class="q2">and Yahuah’s word from Jerusalem; 
 </p><p class="q1">
 <sup>3&#160;</sup>and he will judge between many peoples, 
 </p><p class="q2">and will decide concerning strong nations afar off. 
@@ -278,18 +278,18 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>4&#160;</sup>But every man will sit under his vine and under his fig tree. 
 </p><p class="q2">No one will make them afraid, 
-</p><p class="q2">for the mouth of Yahweh of Armies has spoken. 
+</p><p class="q2">for the mouth of Yahuah of Armies has spoken. 
 <sup>5&#160;</sup>Indeed all the nations may walk in the name of their elohims, 
-</p><p class="q2">but we will walk in the name of Yahweh our Elohim forever and ever. 
+</p><p class="q2">but we will walk in the name of Yahuah our Elohim forever and ever. 
 </p><p class="q1">
-<sup>6&#160;</sup>“In that day,” says Yahweh, 
+<sup>6&#160;</sup>“In that day,” says Yahuah, 
 </p><p class="q2">“I will assemble that which is lame, 
 </p><p class="q2">and I will gather that which is driven away, 
 </p><p class="q2">and that which I have afflicted; 
 </p><p class="q2">
 <sup>7&#160;</sup>and I will make that which was lame a remnant, 
 </p><p class="q2">and that which was cast far off a strong nation: 
-</p><p class="q2">and Yahweh will reign over them on Mount Zion from then on, even forever.” 
+</p><p class="q2">and Yahuah will reign over them on Mount Zion from then on, even forever.” 
 </p><p class="q1">
 <sup>8&#160;</sup>You, tower of the flock, the hill of the daughter of Zion, 
 </p><p class="q2">to you it will come. 
@@ -308,14 +308,14 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will dwell in the field, 
 </p><p class="q2">and will come even to Babylon. 
 </p><p class="q1">There you will be rescued. 
-</p><p class="q2">There Yahweh will redeem you from the hand of your enemies. 
+</p><p class="q2">There Yahuah will redeem you from the hand of your enemies. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>11&#160;</sup>Now many nations have assembled against you, that say, 
 </p><p class="q2">“Let her be defiled, 
 </p><p class="q2">and let our eye gloat over Zion.” 
 </p><p class="q1">
-<sup>12&#160;</sup>But they don’t know the thoughts of Yahweh, 
+<sup>12&#160;</sup>But they don’t know the thoughts of Yahuah, 
 </p><p class="q2">neither do they understand his counsel; 
 </p><p class="q2">for he has gathered them like the sheaves to the threshing floor. 
 </p><p class="q1">
@@ -323,7 +323,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for I will make your horn iron, 
 </p><p class="q2">and I will make your hoofs bronze. 
 </p><p class="q1">You will beat in pieces many peoples. 
-</p><p class="q1">I will devote their gain to Yahweh, 
+</p><p class="q1">I will devote their gain to Yahuah, 
 </p><p class="q2">and their substance to the Lord of the whole earth. 
 </p><p class="b"> &#160; </p>
 <h2 class="chapterlabel" id="5">5</h2>
@@ -341,8 +341,8 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>Therefore he will abandon them until the time that she who is in labor gives birth. 
 </p><p class="q2">Then the rest of his brothers will return to the children of Israel. 
 </p><p class="q1">
-<sup>4&#160;</sup>He shall stand, and shall shepherd in the strength of Yahweh, 
-</p><p class="q2">in the majesty of the name of Yahweh his Elohim. 
+<sup>4&#160;</sup>He shall stand, and shall shepherd in the strength of Yahuah, 
+</p><p class="q2">in the majesty of the name of Yahuah his Elohim. 
 </p><p class="q2">They will live, for then he will be great to the ends of the earth. 
 </p><p class="q1">
 <sup>5&#160;</sup>He will be our peace when Assyria invades our land 
@@ -357,7 +357,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and when he marches within our border. 
 </p><p class="q1">
 <sup>7&#160;</sup>The remnant of Jacob will be among many peoples 
-</p><p class="q2">like dew from Yahweh, 
+</p><p class="q2">like dew from Yahuah, 
 </p><p class="q2">like showers on the grass, 
 </p><p class="q2">that don’t wait for man 
 </p><p class="q2">nor wait for the sons of men. 
@@ -372,7 +372,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Let your hand be lifted up above your adversaries, 
 </p><p class="q2">and let all of your enemies be cut off. 
 </p><p class="q1">
-<sup>10&#160;</sup>“It will happen in that day”, says Yahweh, 
+<sup>10&#160;</sup>“It will happen in that day”, says Yahuah, 
 </p><p class="q2">“that I will cut off your horses from among you 
 </p><p class="q2">and will destroy your chariots. 
 </p><p class="q1">
@@ -392,13 +392,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and wrath on the nations that didn’t listen.” 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>Listen now to what Yahweh says: 
+<sup>1&#160;</sup>Listen now to what Yahuah says: 
 </p><p class="q1">“Arise, plead your case before the mountains, 
 </p><p class="q2">and let the hills hear what you have to say. 
 </p><p class="q1">
-<sup>2&#160;</sup>Hear, you mountains, Yahweh’s indictment, 
+<sup>2&#160;</sup>Hear, you mountains, Yahuah’s indictment, 
 </p><p class="q2">and you enduring foundations of the earth; 
-</p><p class="q2">for Yahweh has a case against his people, 
+</p><p class="q2">for Yahuah has a case against his people, 
 </p><p class="q2">and he will contend with Israel. 
 </p><p class="q1">
 <sup>3&#160;</sup>My people, what have I done to you? 
@@ -411,25 +411,25 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>5&#160;</sup>My people, remember now what Balak king of Moab devised, 
 </p><p class="q2">and what Balaam the son of Beor answered him from Shittim to Gilgal, 
-</p><p class="q2">that you may know the righteous acts of Yahweh.” 
+</p><p class="q2">that you may know the righteous acts of Yahuah.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>6&#160;</sup>How shall I come before Yahweh, 
+<sup>6&#160;</sup>How shall I come before Yahuah, 
 </p><p class="q2">and bow myself before the exalted Elohim? 
 </p><p class="q1">Shall I come before him with burnt offerings, 
 </p><p class="q2">with calves a year old? 
 </p><p class="q1">
-<sup>7&#160;</sup>Will Yahweh be pleased with thousands of rams? 
+<sup>7&#160;</sup>Will Yahuah be pleased with thousands of rams? 
 </p><p class="q2">With tens of thousands of rivers of oil? 
 </p><p class="q1">Shall I give my firstborn for my disobedience? 
 </p><p class="q2">The fruit of my body for the sin of my soul? 
 </p><p class="q1">
 <sup>8&#160;</sup>He has shown you, O man, what is good. 
-</p><p class="q2">What does Yahweh require of you, but to act justly, 
+</p><p class="q2">What does Yahuah require of you, but to act justly, 
 </p><p class="q2">to love mercy, and to walk humbly with your Elohim? 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>9&#160;</sup>Yahweh’s voice calls to the city—</p><p class="q2">and wisdom fears your name—</p><p class="q1">“Listen to the rod, 
+<sup>9&#160;</sup>Yahuah’s voice calls to the city—</p><p class="q2">and wisdom fears your name—</p><p class="q1">“Listen to the rod, 
 </p><p class="q2">and he who appointed it. 
 </p><p class="q1">
 <sup>10&#160;</sup>Are there yet treasures of wickedness in the house of the wicked, 
@@ -494,15 +494,15 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the daughter-in-law against her mother-in-law; 
 </p><p class="q2">a man’s enemies are the men of his own house. 
 </p><p class="q1">
-<sup>7&#160;</sup>But as for me, I will look to Yahweh. 
+<sup>7&#160;</sup>But as for me, I will look to Yahuah. 
 </p><p class="q2">I will wait for the Elohim of my salvation. 
 </p><p class="q2">My Elohim will hear me. 
 </p><p class="q1">
 <sup>8&#160;</sup>Don’t rejoice against me, my enemy. 
 </p><p class="q2">When I fall, I will arise. 
-</p><p class="q2">When I sit in darkness, Yahweh will be a light to me. 
+</p><p class="q2">When I sit in darkness, Yahuah will be a light to me. 
 </p><p class="q1">
-<sup>9&#160;</sup>I will bear the indignation of Yahweh, 
+<sup>9&#160;</sup>I will bear the indignation of Yahuah, 
 </p><p class="q2">because I have sinned against him, 
 </p><p class="q2">until he pleads my case and executes judgment for me. 
 </p><p class="q2">He will bring me out to the light. 
@@ -510,7 +510,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>10&#160;</sup>Then my enemy will see it, 
 </p><p class="q2">and shame will cover her who said to me, 
-</p><p class="q2">“Where is Yahweh your Elohim?” 
+</p><p class="q2">“Where is Yahuah your Elohim?” 
 </p><p class="q1">My eyes will see her. 
 </p><p class="q2">Now she will be trodden down like the mire of the streets. 
 </p><p class="q1">
@@ -540,7 +540,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>17&#160;</sup>They will lick the dust like a serpent. 
 </p><p class="q2">Like crawling things of the earth, they will come trembling out of their dens. 
-</p><p class="q2">They will come with fear to Yahweh our Elohim, 
+</p><p class="q2">They will come with fear to Yahuah our Elohim, 
 </p><p class="q2">and will be afraid because of you. 
 </p><p class="q1">
 <sup>18&#160;</sup>Who is an Elohim like you, who pardons iniquity, 

--- a/book/nahum.html
+++ b/book/nahum.html
@@ -63,28 +63,28 @@ html[dir=ltr] .q2 {
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
 <sup>1&#160;</sup>A revelation about Nineveh. The book of the vision of Nahum the Elkoshite. 
-<sup>2&#160;</sup>Yahweh is a jealous Elohim and avenges. Yahweh avenges and is full of wrath. Yahweh takes vengeance on his adversaries, and he maintains wrath against his enemies. 
-<sup>3&#160;</sup>Yahweh is slow to anger, and great in power, and will by no means leave the guilty unpunished. Yahweh has his way in the whirlwind and in the storm, and the clouds are the dust of his feet. 
+<sup>2&#160;</sup>Yahuah is a jealous Elohim and avenges. Yahuah avenges and is full of wrath. Yahuah takes vengeance on his adversaries, and he maintains wrath against his enemies. 
+<sup>3&#160;</sup>Yahuah is slow to anger, and great in power, and will by no means leave the guilty unpunished. Yahuah has his way in the whirlwind and in the storm, and the clouds are the dust of his feet. 
 <sup>4&#160;</sup>He rebukes the sea and makes it dry, and dries up all the rivers. Bashan and Carmel languish. The flower of Lebanon languishes. 
 <sup>5&#160;</sup>The mountains quake before him, and the hills melt away. The earth trembles at his presence, yes, the world, and all who dwell in it. 
 <sup>6&#160;</sup>Who can stand before his indignation? Who can endure the fierceness of his anger? His wrath is poured out like fire, and the rocks are broken apart by him. 
-<sup>7&#160;</sup>Yahweh is good, a stronghold in the day of trouble; and he knows those who take refuge in him. 
+<sup>7&#160;</sup>Yahuah is good, a stronghold in the day of trouble; and he knows those who take refuge in him. 
 <sup>8&#160;</sup>But with an overflowing flood, he will make a full end of her place, and will pursue his enemies into darkness. 
-<sup>9&#160;</sup>What do you plot against Yahweh? He will make a full end. Affliction won’t rise up the second time. 
+<sup>9&#160;</sup>What do you plot against Yahuah? He will make a full end. Affliction won’t rise up the second time. 
 <sup>10&#160;</sup>For entangled like thorns, and drunken as with their drink, they are consumed utterly like dry stubble. 
-<sup>11&#160;</sup>One has gone out of you who devises evil against Yahweh, who counsels wickedness. 
+<sup>11&#160;</sup>One has gone out of you who devises evil against Yahuah, who counsels wickedness. 
 </p><p>
-<sup>12&#160;</sup>Yahweh says: “Though they are in full strength and likewise many, even so they will be cut down and pass away. Though I have afflicted you, I will afflict you no more. 
+<sup>12&#160;</sup>Yahuah says: “Though they are in full strength and likewise many, even so they will be cut down and pass away. Though I have afflicted you, I will afflict you no more. 
 <sup>13&#160;</sup>Now I will break his yoke from off you, and will burst your bonds apart.” 
 </p><p>
-<sup>14&#160;</sup>Yahweh has commanded concerning you: “No more descendants will bear your name. Out of the house of your elohims, I will cut off the engraved image and the molten image. I will make your grave, for you are vile.” 
+<sup>14&#160;</sup>Yahuah has commanded concerning you: “No more descendants will bear your name. Out of the house of your elohims, I will cut off the engraved image and the molten image. I will make your grave, for you are vile.” 
 </p><p>
 <sup>15&#160;</sup>Behold, on the mountains the feet of him who brings good news, who publishes peace! Keep your feasts, Judah! Perform your vows, for the wicked one will no more pass through you. He is utterly cut off. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
 <sup>1&#160;</sup>He who dashes in pieces has come up against you. Keep the fortress! Watch the way! Strengthen your waist! Fortify your power mightily! 
 </p><p>
-<sup>2&#160;</sup>For Yahweh restores the excellency of Jacob as the excellency of Israel, for the destroyers have destroyed them and ruined their vine branches. 
+<sup>2&#160;</sup>For Yahuah restores the excellency of Jacob as the excellency of Israel, for the destroyers have destroyed them and ruined their vine branches. 
 </p><p>
 <sup>3&#160;</sup>The shield of his mighty men is made red. The valiant men are in scarlet. The chariots flash with steel in the day of his preparation, and the pine spears are brandished. 
 <sup>4&#160;</sup>The chariots rage in the streets. They rush back and forth in the wide ways. Their appearance is like torches. They run like the lightnings. 
@@ -96,14 +96,14 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>She is empty, void, and waste. The heart melts, the knees knock together, their bodies and faces have grown pale. 
 <sup>11&#160;</sup>Where is the den of the lions, and the feeding place of the young lions, where the lion and the lioness walked with the lion’s cubs, and no one made them afraid? 
 <sup>12&#160;</sup>The lion tore in pieces enough for his cubs, and strangled prey for his lionesses, and filled his caves with the kill and his dens with prey. 
-<sup>13&#160;</sup>“Behold, I am against you,” says Yahweh of Armies, “and I will burn her chariots in the smoke, and the sword will devour your young lions; and I will cut off your prey from the earth, and the voice of your messengers will no longer be heard.” 
+<sup>13&#160;</sup>“Behold, I am against you,” says Yahuah of Armies, “and I will burn her chariots in the smoke, and the sword will devour your young lions; and I will cut off your prey from the earth, and the voice of your messengers will no longer be heard.” 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
 <sup>1&#160;</sup>Woe to the bloody city! It is all full of lies and robbery—no end to the prey. 
 <sup>2&#160;</sup>The noise of the whip, the noise of the rattling of wheels, prancing horses, and bounding chariots, 
 <sup>3&#160;</sup>the horseman charging, and the flashing sword, the glittering spear, and a multitude of slain, and a great heap of corpses, and there is no end of the bodies. They stumble on their bodies 
 <sup>4&#160;</sup>because of the multitude of the prostitution of the alluring prostitute, the mistress of witchcraft, who sells nations through her prostitution, and families through her witchcraft. 
-<sup>5&#160;</sup>“Behold, I am against you,” says Yahweh of Armies, “and I will lift your skirts over your face. I will show the nations your nakedness, and the kingdoms your shame. 
+<sup>5&#160;</sup>“Behold, I am against you,” says Yahuah of Armies, “and I will lift your skirts over your face. I will show the nations your nakedness, and the kingdoms your shame. 
 <sup>6&#160;</sup>I will throw abominable filth on you and make you vile, and will make you a spectacle. 
 <sup>7&#160;</sup>It will happen that all those who look at you will flee from you, and say, ‘Nineveh is laid waste! Who will mourn for her?’ Where will I seek comforters for you?” 
 </p><p>

--- a/book/nehemiah.html
+++ b/book/nehemiah.html
@@ -78,7 +78,7 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>They said to me, “The remnant who are left of the captivity there in the province are in great affliction and reproach. The wall of Jerusalem is also broken down, and its gates are burned with fire.” 
 </p><p>
 <sup>4&#160;</sup>When I heard these words, I sat down and wept, and mourned several days; and I fasted and prayed before the Elohim of heaven, 
-<sup>5&#160;</sup>and said, “I beg you, Yahweh, the Elohim of heaven, the great and awesome Elohim who keeps covenant and loving kindness with those who love him and keep his commandments, 
+<sup>5&#160;</sup>and said, “I beg you, Yahuah, the Elohim of heaven, the great and awesome Elohim who keeps covenant and loving kindness with those who love him and keep his commandments, 
 <sup>6&#160;</sup>let your ear now be attentive and your eyes open, that you may listen to the prayer of your servant which I pray before you at this time, day and night, for the children of Israel your servants, while I confess the sins of the children of Israel which we have sinned against you. Yes, I and my father’s house have sinned. 
 <sup>7&#160;</sup>We have dealt very corruptly against you, and have not kept the commandments, nor the statutes, nor the ordinances, which you commanded your servant Moses. 
 </p><p>
@@ -213,7 +213,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Then they said, “We will restore them, and will require nothing of them. We will do so, even as you say.” 
 </p><p>Then I called the priests, and took an oath of them, that they would do according to this promise. 
 <sup>13&#160;</sup>Also I shook out my lap, and said, “So may Elohim shake out every man from his house, and from his labor, that doesn’t perform this promise; even may he be shaken out and emptied like this.” 
-</p><p>All the assembly said, “Amen,” and praised Yahweh. The people did according to this promise. 
+</p><p>All the assembly said, “Amen,” and praised Yahuah. The people did according to this promise. 
 </p><p>
 <sup>14&#160;</sup>Moreover from the time that I was appointed to be their governor in the land of Judah, from the twentieth year even to the thirty-second year of Artaxerxes the king, that is, twelve years, I and my brothers have not eaten the bread of the governor. 
 <sup>15&#160;</sup>But the former governors who were before me were supported by the people, and took bread and wine from them, plus forty shekels of silver; yes, even their servants ruled over the people, but I didn’t do so, because of the fear of Elohim. 
@@ -379,25 +379,25 @@ html[dir=ltr] .q2 {
 </p><p>When the seventh month had come, the children of Israel were in their cities. 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>All the people gathered themselves together as one man into the wide place that was in front of the water gate; and they spoke to Ezra the scribe to bring the book of the law of Moses, which Yahweh had commanded to Israel. 
+<sup>1&#160;</sup>All the people gathered themselves together as one man into the wide place that was in front of the water gate; and they spoke to Ezra the scribe to bring the book of the law of Moses, which Yahuah had commanded to Israel. 
 <sup>2&#160;</sup>Ezra the priest brought the law before the assembly, both men and women, and all who could hear with understanding, on the first day of the seventh month. 
 <sup>3&#160;</sup>He read from it before the wide place that was in front of the water gate from early morning until midday, in the presence of the men and the women, and of those who could understand. The ears of all the people were attentive to the book of the law. 
 <sup>4&#160;</sup>Ezra the scribe stood on a pulpit of wood, which they had made for the purpose; and beside him stood Mattithiah, Shema, Anaiah, Uriah, Hilkiah, and Maaseiah, on his right hand; and on his left hand, Pedaiah, Mishael, Malchijah, Hashum, Hashbaddanah, Zechariah, and Meshullam. 
 <sup>5&#160;</sup>Ezra opened the book in the sight of all the people (for he was above all the people), and when he opened it, all the people stood up. 
-<sup>6&#160;</sup>Then Ezra blessed Yahweh, the great Elohim. 
-</p><p>All the people answered, “Amen, Amen,” with the lifting up of their hands. They bowed their heads, and worshiped Yahweh with their faces to the ground. 
+<sup>6&#160;</sup>Then Ezra blessed Yahuah, the great Elohim. 
+</p><p>All the people answered, “Amen, Amen,” with the lifting up of their hands. They bowed their heads, and worshiped Yahuah with their faces to the ground. 
 <sup>7&#160;</sup>Also Jeshua, Bani, Sherebiah, Jamin, Akkub, Shabbethai, Hodiah, Maaseiah, Kelita, Azariah, Jozabad, Hanan, Pelaiah, and the Levites, caused the people to understand the law; and the people stayed in their place. 
 <sup>8&#160;</sup>They read in the book, in the law of Elohim, distinctly; and they gave the sense, so that they understood the reading. 
 </p><p>
-<sup>9&#160;</sup>Nehemiah, who was the governor, Ezra the priest and scribe, and the Levites who taught the people said to all the people, “Today is set-apart to Yahweh your Elohim. Don’t mourn, nor weep.” For all the people wept when they heard the words of the law. 
-<sup>10&#160;</sup>Then he said to them, “Go your way. Eat the fat, drink the sweet, and send portions to him for whom nothing is prepared, for today is set-apart to our Lord. Don’t be grieved, for the joy of Yahweh is your strength.” 
+<sup>9&#160;</sup>Nehemiah, who was the governor, Ezra the priest and scribe, and the Levites who taught the people said to all the people, “Today is set-apart to Yahuah your Elohim. Don’t mourn, nor weep.” For all the people wept when they heard the words of the law. 
+<sup>10&#160;</sup>Then he said to them, “Go your way. Eat the fat, drink the sweet, and send portions to him for whom nothing is prepared, for today is set-apart to our Lord. Don’t be grieved, for the joy of Yahuah is your strength.” 
 </p><p>
 <sup>11&#160;</sup>So the Levites calmed all the people, saying, “Hold your peace, for the day is set-apart. Don’t be grieved.” 
 </p><p>
 <sup>12&#160;</sup>All the people went their way to eat, to drink, to send portions, and to celebrate, because they had understood the words that were declared to them. 
 </p><p>
 <sup>13&#160;</sup>On the second day, the heads of fathers’ households of all the people, the priests, and the Levites were gathered together to Ezra the scribe, to study the words of the law. 
-<sup>14&#160;</sup>They found written in the law how Yahweh had commanded by Moses that the children of Israel should dwell in booths in the feast of the seventh month; 
+<sup>14&#160;</sup>They found written in the law how Yahuah had commanded by Moses that the children of Israel should dwell in booths in the feast of the seventh month; 
 <sup>15&#160;</sup>and that they should publish and proclaim in all their cities and in Jerusalem, saying, “Go out to the mountain, and get olive branches, branches of wild olive, myrtle branches, palm branches, and branches of thick trees, to make temporary shelters, as it is written.” 
 </p><p>
 <sup>16&#160;</sup>So the people went out and brought them, and made themselves temporary shelters, everyone on the roof of his house, in their courts, in the courts of Elohim’s house, in the wide place of the water gate, and in the wide place of Ephraim’s gate. 
@@ -407,12 +407,12 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Now in the twenty-fourth day of this month the children of Israel were assembled with fasting, with sackcloth, and dirt on them. 
 <sup>2&#160;</sup>The offspring of Israel separated themselves from all foreigners and stood and confessed their sins and the iniquities of their fathers. 
-<sup>3&#160;</sup>They stood up in their place, and read in the book of the law of Yahweh their Elohim a fourth part of the day; and a fourth part they confessed and worshiped Yahweh their Elohim. 
-<sup>4&#160;</sup>Then Jeshua, Bani, Kadmiel, Shebaniah, Bunni, Sherebiah, Bani, and Chenani of the Levites stood up on the stairs, and cried with a loud voice to Yahweh their Elohim. 
+<sup>3&#160;</sup>They stood up in their place, and read in the book of the law of Yahuah their Elohim a fourth part of the day; and a fourth part they confessed and worshiped Yahuah their Elohim. 
+<sup>4&#160;</sup>Then Jeshua, Bani, Kadmiel, Shebaniah, Bunni, Sherebiah, Bani, and Chenani of the Levites stood up on the stairs, and cried with a loud voice to Yahuah their Elohim. 
 </p><p>
-<sup>5&#160;</sup>Then the Levites, Jeshua, and Kadmiel, Bani, Hashabneiah, Sherebiah, Hodiah, Shebaniah, and Pethahiah, said, “Stand up and bless Yahweh your Elohim from everlasting to everlasting! Blessed be your glorious name, which is exalted above all blessing and praise! 
-<sup>6&#160;</sup>You are Yahweh, even you alone. You have made heaven, the heaven of heavens, with all their army, the earth and all things that are on it, the seas and all that is in them, and you preserve them all. The army of heaven worships you. 
-<sup>7&#160;</sup>You are Yahweh, the Elohim who chose Abram, brought him out of Ur of the Chaldees, gave him the name of Abraham, 
+<sup>5&#160;</sup>Then the Levites, Jeshua, and Kadmiel, Bani, Hashabneiah, Sherebiah, Hodiah, Shebaniah, and Pethahiah, said, “Stand up and bless Yahuah your Elohim from everlasting to everlasting! Blessed be your glorious name, which is exalted above all blessing and praise! 
+<sup>6&#160;</sup>You are Yahuah, even you alone. You have made heaven, the heaven of heavens, with all their army, the earth and all things that are on it, the seas and all that is in them, and you preserve them all. The army of heaven worships you. 
+<sup>7&#160;</sup>You are Yahuah, the Elohim who chose Abram, brought him out of Ur of the Chaldees, gave him the name of Abraham, 
 <sup>8&#160;</sup>found his heart faithful before you, and made a covenant with him to give the land of the Canaanite, the Hittite, the Amorite, the Perizzite, the Jebusite, and the Girgashite, to give it to his offspring, and have performed your words, for you are righteous. 
 </p><p>
 <sup>9&#160;</sup>“You saw the affliction of our fathers in Egypt, and heard their cry by the Red Sea, 
@@ -483,14 +483,14 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>Ahiah, Hanan, Anan, 
 <sup>27&#160;</sup>Malluch, Harim, and Baanah. 
 </p><p>
-<sup>28&#160;</sup>The rest of the people, the priests, the Levites, the gatekeepers, the singers, the temple servants, and all those who had separated themselves from the peoples of the lands to the law of Elohim, their women, their sons, and their daughters—everyone who had knowledge and understanding—<sup>29&#160;</sup>joined with their brothers, their nobles, and entered into a curse and into an oath, to walk in Elohim’s law, which was given by Moses the servant of Elohim, and to observe and do all the commandments of Yahweh our Lord, and his ordinances and his statutes; 
+<sup>28&#160;</sup>The rest of the people, the priests, the Levites, the gatekeepers, the singers, the temple servants, and all those who had separated themselves from the peoples of the lands to the law of Elohim, their women, their sons, and their daughters—everyone who had knowledge and understanding—<sup>29&#160;</sup>joined with their brothers, their nobles, and entered into a curse and into an oath, to walk in Elohim’s law, which was given by Moses the servant of Elohim, and to observe and do all the commandments of Yahuah our Lord, and his ordinances and his statutes; 
 <sup>30&#160;</sup>and that we would not give our daughters to the peoples of the land, nor take their daughters for our sons; 
 <sup>31&#160;</sup>and if the peoples of the land bring wares or any grain on the Sabbath day to sell, that we would not buy from them on the Sabbath, or on a set-apart day; and that we would forego the seventh year crops and the exaction of every debt. 
 </p><p>
 <sup>32&#160;</sup>Also we made ordinances for ourselves, to charge ourselves yearly with the third part of a shekel for the service of the house of our Elohim: 
 <sup>33&#160;</sup>for the show bread, for the continual meal offering, for the continual burnt offering, for the Sabbaths, for the new moons, for the set feasts, for the set-apart things, for the sin offerings to make atonement for Israel, and for all the work of the house of our Elohim. 
-<sup>34&#160;</sup>We, the priests, the Levites, and the people, cast lots for the wood offering, to bring it into the house of our Elohim, according to our fathers’ houses, at times appointed year by year, to burn on Yahweh our Elohim’s altar, as it is written in the law; 
-<sup>35&#160;</sup>and to bring the first fruits of our ground and the first fruits of all fruit of all kinds of trees, year by year, to Yahweh’s house; 
+<sup>34&#160;</sup>We, the priests, the Levites, and the people, cast lots for the wood offering, to bring it into the house of our Elohim, according to our fathers’ houses, at times appointed year by year, to burn on Yahuah our Elohim’s altar, as it is written in the law; 
+<sup>35&#160;</sup>and to bring the first fruits of our ground and the first fruits of all fruit of all kinds of trees, year by year, to Yahuah’s house; 
 <sup>36&#160;</sup>also the firstborn of our sons and of our livestock, as it is written in the law, and the firstborn of our herds and of our flocks, to bring to the house of our Elohim, to the priests who minister in the house of our Elohim; 
 <sup>37&#160;</sup>and that we should bring the first fruits of our dough, our wave offerings, the fruit of all kinds of trees, and the new wine and the oil, to the priests, to the rooms of the house of our Elohim; and the tithes of our ground to the Levites; for they, the Levites, take the tithes in all our farming villages. 
 <sup>38&#160;</sup>The priest, the descendent of Aaron, shall be with the Levites when the Levites take tithes. The Levites shall bring up the tithe of the tithes to the house of our Elohim, to the rooms, into the treasure house. 

--- a/book/numbers.html
+++ b/book/numbers.html
@@ -95,7 +95,7 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>Yahweh spoke to Moses in the wilderness of Sinai, in the Tent of Meeting, on the first day of the second month, in the second year after they had come out of the land of Egypt, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses in the wilderness of Sinai, in the Tent of Meeting, on the first day of the second month, in the second year after they had come out of the land of Egypt, saying, 
 <sup>2&#160;</sup>“Take a census of all the congregation of the children of Israel, by their families, by their fathers’ houses, according to the number of the names, every male, one by one, 
 <sup>3&#160;</sup>from twenty years old and upward, all who are able to go out to war in Israel. You and Aaron shall count them by their divisions. 
 <sup>4&#160;</sup>With you there shall be a man of every tribe, each one head of his fathers’ house. 
@@ -125,7 +125,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>These are those who were called of the congregation, the princes of the tribes of their fathers; they were the heads of the thousands of Israel. 
 <sup>17&#160;</sup>Moses and Aaron took these men who are mentioned by name. 
 <sup>18&#160;</sup>They assembled all the congregation together on the first day of the second month; and they declared their ancestry by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, one by one. 
-<sup>19&#160;</sup>As Yahweh commanded Moses, so he counted them in the wilderness of Sinai. 
+<sup>19&#160;</sup>As Yahuah commanded Moses, so he counted them in the wilderness of Sinai. 
 </p><p>
 <sup>20&#160;</sup>The children of Reuben, Israel’s firstborn, their generations, by their families, by their fathers’ houses, according to the number of the names, one by one, every male from twenty years old and upward, all who were able to go out to war: 
 <sup>21&#160;</sup>those who were counted of them, of the tribe of Reuben, were forty-six thousand five hundred. 
@@ -166,17 +166,17 @@ html[dir=ltr] .q2 {
 <sup>44&#160;</sup>These are those who were counted, whom Moses and Aaron counted, and the twelve men who were princes of Israel, each one for his fathers’ house. 
 <sup>45&#160;</sup>So all those who were counted of the children of Israel by their fathers’ houses, from twenty years old and upward, all who were able to go out to war in Israel—<sup>46&#160;</sup>all those who were counted were six hundred three thousand five hundred fifty. 
 <sup>47&#160;</sup>But the Levites after the tribe of their fathers were not counted among them. 
-<sup>48&#160;</sup>For Yahweh spoke to Moses, saying, 
+<sup>48&#160;</sup>For Yahuah spoke to Moses, saying, 
 <sup>49&#160;</sup>“Only the tribe of Levi you shall not count, neither shall you take a census of them among the children of Israel; 
 <sup>50&#160;</sup>but appoint the Levites over the Tabernacle of the Testimony, and over all its furnishings, and over all that belongs to it. They shall carry the tabernacle and all its furnishings; and they shall take care of it, and shall encamp around it. 
 <sup>51&#160;</sup>When the tabernacle is to move, the Levites shall take it down; and when the tabernacle is to be set up, the Levites shall set it up. The stranger who comes near shall be put to death. 
 <sup>52&#160;</sup>The children of Israel shall pitch their tents, every man by his own camp, and every man by his own standard, according to their divisions. 
 <sup>53&#160;</sup>But the Levites shall encamp around the Tabernacle of the Testimony, that there may be no wrath on the congregation of the children of Israel. The Levites shall be responsible for the Tabernacle of the Testimony.” 
 </p><p>
-<sup>54&#160;</sup>Thus the children of Israel did. According to all that Yahweh commanded Moses, so they did. 
+<sup>54&#160;</sup>Thus the children of Israel did. According to all that Yahuah commanded Moses, so they did. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses and to Aaron, saying, 
 <sup>2&#160;</sup>“The children of Israel shall encamp every man by his own standard, with the banners of their fathers’ houses. They shall encamp around the Tent of Meeting at a distance from it. 
 </p><p>
 <sup>3&#160;</sup>“Those who encamp on the east side toward the sunrise shall be of the standard of the camp of Judah, according to their divisions. The prince of the children of Judah shall be Nahshon the son of Amminadab. 
@@ -226,32 +226,32 @@ html[dir=ltr] .q2 {
 <sup>31&#160;</sup>“All who were counted of the camp of Dan were one hundred fifty-seven thousand six hundred. They shall set out last by their standards.” 
 </p><p>
 <sup>32&#160;</sup>These are those who were counted of the children of Israel by their fathers’ houses. All who were counted of the camps according to their armies were six hundred three thousand five hundred fifty. 
-<sup>33&#160;</sup>But the Levites were not counted among the children of Israel, as Yahweh commanded Moses. 
+<sup>33&#160;</sup>But the Levites were not counted among the children of Israel, as Yahuah commanded Moses. 
 </p><p>
-<sup>34&#160;</sup>Thus the children of Israel did. According to all that Yahweh commanded Moses, so they encamped by their standards, and so they set out, everyone by their families, according to their fathers’ houses. 
+<sup>34&#160;</sup>Thus the children of Israel did. According to all that Yahuah commanded Moses, so they encamped by their standards, and so they set out, everyone by their families, according to their fathers’ houses. 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>Now this is the history of the generations of Aaron and Moses in the day that Yahweh spoke with Moses in Mount Sinai. 
+<sup>1&#160;</sup>Now this is the history of the generations of Aaron and Moses in the day that Yahuah spoke with Moses in Mount Sinai. 
 <sup>2&#160;</sup>These are the names of the sons of Aaron: Nadab the firstborn, and Abihu, Eleazar, and Ithamar. 
 </p><p>
 <sup>3&#160;</sup>These are the names of the sons of Aaron, the priests who were anointed, whom he consecrated to minister in the priest’s office. 
-<sup>4&#160;</sup>Nadab and Abihu died before Yahweh when they offered strange fire before Yahweh in the wilderness of Sinai, and they had no children. Eleazar and Ithamar ministered in the priest’s office in the presence of Aaron their father. 
+<sup>4&#160;</sup>Nadab and Abihu died before Yahuah when they offered strange fire before Yahuah in the wilderness of Sinai, and they had no children. Eleazar and Ithamar ministered in the priest’s office in the presence of Aaron their father. 
 </p><p>
-<sup>5&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>5&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>6&#160;</sup>“Bring the tribe of Levi near, and set them before Aaron the priest, that they may minister to him. 
 <sup>7&#160;</sup>They shall keep his requirements, and the requirements of the whole congregation before the Tent of Meeting, to do the service of the tabernacle. 
 <sup>8&#160;</sup>They shall keep all the furnishings of the Tent of Meeting, and the obligations of the children of Israel, to do the service of the tabernacle. 
 <sup>9&#160;</sup>You shall give the Levites to Aaron and to his sons. They are wholly given to him on the behalf of the children of Israel. 
 <sup>10&#160;</sup>You shall appoint Aaron and his sons, and they shall keep their priesthood, but the stranger who comes near shall be put to death.” 
 </p><p>
-<sup>11&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>11&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>12&#160;</sup>“Behold, I have taken the Levites from among the children of Israel instead of all the firstborn who open the womb among the children of Israel; and the Levites shall be mine, 
-<sup>13&#160;</sup>for all the firstborn are mine. On the day that I struck down all the firstborn in the land of Egypt I made set-apart to me all the firstborn in Israel, both man and animal. They shall be mine. I am Yahweh.” 
+<sup>13&#160;</sup>for all the firstborn are mine. On the day that I struck down all the firstborn in the land of Egypt I made set-apart to me all the firstborn in Israel, both man and animal. They shall be mine. I am Yahuah.” 
 </p><p>
-<sup>14&#160;</sup>Yahweh spoke to Moses in the wilderness of Sinai, saying, 
+<sup>14&#160;</sup>Yahuah spoke to Moses in the wilderness of Sinai, saying, 
 <sup>15&#160;</sup>“Count the children of Levi by their fathers’ houses, by their families. You shall count every male from a month old and upward.” 
 </p><p>
-<sup>16&#160;</sup>Moses counted them according to Yahweh’s word, as he was commanded. 
+<sup>16&#160;</sup>Moses counted them according to Yahuah’s word, as he was commanded. 
 </p><p>
 <sup>17&#160;</sup>These were the sons of Levi by their names: Gershon, Kohath, and Merari. 
 </p><p>
@@ -288,26 +288,26 @@ html[dir=ltr] .q2 {
 <sup>37&#160;</sup>the pillars of the court around it, their sockets, their pins, and their cords. 
 </p><p>
 <sup>38&#160;</sup>Those who encamp before the tabernacle eastward, in front of the Tent of Meeting toward the sunrise, shall be Moses, with Aaron and his sons, keeping the requirements of the sanctuary for the duty of the children of Israel. The outsider who comes near shall be put to death. 
-<sup>39&#160;</sup>All who were counted of the Levites, whom Moses and Aaron counted at the commandment of Yahweh, by their families, all the males from a month old and upward, were twenty-two thousand. 
+<sup>39&#160;</sup>All who were counted of the Levites, whom Moses and Aaron counted at the commandment of Yahuah, by their families, all the males from a month old and upward, were twenty-two thousand. 
 </p><p>
-<sup>40&#160;</sup>Yahweh said to Moses, “Count all the firstborn males of the children of Israel from a month old and upward, and take the number of their names. 
-<sup>41&#160;</sup>You shall take the Levites for me—I am Yahweh—instead of all the firstborn among the children of Israel; and the livestock of the Levites instead of all the firstborn among the livestock of the children of Israel.” 
+<sup>40&#160;</sup>Yahuah said to Moses, “Count all the firstborn males of the children of Israel from a month old and upward, and take the number of their names. 
+<sup>41&#160;</sup>You shall take the Levites for me—I am Yahuah—instead of all the firstborn among the children of Israel; and the livestock of the Levites instead of all the firstborn among the livestock of the children of Israel.” 
 </p><p>
-<sup>42&#160;</sup>Moses counted, as Yahweh commanded him, all the firstborn among the children of Israel. 
+<sup>42&#160;</sup>Moses counted, as Yahuah commanded him, all the firstborn among the children of Israel. 
 <sup>43&#160;</sup>All the firstborn males according to the number of names from a month old and upward, of those who were counted of them, were twenty-two thousand two hundred seventy-three. 
 </p><p>
-<sup>44&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>45&#160;</sup>“Take the Levites instead of all the firstborn among the children of Israel, and the livestock of the Levites instead of their livestock; and the Levites shall be mine. I am Yahweh. 
+<sup>44&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>45&#160;</sup>“Take the Levites instead of all the firstborn among the children of Israel, and the livestock of the Levites instead of their livestock; and the Levites shall be mine. I am Yahuah. 
 <sup>46&#160;</sup>For the redemption of the two hundred seventy-three of the firstborn of the children of Israel who exceed the number of the Levites, 
 <sup>47&#160;</sup>you shall take five shekels apiece for each one; according to the shekel of the sanctuary you shall take them (the shekel is twenty gerahs); 
 <sup>48&#160;</sup>and you shall give the money, with which their remainder is redeemed, to Aaron and to his sons.” 
 </p><p>
 <sup>49&#160;</sup>Moses took the redemption money from those who exceeded the number of those who were redeemed by the Levites; 
 <sup>50&#160;</sup>from the firstborn of the children of Israel he took the money, one thousand three hundred sixty-five shekels, according to the shekel of the sanctuary; 
-<sup>51&#160;</sup>and Moses gave the redemption money to Aaron and to his sons, according to Yahweh’s word, as Yahweh commanded Moses. 
+<sup>51&#160;</sup>and Moses gave the redemption money to Aaron and to his sons, according to Yahuah’s word, as Yahuah commanded Moses. 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses and to Aaron, saying, 
 <sup>2&#160;</sup>“Take a census of the sons of Kohath from among the sons of Levi, by their families, by their fathers’ houses, 
 <sup>3&#160;</sup>from thirty years old and upward even until fifty years old, all who enter into the service to do the work in the Tent of Meeting. 
 </p><p>
@@ -332,12 +332,12 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>16&#160;</sup>“The duty of Eleazar the son of Aaron the priest shall be the oil for the light, the sweet incense, the continual meal offering, and the anointing oil, the requirements of all the tabernacle, and of all that is in it, the sanctuary, and its furnishings.” 
 </p><p>
-<sup>17&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>17&#160;</sup>Yahuah spoke to Moses and to Aaron, saying, 
 <sup>18&#160;</sup>“Don’t cut off the tribe of the families of the Kohathites from among the Levites; 
 <sup>19&#160;</sup>but do this to them, that they may live, and not die, when they approach the most set-apart things: Aaron and his sons shall go in and appoint everyone to his service and to his burden; 
 <sup>20&#160;</sup>but they shall not go in to see the sanctuary even for a moment, lest they die.” 
 </p><p>
-<sup>21&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>21&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>22&#160;</sup>“Take a census of the sons of Gershon also, by their fathers’ houses, by their families; 
 <sup>23&#160;</sup>you shall count them from thirty years old and upward until fifty years old: all who enter in to wait on the service, to do the work in the Tent of Meeting. 
 </p><p>
@@ -356,98 +356,98 @@ html[dir=ltr] .q2 {
 <sup>34&#160;</sup>Moses and Aaron and the princes of the congregation counted the sons of the Kohathites by their families, and by their fathers’ houses, 
 <sup>35&#160;</sup>from thirty years old and upward even to fifty years old, everyone who entered into the service for work in the Tent of Meeting. 
 <sup>36&#160;</sup>Those who were counted of them by their families were two thousand seven hundred fifty. 
-<sup>37&#160;</sup>These are those who were counted of the families of the Kohathites, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahweh by Moses. 
+<sup>37&#160;</sup>These are those who were counted of the families of the Kohathites, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahuah by Moses. 
 </p><p>
 <sup>38&#160;</sup>Those who were counted of the sons of Gershon, by their families, and by their fathers’ houses, 
 <sup>39&#160;</sup>from thirty years old and upward even to fifty years old—everyone who entered into the service for work in the Tent of Meeting, 
 <sup>40&#160;</sup>even those who were counted of them, by their families, by their fathers’ houses, were two thousand six hundred thirty. 
-<sup>41&#160;</sup>These are those who were counted of the families of the sons of Gershon, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahweh. 
+<sup>41&#160;</sup>These are those who were counted of the families of the sons of Gershon, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahuah. 
 </p><p>
 <sup>42&#160;</sup>Those who were counted of the families of the sons of Merari, by their families, by their fathers’ houses, 
 <sup>43&#160;</sup>from thirty years old and upward even to fifty years old—everyone who entered into the service for work in the Tent of Meeting, 
 <sup>44&#160;</sup>even those who were counted of them by their families, were three thousand two hundred. 
-<sup>45&#160;</sup>These are those who were counted of the families of the sons of Merari, whom Moses and Aaron counted according to the commandment of Yahweh by Moses. 
+<sup>45&#160;</sup>These are those who were counted of the families of the sons of Merari, whom Moses and Aaron counted according to the commandment of Yahuah by Moses. 
 </p><p>
 <sup>46&#160;</sup>All those who were counted of the Levites whom Moses and Aaron and the princes of Israel counted, by their families and by their fathers’ houses, 
 <sup>47&#160;</sup>from thirty years old and upward even to fifty years old, everyone who entered in to do the work of service and the work of bearing burdens in the Tent of Meeting, 
 <sup>48&#160;</sup>even those who were counted of them, were eight thousand five hundred eighty. 
-<sup>49&#160;</sup>According to the commandment of Yahweh they were counted by Moses, everyone according to his service and according to his burden. Thus they were counted by him, as Yahweh commanded Moses. 
+<sup>49&#160;</sup>According to the commandment of Yahuah they were counted by Moses, everyone according to his service and according to his burden. Thus they were counted by him, as Yahuah commanded Moses. 
 </p><h2 class="chapterlabel" id="5">5</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Command the children of Israel that they put out of the camp every leper, everyone who has a discharge, and whoever is unclean by a corpse. 
 <sup>3&#160;</sup>You shall put both male and female outside of the camp so that they don’t defile their camp, in the midst of which I dwell.” 
 </p><p>
-<sup>4&#160;</sup>The children of Israel did so, and put them outside of the camp; as Yahweh spoke to Moses, so the children of Israel did. 
+<sup>4&#160;</sup>The children of Israel did so, and put them outside of the camp; as Yahuah spoke to Moses, so the children of Israel did. 
 </p><p>
-<sup>5&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>6&#160;</sup>“Speak to the children of Israel: ‘When a man or woman commits any sin that men commit, so as to trespass against Yahweh, and that soul is guilty, 
+<sup>5&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>6&#160;</sup>“Speak to the children of Israel: ‘When a man or woman commits any sin that men commit, so as to trespass against Yahuah, and that soul is guilty, 
 <sup>7&#160;</sup>then he shall confess his sin which he has done; and he shall make restitution for his guilt in full, add to it the fifth part of it, and give it to him in respect of whom he has been guilty. 
-<sup>8&#160;</sup>But if the man has no kinsman to whom restitution may be made for the guilt, the restitution for guilt which is made to Yahweh shall be the priest’s, in addition to the ram of the atonement, by which atonement shall be made for him. 
+<sup>8&#160;</sup>But if the man has no kinsman to whom restitution may be made for the guilt, the restitution for guilt which is made to Yahuah shall be the priest’s, in addition to the ram of the atonement, by which atonement shall be made for him. 
 <sup>9&#160;</sup>Every heave offering of all the set-apart things of the children of Israel, which they present to the priest, shall be his. 
 <sup>10&#160;</sup>Every man’s set-apart things shall be his; whatever any man gives the priest, it shall be his.’&#160;” 
 </p><p>
-<sup>11&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>11&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>12&#160;</sup>“Speak to the children of Israel, and tell them: ‘If any man’s woman goes astray and is unfaithful to him, 
 <sup>13&#160;</sup>and a man lies with her carnally, and it is hidden from the eyes of her man and this is kept concealed, and she is defiled, there is no witness against her, and she isn’t taken in the act; 
 <sup>14&#160;</sup>and the spirit of jealousy comes on him, and he is jealous of his woman and she is defiled; or if the spirit of jealousy comes on him, and he is jealous of his woman and she isn’t defiled; 
 <sup>15&#160;</sup>then the man shall bring his woman to the priest, and shall bring her offering for her: one tenth of an ephah of barley meal. He shall pour no oil on it, nor put frankincense on it, for it is a meal offering of jealousy, a meal offering of memorial, bringing iniquity to memory. 
-<sup>16&#160;</sup>The priest shall bring her near, and set her before Yahweh. 
+<sup>16&#160;</sup>The priest shall bring her near, and set her before Yahuah. 
 <sup>17&#160;</sup>The priest shall take set-apart water in an earthen vessel; and the priest shall take some of the dust that is on the floor of the tabernacle and put it into the water. 
-<sup>18&#160;</sup>The priest shall set the woman before Yahweh, and let the hair of the woman’s head go loose, and put the meal offering of memorial in her hands, which is the meal offering of jealousy. The priest shall have in his hand the water of bitterness that brings a curse. 
+<sup>18&#160;</sup>The priest shall set the woman before Yahuah, and let the hair of the woman’s head go loose, and put the meal offering of memorial in her hands, which is the meal offering of jealousy. The priest shall have in his hand the water of bitterness that brings a curse. 
 <sup>19&#160;</sup>The priest shall cause her to take an oath and shall tell the woman, “If no man has lain with you, and if you haven’t gone aside to uncleanness, being under your man’s authority, be free from this water of bitterness that brings a curse. 
 <sup>20&#160;</sup>But if you have gone astray, being under your man’s authority, and if you are defiled, and some man has lain with you besides your man—” 
-<sup>21&#160;</sup>then the priest shall cause the woman to swear with the oath of cursing, and the priest shall tell the woman, “May Yahweh make you a curse and an oath among your people, when Yahweh allows your thigh to fall away, and your body to swell; 
+<sup>21&#160;</sup>then the priest shall cause the woman to swear with the oath of cursing, and the priest shall tell the woman, “May Yahuah make you a curse and an oath among your people, when Yahuah allows your thigh to fall away, and your body to swell; 
 <sup>22&#160;</sup>and this water that brings a curse will go into your bowels, and make your body swell, and your thigh fall away.” The woman shall say, “Amen, Amen.” 
 </p><p>
 <sup>23&#160;</sup>“&#160;‘The priest shall write these curses in a book, and he shall wipe them into the water of bitterness. 
 <sup>24&#160;</sup>He shall make the woman drink the water of bitterness that causes the curse; and the water that causes the curse shall enter into her and become bitter. 
-<sup>25&#160;</sup>The priest shall take the meal offering of jealousy out of the woman’s hand, and shall wave the meal offering before Yahweh, and bring it to the altar. 
+<sup>25&#160;</sup>The priest shall take the meal offering of jealousy out of the woman’s hand, and shall wave the meal offering before Yahuah, and bring it to the altar. 
 <sup>26&#160;</sup>The priest shall take a handful of the meal offering, as its memorial portion, and burn it on the altar, and afterward shall make the woman drink the water. 
 <sup>27&#160;</sup>When he has made her drink the water, then it shall happen, if she is defiled and has committed a trespass against her man, that the water that causes the curse will enter into her and become bitter, and her body will swell, and her thigh will fall away; and the woman will be a curse among her people. 
 <sup>28&#160;</sup>If the woman isn’t defiled, but is clean; then she shall be free, and shall conceive offspring. 
 </p><p>
 <sup>29&#160;</sup>“&#160;‘This is the law of jealousy, when a woman, being under her man, goes astray, and is defiled, 
-<sup>30&#160;</sup>or when the spirit of jealousy comes on a man, and he is jealous of his woman; then he shall set the woman before Yahweh, and the priest shall execute on her all this law. 
+<sup>30&#160;</sup>or when the spirit of jealousy comes on a man, and he is jealous of his woman; then he shall set the woman before Yahuah, and the priest shall execute on her all this law. 
 <sup>31&#160;</sup>The man shall be free from iniquity, and that woman shall bear her iniquity.’&#160;” 
 </p><h2 class="chapterlabel" id="6">6</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>2&#160;</sup>“Speak to the children of Israel, and tell them: ‘When either man or woman shall make a special vow, the vow of a Nazirite, to separate himself to Yahweh, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and tell them: ‘When either man or woman shall make a special vow, the vow of a Nazirite, to separate himself to Yahuah, 
 <sup>3&#160;</sup>he shall separate himself from wine and strong drink. He shall drink no vinegar of wine, or vinegar of fermented drink, neither shall he drink any juice of grapes, nor eat fresh grapes or dried. 
 <sup>4&#160;</sup>All the days of his separation he shall eat nothing that is made of the grapevine, from the seeds even to the skins. 
 </p><p>
-<sup>5&#160;</sup>“&#160;‘All the days of his vow of separation no razor shall come on his head, until the days are fulfilled in which he separates himself to Yahweh. He shall be set-apart. He shall let the locks of the hair of his head grow long. 
+<sup>5&#160;</sup>“&#160;‘All the days of his vow of separation no razor shall come on his head, until the days are fulfilled in which he separates himself to Yahuah. He shall be set-apart. He shall let the locks of the hair of his head grow long. 
 </p><p>
-<sup>6&#160;</sup>“&#160;‘All the days that he separates himself to Yahweh he shall not go near a dead body. 
+<sup>6&#160;</sup>“&#160;‘All the days that he separates himself to Yahuah he shall not go near a dead body. 
 <sup>7&#160;</sup>He shall not make himself unclean for his father, or for his mother, for his brother, or for his sister, when they die, because his separation to Elohim is on his head. 
-<sup>8&#160;</sup>All the days of his separation he is set-apart to Yahweh. 
+<sup>8&#160;</sup>All the days of his separation he is set-apart to Yahuah. 
 </p><p>
 <sup>9&#160;</sup>“&#160;‘If any man dies very suddenly beside him, and he defiles the head of his separation, then he shall shave his head in the day of his cleansing. On the seventh day he shall shave it. 
 <sup>10&#160;</sup>On the eighth day he shall bring two turtledoves or two young pigeons to the priest, to the door of the Tent of Meeting. 
 <sup>11&#160;</sup>The priest shall offer one for a sin offering, and the other for a burnt offering, and make atonement for him, because he sinned by reason of the dead, and shall make his head set-apart that same day. 
-<sup>12&#160;</sup>He shall separate to Yahweh the days of his separation, and shall bring a male lamb a year old for a trespass offering; but the former days shall be void, because his separation was defiled. 
+<sup>12&#160;</sup>He shall separate to Yahuah the days of his separation, and shall bring a male lamb a year old for a trespass offering; but the former days shall be void, because his separation was defiled. 
 </p><p>
 <sup>13&#160;</sup>“&#160;‘This is the law of the Nazirite: when the days of his separation are fulfilled, he shall be brought to the door of the Tent of Meeting, 
-<sup>14&#160;</sup>and he shall offer his offering to Yahweh: one male lamb a year old without defect for a burnt offering, one ewe lamb a year old without defect for a sin offering, one ram without defect for peace offerings, 
+<sup>14&#160;</sup>and he shall offer his offering to Yahuah: one male lamb a year old without defect for a burnt offering, one ewe lamb a year old without defect for a sin offering, one ram without defect for peace offerings, 
 <sup>15&#160;</sup>a basket of unleavened bread, cakes of fine flour mixed with oil, and unleavened wafers anointed with oil with their meal offering and their drink offerings. 
-<sup>16&#160;</sup>The priest shall present them before Yahweh, and shall offer his sin offering and his burnt offering. 
-<sup>17&#160;</sup>He shall offer the ram for a sacrifice of peace offerings to Yahweh, with the basket of unleavened bread. The priest shall offer also its meal offering and its drink offering. 
+<sup>16&#160;</sup>The priest shall present them before Yahuah, and shall offer his sin offering and his burnt offering. 
+<sup>17&#160;</sup>He shall offer the ram for a sacrifice of peace offerings to Yahuah, with the basket of unleavened bread. The priest shall offer also its meal offering and its drink offering. 
 <sup>18&#160;</sup>The Nazirite shall shave the head of his separation at the door of the Tent of Meeting, take the hair of the head of his separation, and put it on the fire which is under the sacrifice of peace offerings. 
 <sup>19&#160;</sup>The priest shall take the boiled shoulder of the ram, one unleavened cake out of the basket, and one unleavened wafer, and shall put them on the hands of the Nazirite after he has shaved the head of his separation; 
-<sup>20&#160;</sup>and the priest shall wave them for a wave offering before Yahweh. They are set-apart for the priest, together with the breast that is waved and the thigh that is offered. After that the Nazirite may drink wine. 
+<sup>20&#160;</sup>and the priest shall wave them for a wave offering before Yahuah. They are set-apart for the priest, together with the breast that is waved and the thigh that is offered. After that the Nazirite may drink wine. 
 </p><p>
-<sup>21&#160;</sup>“&#160;‘This is the law of the Nazirite who vows and of his offering to Yahweh for his separation, in addition to that which he is able to afford. According to his vow which he vows, so he must do after the law of his separation.’&#160;” 
+<sup>21&#160;</sup>“&#160;‘This is the law of the Nazirite who vows and of his offering to Yahuah for his separation, in addition to that which he is able to afford. According to his vow which he vows, so he must do after the law of his separation.’&#160;” 
 </p><p>
-<sup>22&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>22&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>23&#160;</sup>“Speak to Aaron and to his sons, saying, ‘This is how you shall bless the children of Israel.’ You shall tell them, 
 </p><p class="q1">
-<sup>24&#160;</sup>‘Yahweh bless you, and keep you. 
+<sup>24&#160;</sup>‘Yahuah bless you, and keep you. 
 </p><p class="q2">
-<sup>25&#160;</sup>Yahweh make his face to shine on you, 
+<sup>25&#160;</sup>Yahuah make his face to shine on you, 
 </p><p class="q2">and be gracious to you. 
 </p><p class="q1">
-<sup>26&#160;</sup>Yahweh lift up his face toward you, 
+<sup>26&#160;</sup>Yahuah lift up his face toward you, 
 </p><p class="q2">and give you peace.’ 
 </p><p>
 <sup>27&#160;</sup>“So they shall put my name on the children of Israel; and I will bless them.” 
@@ -455,8 +455,8 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>On the day that Moses had finished setting up the tabernacle, and had anointed it and sanctified it with all its furniture, and the altar with all its vessels, and had anointed and sanctified them; 
 <sup>2&#160;</sup>the princes of Israel, the heads of their fathers’ houses, gave offerings. These were the princes of the tribes. These are they who were over those who were counted; 
-<sup>3&#160;</sup>and they brought their offering before Yahweh, six covered wagons and twelve oxen; a wagon for every two of the princes, and for each one an ox. They presented them before the tabernacle. 
-<sup>4&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>3&#160;</sup>and they brought their offering before Yahuah, six covered wagons and twelve oxen; a wagon for every two of the princes, and for each one an ox. They presented them before the tabernacle. 
+<sup>4&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>5&#160;</sup>“Accept these from them, that they may be used in doing the service of the Tent of Meeting; and you shall give them to the Levites, to every man according to his service.” 
 </p><p>
 <sup>6&#160;</sup>Moses took the wagons and the oxen, and gave them to the Levites. 
@@ -466,7 +466,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>10&#160;</sup>The princes gave offerings for the dedication of the altar in the day that it was anointed. The princes gave their offerings before the altar. 
 </p><p>
-<sup>11&#160;</sup>Yahweh said to Moses, “They shall offer their offering, each prince on his day, for the dedication of the altar.” 
+<sup>11&#160;</sup>Yahuah said to Moses, “They shall offer their offering, each prince on his day, for the dedication of the altar.” 
 </p><p>
 <sup>12&#160;</sup>He who offered his offering the first day was Nahshon the son of Amminadab, of the tribe of Judah, 
 <sup>13&#160;</sup>and his offering was: 
@@ -654,25 +654,25 @@ html[dir=ltr] .q2 {
 <sup>87&#160;</sup>all the cattle for the burnt offering twelve bulls, the rams twelve, the male lambs a year old twelve, and their meal offering; and twelve male goats for a sin offering; 
 <sup>88&#160;</sup>and all the cattle for the sacrifice of peace offerings: twenty-four bulls, sixty rams, sixty male goats, and sixty male lambs a year old. This was the dedication offering of the altar, after it was anointed. 
 </p><p>
-<sup>89&#160;</sup>When Moses went into the Tent of Meeting to speak with Yahweh, he heard his voice speaking to him from above the mercy seat that was on the ark of the Testimony, from between the two cherubim; and he spoke to him. 
+<sup>89&#160;</sup>When Moses went into the Tent of Meeting to speak with Yahuah, he heard his voice speaking to him from above the mercy seat that was on the ark of the Testimony, from between the two cherubim; and he spoke to him. 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Speak to Aaron, and tell him, ‘When you light the lamps, the seven lamps shall give light in front of the lamp stand.’&#160;” 
 </p><p>
-<sup>3&#160;</sup>Aaron did so. He lit its lamps to light the area in front of the lamp stand, as Yahweh commanded Moses. 
-<sup>4&#160;</sup>This was the workmanship of the lamp stand, beaten work of gold. From its base to its flowers, it was beaten work. He made the lamp stand according to the pattern which Yahweh had shown Moses. 
+<sup>3&#160;</sup>Aaron did so. He lit its lamps to light the area in front of the lamp stand, as Yahuah commanded Moses. 
+<sup>4&#160;</sup>This was the workmanship of the lamp stand, beaten work of gold. From its base to its flowers, it was beaten work. He made the lamp stand according to the pattern which Yahuah had shown Moses. 
 </p><p>
-<sup>5&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>5&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>6&#160;</sup>“Take the Levites from among the children of Israel, and cleanse them. 
 <sup>7&#160;</sup>You shall do this to them to cleanse them: sprinkle the water of cleansing on them, let them shave their whole bodies with a razor, let them wash their clothes, and cleanse themselves. 
 <sup>8&#160;</sup>Then let them take a young bull and its meal offering, fine flour mixed with oil; and another young bull you shall take for a sin offering. 
 <sup>9&#160;</sup>You shall present the Levites before the Tent of Meeting. You shall assemble the whole congregation of the children of Israel. 
-<sup>10&#160;</sup>You shall present the Levites before Yahweh. The children of Israel shall lay their hands on the Levites, 
-<sup>11&#160;</sup>and Aaron shall offer the Levites before Yahweh for a wave offering on the behalf of the children of Israel, that it may be theirs to do the service of Yahweh. 
+<sup>10&#160;</sup>You shall present the Levites before Yahuah. The children of Israel shall lay their hands on the Levites, 
+<sup>11&#160;</sup>and Aaron shall offer the Levites before Yahuah for a wave offering on the behalf of the children of Israel, that it may be theirs to do the service of Yahuah. 
 </p><p>
-<sup>12&#160;</sup>“The Levites shall lay their hands on the heads of the bulls, and you shall offer the one for a sin offering and the other for a burnt offering to Yahweh, to make atonement for the Levites. 
-<sup>13&#160;</sup>You shall set the Levites before Aaron and before his sons, and offer them as a wave offering to Yahweh. 
+<sup>12&#160;</sup>“The Levites shall lay their hands on the heads of the bulls, and you shall offer the one for a sin offering and the other for a burnt offering to Yahuah, to make atonement for the Levites. 
+<sup>13&#160;</sup>You shall set the Levites before Aaron and before his sons, and offer them as a wave offering to Yahuah. 
 <sup>14&#160;</sup>Thus you shall separate the Levites from among the children of Israel, and the Levites shall be mine. 
 </p><p>
 <sup>15&#160;</sup>“After that, the Levites shall go in to do the service of the Tent of Meeting. You shall cleanse them, and offer them as a wave offering. 
@@ -681,47 +681,47 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>I have taken the Levites instead of all the firstborn among the children of Israel. 
 <sup>19&#160;</sup>I have given the Levites as a gift to Aaron and to his sons from among the children of Israel, to do the service of the children of Israel in the Tent of Meeting, and to make atonement for the children of Israel, so that there will be no plague among the children of Israel when the children of Israel come near to the sanctuary.” 
 </p><p>
-<sup>20&#160;</sup>Moses, and Aaron, and all the congregation of the children of Israel did so to the Levites. According to all that Yahweh commanded Moses concerning the Levites, so the children of Israel did to them. 
-<sup>21&#160;</sup>The Levites purified themselves from sin, and they washed their clothes; and Aaron offered them for a wave offering before Yahweh and Aaron made atonement for them to cleanse them. 
-<sup>22&#160;</sup>After that, the Levites went in to do their service in the Tent of Meeting before Aaron and before his sons: as Yahweh had commanded Moses concerning the Levites, so they did to them. 
+<sup>20&#160;</sup>Moses, and Aaron, and all the congregation of the children of Israel did so to the Levites. According to all that Yahuah commanded Moses concerning the Levites, so the children of Israel did to them. 
+<sup>21&#160;</sup>The Levites purified themselves from sin, and they washed their clothes; and Aaron offered them for a wave offering before Yahuah and Aaron made atonement for them to cleanse them. 
+<sup>22&#160;</sup>After that, the Levites went in to do their service in the Tent of Meeting before Aaron and before his sons: as Yahuah had commanded Moses concerning the Levites, so they did to them. 
 </p><p>
-<sup>23&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>23&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>24&#160;</sup>“This is what is assigned to the Levites: from twenty-five years old and upward they shall go in to wait on the service in the work of the Tent of Meeting; 
 <sup>25&#160;</sup>and from the age of fifty years they shall retire from doing the work, and shall serve no more, 
 <sup>26&#160;</sup>but shall assist their brothers in the Tent of Meeting, to perform the duty, and shall perform no service. This is how you shall have the Levites do their duties.” 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses in the wilderness of Sinai, in the first month of the second year after they had come out of the land of Egypt, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses in the wilderness of Sinai, in the first month of the second year after they had come out of the land of Egypt, saying, 
 <sup>2&#160;</sup>“Let the children of Israel keep the Passover in its appointed season. 
 <sup>3&#160;</sup>On the fourteenth day of this month, at evening, you shall keep it in its appointed season. You shall keep it according to all its statutes and according to all its ordinances.” 
 </p><p>
 <sup>4&#160;</sup>Moses told the children of Israel that they should keep the Passover. 
-<sup>5&#160;</sup>They kept the Passover in the first month, on the fourteenth day of the month at evening, in the wilderness of Sinai. According to all that Yahweh commanded Moses, so the children of Israel did. 
+<sup>5&#160;</sup>They kept the Passover in the first month, on the fourteenth day of the month at evening, in the wilderness of Sinai. According to all that Yahuah commanded Moses, so the children of Israel did. 
 <sup>6&#160;</sup>There were certain men who were unclean because of the dead body of a man, so that they could not keep the Passover on that day, and they came before Moses and Aaron on that day. 
-<sup>7&#160;</sup>Those men said to him, “We are unclean because of the dead body of a man. Why are we kept back, that we may not offer the offering of Yahweh in its appointed season among the children of Israel?” 
+<sup>7&#160;</sup>Those men said to him, “We are unclean because of the dead body of a man. Why are we kept back, that we may not offer the offering of Yahuah in its appointed season among the children of Israel?” 
 </p><p>
-<sup>8&#160;</sup>Moses answered them, “Wait, that I may hear what Yahweh will command concerning you.” 
+<sup>8&#160;</sup>Moses answered them, “Wait, that I may hear what Yahuah will command concerning you.” 
 </p><p>
-<sup>9&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>10&#160;</sup>“Say to the children of Israel, ‘If any man of you or of your generations is unclean by reason of a dead body, or is on a journey far away, he shall still keep the Passover to Yahweh. 
+<sup>9&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>10&#160;</sup>“Say to the children of Israel, ‘If any man of you or of your generations is unclean by reason of a dead body, or is on a journey far away, he shall still keep the Passover to Yahuah. 
 <sup>11&#160;</sup>In the second month, on the fourteenth day at evening they shall keep it; they shall eat it with unleavened bread and bitter herbs. 
 <sup>12&#160;</sup>They shall leave none of it until the morning, nor break a bone of it. According to all the statute of the Passover they shall keep it. 
-<sup>13&#160;</sup>But the man who is clean, and is not on a journey, and fails to keep the Passover, that soul shall be cut off from his people. Because he didn’t offer the offering of Yahweh in its appointed season, that man shall bear his sin. 
+<sup>13&#160;</sup>But the man who is clean, and is not on a journey, and fails to keep the Passover, that soul shall be cut off from his people. Because he didn’t offer the offering of Yahuah in its appointed season, that man shall bear his sin. 
 </p><p>
-<sup>14&#160;</sup>“&#160;‘If a foreigner lives among you and desires to keep the Passover to Yahweh, then he shall do so according to the statute of the Passover, and according to its ordinance. You shall have one statute, both for the foreigner and for him who is born in the land.’&#160;” 
+<sup>14&#160;</sup>“&#160;‘If a foreigner lives among you and desires to keep the Passover to Yahuah, then he shall do so according to the statute of the Passover, and according to its ordinance. You shall have one statute, both for the foreigner and for him who is born in the land.’&#160;” 
 </p><p>
 <sup>15&#160;</sup>On the day that the tabernacle was raised up, the cloud covered the tabernacle, even the Tent of the Testimony. At evening it was over the tabernacle, as it were the appearance of fire, until morning. 
 <sup>16&#160;</sup>So it was continually. The cloud covered it, and the appearance of fire by night. 
 <sup>17&#160;</sup>Whenever the cloud was taken up from over the Tent, then after that the children of Israel traveled; and in the place where the cloud remained, there the children of Israel encamped. 
-<sup>18&#160;</sup>At the commandment of Yahweh, the children of Israel traveled, and at the commandment of Yahweh they encamped. As long as the cloud remained on the tabernacle they remained encamped. 
-<sup>19&#160;</sup>When the cloud stayed on the tabernacle many days, then the children of Israel kept Yahweh’s command, and didn’t travel. 
-<sup>20&#160;</sup>Sometimes the cloud was a few days on the tabernacle; then according to the commandment of Yahweh they remained encamped, and according to the commandment of Yahweh they traveled. 
+<sup>18&#160;</sup>At the commandment of Yahuah, the children of Israel traveled, and at the commandment of Yahuah they encamped. As long as the cloud remained on the tabernacle they remained encamped. 
+<sup>19&#160;</sup>When the cloud stayed on the tabernacle many days, then the children of Israel kept Yahuah’s command, and didn’t travel. 
+<sup>20&#160;</sup>Sometimes the cloud was a few days on the tabernacle; then according to the commandment of Yahuah they remained encamped, and according to the commandment of Yahuah they traveled. 
 <sup>21&#160;</sup>Sometimes the cloud was from evening until morning; and when the cloud was taken up in the morning, they traveled; or by day and by night, when the cloud was taken up, they traveled. 
 <sup>22&#160;</sup>Whether it was two days, or a month, or a year that the cloud stayed on the tabernacle, remaining on it, the children of Israel remained encamped, and didn’t travel; but when it was taken up, they traveled. 
-<sup>23&#160;</sup>At the commandment of Yahweh they encamped, and at the commandment of Yahweh they traveled. They kept Yahweh’s command, at the commandment of Yahweh by Moses. 
+<sup>23&#160;</sup>At the commandment of Yahuah they encamped, and at the commandment of Yahuah they traveled. They kept Yahuah’s command, at the commandment of Yahuah by Moses. 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Make two trumpets of silver. You shall make them of beaten work. You shall use them for the calling of the congregation and for the journeying of the camps. 
 <sup>3&#160;</sup>When they blow them, all the congregation shall gather themselves to you at the door of the Tent of Meeting. 
 <sup>4&#160;</sup>If they blow just one, then the princes, the heads of the thousands of Israel, shall gather themselves to you. 
@@ -730,13 +730,13 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>But when the assembly is to be gathered together, you shall blow, but you shall not sound an alarm. 
 </p><p>
 <sup>8&#160;</sup>“The sons of Aaron, the priests, shall blow the trumpets. This shall be to you for a statute forever throughout your generations. 
-<sup>9&#160;</sup>When you go to war in your land against the adversary who oppresses you, then you shall sound an alarm with the trumpets. Then you will be remembered before Yahweh your Elohim, and you will be saved from your enemies. 
+<sup>9&#160;</sup>When you go to war in your land against the adversary who oppresses you, then you shall sound an alarm with the trumpets. Then you will be remembered before Yahuah your Elohim, and you will be saved from your enemies. 
 </p><p>
-<sup>10&#160;</sup>“Also in the day of your gladness, and in your set feasts, and in the beginnings of your months, you shall blow the trumpets over your burnt offerings, and over the sacrifices of your peace offerings; and they shall be to you for a memorial before your Elohim. I am Yahweh your Elohim.” 
+<sup>10&#160;</sup>“Also in the day of your gladness, and in your set feasts, and in the beginnings of your months, you shall blow the trumpets over your burnt offerings, and over the sacrifices of your peace offerings; and they shall be to you for a memorial before your Elohim. I am Yahuah your Elohim.” 
 </p><p>
 <sup>11&#160;</sup>In the second year, in the second month, on the twentieth day of the month, the cloud was taken up from over the tabernacle of the covenant. 
 <sup>12&#160;</sup>The children of Israel went forward on their journeys out of the wilderness of Sinai; and the cloud stayed in the wilderness of Paran. 
-<sup>13&#160;</sup>They first went forward according to the commandment of Yahweh by Moses. 
+<sup>13&#160;</sup>They first went forward according to the commandment of Yahuah by Moses. 
 </p><p>
 <sup>14&#160;</sup>First, the standard of the camp of the children of Judah went forward according to their armies. Nahshon the son of Amminadab was over his army. 
 <sup>15&#160;</sup>Nethanel the son of Zuar was over the army of the tribe of the children of Issachar. 
@@ -757,22 +757,22 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>Ahira the son of Enan was over the army of the tribe of the children of Naphtali. 
 <sup>28&#160;</sup>Thus were the travels of the children of Israel according to their armies; and they went forward. 
 </p><p>
-<sup>29&#160;</sup>Moses said to Hobab, the son of Reuel the Midianite, Moses’ father-in-law, “We are journeying to the place of which Yahweh said, ‘I will give it to you.’ Come with us, and we will treat you well; for Yahweh has spoken good concerning Israel.” 
+<sup>29&#160;</sup>Moses said to Hobab, the son of Reuel the Midianite, Moses’ father-in-law, “We are journeying to the place of which Yahuah said, ‘I will give it to you.’ Come with us, and we will treat you well; for Yahuah has spoken good concerning Israel.” 
 </p><p>
 <sup>30&#160;</sup>He said to him, “I will not go; but I will depart to my own land, and to my relatives.” 
 </p><p>
 <sup>31&#160;</sup>Moses said, “Don’t leave us, please; because you know how we are to encamp in the wilderness, and you can be our eyes. 
-<sup>32&#160;</sup>It shall be, if you go with us—yes, it shall be—that whatever good Yahweh does to us, we will do the same to you.” 
+<sup>32&#160;</sup>It shall be, if you go with us—yes, it shall be—that whatever good Yahuah does to us, we will do the same to you.” 
 </p><p>
-<sup>33&#160;</sup>They set forward from the Mount of Yahweh three days’ journey. The ark of Yahweh’s covenant went before them three days’ journey, to seek out a resting place for them. 
-<sup>34&#160;</sup>The cloud of Yahweh was over them by day, when they set forward from the camp. 
-<sup>35&#160;</sup>When the ark went forward, Moses said, “Rise up, Yahweh, and let your enemies be scattered! Let those who hate you flee before you!” 
-<sup>36&#160;</sup>When it rested, he said, “Return, Yahweh, to the ten thousands of the thousands of Israel.” 
+<sup>33&#160;</sup>They set forward from the Mount of Yahuah three days’ journey. The ark of Yahuah’s covenant went before them three days’ journey, to seek out a resting place for them. 
+<sup>34&#160;</sup>The cloud of Yahuah was over them by day, when they set forward from the camp. 
+<sup>35&#160;</sup>When the ark went forward, Moses said, “Rise up, Yahuah, and let your enemies be scattered! Let those who hate you flee before you!” 
+<sup>36&#160;</sup>When it rested, he said, “Return, Yahuah, to the ten thousands of the thousands of Israel.” 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p>
-<sup>1&#160;</sup>The people were complaining in the ears of Yahweh. When Yahweh heard it, his anger burned; and Yahweh’s fire burned among them, and consumed some of the outskirts of the camp. 
-<sup>2&#160;</sup>The people cried to Moses; and Moses prayed to Yahweh, and the fire abated. 
-<sup>3&#160;</sup>The name of that place was called Taberah, because Yahweh’s fire burned among them. 
+<sup>1&#160;</sup>The people were complaining in the ears of Yahuah. When Yahuah heard it, his anger burned; and Yahuah’s fire burned among them, and consumed some of the outskirts of the camp. 
+<sup>2&#160;</sup>The people cried to Moses; and Moses prayed to Yahuah, and the fire abated. 
+<sup>3&#160;</sup>The name of that place was called Taberah, because Yahuah’s fire burned among them. 
 </p><p>
 <sup>4&#160;</sup>The mixed multitude that was among them lusted exceedingly; and the children of Israel also wept again, and said, “Who will give us meat to eat? 
 <sup>5&#160;</sup>We remember the fish, which we ate in Egypt for nothing; the cucumbers, and the melons, and the leeks, and the onions, and the garlic; 
@@ -781,72 +781,72 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>The people went around, gathered it, and ground it in mills, or beat it in mortars, and boiled it in pots, and made cakes of it. Its taste was like the taste of fresh oil. 
 <sup>9&#160;</sup>When the dew fell on the camp in the night, the manna fell on it. 
 </p><p>
-<sup>10&#160;</sup>Moses heard the people weeping throughout their families, every man at the door of his tent; and Yahweh’s anger burned greatly; and Moses was displeased. 
-<sup>11&#160;</sup>Moses said to Yahweh, “Why have you treated your servant so badly? Why haven’t I found favor in your sight, that you lay the burden of all this people on me? 
+<sup>10&#160;</sup>Moses heard the people weeping throughout their families, every man at the door of his tent; and Yahuah’s anger burned greatly; and Moses was displeased. 
+<sup>11&#160;</sup>Moses said to Yahuah, “Why have you treated your servant so badly? Why haven’t I found favor in your sight, that you lay the burden of all this people on me? 
 <sup>12&#160;</sup>Have I conceived all this people? Have I brought them out, that you should tell me, ‘Carry them in your bosom, as a nurse carries a nursing infant, to the land which you swore to their fathers’? 
 <sup>13&#160;</sup>Where could I get meat to give all these people? For they weep before me, saying, ‘Give us meat, that we may eat.’ 
 <sup>14&#160;</sup>I am not able to bear all this people alone, because it is too heavy for me. 
 <sup>15&#160;</sup>If you treat me this way, please kill me right now, if I have found favor in your sight; and don’t let me see my wretchedness.” 
 </p><p>
-<sup>16&#160;</sup>Yahweh said to Moses, “Gather to me seventy men of the elders of Israel, whom you know to be the elders of the people and officers over them; and bring them to the Tent of Meeting, that they may stand there with you. 
+<sup>16&#160;</sup>Yahuah said to Moses, “Gather to me seventy men of the elders of Israel, whom you know to be the elders of the people and officers over them; and bring them to the Tent of Meeting, that they may stand there with you. 
 <sup>17&#160;</sup>I will come down and talk with you there. I will take of the Spirit which is on you, and will put it on them; and they shall bear the burden of the people with you, that you don’t bear it yourself alone. 
 </p><p>
-<sup>18&#160;</sup>“Say to the people, ‘Sanctify yourselves in preparation for tomorrow, and you will eat meat; for you have wept in the ears of Yahweh, saying, “Who will give us meat to eat? For it was well with us in Egypt.” Therefore Yahweh will give you meat, and you will eat. 
+<sup>18&#160;</sup>“Say to the people, ‘Sanctify yourselves in preparation for tomorrow, and you will eat meat; for you have wept in the ears of Yahuah, saying, “Who will give us meat to eat? For it was well with us in Egypt.” Therefore Yahuah will give you meat, and you will eat. 
 <sup>19&#160;</sup>You will not eat just one day, or two days, or five days, or ten days, or twenty days, 
-<sup>20&#160;</sup>but a whole month, until it comes out at your nostrils, and it is loathsome to you; because you have rejected Yahweh who is among you, and have wept before him, saying, “Why did we come out of Egypt?”&#160;’&#160;” 
+<sup>20&#160;</sup>but a whole month, until it comes out at your nostrils, and it is loathsome to you; because you have rejected Yahuah who is among you, and have wept before him, saying, “Why did we come out of Egypt?”&#160;’&#160;” 
 </p><p>
 <sup>21&#160;</sup>Moses said, “The people, among whom I am, are six hundred thousand men on foot; and you have said, ‘I will give them meat, that they may eat a whole month.’ 
 <sup>22&#160;</sup>Shall flocks and herds be slaughtered for them, to be sufficient for them? Shall all the fish of the sea be gathered together for them, to be sufficient for them?” 
 </p><p>
-<sup>23&#160;</sup>Yahweh said to Moses, “Has Yahweh’s hand grown short? Now you will see whether my word will happen to you or not.” 
+<sup>23&#160;</sup>Yahuah said to Moses, “Has Yahuah’s hand grown short? Now you will see whether my word will happen to you or not.” 
 </p><p>
-<sup>24&#160;</sup>Moses went out, and told the people Yahweh’s words; and he gathered seventy men of the elders of the people, and set them around the Tent. 
-<sup>25&#160;</sup>Yahweh came down in the cloud, and spoke to him, and took of the Spirit that was on him, and put it on the seventy elders. When the Spirit rested on them, they prophesied, but they did so no more. 
+<sup>24&#160;</sup>Moses went out, and told the people Yahuah’s words; and he gathered seventy men of the elders of the people, and set them around the Tent. 
+<sup>25&#160;</sup>Yahuah came down in the cloud, and spoke to him, and took of the Spirit that was on him, and put it on the seventy elders. When the Spirit rested on them, they prophesied, but they did so no more. 
 <sup>26&#160;</sup>But two men remained in the camp. The name of one was Eldad, and the name of the other Medad; and the Spirit rested on them. They were of those who were written, but had not gone out to the Tent; and they prophesied in the camp. 
 <sup>27&#160;</sup>A young man ran, and told Moses, and said, “Eldad and Medad are prophesying in the camp!” 
 </p><p>
 <sup>28&#160;</sup>Joshua the son of Nun, the servant of Moses, one of his chosen men, answered, “My lord Moses, forbid them!” 
 </p><p>
-<sup>29&#160;</sup>Moses said to him, “Are you jealous for my sake? I wish that all Yahweh’s people were prophets, that Yahweh would put his Spirit on them!” 
+<sup>29&#160;</sup>Moses said to him, “Are you jealous for my sake? I wish that all Yahuah’s people were prophets, that Yahuah would put his Spirit on them!” 
 </p><p>
 <sup>30&#160;</sup>Moses went into the camp, he and the elders of Israel. 
-<sup>31&#160;</sup>A wind from Yahweh went out and brought quails from the sea, and let them fall by the camp, about a day’s journey on this side, and a day’s journey on the other side, around the camp, and about two cubits above the surface of the earth. 
+<sup>31&#160;</sup>A wind from Yahuah went out and brought quails from the sea, and let them fall by the camp, about a day’s journey on this side, and a day’s journey on the other side, around the camp, and about two cubits above the surface of the earth. 
 <sup>32&#160;</sup>The people rose up all that day, and all of that night, and all the next day, and gathered the quails. He who gathered least gathered ten homers; and they spread them all out for themselves around the camp. 
-<sup>33&#160;</sup>While the meat was still between their teeth, before it was chewed, Yahweh’s anger burned against the people, and Yahweh struck the people with a very great plague. 
+<sup>33&#160;</sup>While the meat was still between their teeth, before it was chewed, Yahuah’s anger burned against the people, and Yahuah struck the people with a very great plague. 
 <sup>34&#160;</sup>The name of that place was called Kibroth Hattaavah, because there they buried the people who lusted. 
 </p><p>
 <sup>35&#160;</sup>From Kibroth Hattaavah the people traveled to Hazeroth; and they stayed at Hazeroth. 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
 <sup>1&#160;</sup>Miriam and Aaron spoke against Moses because of the Cushite woman whom he had taken; for he had taken a Cushite woman. 
-<sup>2&#160;</sup>They said, “Has Yahweh indeed spoken only with Moses? Hasn’t he spoken also with us?” And Yahweh heard it. 
+<sup>2&#160;</sup>They said, “Has Yahuah indeed spoken only with Moses? Hasn’t he spoken also with us?” And Yahuah heard it. 
 </p><p>
 <sup>3&#160;</sup>Now the man Moses was very humble, more than all the men who were on the surface of the earth. 
-<sup>4&#160;</sup>Yahweh spoke suddenly to Moses, to Aaron, and to Miriam, “You three come out to the Tent of Meeting!” 
+<sup>4&#160;</sup>Yahuah spoke suddenly to Moses, to Aaron, and to Miriam, “You three come out to the Tent of Meeting!” 
 </p><p>The three of them came out. 
-<sup>5&#160;</sup>Yahweh came down in a pillar of cloud, and stood at the door of the Tent, and called Aaron and Miriam; and they both came forward. 
-<sup>6&#160;</sup>He said, “Now hear my words. If there is a prophet among you, I, Yahweh, will make myself known to him in a vision. I will speak with him in a dream. 
+<sup>5&#160;</sup>Yahuah came down in a pillar of cloud, and stood at the door of the Tent, and called Aaron and Miriam; and they both came forward. 
+<sup>6&#160;</sup>He said, “Now hear my words. If there is a prophet among you, I, Yahuah, will make myself known to him in a vision. I will speak with him in a dream. 
 <sup>7&#160;</sup>My servant Moses is not so. He is faithful in all my house. 
-<sup>8&#160;</sup>With him, I will speak mouth to mouth, even plainly, and not in riddles; and he shall see Yahweh’s form. Why then were you not afraid to speak against my servant, against Moses?” 
-<sup>9&#160;</sup>Yahweh’s anger burned against them; and he departed. 
+<sup>8&#160;</sup>With him, I will speak mouth to mouth, even plainly, and not in riddles; and he shall see Yahuah’s form. Why then were you not afraid to speak against my servant, against Moses?” 
+<sup>9&#160;</sup>Yahuah’s anger burned against them; and he departed. 
 </p><p>
 <sup>10&#160;</sup>The cloud departed from over the Tent; and behold, Miriam was leprous, as white as snow. Aaron looked at Miriam, and behold, she was leprous. 
 </p><p>
 <sup>11&#160;</sup>Aaron said to Moses, “Oh, my lord, please don’t count this sin against us, in which we have done foolishly, and in which we have sinned. 
 <sup>12&#160;</sup>Let her not, I pray, be as one dead, of whom the flesh is half consumed when he comes out of his mother’s womb.” 
 </p><p>
-<sup>13&#160;</sup>Moses cried to Yahweh, saying, “Heal her, Elohim, I beg you!” 
+<sup>13&#160;</sup>Moses cried to Yahuah, saying, “Heal her, Elohim, I beg you!” 
 </p><p>
-<sup>14&#160;</sup>Yahweh said to Moses, “If her father had but spit in her face, shouldn’t she be ashamed seven days? Let her be shut up outside of the camp seven days, and after that she shall be brought in again.” 
+<sup>14&#160;</sup>Yahuah said to Moses, “If her father had but spit in her face, shouldn’t she be ashamed seven days? Let her be shut up outside of the camp seven days, and after that she shall be brought in again.” 
 </p><p>
 <sup>15&#160;</sup>Miriam was shut up outside of the camp seven days, and the people didn’t travel until Miriam was brought in again. 
 <sup>16&#160;</sup>Afterward the people traveled from Hazeroth, and encamped in the wilderness of Paran. 
 </p><h2 class="chapterlabel" id="13">13</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Send men, that they may spy out the land of Canaan, which I give to the children of Israel. Of every tribe of their fathers, you shall send a man, every one a prince among them.” 
 </p><p>
-<sup>3&#160;</sup>Moses sent them from the wilderness of Paran according to the commandment of Yahweh. All of them were men who were heads of the children of Israel. 
+<sup>3&#160;</sup>Moses sent them from the wilderness of Paran according to the commandment of Yahuah. All of them were men who were heads of the children of Israel. 
 <sup>4&#160;</sup>These were their names: 
 </p><p class="m">Of the tribe of Reuben, Shammua the son of Zaccur. 
 </p><p class="m">
@@ -897,141 +897,141 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>All the congregation lifted up their voice, and cried; and the people wept that night. 
 <sup>2&#160;</sup>All the children of Israel murmured against Moses and against Aaron. The whole congregation said to them, “We wish that we had died in the land of Egypt, or that we had died in this wilderness! 
-<sup>3&#160;</sup>Why does Yahweh bring us to this land, to fall by the sword? Our women and our little ones will be captured or killed! Wouldn’t it be better for us to return into Egypt?” 
+<sup>3&#160;</sup>Why does Yahuah bring us to this land, to fall by the sword? Our women and our little ones will be captured or killed! Wouldn’t it be better for us to return into Egypt?” 
 <sup>4&#160;</sup>They said to one another, “Let’s choose a leader, and let’s return into Egypt.” 
 </p><p>
 <sup>5&#160;</sup>Then Moses and Aaron fell on their faces before all the assembly of the congregation of the children of Israel. 
 </p><p>
 <sup>6&#160;</sup>Joshua the son of Nun and Caleb the son of Jephunneh, who were of those who spied out the land, tore their clothes. 
 <sup>7&#160;</sup>They spoke to all the congregation of the children of Israel, saying, “The land, which we passed through to spy it out, is an exceedingly good land. 
-<sup>8&#160;</sup>If Yahweh delights in us, then he will bring us into this land, and give it to us: a land which flows with milk and honey. 
-<sup>9&#160;</sup>Only don’t rebel against Yahweh, neither fear the people of the land; for they are bread for us. Their defense is removed from over them, and Yahweh is with us. Don’t fear them.” 
+<sup>8&#160;</sup>If Yahuah delights in us, then he will bring us into this land, and give it to us: a land which flows with milk and honey. 
+<sup>9&#160;</sup>Only don’t rebel against Yahuah, neither fear the people of the land; for they are bread for us. Their defense is removed from over them, and Yahuah is with us. Don’t fear them.” 
 </p><p>
 <sup>10&#160;</sup>But all the congregation threatened to stone them with stones. 
-</p><p>Yahweh’s glory appeared in the Tent of Meeting to all the children of Israel. 
-<sup>11&#160;</sup>Yahweh said to Moses, “How long will this people despise me? How long will they not believe in me, for all the signs which I have worked among them? 
+</p><p>Yahuah’s glory appeared in the Tent of Meeting to all the children of Israel. 
+<sup>11&#160;</sup>Yahuah said to Moses, “How long will this people despise me? How long will they not believe in me, for all the signs which I have worked among them? 
 <sup>12&#160;</sup>I will strike them with the pestilence, and disinherit them, and will make of you a nation greater and mightier than they.” 
 </p><p>
-<sup>13&#160;</sup>Moses said to Yahweh, “Then the Egyptians will hear it; for you brought up this people in your might from among them. 
-<sup>14&#160;</sup>They will tell it to the inhabitants of this land. They have heard that you Yahweh are among this people; for you Yahweh are seen face to face, and your cloud stands over them, and you go before them, in a pillar of cloud by day, and in a pillar of fire by night. 
+<sup>13&#160;</sup>Moses said to Yahuah, “Then the Egyptians will hear it; for you brought up this people in your might from among them. 
+<sup>14&#160;</sup>They will tell it to the inhabitants of this land. They have heard that you Yahuah are among this people; for you Yahuah are seen face to face, and your cloud stands over them, and you go before them, in a pillar of cloud by day, and in a pillar of fire by night. 
 <sup>15&#160;</sup>Now if you killed this people as one man, then the nations which have heard the fame of you will speak, saying, 
-<sup>16&#160;</sup>‘Because Yahweh was not able to bring this people into the land which he swore to them, therefore he has slain them in the wilderness.’ 
+<sup>16&#160;</sup>‘Because Yahuah was not able to bring this people into the land which he swore to them, therefore he has slain them in the wilderness.’ 
 <sup>17&#160;</sup>Now please let the power of the Lord be great, according as you have spoken, saying, 
-<sup>18&#160;</sup>‘Yahweh is slow to anger, and abundant in loving kindness, forgiving iniquity and disobedience; and he will by no means clear the guilty, visiting the iniquity of the fathers on the children, on the third and on the fourth generation.’ 
+<sup>18&#160;</sup>‘Yahuah is slow to anger, and abundant in loving kindness, forgiving iniquity and disobedience; and he will by no means clear the guilty, visiting the iniquity of the fathers on the children, on the third and on the fourth generation.’ 
 <sup>19&#160;</sup>Please pardon the iniquity of this people according to the greatness of your loving kindness, and just as you have forgiven this people, from Egypt even until now.” 
 </p><p>
-<sup>20&#160;</sup>Yahweh said, “I have pardoned according to your word; 
-<sup>21&#160;</sup>but in very deed—as I live, and as all the earth shall be filled with Yahweh’s glory—<sup>22&#160;</sup>because all those men who have seen my glory and my signs, which I worked in Egypt and in the wilderness, yet have tempted me these ten times, and have not listened to my voice; 
+<sup>20&#160;</sup>Yahuah said, “I have pardoned according to your word; 
+<sup>21&#160;</sup>but in very deed—as I live, and as all the earth shall be filled with Yahuah’s glory—<sup>22&#160;</sup>because all those men who have seen my glory and my signs, which I worked in Egypt and in the wilderness, yet have tempted me these ten times, and have not listened to my voice; 
 <sup>23&#160;</sup>surely they shall not see the land which I swore to their fathers, neither shall any of those who despised me see it. 
 <sup>24&#160;</sup>But my servant Caleb, because he had another spirit with him, and has followed me fully, him I will bring into the land into which he went. His offspring shall possess it. 
 <sup>25&#160;</sup>Since the Amalekite and the Canaanite dwell in the valley, tomorrow turn and go into the wilderness by the way to the Red Sea.” 
-<sup>26&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>26&#160;</sup>Yahuah spoke to Moses and to Aaron, saying, 
 <sup>27&#160;</sup>“How long shall I bear with this evil congregation that complain against me? I have heard the complaints of the children of Israel, which they complain against me. 
-<sup>28&#160;</sup>Tell them, ‘As I live, says Yahweh, surely as you have spoken in my ears, so I will do to you. 
+<sup>28&#160;</sup>Tell them, ‘As I live, says Yahuah, surely as you have spoken in my ears, so I will do to you. 
 <sup>29&#160;</sup>Your dead bodies shall fall in this wilderness; and all who were counted of you, according to your whole number, from twenty years old and upward, who have complained against me, 
 <sup>30&#160;</sup>surely you shall not come into the land concerning which I swore that I would make you dwell therein, except Caleb the son of Jephunneh, and Joshua the son of Nun. 
 <sup>31&#160;</sup>But I will bring in your little ones that you said should be captured or killed, and they shall know the land which you have rejected. 
 <sup>32&#160;</sup>But as for you, your dead bodies shall fall in this wilderness. 
 <sup>33&#160;</sup>Your children shall be wanderers in the wilderness forty years, and shall bear your prostitution, until your dead bodies are consumed in the wilderness. 
 <sup>34&#160;</sup>After the number of the days in which you spied out the land, even forty days, for every day a year, you will bear your iniquities, even forty years, and you will know my alienation.’ 
-<sup>35&#160;</sup>I, Yahweh, have spoken. I will surely do this to all this evil congregation who are gathered together against me. In this wilderness they shall be consumed, and there they shall die.” 
+<sup>35&#160;</sup>I, Yahuah, have spoken. I will surely do this to all this evil congregation who are gathered together against me. In this wilderness they shall be consumed, and there they shall die.” 
 </p><p>
 <sup>36&#160;</sup>The men whom Moses sent to spy out the land, who returned and made all the congregation to murmur against him by bringing up an evil report against the land, 
-<sup>37&#160;</sup>even those men who brought up an evil report of the land, died by the plague before Yahweh. 
+<sup>37&#160;</sup>even those men who brought up an evil report of the land, died by the plague before Yahuah. 
 <sup>38&#160;</sup>But Joshua the son of Nun and Caleb the son of Jephunneh remained alive of those men who went to spy out the land. 
 </p><p>
 <sup>39&#160;</sup>Moses told these words to all the children of Israel, and the people mourned greatly. 
-<sup>40&#160;</sup>They rose up early in the morning and went up to the top of the mountain, saying, “Behold, we are here, and will go up to the place which Yahweh has promised; for we have sinned.” 
+<sup>40&#160;</sup>They rose up early in the morning and went up to the top of the mountain, saying, “Behold, we are here, and will go up to the place which Yahuah has promised; for we have sinned.” 
 </p><p>
-<sup>41&#160;</sup>Moses said, “Why now do you disobey the commandment of Yahweh, since it shall not prosper? 
-<sup>42&#160;</sup>Don’t go up, for Yahweh isn’t among you; that way you won’t be struck down before your enemies. 
-<sup>43&#160;</sup>For there the Amalekite and the Canaanite are before you, and you will fall by the sword because you turned back from following Yahweh; therefore Yahweh will not be with you.” 
+<sup>41&#160;</sup>Moses said, “Why now do you disobey the commandment of Yahuah, since it shall not prosper? 
+<sup>42&#160;</sup>Don’t go up, for Yahuah isn’t among you; that way you won’t be struck down before your enemies. 
+<sup>43&#160;</sup>For there the Amalekite and the Canaanite are before you, and you will fall by the sword because you turned back from following Yahuah; therefore Yahuah will not be with you.” 
 </p><p>
-<sup>44&#160;</sup>But they presumed to go up to the top of the mountain. Nevertheless, the ark of Yahweh’s covenant and Moses didn’t depart out of the camp. 
+<sup>44&#160;</sup>But they presumed to go up to the top of the mountain. Nevertheless, the ark of Yahuah’s covenant and Moses didn’t depart out of the camp. 
 <sup>45&#160;</sup>Then the Amalekites came down, and the Canaanites who lived in that mountain, and struck them and beat them down even to Hormah. 
 </p><h2 class="chapterlabel" id="15">15</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you have come into the land of your habitations, which I give to you, 
-<sup>3&#160;</sup>and will make an offering by fire to Yahweh—a burnt offering, or a sacrifice, to accomplish a vow, or as a free will offering, or in your set feasts, to make a pleasant aroma to Yahweh, of the herd, or of the flock—<sup>4&#160;</sup>then he who offers his offering shall offer to Yahweh a meal offering of one tenth of an ephah of fine flour mixed with one fourth of a hin of oil. 
+<sup>3&#160;</sup>and will make an offering by fire to Yahuah—a burnt offering, or a sacrifice, to accomplish a vow, or as a free will offering, or in your set feasts, to make a pleasant aroma to Yahuah, of the herd, or of the flock—<sup>4&#160;</sup>then he who offers his offering shall offer to Yahuah a meal offering of one tenth of an ephah of fine flour mixed with one fourth of a hin of oil. 
 <sup>5&#160;</sup>You shall prepare wine for the drink offering, one fourth of a hin, with the burnt offering or for the sacrifice, for each lamb. 
 </p><p>
 <sup>6&#160;</sup>“&#160;‘For a ram, you shall prepare for a meal offering two tenths of an ephah of fine flour mixed with the third part of a hin of oil; 
-<sup>7&#160;</sup>and for the drink offering you shall offer the third part of a hin of wine, of a pleasant aroma to Yahweh. 
-<sup>8&#160;</sup>When you prepare a bull for a burnt offering or for a sacrifice, to accomplish a vow, or for peace offerings to Yahweh, 
+<sup>7&#160;</sup>and for the drink offering you shall offer the third part of a hin of wine, of a pleasant aroma to Yahuah. 
+<sup>8&#160;</sup>When you prepare a bull for a burnt offering or for a sacrifice, to accomplish a vow, or for peace offerings to Yahuah, 
 <sup>9&#160;</sup>then he shall offer with the bull a meal offering of three tenths of an ephah of fine flour mixed with half a hin of oil; 
-<sup>10&#160;</sup>and you shall offer for the drink offering half a hin of wine, for an offering made by fire, of a pleasant aroma to Yahweh. 
+<sup>10&#160;</sup>and you shall offer for the drink offering half a hin of wine, for an offering made by fire, of a pleasant aroma to Yahuah. 
 <sup>11&#160;</sup>Thus it shall be done for each bull, for each ram, for each of the male lambs, or of the young goats. 
 <sup>12&#160;</sup>According to the number that you shall prepare, so you shall do to everyone according to their number. 
 </p><p>
-<sup>13&#160;</sup>“&#160;‘All who are native-born shall do these things in this way, in offering an offering made by fire, of a pleasant aroma to Yahweh. 
-<sup>14&#160;</sup>If a stranger lives as a foreigner with you, or whoever may be among you throughout your generations, and will offer an offering made by fire, of a pleasant aroma to Yahweh, as you do, so he shall do. 
-<sup>15&#160;</sup>For the assembly, there shall be one statute for you and for the stranger who lives as a foreigner, a statute forever throughout your generations. As you are, so the foreigner shall be before Yahweh. 
+<sup>13&#160;</sup>“&#160;‘All who are native-born shall do these things in this way, in offering an offering made by fire, of a pleasant aroma to Yahuah. 
+<sup>14&#160;</sup>If a stranger lives as a foreigner with you, or whoever may be among you throughout your generations, and will offer an offering made by fire, of a pleasant aroma to Yahuah, as you do, so he shall do. 
+<sup>15&#160;</sup>For the assembly, there shall be one statute for you and for the stranger who lives as a foreigner, a statute forever throughout your generations. As you are, so the foreigner shall be before Yahuah. 
 <sup>16&#160;</sup>One law and one ordinance shall be for you and for the stranger who lives as a foreigner with you.’&#160;” 
 </p><p>
-<sup>17&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>17&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>18&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you come into the land where I bring you, 
-<sup>19&#160;</sup>then it shall be that when you eat of the bread of the land, you shall offer up a wave offering to Yahweh. 
+<sup>19&#160;</sup>then it shall be that when you eat of the bread of the land, you shall offer up a wave offering to Yahuah. 
 <sup>20&#160;</sup>Of the first of your dough you shall offer up a cake for a wave offering. As the wave offering of the threshing floor, so you shall heave it. 
-<sup>21&#160;</sup>Of the first of your dough, you shall give to Yahweh a wave offering throughout your generations. 
+<sup>21&#160;</sup>Of the first of your dough, you shall give to Yahuah a wave offering throughout your generations. 
 </p><p>
-<sup>22&#160;</sup>“&#160;‘When you err, and don’t observe all these commandments which Yahweh has spoken to Moses—<sup>23&#160;</sup>even all that Yahweh has commanded you by Moses, from the day that Yahweh gave commandment and onward throughout your generations—<sup>24&#160;</sup>then it shall be, if it was done unwittingly, without the knowledge of the congregation, that all the congregation shall offer one young bull for a burnt offering, for a pleasant aroma to Yahweh, with its meal offering and its drink offering, according to the ordinance, and one male goat for a sin offering. 
-<sup>25&#160;</sup>The priest shall make atonement for all the congregation of the children of Israel, and they shall be forgiven; for it was an error, and they have brought their offering, an offering made by fire to Yahweh, and their sin offering before Yahweh, for their error. 
+<sup>22&#160;</sup>“&#160;‘When you err, and don’t observe all these commandments which Yahuah has spoken to Moses—<sup>23&#160;</sup>even all that Yahuah has commanded you by Moses, from the day that Yahuah gave commandment and onward throughout your generations—<sup>24&#160;</sup>then it shall be, if it was done unwittingly, without the knowledge of the congregation, that all the congregation shall offer one young bull for a burnt offering, for a pleasant aroma to Yahuah, with its meal offering and its drink offering, according to the ordinance, and one male goat for a sin offering. 
+<sup>25&#160;</sup>The priest shall make atonement for all the congregation of the children of Israel, and they shall be forgiven; for it was an error, and they have brought their offering, an offering made by fire to Yahuah, and their sin offering before Yahuah, for their error. 
 <sup>26&#160;</sup>All the congregation of the children of Israel shall be forgiven, as well as the stranger who lives as a foreigner among them; for with regard to all the people, it was done unwittingly. 
 </p><p>
 <sup>27&#160;</sup>“&#160;‘If a person sins unwittingly, then he shall offer a female goat a year old for a sin offering. 
-<sup>28&#160;</sup>The priest shall make atonement for the soul who errs when he sins unwittingly before Yahweh. He shall make atonement for him; and he shall be forgiven. 
+<sup>28&#160;</sup>The priest shall make atonement for the soul who errs when he sins unwittingly before Yahuah. He shall make atonement for him; and he shall be forgiven. 
 <sup>29&#160;</sup>You shall have one law for him who does anything unwittingly, for him who is native-born among the children of Israel, and for the stranger who lives as a foreigner among them. 
 </p><p>
-<sup>30&#160;</sup>“&#160;‘But the soul who does anything with a high hand, whether he is native-born or a foreigner, blasphemes Yahweh. That soul shall be cut off from among his people. 
-<sup>31&#160;</sup>Because he has despised Yahweh’s word, and has broken his commandment, that soul shall be utterly cut off. His iniquity shall be on him.’&#160;” 
+<sup>30&#160;</sup>“&#160;‘But the soul who does anything with a high hand, whether he is native-born or a foreigner, blasphemes Yahuah. That soul shall be cut off from among his people. 
+<sup>31&#160;</sup>Because he has despised Yahuah’s word, and has broken his commandment, that soul shall be utterly cut off. His iniquity shall be on him.’&#160;” 
 </p><p>
 <sup>32&#160;</sup>While the children of Israel were in the wilderness, they found a man gathering sticks on the Sabbath day. 
 <sup>33&#160;</sup>Those who found him gathering sticks brought him to Moses and Aaron, and to all the congregation. 
 <sup>34&#160;</sup>They put him in custody, because it had not been declared what should be done to him. 
 </p><p>
-<sup>35&#160;</sup>Yahweh said to Moses, “The man shall surely be put to death. All the congregation shall stone him with stones outside of the camp.” 
-<sup>36&#160;</sup>All the congregation brought him outside of the camp, and stoned him to death with stones, as Yahweh commanded Moses. 
+<sup>35&#160;</sup>Yahuah said to Moses, “The man shall surely be put to death. All the congregation shall stone him with stones outside of the camp.” 
+<sup>36&#160;</sup>All the congregation brought him outside of the camp, and stoned him to death with stones, as Yahuah commanded Moses. 
 </p><p>
-<sup>37&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>37&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>38&#160;</sup>“Speak to the children of Israel, and tell them that they should make themselves fringes on the borders of their garments throughout their generations, and that they put on the fringe of each border a cord of blue. 
-<sup>39&#160;</sup>It shall be to you for a fringe, that you may see it, and remember all Yahweh’s commandments, and do them; and that you don’t follow your own heart and your own eyes, after which you used to play the prostitute; 
+<sup>39&#160;</sup>It shall be to you for a fringe, that you may see it, and remember all Yahuah’s commandments, and do them; and that you don’t follow your own heart and your own eyes, after which you used to play the prostitute; 
 <sup>40&#160;</sup>so that you may remember and do all my commandments, and be set-apart to your Elohim. 
-<sup>41&#160;</sup>I am Yahweh your Elohim, who brought you out of the land of Egypt, to be your Elohim: I am Yahweh your Elohim.” 
+<sup>41&#160;</sup>I am Yahuah your Elohim, who brought you out of the land of Egypt, to be your Elohim: I am Yahuah your Elohim.” 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p>
 <sup>1&#160;</sup>Now Korah, the son of Izhar, the son of Kohath, the son of Levi, with Dathan and Abiram, the sons of Eliab, and On, the son of Peleth, sons of Reuben, took some men. 
 <sup>2&#160;</sup>They rose up before Moses, with some of the children of Israel, two hundred fifty princes of the congregation, called to the assembly, men of renown. 
-<sup>3&#160;</sup>They assembled themselves together against Moses and against Aaron, and said to them, “You take too much on yourself, since all the congregation are set-apart, everyone of them, and Yahweh is among them! Why do you lift yourselves up above Yahweh’s assembly?” 
+<sup>3&#160;</sup>They assembled themselves together against Moses and against Aaron, and said to them, “You take too much on yourself, since all the congregation are set-apart, everyone of them, and Yahuah is among them! Why do you lift yourselves up above Yahuah’s assembly?” 
 </p><p>
 <sup>4&#160;</sup>When Moses heard it, he fell on his face. 
-<sup>5&#160;</sup>He said to Korah and to all his company, “In the morning, Yahweh will show who are his, and who is set-apart, and will cause him to come near to him. Even him whom he shall choose, he will cause to come near to him. 
+<sup>5&#160;</sup>He said to Korah and to all his company, “In the morning, Yahuah will show who are his, and who is set-apart, and will cause him to come near to him. Even him whom he shall choose, he will cause to come near to him. 
 <sup>6&#160;</sup>Do this: have Korah and all his company take censers, 
-<sup>7&#160;</sup>put fire in them, and put incense on them before Yahweh tomorrow. It shall be that the man whom Yahweh chooses, he shall be set-apart. You have gone too far, you sons of Levi!” 
+<sup>7&#160;</sup>put fire in them, and put incense on them before Yahuah tomorrow. It shall be that the man whom Yahuah chooses, he shall be set-apart. You have gone too far, you sons of Levi!” 
 </p><p>
 <sup>8&#160;</sup>Moses said to Korah, “Hear now, you sons of Levi! 
-<sup>9&#160;</sup>Is it a small thing to you that the Elohim of Israel has separated you from the congregation of Israel, to bring you near to himself, to do the service of Yahweh’s tabernacle, and to stand before the congregation to minister to them; 
+<sup>9&#160;</sup>Is it a small thing to you that the Elohim of Israel has separated you from the congregation of Israel, to bring you near to himself, to do the service of Yahuah’s tabernacle, and to stand before the congregation to minister to them; 
 <sup>10&#160;</sup>and that he has brought you near, and all your brothers the sons of Levi with you? Do you seek the priesthood also? 
-<sup>11&#160;</sup>Therefore you and all your company have gathered together against Yahweh! What is Aaron that you complain against him?” 
+<sup>11&#160;</sup>Therefore you and all your company have gathered together against Yahuah! What is Aaron that you complain against him?” 
 </p><p>
 <sup>12&#160;</sup>Moses sent to call Dathan and Abiram, the sons of Eliab; and they said, “We won’t come up! 
 <sup>13&#160;</sup>Is it a small thing that you have brought us up out of a land flowing with milk and honey, to kill us in the wilderness, but you must also make yourself a prince over us? 
 <sup>14&#160;</sup>Moreover you haven’t brought us into a land flowing with milk and honey, nor given us inheritance of fields and vineyards. Will you put out the eyes of these men? We won’t come up.” 
 </p><p>
-<sup>15&#160;</sup>Moses was very angry, and said to Yahweh, “Don’t respect their offering. I have not taken one donkey from them, neither have I hurt one of them.” 
+<sup>15&#160;</sup>Moses was very angry, and said to Yahuah, “Don’t respect their offering. I have not taken one donkey from them, neither have I hurt one of them.” 
 </p><p>
-<sup>16&#160;</sup>Moses said to Korah, “You and all your company go before Yahweh, you, and they, and Aaron, tomorrow. 
-<sup>17&#160;</sup>Each man take his censer and put incense on it, and each man bring before Yahweh his censer, two hundred fifty censers; you also, and Aaron, each with his censer.” 
+<sup>16&#160;</sup>Moses said to Korah, “You and all your company go before Yahuah, you, and they, and Aaron, tomorrow. 
+<sup>17&#160;</sup>Each man take his censer and put incense on it, and each man bring before Yahuah his censer, two hundred fifty censers; you also, and Aaron, each with his censer.” 
 </p><p>
 <sup>18&#160;</sup>They each took his censer, and put fire in it, and laid incense on it, and stood at the door of the Tent of Meeting with Moses and Aaron. 
 <sup>19&#160;</sup>Korah assembled all the congregation opposite them to the door of the Tent of Meeting. 
-</p><p>Yahweh’s glory appeared to all the congregation. 
-<sup>20&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+</p><p>Yahuah’s glory appeared to all the congregation. 
+<sup>20&#160;</sup>Yahuah spoke to Moses and to Aaron, saying, 
 <sup>21&#160;</sup>“Separate yourselves from among this congregation, that I may consume them in a moment!” 
 </p><p>
 <sup>22&#160;</sup>They fell on their faces, and said, “Elohim, the Elohim of the spirits of all flesh, shall one man sin, and will you be angry with all the congregation?” 
 </p><p>
-<sup>23&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>23&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>24&#160;</sup>“Speak to the congregation, saying, ‘Get away from around the tent of Korah, Dathan, and Abiram!’&#160;” 
 </p><p>
 <sup>25&#160;</sup>Moses rose up and went to Dathan and Abiram; and the elders of Israel followed him. 
@@ -1039,31 +1039,31 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>27&#160;</sup>So they went away from the tent of Korah, Dathan, and Abiram, on every side. Dathan and Abiram came out, and stood at the door of their tents with their women, their sons, and their little ones. 
 </p><p>
-<sup>28&#160;</sup>Moses said, “Hereby you shall know that Yahweh has sent me to do all these works; for they are not from my own mind. 
-<sup>29&#160;</sup>If these men die the common death of all men, or if they experience what all men experience, then Yahweh hasn’t sent me. 
-<sup>30&#160;</sup>But if Yahweh makes a new thing, and the ground opens its mouth, and swallows them up with all that belong to them, and they go down alive into Sheol, then you shall understand that these men have despised Yahweh.” 
+<sup>28&#160;</sup>Moses said, “Hereby you shall know that Yahuah has sent me to do all these works; for they are not from my own mind. 
+<sup>29&#160;</sup>If these men die the common death of all men, or if they experience what all men experience, then Yahuah hasn’t sent me. 
+<sup>30&#160;</sup>But if Yahuah makes a new thing, and the ground opens its mouth, and swallows them up with all that belong to them, and they go down alive into Sheol, then you shall understand that these men have despised Yahuah.” 
 </p><p>
 <sup>31&#160;</sup>As he finished speaking all these words, the ground that was under them split apart. 
 <sup>32&#160;</sup>The earth opened its mouth and swallowed them up with their households, all of Korah’s men, and all their goods. 
 <sup>33&#160;</sup>So they, and all that belonged to them went down alive into Sheol. The earth closed on them, and they perished from among the assembly. 
 <sup>34&#160;</sup>All Israel that were around them fled at their cry; for they said, “Lest the earth swallow us up!” 
-<sup>35&#160;</sup>Fire came out from Yahweh, and devoured the two hundred fifty men who offered the incense. 
+<sup>35&#160;</sup>Fire came out from Yahuah, and devoured the two hundred fifty men who offered the incense. 
 </p><p>
-<sup>36&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>36&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>37&#160;</sup>“Speak to Eleazar the son of Aaron the priest, that he take up the censers out of the burning, and scatter the fire away from the camp; for they are set-apart, 
-<sup>38&#160;</sup>even the censers of those who sinned against their own lives. Let them be beaten into plates for a covering of the altar, for they offered them before Yahweh. Therefore they are set-apart. They shall be a sign to the children of Israel.” 
+<sup>38&#160;</sup>even the censers of those who sinned against their own lives. Let them be beaten into plates for a covering of the altar, for they offered them before Yahuah. Therefore they are set-apart. They shall be a sign to the children of Israel.” 
 </p><p>
 <sup>39&#160;</sup>Eleazar the priest took the bronze censers which those who were burned had offered; and they beat them out for a covering of the altar, 
-<sup>40&#160;</sup>to be a memorial to the children of Israel, to the end that no stranger who isn’t of the offspring of Aaron, would come near to burn incense before Yahweh, that he not be as Korah and as his company; as Yahweh spoke to him by Moses. 
+<sup>40&#160;</sup>to be a memorial to the children of Israel, to the end that no stranger who isn’t of the offspring of Aaron, would come near to burn incense before Yahuah, that he not be as Korah and as his company; as Yahuah spoke to him by Moses. 
 </p><p>
-<sup>41&#160;</sup>But on the next day all the congregation of the children of Israel complained against Moses and against Aaron, saying, “You have killed Yahweh’s people!” 
+<sup>41&#160;</sup>But on the next day all the congregation of the children of Israel complained against Moses and against Aaron, saying, “You have killed Yahuah’s people!” 
 </p><p>
-<sup>42&#160;</sup>When the congregation was assembled against Moses and against Aaron, they looked toward the Tent of Meeting. Behold, the cloud covered it, and Yahweh’s glory appeared. 
+<sup>42&#160;</sup>When the congregation was assembled against Moses and against Aaron, they looked toward the Tent of Meeting. Behold, the cloud covered it, and Yahuah’s glory appeared. 
 <sup>43&#160;</sup>Moses and Aaron came to the front of the Tent of Meeting. 
-<sup>44&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>44&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>45&#160;</sup>“Get away from among this congregation, that I may consume them in a moment!” They fell on their faces. 
 </p><p>
-<sup>46&#160;</sup>Moses said to Aaron, “Take your censer, put fire from the altar in it, lay incense on it, carry it quickly to the congregation, and make atonement for them; for wrath has gone out from Yahweh! The plague has begun.” 
+<sup>46&#160;</sup>Moses said to Aaron, “Take your censer, put fire from the altar in it, lay incense on it, carry it quickly to the congregation, and make atonement for them; for wrath has gone out from Yahuah! The plague has begun.” 
 </p><p>
 <sup>47&#160;</sup>Aaron did as Moses said, and ran into the middle of the assembly. The plague had already begun among the people. He put on the incense, and made atonement for the people. 
 <sup>48&#160;</sup>He stood between the dead and the living; and the plague was stayed. 
@@ -1071,71 +1071,71 @@ html[dir=ltr] .q2 {
 <sup>50&#160;</sup>Aaron returned to Moses to the door of the Tent of Meeting, and the plague was stopped. 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Speak to the children of Israel, and take rods from them, one for each fathers’ house, of all their princes according to their fathers’ houses, twelve rods. Write each man’s name on his rod. 
 <sup>3&#160;</sup>You shall write Aaron’s name on Levi’s rod. There shall be one rod for each head of their fathers’ houses. 
 <sup>4&#160;</sup>You shall lay them up in the Tent of Meeting before the covenant, where I meet with you. 
 <sup>5&#160;</sup>It shall happen that the rod of the man whom I shall choose shall bud. I will make the murmurings of the children of Israel, which they murmur against you, cease from me.” 
 </p><p>
 <sup>6&#160;</sup>Moses spoke to the children of Israel; and all their princes gave him rods, for each prince one, according to their fathers’ houses, a total of twelve rods. Aaron’s rod was among their rods. 
-<sup>7&#160;</sup>Moses laid up the rods before Yahweh in the Tent of the Testimony. 
+<sup>7&#160;</sup>Moses laid up the rods before Yahuah in the Tent of the Testimony. 
 </p><p>
 <sup>8&#160;</sup>On the next day, Moses went into the Tent of the Testimony; and behold, Aaron’s rod for the house of Levi had sprouted, budded, produced blossoms, and bore ripe almonds. 
-<sup>9&#160;</sup>Moses brought out all the rods from before Yahweh to all the children of Israel. They looked, and each man took his rod. 
+<sup>9&#160;</sup>Moses brought out all the rods from before Yahuah to all the children of Israel. They looked, and each man took his rod. 
 </p><p>
-<sup>10&#160;</sup>Yahweh said to Moses, “Put back the rod of Aaron before the covenant, to be kept for a token against the children of rebellion; that you may make an end of their complaining against me, that they not die.” 
-<sup>11&#160;</sup>Moses did so. As Yahweh commanded him, so he did. 
+<sup>10&#160;</sup>Yahuah said to Moses, “Put back the rod of Aaron before the covenant, to be kept for a token against the children of rebellion; that you may make an end of their complaining against me, that they not die.” 
+<sup>11&#160;</sup>Moses did so. As Yahuah commanded him, so he did. 
 </p><p>
 <sup>12&#160;</sup>The children of Israel spoke to Moses, saying, “Behold, we perish! We are undone! We are all undone! 
-<sup>13&#160;</sup>Everyone who keeps approaching Yahweh’s tabernacle, dies! Will we all perish?” 
+<sup>13&#160;</sup>Everyone who keeps approaching Yahuah’s tabernacle, dies! Will we all perish?” 
 </p><h2 class="chapterlabel" id="18">18</h2>
 <p>
-<sup>1&#160;</sup>Yahweh said to Aaron, “You and your sons and your fathers’ house with you shall bear the iniquity of the sanctuary; and you and your sons with you shall bear the iniquity of your priesthood. 
+<sup>1&#160;</sup>Yahuah said to Aaron, “You and your sons and your fathers’ house with you shall bear the iniquity of the sanctuary; and you and your sons with you shall bear the iniquity of your priesthood. 
 <sup>2&#160;</sup>Bring your brothers also, the tribe of Levi, the tribe of your father, near with you, that they may be joined to you, and minister to you; but you and your sons with you shall be before the Tent of the Testimony. 
 <sup>3&#160;</sup>They shall keep your commands and the duty of the whole Tent; only they shall not come near to the vessels of the sanctuary and to the altar, that they not die, neither they nor you. 
 <sup>4&#160;</sup>They shall be joined to you and keep the responsibility of the Tent of Meeting, for all the service of the Tent. A stranger shall not come near to you. 
 </p><p>
 <sup>5&#160;</sup>“You shall perform the duty of the sanctuary and the duty of the altar, that there be no more wrath on the children of Israel. 
-<sup>6&#160;</sup>Behold, I myself have taken your brothers the Levites from among the children of Israel. They are a gift to you, dedicated to Yahweh, to do the service of the Tent of Meeting. 
+<sup>6&#160;</sup>Behold, I myself have taken your brothers the Levites from among the children of Israel. They are a gift to you, dedicated to Yahuah, to do the service of the Tent of Meeting. 
 <sup>7&#160;</sup>You and your sons with you shall keep your priesthood for everything of the altar, and for that within the veil. You shall serve. I give you the service of the priesthood as a gift. The stranger who comes near shall be put to death.” 
 </p><p>
-<sup>8&#160;</sup>Yahweh spoke to Aaron, “Behold, I myself have given you the command of my wave offerings, even all the set-apart things of the children of Israel. I have given them to you by reason of the anointing, and to your sons, as a portion forever. 
+<sup>8&#160;</sup>Yahuah spoke to Aaron, “Behold, I myself have given you the command of my wave offerings, even all the set-apart things of the children of Israel. I have given them to you by reason of the anointing, and to your sons, as a portion forever. 
 <sup>9&#160;</sup>This shall be yours of the most set-apart things from the fire: every offering of theirs, even every meal offering of theirs, and every sin offering of theirs, and every trespass offering of theirs, which they shall render to me, shall be most set-apart for you and for your sons. 
 <sup>10&#160;</sup>You shall eat of it like the most set-apart things. Every male shall eat of it. It shall be set-apart to you. 
 </p><p>
 <sup>11&#160;</sup>“This is yours, too: the wave offering of their gift, even all the wave offerings of the children of Israel. I have given them to you, and to your sons and to your daughters with you, as a portion forever. Everyone who is clean in your house shall eat of it. 
 </p><p>
-<sup>12&#160;</sup>“I have given to you all the best of the oil, all the best of the vintage, and of the grain, the first fruits of them which they give to Yahweh. 
-<sup>13&#160;</sup>The first-ripe fruits of all that is in their land, which they bring to Yahweh, shall be yours. Everyone who is clean in your house shall eat of it. 
+<sup>12&#160;</sup>“I have given to you all the best of the oil, all the best of the vintage, and of the grain, the first fruits of them which they give to Yahuah. 
+<sup>13&#160;</sup>The first-ripe fruits of all that is in their land, which they bring to Yahuah, shall be yours. Everyone who is clean in your house shall eat of it. 
 </p><p>
 <sup>14&#160;</sup>“Everything devoted in Israel shall be yours. 
-<sup>15&#160;</sup>Everything that opens the womb, of all flesh which they offer to Yahweh, both of man and animal, shall be yours. Nevertheless, you shall surely redeem the firstborn of man, and you shall redeem the firstborn of unclean animals. 
+<sup>15&#160;</sup>Everything that opens the womb, of all flesh which they offer to Yahuah, both of man and animal, shall be yours. Nevertheless, you shall surely redeem the firstborn of man, and you shall redeem the firstborn of unclean animals. 
 <sup>16&#160;</sup>You shall redeem those who are to be redeemed of them from a month old, according to your estimation, for five shekels of money, according to the shekel of the sanctuary, which weighs twenty gerahs. 
 </p><p>
-<sup>17&#160;</sup>“But you shall not redeem the firstborn of a cow, or the firstborn of a sheep, or the firstborn of a goat. They are set-apart. You shall sprinkle their blood on the altar, and shall burn their fat for an offering made by fire, for a pleasant aroma to Yahweh. 
+<sup>17&#160;</sup>“But you shall not redeem the firstborn of a cow, or the firstborn of a sheep, or the firstborn of a goat. They are set-apart. You shall sprinkle their blood on the altar, and shall burn their fat for an offering made by fire, for a pleasant aroma to Yahuah. 
 <sup>18&#160;</sup>Their meat shall be yours, as the wave offering breast and as the right thigh, it shall be yours. 
-<sup>19&#160;</sup>All the wave offerings of the set-apart things which the children of Israel offer to Yahweh, I have given you and your sons and your daughters with you, as a portion forever. It is a covenant of salt forever before Yahweh to you and to your offspring with you.” 
+<sup>19&#160;</sup>All the wave offerings of the set-apart things which the children of Israel offer to Yahuah, I have given you and your sons and your daughters with you, as a portion forever. It is a covenant of salt forever before Yahuah to you and to your offspring with you.” 
 </p><p>
-<sup>20&#160;</sup>Yahweh said to Aaron, “You shall have no inheritance in their land, neither shall you have any portion among them. I am your portion and your inheritance among the children of Israel. 
+<sup>20&#160;</sup>Yahuah said to Aaron, “You shall have no inheritance in their land, neither shall you have any portion among them. I am your portion and your inheritance among the children of Israel. 
 </p><p>
 <sup>21&#160;</sup>“To the children of Levi, behold, I have given all the tithe in Israel for an inheritance, in return for their service which they serve, even the service of the Tent of Meeting. 
 <sup>22&#160;</sup>Henceforth the children of Israel shall not come near the Tent of Meeting, lest they bear sin, and die. 
 <sup>23&#160;</sup>But the Levites shall do the service of the Tent of Meeting, and they shall bear their iniquity. It shall be a statute forever throughout your generations. Among the children of Israel, they shall have no inheritance. 
-<sup>24&#160;</sup>For the tithe of the children of Israel, which they offer as a wave offering to Yahweh, I have given to the Levites for an inheritance. Therefore I have said to them, ‘Among the children of Israel they shall have no inheritance.’&#160;” 
+<sup>24&#160;</sup>For the tithe of the children of Israel, which they offer as a wave offering to Yahuah, I have given to the Levites for an inheritance. Therefore I have said to them, ‘Among the children of Israel they shall have no inheritance.’&#160;” 
 </p><p>
-<sup>25&#160;</sup>Yahweh spoke to Moses, saying, 
-<sup>26&#160;</sup>“Moreover you shall speak to the Levites, and tell them, ‘When you take of the children of Israel the tithe which I have given you from them for your inheritance, then you shall offer up a wave offering of it for Yahweh, a tithe of the tithe. 
+<sup>25&#160;</sup>Yahuah spoke to Moses, saying, 
+<sup>26&#160;</sup>“Moreover you shall speak to the Levites, and tell them, ‘When you take of the children of Israel the tithe which I have given you from them for your inheritance, then you shall offer up a wave offering of it for Yahuah, a tithe of the tithe. 
 <sup>27&#160;</sup>Your wave offering shall be credited to you, as though it were the grain of the threshing floor, and as the fullness of the wine press. 
-<sup>28&#160;</sup>Thus you also shall offer a wave offering to Yahweh of all your tithes, which you receive of the children of Israel; and of it you shall give Yahweh’s wave offering to Aaron the priest. 
-<sup>29&#160;</sup>Out of all your gifts, you shall offer every wave offering to Yahweh, of all its best parts, even the set-apart part of it.’ 
+<sup>28&#160;</sup>Thus you also shall offer a wave offering to Yahuah of all your tithes, which you receive of the children of Israel; and of it you shall give Yahuah’s wave offering to Aaron the priest. 
+<sup>29&#160;</sup>Out of all your gifts, you shall offer every wave offering to Yahuah, of all its best parts, even the set-apart part of it.’ 
 </p><p>
 <sup>30&#160;</sup>“Therefore you shall tell them, ‘When you heave its best from it, then it shall be credited to the Levites as the increase of the threshing floor, and as the increase of the wine press. 
 <sup>31&#160;</sup>You may eat it anywhere, you and your households, for it is your reward in return for your service in the Tent of Meeting. 
 <sup>32&#160;</sup>You shall bear no sin by reason of it, when you have heaved from it its best. You shall not profane the set-apart things of the children of Israel, that you not die.’&#160;” 
 </p><h2 class="chapterlabel" id="19">19</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
-<sup>2&#160;</sup>“This is the statute of the law which Yahweh has commanded. Tell the children of Israel to bring you a red heifer without spot, in which is no defect, and which was never yoked. 
+<sup>1&#160;</sup>Yahuah spoke to Moses and to Aaron, saying, 
+<sup>2&#160;</sup>“This is the statute of the law which Yahuah has commanded. Tell the children of Israel to bring you a red heifer without spot, in which is no defect, and which was never yoked. 
 <sup>3&#160;</sup>You shall give her to Eleazar the priest, and he shall bring her outside of the camp, and one shall kill her before his face. 
 <sup>4&#160;</sup>Eleazar the priest shall take some of her blood with his finger, and sprinkle her blood toward the front of the Tent of Meeting seven times. 
 <sup>5&#160;</sup>One shall burn the heifer in his sight; her skin, and her meat, and her blood, with her dung, shall he burn. 
@@ -1148,7 +1148,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>11&#160;</sup>“He who touches the dead body of any man shall be unclean seven days. 
 <sup>12&#160;</sup>He shall purify himself with water on the third day, and on the seventh day he shall be clean; but if he doesn’t purify himself the third day, then the seventh day he shall not be clean. 
-<sup>13&#160;</sup>Whoever touches a dead person, the body of a man who has died, and doesn’t purify himself, defiles Yahweh’s tabernacle; and that soul shall be cut off from Israel; because the water for impurity was not sprinkled on him, he shall be unclean. His uncleanness is yet on him. 
+<sup>13&#160;</sup>Whoever touches a dead person, the body of a man who has died, and doesn’t purify himself, defiles Yahuah’s tabernacle; and that soul shall be cut off from Israel; because the water for impurity was not sprinkled on him, he shall be unclean. His uncleanness is yet on him. 
 </p><p>
 <sup>14&#160;</sup>“This is the law when a man dies in a tent: everyone who comes into the tent, and everyone who is in the tent, shall be unclean seven days. 
 <sup>15&#160;</sup>Every open vessel, which has no covering bound on it, is unclean. 
@@ -1158,7 +1158,7 @@ html[dir=ltr] .q2 {
 <sup>17&#160;</sup>“For the unclean, they shall take of the ashes of the burning of the sin offering; and running water shall be poured on them in a vessel. 
 <sup>18&#160;</sup>A clean person shall take hyssop, dip it in the water, and sprinkle it on the tent, on all the vessels, on the persons who were there, and on him who touched the bone, or the slain, or the dead, or the grave. 
 <sup>19&#160;</sup>The clean person shall sprinkle on the unclean on the third day, and on the seventh day. On the seventh day, he shall purify him. He shall wash his clothes and bathe himself in water, and shall be clean at evening. 
-<sup>20&#160;</sup>But the man who shall be unclean, and shall not purify himself, that soul shall be cut off from among the assembly, because he has defiled the sanctuary of Yahweh. The water for impurity has not been sprinkled on him. He is unclean. 
+<sup>20&#160;</sup>But the man who shall be unclean, and shall not purify himself, that soul shall be cut off from among the assembly, because he has defiled the sanctuary of Yahuah. The water for impurity has not been sprinkled on him. He is unclean. 
 <sup>21&#160;</sup>It shall be a perpetual statute to them. He who sprinkles the water for impurity shall wash his clothes, and he who touches the water for impurity shall be unclean until evening. 
 </p><p>
 <sup>22&#160;</sup>“Whatever the unclean person touches shall be unclean; and the soul that touches it shall be unclean until evening.” 
@@ -1166,26 +1166,26 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>The children of Israel, even the whole congregation, came into the wilderness of Zin in the first month. The people stayed in Kadesh. Miriam died there, and was buried there. 
 <sup>2&#160;</sup>There was no water for the congregation; and they assembled themselves together against Moses and against Aaron. 
-<sup>3&#160;</sup>The people quarreled with Moses, and spoke, saying, “We wish that we had died when our brothers died before Yahweh! 
-<sup>4&#160;</sup>Why have you brought Yahweh’s assembly into this wilderness, that we should die there, we and our animals? 
+<sup>3&#160;</sup>The people quarreled with Moses, and spoke, saying, “We wish that we had died when our brothers died before Yahuah! 
+<sup>4&#160;</sup>Why have you brought Yahuah’s assembly into this wilderness, that we should die there, we and our animals? 
 <sup>5&#160;</sup>Why have you made us to come up out of Egypt, to bring us in to this evil place? It is no place of seed, or of figs, or of vines, or of pomegranates; neither is there any water to drink.” 
 </p><p>
-<sup>6&#160;</sup>Moses and Aaron went from the presence of the assembly to the door of the Tent of Meeting, and fell on their faces. Yahweh’s glory appeared to them. 
-<sup>7&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>6&#160;</sup>Moses and Aaron went from the presence of the assembly to the door of the Tent of Meeting, and fell on their faces. Yahuah’s glory appeared to them. 
+<sup>7&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>8&#160;</sup>“Take the rod, and assemble the congregation, you, and Aaron your brother, and speak to the rock before their eyes, that it pour out its water. You shall bring water to them out of the rock; so you shall give the congregation and their livestock drink.” 
 </p><p>
-<sup>9&#160;</sup>Moses took the rod from before Yahweh, as he commanded him. 
+<sup>9&#160;</sup>Moses took the rod from before Yahuah, as he commanded him. 
 <sup>10&#160;</sup>Moses and Aaron gathered the assembly together before the rock, and he said to them, “Hear now, you rebels! Shall we bring water out of this rock for you?” 
 <sup>11&#160;</sup>Moses lifted up his hand, and struck the rock with his rod twice, and water came out abundantly. The congregation and their livestock drank. 
 </p><p>
-<sup>12&#160;</sup>Yahweh said to Moses and Aaron, “Because you didn’t believe in me, to sanctify me in the eyes of the children of Israel, therefore you shall not bring this assembly into the land which I have given them.” 
+<sup>12&#160;</sup>Yahuah said to Moses and Aaron, “Because you didn’t believe in me, to sanctify me in the eyes of the children of Israel, therefore you shall not bring this assembly into the land which I have given them.” 
 </p><p>
-<sup>13&#160;</sup>These are the waters of Meribah; because the children of Israel strove with Yahweh, and he was sanctified in them. 
+<sup>13&#160;</sup>These are the waters of Meribah; because the children of Israel strove with Yahuah, and he was sanctified in them. 
 </p><p>
 <sup>14&#160;</sup>Moses sent messengers from Kadesh to the king of Edom, saying: 
 </p><p>“Your brother Israel says: You know all the travail that has happened to us; 
 <sup>15&#160;</sup>how our fathers went down into Egypt, and we lived in Egypt a long time. The Egyptians mistreated us and our fathers. 
-<sup>16&#160;</sup>When we cried to Yahweh, he heard our voice, sent an angel, and brought us out of Egypt. Behold, we are in Kadesh, a city in the edge of your border. 
+<sup>16&#160;</sup>When we cried to Yahuah, he heard our voice, sent an angel, and brought us out of Egypt. Behold, we are in Kadesh, a city in the edge of your border. 
 </p><p>
 <sup>17&#160;</sup>“Please let us pass through your land. We will not pass through field or through vineyard, neither will we drink from the water of the wells. We will go along the king’s highway. We will not turn away to the right hand nor to the left, until we have passed your border.” 
 </p><p>
@@ -1197,37 +1197,37 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>Thus Edom refused to give Israel passage through his border, so Israel turned away from him. 
 </p><p>
 <sup>22&#160;</sup>They traveled from Kadesh, and the children of Israel, even the whole congregation, came to Mount Hor. 
-<sup>23&#160;</sup>Yahweh spoke to Moses and Aaron in Mount Hor, by the border of the land of Edom, saying, 
+<sup>23&#160;</sup>Yahuah spoke to Moses and Aaron in Mount Hor, by the border of the land of Edom, saying, 
 <sup>24&#160;</sup>“Aaron shall be gathered to his people; for he shall not enter into the land which I have given to the children of Israel, because you rebelled against my word at the waters of Meribah. 
 <sup>25&#160;</sup>Take Aaron and Eleazar his son, and bring them up to Mount Hor; 
 <sup>26&#160;</sup>and strip Aaron of his garments, and put them on Eleazar his son. Aaron shall be gathered, and shall die there.” 
 </p><p>
-<sup>27&#160;</sup>Moses did as Yahweh commanded. They went up onto Mount Hor in the sight of all the congregation. 
+<sup>27&#160;</sup>Moses did as Yahuah commanded. They went up onto Mount Hor in the sight of all the congregation. 
 <sup>28&#160;</sup>Moses stripped Aaron of his garments, and put them on Eleazar his son. Aaron died there on the top of the mountain, and Moses and Eleazar came down from the mountain. 
 <sup>29&#160;</sup>When all the congregation saw that Aaron was dead, they wept for Aaron thirty days, even all the house of Israel. 
 </p><h2 class="chapterlabel" id="21">21</h2>
 <p>
 <sup>1&#160;</sup>The Canaanite, the king of Arad, who lived in the South, heard that Israel came by the way of Atharim. He fought against Israel, and took some of them captive. 
-<sup>2&#160;</sup>Israel vowed a vow to Yahweh, and said, “If you will indeed deliver this people into my hand, then I will utterly destroy their cities.” 
-<sup>3&#160;</sup>Yahweh listened to the voice of Israel, and delivered up the Canaanites; and they utterly destroyed them and their cities. The name of the place was called Hormah. 
+<sup>2&#160;</sup>Israel vowed a vow to Yahuah, and said, “If you will indeed deliver this people into my hand, then I will utterly destroy their cities.” 
+<sup>3&#160;</sup>Yahuah listened to the voice of Israel, and delivered up the Canaanites; and they utterly destroyed them and their cities. The name of the place was called Hormah. 
 </p><p>
 <sup>4&#160;</sup>They traveled from Mount Hor by the way to the Red Sea, to go around the land of Edom. The soul of the people was very discouraged because of the journey. 
 <sup>5&#160;</sup>The people spoke against Elohim and against Moses: “Why have you brought us up out of Egypt to die in the wilderness? For there is no bread, there is no water, and our soul loathes this disgusting food!” 
 </p><p>
-<sup>6&#160;</sup>Yahweh sent venomous snakes among the people, and they bit the people. Many people of Israel died. 
-<sup>7&#160;</sup>The people came to Moses, and said, “We have sinned, because we have spoken against Yahweh and against you. Pray to Yahweh, that he take away the serpents from us.” Moses prayed for the people. 
+<sup>6&#160;</sup>Yahuah sent venomous snakes among the people, and they bit the people. Many people of Israel died. 
+<sup>7&#160;</sup>The people came to Moses, and said, “We have sinned, because we have spoken against Yahuah and against you. Pray to Yahuah, that he take away the serpents from us.” Moses prayed for the people. 
 </p><p>
-<sup>8&#160;</sup>Yahweh said to Moses, “Make a venomous snake, and set it on a pole. It shall happen that everyone who is bitten, when he sees it, shall live.” 
+<sup>8&#160;</sup>Yahuah said to Moses, “Make a venomous snake, and set it on a pole. It shall happen that everyone who is bitten, when he sees it, shall live.” 
 <sup>9&#160;</sup>Moses made a serpent of bronze, and set it on the pole. If a serpent had bitten any man, when he looked at the serpent of bronze, he lived. 
 </p><p>
 <sup>10&#160;</sup>The children of Israel traveled, and encamped in Oboth. 
 <sup>11&#160;</sup>They traveled from Oboth, and encamped at Iyeabarim, in the wilderness which is before Moab, toward the sunrise. 
 <sup>12&#160;</sup>From there they traveled, and encamped in the valley of Zered. 
 <sup>13&#160;</sup>From there they traveled, and encamped on the other side of the Arnon, which is in the wilderness that comes out of the border of the Amorites; for the Arnon is the border of Moab, between Moab and the Amorites. 
-<sup>14&#160;</sup>Therefore it is said in <span class="bk">The Book of the Wars of Yahweh</span>, “Vaheb in Suphah, the valleys of the Arnon, 
+<sup>14&#160;</sup>Therefore it is said in <span class="bk">The Book of the Wars of Yahuah</span>, “Vaheb in Suphah, the valleys of the Arnon, 
 <sup>15&#160;</sup>the slope of the valleys that incline toward the dwelling of Ar, leans on the border of Moab.” 
 </p><p>
-<sup>16&#160;</sup>From there they traveled to Beer; that is the well of which Yahweh said to Moses, “Gather the people together, and I will give them water.” 
+<sup>16&#160;</sup>From there they traveled to Beer; that is the well of which Yahuah said to Moses, “Gather the people together, and I will give them water.” 
 </p><p>
 <sup>17&#160;</sup>Then Israel sang this song: 
 </p><p class="q1">“Spring up, well! Sing to it, 
@@ -1269,7 +1269,7 @@ html[dir=ltr] .q2 {
 <sup>32&#160;</sup>Moses sent to spy out Jazer. They took its villages, and drove out the Amorites who were there. 
 <sup>33&#160;</sup>They turned and went up by the way of Bashan. Og the king of Bashan went out against them, he and all his people, to battle at Edrei. 
 </p><p>
-<sup>34&#160;</sup>Yahweh said to Moses, “Don’t fear him, for I have delivered him into your hand, with all his people, and his land. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
+<sup>34&#160;</sup>Yahuah said to Moses, “Don’t fear him, for I have delivered him into your hand, with all his people, and his land. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
 </p><p>
 <sup>35&#160;</sup>So they struck him, with his sons and all his people, until there were no survivors; and they possessed his land. 
 </p><h2 class="chapterlabel" id="22">22</h2>
@@ -1284,7 +1284,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>7&#160;</sup>The elders of Moab and the elders of Midian departed with the rewards of divination in their hand. They came to Balaam, and spoke to him the words of Balak. 
 </p><p>
-<sup>8&#160;</sup>He said to them, “Lodge here this night, and I will bring you word again, as Yahweh shall speak to me.” The princes of Moab stayed with Balaam. 
+<sup>8&#160;</sup>He said to them, “Lodge here this night, and I will bring you word again, as Yahuah shall speak to me.” The princes of Moab stayed with Balaam. 
 </p><p>
 <sup>9&#160;</sup>Elohim came to Balaam, and said, “Who are these men with you?” 
 </p><p>
@@ -1293,7 +1293,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>12&#160;</sup>Elohim said to Balaam, “You shall not go with them. You shall not curse the people, for they are blessed.” 
 </p><p>
-<sup>13&#160;</sup>Balaam rose up in the morning, and said to the princes of Balak, “Go to your land; for Yahweh refuses to permit me to go with you.” 
+<sup>13&#160;</sup>Balaam rose up in the morning, and said to the princes of Balak, “Go to your land; for Yahuah refuses to permit me to go with you.” 
 </p><p>
 <sup>14&#160;</sup>The princes of Moab rose up, and they went to Balak, and said, “Balaam refuses to come with us.” 
 </p><p>
@@ -1301,34 +1301,34 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>They came to Balaam, and said to him, “Balak the son of Zippor says, ‘Please let nothing hinder you from coming to me, 
 <sup>17&#160;</sup>for I will promote you to very great honor, and whatever you say to me I will do. Please come therefore, and curse this people for me.’&#160;” 
 </p><p>
-<sup>18&#160;</sup>Balaam answered the servants of Balak, “If Balak would give me his house full of silver and gold, I can’t go beyond the word of Yahweh my Elohim, to do less or more. 
-<sup>19&#160;</sup>Now therefore please stay here tonight as well, that I may know what else Yahweh will speak to me.” 
+<sup>18&#160;</sup>Balaam answered the servants of Balak, “If Balak would give me his house full of silver and gold, I can’t go beyond the word of Yahuah my Elohim, to do less or more. 
+<sup>19&#160;</sup>Now therefore please stay here tonight as well, that I may know what else Yahuah will speak to me.” 
 </p><p>
 <sup>20&#160;</sup>Elohim came to Balaam at night, and said to him, “If the men have come to call you, rise up, go with them; but only the word which I speak to you, that you shall do.” 
 </p><p>
 <sup>21&#160;</sup>Balaam rose up in the morning, and saddled his donkey, and went with the princes of Moab. 
-<sup>22&#160;</sup>Elohim’s anger burned because he went; and Yahweh’s angel placed himself in the way as an adversary against him. Now he was riding on his donkey, and his two servants were with him. 
-<sup>23&#160;</sup>The donkey saw Yahweh’s angel standing in the way, with his sword drawn in his hand; and the donkey turned out of the path, and went into the field. Balaam struck the donkey, to turn her into the path. 
-<sup>24&#160;</sup>Then Yahweh’s angel stood in a narrow path between the vineyards, a wall being on this side, and a wall on that side. 
-<sup>25&#160;</sup>The donkey saw Yahweh’s angel, and she thrust herself to the wall, and crushed Balaam’s foot against the wall. He struck her again. 
+<sup>22&#160;</sup>Elohim’s anger burned because he went; and Yahuah’s angel placed himself in the way as an adversary against him. Now he was riding on his donkey, and his two servants were with him. 
+<sup>23&#160;</sup>The donkey saw Yahuah’s angel standing in the way, with his sword drawn in his hand; and the donkey turned out of the path, and went into the field. Balaam struck the donkey, to turn her into the path. 
+<sup>24&#160;</sup>Then Yahuah’s angel stood in a narrow path between the vineyards, a wall being on this side, and a wall on that side. 
+<sup>25&#160;</sup>The donkey saw Yahuah’s angel, and she thrust herself to the wall, and crushed Balaam’s foot against the wall. He struck her again. 
 </p><p>
-<sup>26&#160;</sup>Yahweh’s angel went further, and stood in a narrow place, where there was no way to turn either to the right hand or to the left. 
-<sup>27&#160;</sup>The donkey saw Yahweh’s angel, and she lay down under Balaam. Balaam’s anger burned, and he struck the donkey with his staff. 
+<sup>26&#160;</sup>Yahuah’s angel went further, and stood in a narrow place, where there was no way to turn either to the right hand or to the left. 
+<sup>27&#160;</sup>The donkey saw Yahuah’s angel, and she lay down under Balaam. Balaam’s anger burned, and he struck the donkey with his staff. 
 </p><p>
-<sup>28&#160;</sup>Yahweh opened the mouth of the donkey, and she said to Balaam, “What have I done to you, that you have struck me these three times?” 
+<sup>28&#160;</sup>Yahuah opened the mouth of the donkey, and she said to Balaam, “What have I done to you, that you have struck me these three times?” 
 </p><p>
 <sup>29&#160;</sup>Balaam said to the donkey, “Because you have mocked me, I wish there were a sword in my hand, for now I would have killed you.” 
 </p><p>
 <sup>30&#160;</sup>The donkey said to Balaam, “Am I not your donkey, on which you have ridden all your life long until today? Was I ever in the habit of doing so to you?” 
 </p><p>He said, “No.” 
 </p><p>
-<sup>31&#160;</sup>Then Yahweh opened the eyes of Balaam, and he saw Yahweh’s angel standing in the way, with his sword drawn in his hand; and he bowed his head, and fell on his face. 
-<sup>32&#160;</sup>Yahweh’s angel said to him, “Why have you struck your donkey these three times? Behold, I have come out as an adversary, because your way is perverse before me. 
+<sup>31&#160;</sup>Then Yahuah opened the eyes of Balaam, and he saw Yahuah’s angel standing in the way, with his sword drawn in his hand; and he bowed his head, and fell on his face. 
+<sup>32&#160;</sup>Yahuah’s angel said to him, “Why have you struck your donkey these three times? Behold, I have come out as an adversary, because your way is perverse before me. 
 <sup>33&#160;</sup>The donkey saw me, and turned away before me these three times. Unless she had turned away from me, surely now I would have killed you, and saved her alive.” 
 </p><p>
-<sup>34&#160;</sup>Balaam said to Yahweh’s angel, “I have sinned; for I didn’t know that you stood in the way against me. Now therefore, if it displeases you, I will go back again.” 
+<sup>34&#160;</sup>Balaam said to Yahuah’s angel, “I have sinned; for I didn’t know that you stood in the way against me. Now therefore, if it displeases you, I will go back again.” 
 </p><p>
-<sup>35&#160;</sup>Yahweh’s angel said to Balaam, “Go with the men; but you shall only speak the word that I shall speak to you.” 
+<sup>35&#160;</sup>Yahuah’s angel said to Balaam, “Go with the men; but you shall only speak the word that I shall speak to you.” 
 </p><p>So Balaam went with the princes of Balak. 
 <sup>36&#160;</sup>When Balak heard that Balaam had come, he went out to meet him to the City of Moab, which is on the border of the Arnon, which is in the utmost part of the border. 
 <sup>37&#160;</sup>Balak said to Balaam, “Didn’t I earnestly send for you to summon you? Why didn’t you come to me? Am I not able indeed to promote you to honor?” 
@@ -1343,11 +1343,11 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>Balaam said to Balak, “Build here seven altars for me, and prepare here seven bulls and seven rams for me.” 
 </p><p>
 <sup>2&#160;</sup>Balak did as Balaam had spoken; and Balak and Balaam offered on every altar a bull and a ram. 
-<sup>3&#160;</sup>Balaam said to Balak, “Stand by your burnt offering, and I will go. Perhaps Yahweh will come to meet me. Whatever he shows me I will tell you.” 
+<sup>3&#160;</sup>Balaam said to Balak, “Stand by your burnt offering, and I will go. Perhaps Yahuah will come to meet me. Whatever he shows me I will tell you.” 
 </p><p>He went to a bare height. 
 <sup>4&#160;</sup>Elohim met Balaam, and he said to him, “I have prepared the seven altars, and I have offered up a bull and a ram on every altar.” 
 </p><p>
-<sup>5&#160;</sup>Yahweh put a word in Balaam’s mouth, and said, “Return to Balak, and thus you shall speak.” 
+<sup>5&#160;</sup>Yahuah put a word in Balaam’s mouth, and said, “Return to Balak, and thus you shall speak.” 
 </p><p>
 <sup>6&#160;</sup>He returned to him, and behold, he was standing by his burnt offering, he, and all the princes of Moab. 
 <sup>7&#160;</sup>He took up his parable, and said, 
@@ -1357,7 +1357,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Come, defy Israel. 
 </p><p class="q1">
 <sup>8&#160;</sup>How shall I curse whom Elohim has not cursed? 
-</p><p class="q2">How shall I defy whom Yahweh has not defied? 
+</p><p class="q2">How shall I defy whom Yahuah has not defied? 
 </p><p class="q1">
 <sup>9&#160;</sup>For from the top of the rocks I see him. 
 </p><p class="q2">From the hills I see him. 
@@ -1371,16 +1371,16 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>11&#160;</sup>Balak said to Balaam, “What have you done to me? I took you to curse my enemies, and behold, you have blessed them altogether.” 
 </p><p>
-<sup>12&#160;</sup>He answered and said, “Must I not take heed to speak that which Yahweh puts in my mouth?” 
+<sup>12&#160;</sup>He answered and said, “Must I not take heed to speak that which Yahuah puts in my mouth?” 
 </p><p>
 <sup>13&#160;</sup>Balak said to him, “Please come with me to another place, where you may see them. You shall see just part of them, and shall not see them all. Curse them from there for me.” 
 </p><p>
 <sup>14&#160;</sup>He took him into the field of Zophim, to the top of Pisgah, and built seven altars, and offered up a bull and a ram on every altar. 
 <sup>15&#160;</sup>He said to Balak, “Stand here by your burnt offering, while I meet Elohim over there.” 
 </p><p>
-<sup>16&#160;</sup>Yahweh met Balaam, and put a word in his mouth, and said, “Return to Balak, and say this.” 
+<sup>16&#160;</sup>Yahuah met Balaam, and put a word in his mouth, and said, “Return to Balak, and say this.” 
 </p><p>
-<sup>17&#160;</sup>He came to him, and behold, he was standing by his burnt offering, and the princes of Moab with him. Balak said to him, “What has Yahweh spoken?” 
+<sup>17&#160;</sup>He came to him, and behold, he was standing by his burnt offering, and the princes of Moab with him. Balak said to him, “What has Yahuah spoken?” 
 </p><p>
 <sup>18&#160;</sup>He took up his parable, and said, 
 </p><p class="q1">“Rise up, Balak, and hear! 
@@ -1396,7 +1396,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>21&#160;</sup>He has not seen iniquity in Jacob. 
 </p><p class="q2">Neither has he seen perverseness in Israel. 
-</p><p class="q1">Yahweh his Elohim is with him. 
+</p><p class="q1">Yahuah his Elohim is with him. 
 </p><p class="q2">The shout of a king is among them. 
 </p><p class="q1">
 <sup>22&#160;</sup>Elohim brings them out of Egypt. 
@@ -1414,7 +1414,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>25&#160;</sup>Balak said to Balaam, “Neither curse them at all, nor bless them at all.” 
 </p><p>
-<sup>26&#160;</sup>But Balaam answered Balak, “Didn’t I tell you, saying, ‘All that Yahweh speaks, that I must do’?” 
+<sup>26&#160;</sup>But Balaam answered Balak, “Didn’t I tell you, saying, ‘All that Yahuah speaks, that I must do’?” 
 </p><p>
 <sup>27&#160;</sup>Balak said to Balaam, “Come now, I will take you to another place; perhaps it will please Elohim that you may curse them for me from there.” 
 </p><p>
@@ -1424,7 +1424,7 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>Balak did as Balaam had said, and offered up a bull and a ram on every altar. 
 </p><h2 class="chapterlabel" id="24">24</h2>
 <p>
-<sup>1&#160;</sup>When Balaam saw that it pleased Yahweh to bless Israel, he didn’t go, as at the other times, to use divination, but he set his face toward the wilderness. 
+<sup>1&#160;</sup>When Balaam saw that it pleased Yahuah to bless Israel, he didn’t go, as at the other times, to use divination, but he set his face toward the wilderness. 
 <sup>2&#160;</sup>Balaam lifted up his eyes, and he saw Israel dwelling according to their tribes; and the Spirit of Elohim came on him. 
 <sup>3&#160;</sup>He took up his parable, and said, 
 </p><p class="q1">“Balaam the son of Beor says, 
@@ -1439,7 +1439,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>6&#160;</sup>As valleys they are spread out, 
 </p><p class="q2">as gardens by the riverside, 
-</p><p class="q2">as aloes which Yahweh has planted, 
+</p><p class="q2">as aloes which Yahuah has planted, 
 </p><p class="q2">as cedar trees beside the waters. 
 </p><p class="q1">
 <sup>7&#160;</sup>Water shall flow from his buckets. 
@@ -1460,10 +1460,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Everyone who curses you is cursed.” 
 </p><p>
 <sup>10&#160;</sup>Balak’s anger burned against Balaam, and he struck his hands together. Balak said to Balaam, “I called you to curse my enemies, and, behold, you have altogether blessed them these three times. 
-<sup>11&#160;</sup>Therefore, flee to your place, now! I thought to promote you to great honor; but, behold, Yahweh has kept you back from honor.” 
+<sup>11&#160;</sup>Therefore, flee to your place, now! I thought to promote you to great honor; but, behold, Yahuah has kept you back from honor.” 
 </p><p>
 <sup>12&#160;</sup>Balaam said to Balak, “Didn’t I also tell your messengers whom you sent to me, saying, 
-<sup>13&#160;</sup>‘If Balak would give me his house full of silver and gold, I can’t go beyond Yahweh’s word, to do either good or bad from my own mind. I will say what Yahweh says’? 
+<sup>13&#160;</sup>‘If Balak would give me his house full of silver and gold, I can’t go beyond Yahuah’s word, to do either good or bad from my own mind. I will say what Yahuah says’? 
 <sup>14&#160;</sup>Now, behold, I go to my people. Come, I will inform you what this people shall do to your people in the latter days.” 
 </p><p>
 <sup>15&#160;</sup>He took up his parable, and said, 
@@ -1512,8 +1512,8 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>Israel stayed in Shittim; and the people began to play the prostitute with the daughters of Moab; 
 <sup>2&#160;</sup>for they called the people to the sacrifices of their elohims. The people ate and bowed down to their elohims. 
-<sup>3&#160;</sup>Israel joined himself to Baal Peor, and Yahweh’s anger burned against Israel. 
-<sup>4&#160;</sup>Yahweh said to Moses, “Take all the chiefs of the people, and hang them up to Yahweh before the sun, that the fierce anger of Yahweh may turn away from Israel.” 
+<sup>3&#160;</sup>Israel joined himself to Baal Peor, and Yahuah’s anger burned against Israel. 
+<sup>4&#160;</sup>Yahuah said to Moses, “Take all the chiefs of the people, and hang them up to Yahuah before the sun, that the fierce anger of Yahuah may turn away from Israel.” 
 </p><p>
 <sup>5&#160;</sup>Moses said to the judges of Israel, “Everyone kill his men who have joined themselves to Baal Peor.” 
 </p><p>
@@ -1522,7 +1522,7 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>He went after the man of Israel into the pavilion, and thrust both of them through, the man of Israel, and the woman through her body. So the plague was stopped among the children of Israel. 
 <sup>9&#160;</sup>Those who died by the plague were twenty-four thousand. 
 </p><p>
-<sup>10&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>10&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>11&#160;</sup>“Phinehas, the son of Eleazar, the son of Aaron the priest, has turned my wrath away from the children of Israel, in that he was jealous with my jealousy among them, so that I didn’t consume the children of Israel in my jealousy. 
 <sup>12&#160;</sup>Therefore say, ‘Behold, I give to him my covenant of peace. 
 <sup>13&#160;</sup>It shall be to him, and to his offspring after him, the covenant of an everlasting priesthood, because he was jealous for his Elohim, and made atonement for the children of Israel.’&#160;” 
@@ -1530,21 +1530,21 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>Now the name of the man of Israel that was slain, who was slain with the Midianite woman, was Zimri, the son of Salu, a prince of a fathers’ house among the Simeonites. 
 <sup>15&#160;</sup>The name of the Midianite woman who was slain was Cozbi, the daughter of Zur. He was head of the people of a fathers’ house in Midian. 
 </p><p>
-<sup>16&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>16&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>17&#160;</sup>“Harass the Midianites, and strike them; 
 <sup>18&#160;</sup>for they harassed you with their wiles, wherein they have deceived you in the matter of Peor, and in the incident regarding Cozbi, the daughter of the prince of Midian, their sister, who was slain on the day of the plague in the matter of Peor.” 
 </p><h2 class="chapterlabel" id="26">26</h2>
 <p>
-<sup>1&#160;</sup>After the plague, Yahweh spoke to Moses and to Eleazar the son of Aaron the priest, saying, 
+<sup>1&#160;</sup>After the plague, Yahuah spoke to Moses and to Eleazar the son of Aaron the priest, saying, 
 <sup>2&#160;</sup>“Take a census of all the congregation of the children of Israel, from twenty years old and upward, by their fathers’ houses, all who are able to go out to war in Israel.” 
 <sup>3&#160;</sup>Moses and Eleazar the priest spoke with them in the plains of Moab by the Jordan at Jericho, saying, 
-<sup>4&#160;</sup>“Take a census, from twenty years old and upward, as Yahweh commanded Moses and the children of Israel.” 
+<sup>4&#160;</sup>“Take a census, from twenty years old and upward, as Yahuah commanded Moses and the children of Israel.” 
 </p><p>These are those who came out of the land of Egypt. 
 <sup>5&#160;</sup>Reuben, the firstborn of Israel; the sons of Reuben: of Hanoch, the family of the Hanochites; of Pallu, the family of the Palluites; 
 <sup>6&#160;</sup>of Hezron, the family of the Hezronites; of Carmi, the family of the Carmites. 
 <sup>7&#160;</sup>These are the families of the Reubenites; and those who were counted of them were forty-three thousand seven hundred thirty. 
 <sup>8&#160;</sup>The son of Pallu: Eliab. 
-<sup>9&#160;</sup>The sons of Eliab: Nemuel, Dathan, and Abiram. These are that Dathan and Abiram who were called by the congregation, who rebelled against Moses and against Aaron in the company of Korah when they rebelled against Yahweh; 
+<sup>9&#160;</sup>The sons of Eliab: Nemuel, Dathan, and Abiram. These are that Dathan and Abiram who were called by the congregation, who rebelled against Moses and against Aaron in the company of Korah when they rebelled against Yahuah; 
 <sup>10&#160;</sup>and the earth opened its mouth, and swallowed them up together with Korah when that company died; at the time the fire devoured two hundred fifty men, and they became a sign. 
 <sup>11&#160;</sup>Notwithstanding, the sons of Korah didn’t die. 
 <sup>12&#160;</sup>The sons of Simeon after their families: of Nemuel, the family of the Nemuelites; of Jamin, the family of the Jaminites; of Jachin, the family of the Jachinites; 
@@ -1588,7 +1588,7 @@ html[dir=ltr] .q2 {
 <sup>50&#160;</sup>These are the families of Naphtali according to their families; and those who were counted of them were forty-five thousand four hundred. 
 <sup>51&#160;</sup>These are those who were counted of the children of Israel, six hundred one thousand seven hundred thirty. 
 </p><p>
-<sup>52&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>52&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>53&#160;</sup>“To these the land shall be divided for an inheritance according to the number of names. 
 <sup>54&#160;</sup>To the more you shall give the more inheritance, and to the fewer you shall give the less inheritance. To everyone according to those who were counted of him shall his inheritance be given. 
 <sup>55&#160;</sup>Notwithstanding, the land shall be divided by lot. According to the names of the tribes of their fathers they shall inherit. 
@@ -1598,74 +1598,74 @@ html[dir=ltr] .q2 {
 <sup>58&#160;</sup>These are the families of Levi: the family of the Libnites, the family of the Hebronites, the family of the Mahlites, the family of the Mushites, and the family of the Korahites. Kohath brought forth Amram. 
 <sup>59&#160;</sup>The name of Amram’s woman was Jochebed, the daughter of Levi, who was born to Levi in Egypt. She bore to Amram Aaron and Moses, and Miriam their sister. 
 <sup>60&#160;</sup>To Aaron were born Nadab and Abihu, Eleazar and Ithamar. 
-<sup>61&#160;</sup>Nadab and Abihu died when they offered strange fire before Yahweh. 
+<sup>61&#160;</sup>Nadab and Abihu died when they offered strange fire before Yahuah. 
 <sup>62&#160;</sup>Those who were counted of them were twenty-three thousand, every male from a month old and upward; for they were not counted among the children of Israel, because there was no inheritance given them among the children of Israel. 
 <sup>63&#160;</sup>These are those who were counted by Moses and Eleazar the priest, who counted the children of Israel in the plains of Moab by the Jordan at Jericho. 
 <sup>64&#160;</sup>But among these there was not a man of them who were counted by Moses and Aaron the priest, who counted the children of Israel in the wilderness of Sinai. 
-<sup>65&#160;</sup>For Yahweh had said of them, “They shall surely die in the wilderness.” There was not a man left of them, except Caleb the son of Jephunneh, and Joshua the son of Nun. 
+<sup>65&#160;</sup>For Yahuah had said of them, “They shall surely die in the wilderness.” There was not a man left of them, except Caleb the son of Jephunneh, and Joshua the son of Nun. 
 </p><h2 class="chapterlabel" id="27">27</h2>
 <p>
 <sup>1&#160;</sup>Then the daughters of Zelophehad, the son of Hepher, the son of Gilead, the son of Machir, the son of Manasseh, of the families of Manasseh the son of Joseph came near. These are the names of his daughters: Mahlah, Noah, Hoglah, Milcah, and Tirzah. 
 <sup>2&#160;</sup>They stood before Moses, before Eleazar the priest, and before the princes and all the congregation, at the door of the Tent of Meeting, saying, 
-<sup>3&#160;</sup>“Our father died in the wilderness. He was not among the company of those who gathered themselves together against Yahweh in the company of Korah, but he died in his own sin. He had no sons. 
+<sup>3&#160;</sup>“Our father died in the wilderness. He was not among the company of those who gathered themselves together against Yahuah in the company of Korah, but he died in his own sin. He had no sons. 
 <sup>4&#160;</sup>Why should the name of our father be taken away from among his family, because he had no son? Give to us a possession among the brothers of our father.” 
 </p><p>
-<sup>5&#160;</sup>Moses brought their cause before Yahweh. 
-<sup>6&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>5&#160;</sup>Moses brought their cause before Yahuah. 
+<sup>6&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>7&#160;</sup>“The daughters of Zelophehad speak right. You shall surely give them a possession of an inheritance among their father’s brothers. You shall cause the inheritance of their father to pass to them. 
 <sup>8&#160;</sup>You shall speak to the children of Israel, saying, ‘If a man dies, and has no son, then you shall cause his inheritance to pass to his daughter. 
 <sup>9&#160;</sup>If he has no daughter, then you shall give his inheritance to his brothers. 
 <sup>10&#160;</sup>If he has no brothers, then you shall give his inheritance to his father’s brothers. 
-<sup>11&#160;</sup>If his father has no brothers, then you shall give his inheritance to his kinsman who is next to him of his family, and he shall possess it. This shall be a statute and ordinance for the children of Israel, as Yahweh commanded Moses.’&#160;” 
+<sup>11&#160;</sup>If his father has no brothers, then you shall give his inheritance to his kinsman who is next to him of his family, and he shall possess it. This shall be a statute and ordinance for the children of Israel, as Yahuah commanded Moses.’&#160;” 
 </p><p>
-<sup>12&#160;</sup>Yahweh said to Moses, “Go up into this mountain of Abarim, and see the land which I have given to the children of Israel. 
+<sup>12&#160;</sup>Yahuah said to Moses, “Go up into this mountain of Abarim, and see the land which I have given to the children of Israel. 
 <sup>13&#160;</sup>When you have seen it, you also shall be gathered to your people, as Aaron your brother was gathered; 
 <sup>14&#160;</sup>because in the strife of the congregation, you rebelled against my word in the wilderness of Zin, to honor me as set-apart at the waters before their eyes.” (These are the waters of Meribah of Kadesh in the wilderness of Zin.) 
 </p><p>
-<sup>15&#160;</sup>Moses spoke to Yahweh, saying, 
-<sup>16&#160;</sup>“Let Yahweh, the Elohim of the spirits of all flesh, appoint a man over the congregation, 
-<sup>17&#160;</sup>who may go out before them, and who may come in before them, and who may lead them out, and who may bring them in, that the congregation of Yahweh may not be as sheep which have no shepherd.” 
+<sup>15&#160;</sup>Moses spoke to Yahuah, saying, 
+<sup>16&#160;</sup>“Let Yahuah, the Elohim of the spirits of all flesh, appoint a man over the congregation, 
+<sup>17&#160;</sup>who may go out before them, and who may come in before them, and who may lead them out, and who may bring them in, that the congregation of Yahuah may not be as sheep which have no shepherd.” 
 </p><p>
-<sup>18&#160;</sup>Yahweh said to Moses, “Take Joshua the son of Nun, a man in whom is the Spirit, and lay your hand on him. 
+<sup>18&#160;</sup>Yahuah said to Moses, “Take Joshua the son of Nun, a man in whom is the Spirit, and lay your hand on him. 
 <sup>19&#160;</sup>Set him before Eleazar the priest, and before all the congregation; and commission him in their sight. 
 <sup>20&#160;</sup>You shall give authority to him, that all the congregation of the children of Israel may obey. 
-<sup>21&#160;</sup>He shall stand before Eleazar the priest, who shall inquire for him by the judgment of the Urim before Yahweh. At his word they shall go out, and at his word they shall come in, both he and all the children of Israel with him, even all the congregation.” 
+<sup>21&#160;</sup>He shall stand before Eleazar the priest, who shall inquire for him by the judgment of the Urim before Yahuah. At his word they shall go out, and at his word they shall come in, both he and all the children of Israel with him, even all the congregation.” 
 </p><p>
-<sup>22&#160;</sup>Moses did as Yahweh commanded him. He took Joshua, and set him before Eleazar the priest and before all the congregation. 
-<sup>23&#160;</sup>He laid his hands on him and commissioned him, as Yahweh spoke by Moses. 
+<sup>22&#160;</sup>Moses did as Yahuah commanded him. He took Joshua, and set him before Eleazar the priest and before all the congregation. 
+<sup>23&#160;</sup>He laid his hands on him and commissioned him, as Yahuah spoke by Moses. 
 </p><h2 class="chapterlabel" id="28">28</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Command the children of Israel, and tell them, ‘See that you present my offering, my food for my offerings made by fire, as a pleasant aroma to me, in their due season.’ 
-<sup>3&#160;</sup>You shall tell them, ‘This is the offering made by fire which you shall offer to Yahweh: male lambs a year old without defect, two day by day, for a continual burnt offering. 
+<sup>3&#160;</sup>You shall tell them, ‘This is the offering made by fire which you shall offer to Yahuah: male lambs a year old without defect, two day by day, for a continual burnt offering. 
 <sup>4&#160;</sup>You shall offer the one lamb in the morning, and you shall offer the other lamb at evening, 
 <sup>5&#160;</sup>with one tenth of an ephah of fine flour for a meal offering, mixed with the fourth part of a hin of beaten oil. 
-<sup>6&#160;</sup>It is a continual burnt offering which was ordained in Mount Sinai for a pleasant aroma, an offering made by fire to Yahweh. 
-<sup>7&#160;</sup>Its drink offering shall be the fourth part of a hin for each lamb. You shall pour out a drink offering of strong drink to Yahweh in the set-apart place. 
-<sup>8&#160;</sup>The other lamb you shall offer at evening. As the meal offering of the morning, and as its drink offering, you shall offer it, an offering made by fire, for a pleasant aroma to Yahweh. 
+<sup>6&#160;</sup>It is a continual burnt offering which was ordained in Mount Sinai for a pleasant aroma, an offering made by fire to Yahuah. 
+<sup>7&#160;</sup>Its drink offering shall be the fourth part of a hin for each lamb. You shall pour out a drink offering of strong drink to Yahuah in the set-apart place. 
+<sup>8&#160;</sup>The other lamb you shall offer at evening. As the meal offering of the morning, and as its drink offering, you shall offer it, an offering made by fire, for a pleasant aroma to Yahuah. 
 </p><p>
 <sup>9&#160;</sup>“&#160;‘On the Sabbath day, you shall offer two male lambs a year old without defect, and two tenths of an ephah of fine flour for a meal offering mixed with oil, and its drink offering: 
 <sup>10&#160;</sup>this is the burnt offering of every Sabbath, in addition to the continual burnt offering and its drink offering. 
 </p><p>
-<sup>11&#160;</sup>“&#160;‘In the beginnings of your months, you shall offer a burnt offering to Yahweh: two young bulls, one ram, seven male lambs a year old without defect, 
+<sup>11&#160;</sup>“&#160;‘In the beginnings of your months, you shall offer a burnt offering to Yahuah: two young bulls, one ram, seven male lambs a year old without defect, 
 <sup>12&#160;</sup>and three tenths of an ephah of fine flour for a meal offering mixed with oil, for each bull; and two tenth parts of fine flour for a meal offering mixed with oil, for the one ram; 
-<sup>13&#160;</sup>and one tenth part of fine flour mixed with oil for a meal offering to every lamb, as a burnt offering of a pleasant aroma, an offering made by fire to Yahweh. 
+<sup>13&#160;</sup>and one tenth part of fine flour mixed with oil for a meal offering to every lamb, as a burnt offering of a pleasant aroma, an offering made by fire to Yahuah. 
 <sup>14&#160;</sup>Their drink offerings shall be half a hin of wine for a bull, the third part of a hin for the ram, and the fourth part of a hin for a lamb. This is the burnt offering of every month throughout the months of the year. 
-<sup>15&#160;</sup>Also, one male goat for a sin offering to Yahweh shall be offered in addition to the continual burnt offering and its drink offering. 
+<sup>15&#160;</sup>Also, one male goat for a sin offering to Yahuah shall be offered in addition to the continual burnt offering and its drink offering. 
 </p><p>
-<sup>16&#160;</sup>“&#160;‘In the first month, on the fourteenth day of the month, is Yahweh’s Passover. 
+<sup>16&#160;</sup>“&#160;‘In the first month, on the fourteenth day of the month, is Yahuah’s Passover. 
 <sup>17&#160;</sup>On the fifteenth day of this month shall be a feast. Unleavened bread shall be eaten for seven days. 
 <sup>18&#160;</sup>In the first day shall be a set-apart convocation. You shall do no regular work, 
-<sup>19&#160;</sup>but you shall offer an offering made by fire, a burnt offering to Yahweh: two young bulls, one ram, and seven male lambs a year old. They shall be without defect, 
+<sup>19&#160;</sup>but you shall offer an offering made by fire, a burnt offering to Yahuah: two young bulls, one ram, and seven male lambs a year old. They shall be without defect, 
 <sup>20&#160;</sup>with their meal offering, fine flour mixed with oil. You shall offer three tenths for a bull, and two tenths for the ram. 
 <sup>21&#160;</sup>You shall offer one tenth for every lamb of the seven lambs; 
 <sup>22&#160;</sup>and one male goat for a sin offering, to make atonement for you. 
 <sup>23&#160;</sup>You shall offer these in addition to the burnt offering of the morning, which is for a continual burnt offering. 
-<sup>24&#160;</sup>In this way you shall offer daily, for seven days, the food of the offering made by fire, of a pleasant aroma to Yahweh. It shall be offered in addition to the continual burnt offering and its drink offering. 
+<sup>24&#160;</sup>In this way you shall offer daily, for seven days, the food of the offering made by fire, of a pleasant aroma to Yahuah. It shall be offered in addition to the continual burnt offering and its drink offering. 
 <sup>25&#160;</sup>On the seventh day you shall have a set-apart convocation. You shall do no regular work. 
 </p><p>
-<sup>26&#160;</sup>“&#160;‘Also in the day of the first fruits, when you offer a new meal offering to Yahweh in your feast of weeks, you shall have a set-apart convocation. You shall do no regular work; 
-<sup>27&#160;</sup>but you shall offer a burnt offering for a pleasant aroma to Yahweh: two young bulls, one ram, seven male lambs a year old; 
+<sup>26&#160;</sup>“&#160;‘Also in the day of the first fruits, when you offer a new meal offering to Yahuah in your feast of weeks, you shall have a set-apart convocation. You shall do no regular work; 
+<sup>27&#160;</sup>but you shall offer a burnt offering for a pleasant aroma to Yahuah: two young bulls, one ram, seven male lambs a year old; 
 <sup>28&#160;</sup>and their meal offering, fine flour mixed with oil, three tenths for each bull, two tenths for the one ram, 
 <sup>29&#160;</sup>one tenth for every lamb of the seven lambs; 
 <sup>30&#160;</sup>and one male goat, to make atonement for you. 
@@ -1673,20 +1673,20 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="29">29</h2>
 <p>
 <sup>1&#160;</sup>“&#160;‘In the seventh month, on the first day of the month, you shall have a set-apart convocation; you shall do no regular work. It is a day of blowing of trumpets to you. 
-<sup>2&#160;</sup>You shall offer a burnt offering for a pleasant aroma to Yahweh: one young bull, one ram, seven male lambs a year old without defect; 
+<sup>2&#160;</sup>You shall offer a burnt offering for a pleasant aroma to Yahuah: one young bull, one ram, seven male lambs a year old without defect; 
 <sup>3&#160;</sup>and their meal offering, fine flour mixed with oil: three tenths for the bull, two tenths for the ram, 
 <sup>4&#160;</sup>and one tenth for every lamb of the seven lambs; 
 <sup>5&#160;</sup>and one male goat for a sin offering, to make atonement for you; 
-<sup>6&#160;</sup>in addition to the burnt offering of the new moon with its meal offering, and the continual burnt offering with its meal offering, and their drink offerings, according to their ordinance, for a pleasant aroma, an offering made by fire to Yahweh. 
+<sup>6&#160;</sup>in addition to the burnt offering of the new moon with its meal offering, and the continual burnt offering with its meal offering, and their drink offerings, according to their ordinance, for a pleasant aroma, an offering made by fire to Yahuah. 
 </p><p>
 <sup>7&#160;</sup>“&#160;‘On the tenth day of this seventh month you shall have a set-apart convocation. You shall afflict your souls. You shall do no kind of work; 
-<sup>8&#160;</sup>but you shall offer a burnt offering to Yahweh for a pleasant aroma: one young bull, one ram, seven male lambs a year old, all without defect; 
+<sup>8&#160;</sup>but you shall offer a burnt offering to Yahuah for a pleasant aroma: one young bull, one ram, seven male lambs a year old, all without defect; 
 <sup>9&#160;</sup>and their meal offering, fine flour mixed with oil: three tenths for the bull, two tenths for the one ram, 
 <sup>10&#160;</sup>one tenth for every lamb of the seven lambs; 
 <sup>11&#160;</sup>one male goat for a sin offering, in addition to the sin offering of atonement, and the continual burnt offering, and its meal offering, and their drink offerings. 
 </p><p>
-<sup>12&#160;</sup>“&#160;‘On the fifteenth day of the seventh month you shall have a set-apart convocation. You shall do no regular work. You shall keep a feast to Yahweh seven days. 
-<sup>13&#160;</sup>You shall offer a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh: thirteen young bulls, two rams, fourteen male lambs a year old, all without defect; 
+<sup>12&#160;</sup>“&#160;‘On the fifteenth day of the seventh month you shall have a set-apart convocation. You shall do no regular work. You shall keep a feast to Yahuah seven days. 
+<sup>13&#160;</sup>You shall offer a burnt offering, an offering made by fire, of a pleasant aroma to Yahuah: thirteen young bulls, two rams, fourteen male lambs a year old, all without defect; 
 <sup>14&#160;</sup>and their meal offering, fine flour mixed with oil: three tenths for every bull of the thirteen bulls, two tenths for each ram of the two rams, 
 <sup>15&#160;</sup>and one tenth for every lamb of the fourteen lambs; 
 <sup>16&#160;</sup>and one male goat for a sin offering, in addition to the continual burnt offering, its meal offering, and its drink offering. 
@@ -1716,46 +1716,46 @@ html[dir=ltr] .q2 {
 <sup>34&#160;</sup>and one male goat for a sin offering; in addition to the continual burnt offering, its meal offering, and its drink offering. 
 </p><p>
 <sup>35&#160;</sup>“&#160;‘On the eighth day you shall have a solemn assembly. You shall do no regular work; 
-<sup>36&#160;</sup>but you shall offer a burnt offering, an offering made by fire, a pleasant aroma to Yahweh: one bull, one ram, seven male lambs a year old without defect; 
+<sup>36&#160;</sup>but you shall offer a burnt offering, an offering made by fire, a pleasant aroma to Yahuah: one bull, one ram, seven male lambs a year old without defect; 
 <sup>37&#160;</sup>their meal offering and their drink offerings for the bull, for the ram, and for the lambs, shall be according to their number, after the ordinance, 
 <sup>38&#160;</sup>and one male goat for a sin offering, in addition to the continual burnt offering, with its meal offering, and its drink offering. 
 </p><p>
-<sup>39&#160;</sup>“&#160;‘You shall offer these to Yahweh in your set feasts—in addition to your vows and your free will offerings—for your burnt offerings, your meal offerings, your drink offerings, and your peace offerings.’&#160;” 
+<sup>39&#160;</sup>“&#160;‘You shall offer these to Yahuah in your set feasts—in addition to your vows and your free will offerings—for your burnt offerings, your meal offerings, your drink offerings, and your peace offerings.’&#160;” 
 </p><p>
-<sup>40&#160;</sup>Moses told the children of Israel according to all that Yahweh commanded Moses. 
+<sup>40&#160;</sup>Moses told the children of Israel according to all that Yahuah commanded Moses. 
 </p><h2 class="chapterlabel" id="30">30</h2>
 <p>
-<sup>1&#160;</sup>Moses spoke to the heads of the tribes of the children of Israel, saying, “This is the thing which Yahweh has commanded. 
-<sup>2&#160;</sup>When a man vows a vow to Yahweh, or swears an oath to bind his soul with a bond, he shall not break his word. He shall do according to all that proceeds out of his mouth. 
+<sup>1&#160;</sup>Moses spoke to the heads of the tribes of the children of Israel, saying, “This is the thing which Yahuah has commanded. 
+<sup>2&#160;</sup>When a man vows a vow to Yahuah, or swears an oath to bind his soul with a bond, he shall not break his word. He shall do according to all that proceeds out of his mouth. 
 </p><p>
-<sup>3&#160;</sup>“Also, when a woman vows a vow to Yahweh and binds herself by a pledge, being in her father’s house, in her youth, 
+<sup>3&#160;</sup>“Also, when a woman vows a vow to Yahuah and binds herself by a pledge, being in her father’s house, in her youth, 
 <sup>4&#160;</sup>and her father hears her vow and her pledge with which she has bound her soul, and her father says nothing to her, then all her vows shall stand, and every pledge with which she has bound her soul shall stand. 
-<sup>5&#160;</sup>But if her father forbids her in the day that he hears, none of her vows or of her pledges with which she has bound her soul, shall stand. Yahweh will forgive her, because her father has forbidden her. 
+<sup>5&#160;</sup>But if her father forbids her in the day that he hears, none of her vows or of her pledges with which she has bound her soul, shall stand. Yahuah will forgive her, because her father has forbidden her. 
 </p><p>
 <sup>6&#160;</sup>“If she has a man, while her vows are on her, or the rash utterance of her lips with which she has bound her soul, 
 <sup>7&#160;</sup>and her man hears it, and says nothing to her in the day that he hears it; then her vows shall stand, and her pledges with which she has bound her soul shall stand. 
-<sup>8&#160;</sup>But if her man forbids her in the day that he hears it, then he makes void her vow which is on her and the rash utterance of her lips, with which she has bound her soul. Yahweh will forgive her. 
+<sup>8&#160;</sup>But if her man forbids her in the day that he hears it, then he makes void her vow which is on her and the rash utterance of her lips, with which she has bound her soul. Yahuah will forgive her. 
 </p><p>
 <sup>9&#160;</sup>“But the vow of a widow, or of her who is divorced, everything with which she has bound her soul shall stand against her. 
 </p><p>
 <sup>10&#160;</sup>“If she vowed in her man’s house or bound her soul by a bond with an oath, 
 <sup>11&#160;</sup>and her man heard it, and held his peace at her and didn’t disallow her, then all her vows shall stand, and every pledge with which she bound her soul shall stand. 
-<sup>12&#160;</sup>But if her man made them null and void in the day that he heard them, then whatever proceeded out of her lips concerning her vows, or concerning the bond of her soul, shall not stand. Her man has made them void. Yahweh will forgive her. 
+<sup>12&#160;</sup>But if her man made them null and void in the day that he heard them, then whatever proceeded out of her lips concerning her vows, or concerning the bond of her soul, shall not stand. Her man has made them void. Yahuah will forgive her. 
 <sup>13&#160;</sup>Every vow, and every binding oath to afflict the soul, her man may establish it, or her man may make it void. 
 <sup>14&#160;</sup>But if her man says nothing to her from day to day, then he establishes all her vows or all her pledges which are on her. He has established them, because he said nothing to her in the day that he heard them. 
 <sup>15&#160;</sup>But if he makes them null and void after he has heard them, then he shall bear her iniquity.” 
 </p><p>
-<sup>16&#160;</sup>These are the statutes which Yahweh commanded Moses, between a man and his woman, between a father and his daughter, being in her youth, in her father’s house. 
+<sup>16&#160;</sup>These are the statutes which Yahuah commanded Moses, between a man and his woman, between a father and his daughter, being in her youth, in her father’s house. 
 </p><h2 class="chapterlabel" id="31">31</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Avenge the children of Israel on the Midianites. Afterward you shall be gathered to your people.” 
 </p><p>
-<sup>3&#160;</sup>Moses spoke to the people, saying, “Arm men from among you for war, that they may go against Midian, to execute Yahweh’s vengeance on Midian. 
+<sup>3&#160;</sup>Moses spoke to the people, saying, “Arm men from among you for war, that they may go against Midian, to execute Yahuah’s vengeance on Midian. 
 <sup>4&#160;</sup>You shall send one thousand out of every tribe, throughout all the tribes of Israel, to the war.” 
 <sup>5&#160;</sup>So there were delivered, out of the thousands of Israel, a thousand from every tribe, twelve thousand armed for war. 
 <sup>6&#160;</sup>Moses sent them, one thousand of every tribe, to the war with Phinehas the son of Eleazar the priest, to the war, with the vessels of the sanctuary and the trumpets for the alarm in his hand. 
-<sup>7&#160;</sup>They fought against Midian, as Yahweh commanded Moses. They killed every male. 
+<sup>7&#160;</sup>They fought against Midian, as Yahuah commanded Moses. They killed every male. 
 <sup>8&#160;</sup>They killed the kings of Midian with the rest of their slain: Evi, Rekem, Zur, Hur, and Reba, the five kings of Midian. They also killed Balaam the son of Beor with the sword. 
 <sup>9&#160;</sup>The children of Israel took the women of Midian captive with their little ones; and all their livestock, all their flocks, and all their goods, they took as plunder. 
 <sup>10&#160;</sup>All their cities in the places in which they lived, and all their encampments, they burned with fire. 
@@ -1764,70 +1764,70 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>Moses and Eleazar the priest, with all the princes of the congregation, went out to meet them outside of the camp. 
 <sup>14&#160;</sup>Moses was angry with the officers of the army, the captains of thousands and the captains of hundreds, who came from the service of the war. 
 <sup>15&#160;</sup>Moses said to them, “Have you saved all the women alive? 
-<sup>16&#160;</sup>Behold, these caused the children of Israel, through the counsel of Balaam, to commit trespass against Yahweh in the matter of Peor, and so the plague was among the congregation of Yahweh. 
+<sup>16&#160;</sup>Behold, these caused the children of Israel, through the counsel of Balaam, to commit trespass against Yahuah in the matter of Peor, and so the plague was among the congregation of Yahuah. 
 <sup>17&#160;</sup>Now therefore kill every male among the little ones, and kill every woman who has known man by lying with him. 
 <sup>18&#160;</sup>But all the girls, who have not known man by lying with him, keep alive for yourselves. 
 </p><p>
 <sup>19&#160;</sup>“Encamp outside of the camp for seven days. Whoever has killed any person, and whoever has touched any slain, purify yourselves on the third day and on the seventh day, you and your captives. 
 <sup>20&#160;</sup>You shall purify every garment, and all that is made of skin, and all work of goats’ hair, and all things made of wood.” 
 </p><p>
-<sup>21&#160;</sup>Eleazar the priest said to the men of war who went to the battle, “This is the statute of the law which Yahweh has commanded Moses. 
+<sup>21&#160;</sup>Eleazar the priest said to the men of war who went to the battle, “This is the statute of the law which Yahuah has commanded Moses. 
 <sup>22&#160;</sup>However the gold, and the silver, the bronze, the iron, the tin, and the lead, 
 <sup>23&#160;</sup>everything that may withstand the fire, you shall make to go through the fire, and it shall be clean; nevertheless it shall be purified with the water for impurity. All that doesn’t withstand the fire you shall make to go through the water. 
 <sup>24&#160;</sup>You shall wash your clothes on the seventh day, and you shall be clean. Afterward you shall come into the camp.” 
 </p><p>
-<sup>25&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>25&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>26&#160;</sup>“Count the plunder that was taken, both of man and of animal, you, and Eleazar the priest, and the heads of the fathers’ households of the congregation; 
 <sup>27&#160;</sup>and divide the plunder into two parts: between the men skilled in war, who went out to battle, and all the congregation. 
-<sup>28&#160;</sup>Levy a tribute to Yahweh of the men of war who went out to battle: one soul of five hundred; of the persons, of the cattle, of the donkeys, and of the flocks. 
-<sup>29&#160;</sup>Take it from their half, and give it to Eleazar the priest, for Yahweh’s wave offering. 
-<sup>30&#160;</sup>Of the children of Israel’s half, you shall take one drawn out of every fifty, of the persons, of the cattle, of the donkeys, and of the flocks, of all the livestock, and give them to the Levites, who perform the duty of Yahweh’s tabernacle.” 
+<sup>28&#160;</sup>Levy a tribute to Yahuah of the men of war who went out to battle: one soul of five hundred; of the persons, of the cattle, of the donkeys, and of the flocks. 
+<sup>29&#160;</sup>Take it from their half, and give it to Eleazar the priest, for Yahuah’s wave offering. 
+<sup>30&#160;</sup>Of the children of Israel’s half, you shall take one drawn out of every fifty, of the persons, of the cattle, of the donkeys, and of the flocks, of all the livestock, and give them to the Levites, who perform the duty of Yahuah’s tabernacle.” 
 </p><p>
-<sup>31&#160;</sup>Moses and Eleazar the priest did as Yahweh commanded Moses. 
+<sup>31&#160;</sup>Moses and Eleazar the priest did as Yahuah commanded Moses. 
 </p><p>
 <sup>32&#160;</sup>Now the plunder, over and above the booty which the men of war took, was six hundred seventy-five thousand sheep, 
 <sup>33&#160;</sup>seventy-two thousand head of cattle, 
 <sup>34&#160;</sup>sixty-one thousand donkeys, 
 <sup>35&#160;</sup>and thirty-two thousand persons in all, of the women who had not known man by lying with him. 
 <sup>36&#160;</sup>The half, which was the portion of those who went out to war, was in number three hundred thirty-seven thousand five hundred sheep; 
-<sup>37&#160;</sup>and Yahweh’s tribute of the sheep was six hundred seventy-five. 
-<sup>38&#160;</sup>The cattle were thirty-six thousand, of which Yahweh’s tribute was seventy-two. 
-<sup>39&#160;</sup>The donkeys were thirty thousand five hundred, of which Yahweh’s tribute was sixty-one. 
-<sup>40&#160;</sup>The persons were sixteen thousand, of whom Yahweh’s tribute was thirty-two persons. 
-<sup>41&#160;</sup>Moses gave the tribute, which was Yahweh’s wave offering, to Eleazar the priest, as Yahweh commanded Moses. 
+<sup>37&#160;</sup>and Yahuah’s tribute of the sheep was six hundred seventy-five. 
+<sup>38&#160;</sup>The cattle were thirty-six thousand, of which Yahuah’s tribute was seventy-two. 
+<sup>39&#160;</sup>The donkeys were thirty thousand five hundred, of which Yahuah’s tribute was sixty-one. 
+<sup>40&#160;</sup>The persons were sixteen thousand, of whom Yahuah’s tribute was thirty-two persons. 
+<sup>41&#160;</sup>Moses gave the tribute, which was Yahuah’s wave offering, to Eleazar the priest, as Yahuah commanded Moses. 
 <sup>42&#160;</sup>Of the children of Israel’s half, which Moses divided off from the men who fought 
 <sup>43&#160;</sup>(now the congregation’s half was three hundred thirty-seven thousand five hundred sheep, 
 <sup>44&#160;</sup>thirty-six thousand head of cattle, 
 <sup>45&#160;</sup>thirty thousand five hundred donkeys, 
 <sup>46&#160;</sup>and sixteen thousand persons), 
-<sup>47&#160;</sup>even of the children of Israel’s half, Moses took one drawn out of every fifty, both of man and of animal, and gave them to the Levites, who performed the duty of Yahweh’s tabernacle, as Yahweh commanded Moses. 
+<sup>47&#160;</sup>even of the children of Israel’s half, Moses took one drawn out of every fifty, both of man and of animal, and gave them to the Levites, who performed the duty of Yahuah’s tabernacle, as Yahuah commanded Moses. 
 </p><p>
 <sup>48&#160;</sup>The officers who were over the thousands of the army, the captains of thousands, and the captains of hundreds, came near to Moses. 
 <sup>49&#160;</sup>They said to Moses, “Your servants have taken the sum of the men of war who are under our command, and there lacks not one man of us. 
-<sup>50&#160;</sup>We have brought Yahweh’s offering, what every man found: gold ornaments, armlets, bracelets, signet rings, earrings, and necklaces, to make atonement for our souls before Yahweh.” 
+<sup>50&#160;</sup>We have brought Yahuah’s offering, what every man found: gold ornaments, armlets, bracelets, signet rings, earrings, and necklaces, to make atonement for our souls before Yahuah.” 
 </p><p>
 <sup>51&#160;</sup>Moses and Eleazar the priest took their gold, even all worked jewels. 
-<sup>52&#160;</sup>All the gold of the wave offering that they offered up to Yahweh, of the captains of thousands, and of the captains of hundreds, was sixteen thousand seven hundred fifty shekels. 
+<sup>52&#160;</sup>All the gold of the wave offering that they offered up to Yahuah, of the captains of thousands, and of the captains of hundreds, was sixteen thousand seven hundred fifty shekels. 
 <sup>53&#160;</sup>The men of war had taken booty, every man for himself. 
-<sup>54&#160;</sup>Moses and Eleazar the priest took the gold of the captains of thousands and of hundreds, and brought it into the Tent of Meeting for a memorial for the children of Israel before Yahweh. 
+<sup>54&#160;</sup>Moses and Eleazar the priest took the gold of the captains of thousands and of hundreds, and brought it into the Tent of Meeting for a memorial for the children of Israel before Yahuah. 
 </p><h2 class="chapterlabel" id="32">32</h2>
 <p>
 <sup>1&#160;</sup>Now the children of Reuben and the children of Gad had a very great multitude of livestock. They saw the land of Jazer, and the land of Gilead. Behold, the place was a place for livestock. 
 <sup>2&#160;</sup>Then the children of Gad and the children of Reuben came and spoke to Moses, and to Eleazar the priest, and to the princes of the congregation, saying, 
 <sup>3&#160;</sup>“Ataroth, Dibon, Jazer, Nimrah, Heshbon, Elealeh, Sebam, Nebo, and Beon, 
-<sup>4&#160;</sup>the land which Yahweh struck before the congregation of Israel, is a land for livestock; and your servants have livestock.” 
+<sup>4&#160;</sup>the land which Yahuah struck before the congregation of Israel, is a land for livestock; and your servants have livestock.” 
 <sup>5&#160;</sup>They said, “If we have found favor in your sight, let this land be given to your servants for a possession. Don’t bring us over the Jordan.” 
 </p><p>
 <sup>6&#160;</sup>Moses said to the children of Gad, and to the children of Reuben, “Shall your brothers go to war while you sit here? 
-<sup>7&#160;</sup>Why do you discourage the heart of the children of Israel from going over into the land which Yahweh has given them? 
+<sup>7&#160;</sup>Why do you discourage the heart of the children of Israel from going over into the land which Yahuah has given them? 
 <sup>8&#160;</sup>Your fathers did so when I sent them from Kadesh Barnea to see the land. 
-<sup>9&#160;</sup>For when they went up to the valley of Eshcol, and saw the land, they discouraged the heart of the children of Israel, that they should not go into the land which Yahweh had given them. 
-<sup>10&#160;</sup>Yahweh’s anger burned in that day, and he swore, saying, 
+<sup>9&#160;</sup>For when they went up to the valley of Eshcol, and saw the land, they discouraged the heart of the children of Israel, that they should not go into the land which Yahuah had given them. 
+<sup>10&#160;</sup>Yahuah’s anger burned in that day, and he swore, saying, 
 <sup>11&#160;</sup>‘Surely none of the men who came up out of Egypt, from twenty years old and upward, shall see the land which I swore to Abraham, to Isaac, and to Jacob; because they have not wholly followed me, 
-<sup>12&#160;</sup>except Caleb the son of Jephunneh the Kenizzite, and Joshua the son of Nun, because they have followed Yahweh completely.’ 
-<sup>13&#160;</sup>Yahweh’s anger burned against Israel, and he made them wander back and forth in the wilderness forty years, until all the generation who had done evil in Yahweh’s sight was consumed. 
+<sup>12&#160;</sup>except Caleb the son of Jephunneh the Kenizzite, and Joshua the son of Nun, because they have followed Yahuah completely.’ 
+<sup>13&#160;</sup>Yahuah’s anger burned against Israel, and he made them wander back and forth in the wilderness forty years, until all the generation who had done evil in Yahuah’s sight was consumed. 
 </p><p>
-<sup>14&#160;</sup>“Behold, you have risen up in your fathers’ place, an increase of sinful men, to increase the fierce anger of Yahweh toward Israel. 
+<sup>14&#160;</sup>“Behold, you have risen up in your fathers’ place, an increase of sinful men, to increase the fierce anger of Yahuah toward Israel. 
 <sup>15&#160;</sup>For if you turn away from after him, he will yet again leave them in the wilderness; and you will destroy all these people.” 
 </p><p>
 <sup>16&#160;</sup>They came near to him, and said, “We will build sheepfolds here for our livestock, and cities for our little ones; 
@@ -1835,23 +1835,23 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>We will not return to our houses until the children of Israel have all received their inheritance. 
 <sup>19&#160;</sup>For we will not inherit with them on the other side of the Jordan and beyond, because our inheritance has come to us on this side of the Jordan eastward.” 
 </p><p>
-<sup>20&#160;</sup>Moses said to them: “If you will do this thing, if you will arm yourselves to go before Yahweh to the war, 
-<sup>21&#160;</sup>and every one of your armed men will pass over the Jordan before Yahweh until he has driven out his enemies from before him, 
-<sup>22&#160;</sup>and the land is subdued before Yahweh; then afterward you shall return, and be clear of obligation to Yahweh and to Israel. Then this land shall be your possession before Yahweh. 
+<sup>20&#160;</sup>Moses said to them: “If you will do this thing, if you will arm yourselves to go before Yahuah to the war, 
+<sup>21&#160;</sup>and every one of your armed men will pass over the Jordan before Yahuah until he has driven out his enemies from before him, 
+<sup>22&#160;</sup>and the land is subdued before Yahuah; then afterward you shall return, and be clear of obligation to Yahuah and to Israel. Then this land shall be your possession before Yahuah. 
 </p><p>
-<sup>23&#160;</sup>“But if you will not do so, behold, you have sinned against Yahweh; and be sure your sin will find you out. 
+<sup>23&#160;</sup>“But if you will not do so, behold, you have sinned against Yahuah; and be sure your sin will find you out. 
 <sup>24&#160;</sup>Build cities for your little ones, and folds for your sheep; and do that which has proceeded out of your mouth.” 
 </p><p>
 <sup>25&#160;</sup>The children of Gad and the children of Reuben spoke to Moses, saying, “Your servants will do as my lord commands. 
 <sup>26&#160;</sup>Our little ones, our women, our flocks, and all our livestock shall be there in the cities of Gilead; 
-<sup>27&#160;</sup>but your servants will pass over, every man who is armed for war, before Yahweh to battle, as my lord says.” 
+<sup>27&#160;</sup>but your servants will pass over, every man who is armed for war, before Yahuah to battle, as my lord says.” 
 </p><p>
 <sup>28&#160;</sup>So Moses commanded concerning them to Eleazar the priest, and to Joshua the son of Nun, and to the heads of the fathers’ households of the tribes of the children of Israel. 
-<sup>29&#160;</sup>Moses said to them, “If the children of Gad and the children of Reuben will pass with you over the Jordan, every man who is armed to battle before Yahweh, and the land is subdued before you, then you shall give them the land of Gilead for a possession; 
+<sup>29&#160;</sup>Moses said to them, “If the children of Gad and the children of Reuben will pass with you over the Jordan, every man who is armed to battle before Yahuah, and the land is subdued before you, then you shall give them the land of Gilead for a possession; 
 <sup>30&#160;</sup>but if they will not pass over with you armed, they shall have possessions among you in the land of Canaan.” 
 </p><p>
-<sup>31&#160;</sup>The children of Gad and the children of Reuben answered, saying, “As Yahweh has said to your servants, so will we do. 
-<sup>32&#160;</sup>We will pass over armed before Yahweh into the land of Canaan, and the possession of our inheritance shall remain with us beyond the Jordan.” 
+<sup>31&#160;</sup>The children of Gad and the children of Reuben answered, saying, “As Yahuah has said to your servants, so will we do. 
+<sup>32&#160;</sup>We will pass over armed before Yahuah into the land of Canaan, and the possession of our inheritance shall remain with us beyond the Jordan.” 
 </p><p>
 <sup>33&#160;</sup>Moses gave to them, even to the children of Gad, and to the children of Reuben, and to the half-tribe of Manasseh the son of Joseph, the kingdom of Sihon king of the Amorites, and the kingdom of Og king of Bashan; the land, according to its cities and borders, even the cities of the surrounding land. 
 <sup>34&#160;</sup>The children of Gad built Dibon, Ataroth, Aroer, 
@@ -1866,9 +1866,9 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="33">33</h2>
 <p>
 <sup>1&#160;</sup>These are the journeys of the children of Israel, when they went out of the land of Egypt by their armies under the hand of Moses and Aaron. 
-<sup>2&#160;</sup>Moses wrote the starting points of their journeys by the commandment of Yahweh. These are their journeys according to their starting points. 
+<sup>2&#160;</sup>Moses wrote the starting points of their journeys by the commandment of Yahuah. These are their journeys according to their starting points. 
 <sup>3&#160;</sup>They traveled from Rameses in the first month, on the fifteenth day of the first month; on the next day after the Passover, the children of Israel went out with a high hand in the sight of all the Egyptians, 
-<sup>4&#160;</sup>while the Egyptians were burying all their firstborn, whom Yahweh had struck among them. Yahweh also executed judgments on their elohims. 
+<sup>4&#160;</sup>while the Egyptians were burying all their firstborn, whom Yahuah had struck among them. Yahuah also executed judgments on their elohims. 
 <sup>5&#160;</sup>The children of Israel traveled from Rameses, and encamped in Succoth. 
 <sup>6&#160;</sup>They traveled from Succoth, and encamped in Etham, which is in the edge of the wilderness. 
 <sup>7&#160;</sup>They traveled from Etham, and turned back to Pihahiroth, which is before Baal Zephon, and they encamped before Migdol. 
@@ -1902,7 +1902,7 @@ html[dir=ltr] .q2 {
 <sup>35&#160;</sup>They traveled from Abronah, and encamped in Ezion Geber. 
 <sup>36&#160;</sup>They traveled from Ezion Geber, and encamped at Kadesh in the wilderness of Zin. 
 <sup>37&#160;</sup>They traveled from Kadesh, and encamped in Mount Hor, in the edge of the land of Edom. 
-<sup>38&#160;</sup>Aaron the priest went up into Mount Hor at the commandment of Yahweh and died there, in the fortieth year after the children of Israel had come out of the land of Egypt, in the fifth month, on the first day of the month. 
+<sup>38&#160;</sup>Aaron the priest went up into Mount Hor at the commandment of Yahuah and died there, in the fortieth year after the children of Israel had come out of the land of Egypt, in the fifth month, on the first day of the month. 
 <sup>39&#160;</sup>Aaron was one hundred twenty-three years old when he died in Mount Hor. 
 <sup>40&#160;</sup>The Canaanite king of Arad, who lived in the South in the land of Canaan, heard of the coming of the children of Israel. 
 <sup>41&#160;</sup>They traveled from Mount Hor, and encamped in Zalmonah. 
@@ -1914,7 +1914,7 @@ html[dir=ltr] .q2 {
 <sup>47&#160;</sup>They traveled from Almon Diblathaim, and encamped in the mountains of Abarim, before Nebo. 
 <sup>48&#160;</sup>They traveled from the mountains of Abarim, and encamped in the plains of Moab by the Jordan at Jericho. 
 <sup>49&#160;</sup>They encamped by the Jordan, from Beth Jeshimoth even to Abel Shittim in the plains of Moab. 
-<sup>50&#160;</sup>Yahweh spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
+<sup>50&#160;</sup>Yahuah spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
 <sup>51&#160;</sup>Speak to the children of Israel, and tell them, “When you pass over the Jordan into the land of Canaan, 
 <sup>52&#160;</sup>then you shall drive out all the inhabitants of the land from before you, destroy all their stone idols, destroy all their molten images, and demolish all their high places. 
 <sup>53&#160;</sup>You shall take possession of the land, and dwell therein; for I have given the land to you to possess it. 
@@ -1924,7 +1924,7 @@ html[dir=ltr] .q2 {
 <sup>56&#160;</sup>It shall happen that as I thought to do to them, so I will do to you.” 
 </p><h2 class="chapterlabel" id="34">34</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>2&#160;</sup>“Command the children of Israel, and tell them, ‘When you come into the land of Canaan (this is the land that shall fall to you for an inheritance, even the land of Canaan according to its borders), 
 <sup>3&#160;</sup>then your south quarter shall be from the wilderness of Zin along by the side of Edom, and your south border shall be from the end of the Salt Sea eastward. 
 <sup>4&#160;</sup>Your border shall turn about southward of the ascent of Akrabbim, and pass along to Zin; and it shall pass southward of Kadesh Barnea; and it shall go from there to Hazar Addar, and pass along to Azmon. 
@@ -1940,11 +1940,11 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>The border shall go down from Shepham to Riblah, on the east side of Ain. The border shall go down, and shall reach to the side of the sea of Chinnereth eastward. 
 <sup>12&#160;</sup>The border shall go down to the Jordan, and end at the Salt Sea. This shall be your land according to its borders around it.’&#160;” 
 </p><p>
-<sup>13&#160;</sup>Moses commanded the children of Israel, saying, “This is the land which you shall inherit by lot, which Yahweh has commanded to give to the nine tribes, and to the half-tribe; 
+<sup>13&#160;</sup>Moses commanded the children of Israel, saying, “This is the land which you shall inherit by lot, which Yahuah has commanded to give to the nine tribes, and to the half-tribe; 
 <sup>14&#160;</sup>for the tribe of the children of Reuben according to their fathers’ houses, the tribe of the children of Gad according to their fathers’ houses, and the half-tribe of Manasseh have received their inheritance. 
 <sup>15&#160;</sup>The two tribes and the half-tribe have received their inheritance beyond the Jordan at Jericho eastward, toward the sunrise.” 
 </p><p>
-<sup>16&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>16&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>17&#160;</sup>“These are the names of the men who shall divide the land to you for inheritance: Eleazar the priest, and Joshua the son of Nun. 
 <sup>18&#160;</sup>You shall take one prince of every tribe, to divide the land for inheritance. 
 <sup>19&#160;</sup>These are the names of the men: Of the tribe of Judah, Caleb the son of Jephunneh. 
@@ -1957,10 +1957,10 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>Of the tribe of the children of Issachar a prince, Paltiel the son of Azzan. 
 <sup>27&#160;</sup>Of the tribe of the children of Asher a prince, Ahihud the son of Shelomi. 
 <sup>28&#160;</sup>Of the tribe of the children of Naphtali a prince, Pedahel the son of Ammihud.” 
-<sup>29&#160;</sup>These are they whom Yahweh commanded to divide the inheritance to the children of Israel in the land of Canaan. 
+<sup>29&#160;</sup>These are they whom Yahuah commanded to divide the inheritance to the children of Israel in the land of Canaan. 
 </p><h2 class="chapterlabel" id="35">35</h2>
 <p>
-<sup>1&#160;</sup>Yahweh spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
+<sup>1&#160;</sup>Yahuah spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
 <sup>2&#160;</sup>“Command the children of Israel to give to the Levites cities to dwell in out of their inheritance. You shall give pasture lands for the cities around them to the Levites. 
 <sup>3&#160;</sup>They shall have the cities to dwell in. Their pasture lands shall be for their livestock, and for their possessions, and for all their animals. 
 </p><p>
@@ -1970,7 +1970,7 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>“The cities which you shall give to the Levites, they shall be the six cities of refuge, which you shall give for the man slayer to flee to. Besides them you shall give forty-two cities. 
 <sup>7&#160;</sup>All the cities which you shall give to the Levites shall be forty-eight cities together with their pasture lands. 
 <sup>8&#160;</sup>Concerning the cities which you shall give of the possession of the children of Israel, from the many you shall take many, and from the few you shall take few. Everyone according to his inheritance which he inherits shall give some of his cities to the Levites.” 
-<sup>9&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>9&#160;</sup>Yahuah spoke to Moses, saying, 
 <sup>10&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you pass over the Jordan into the land of Canaan, 
 <sup>11&#160;</sup>then you shall appoint for yourselves cities to be cities of refuge for you, that the man slayer who kills any person unwittingly may flee there. 
 <sup>12&#160;</sup>The cities shall be for your refuge from the avenger, that the man slayer not die until he stands before the congregation for judgment. 
@@ -2003,22 +2003,22 @@ html[dir=ltr] .q2 {
 <sup>32&#160;</sup>“&#160;‘You shall take no ransom for him who has fled to his city of refuge, that he may come again to dwell in the land before the death of the priest. 
 </p><p>
 <sup>33&#160;</sup>“&#160;‘So you shall not pollute the land where you live; for blood pollutes the land. No atonement can be made for the land for the blood that is shed in it, but by the blood of him who shed it. 
-<sup>34&#160;</sup>You shall not defile the land which you inhabit, where I dwell; for I, Yahweh, dwell among the children of Israel.’&#160;” 
+<sup>34&#160;</sup>You shall not defile the land which you inhabit, where I dwell; for I, Yahuah, dwell among the children of Israel.’&#160;” 
 </p><h2 class="chapterlabel" id="36">36</h2>
 <p>
 <sup>1&#160;</sup>The heads of the fathers’ households of the family of the children of Gilead, the son of Machir, the son of Manasseh, of the families of the sons of Joseph, came near and spoke before Moses and before the princes, the heads of the fathers’ households of the children of Israel. 
-<sup>2&#160;</sup>They said, “Yahweh commanded my lord to give the land for inheritance by lot to the children of Israel. My lord was commanded by Yahweh to give the inheritance of Zelophehad our brother to his daughters. 
+<sup>2&#160;</sup>They said, “Yahuah commanded my lord to give the land for inheritance by lot to the children of Israel. My lord was commanded by Yahuah to give the inheritance of Zelophehad our brother to his daughters. 
 <sup>3&#160;</sup>If they are women to any of the sons of the other tribes of the children of Israel, then their inheritance will be taken away from the inheritance of our fathers, and will be added to the inheritance of the tribe to which they shall belong. So it will be taken away from the lot of our inheritance. 
 <sup>4&#160;</sup>When the jubilee of the children of Israel comes, then their inheritance will be added to the inheritance of the tribe to which they shall belong. So their inheritance will be taken away from the inheritance of the tribe of our fathers.” 
 </p><p>
-<sup>5&#160;</sup>Moses commanded the children of Israel according to Yahweh’s word, saying, “The tribe of the sons of Joseph speak what is right. 
-<sup>6&#160;</sup>This is the thing which Yahweh commands concerning the daughters of Zelophehad, saying, ‘Let them be women to whom they think best, only they shall be women into the family of the tribe of their father. 
+<sup>5&#160;</sup>Moses commanded the children of Israel according to Yahuah’s word, saying, “The tribe of the sons of Joseph speak what is right. 
+<sup>6&#160;</sup>This is the thing which Yahuah commands concerning the daughters of Zelophehad, saying, ‘Let them be women to whom they think best, only they shall be women into the family of the tribe of their father. 
 <sup>7&#160;</sup>So shall no inheritance of the children of Israel move from tribe to tribe; for the children of Israel shall all keep the inheritance of the tribe of his fathers. 
 <sup>8&#160;</sup>Every daughter who possesses an inheritance in any tribe of the children of Israel shall be woman to one of the family of the tribe of her father, that the children of Israel may each possess the inheritance of his fathers. 
 <sup>9&#160;</sup>So shall no inheritance move from one tribe to another tribe; for the tribes of the children of Israel shall each keep his own inheritance.’&#160;” 
 </p><p>
-<sup>10&#160;</sup>The daughters of Zelophehad did as Yahweh commanded Moses: 
+<sup>10&#160;</sup>The daughters of Zelophehad did as Yahuah commanded Moses: 
 <sup>11&#160;</sup>for Mahlah, Tirzah, Hoglah, Milcah, and Noah, the daughters of Zelophehad, were women to their father’s brothers’ sons. 
 <sup>12&#160;</sup>They were women into the families of the sons of Manasseh the son of Joseph. Their inheritance remained in the tribe of the family of their father. 
 </p><p>
-<sup>13&#160;</sup>These are the commandments and the ordinances which Yahweh commanded by Moses to the children of Israel in the plains of Moab by the Jordan at Jericho. </p></div><script src="../main.js"></script></body></html>
+<sup>13&#160;</sup>These are the commandments and the ordinances which Yahuah commanded by Moses to the children of Israel in the plains of Moab by the Jordan at Jericho. </p></div><script src="../main.js"></script></body></html>

--- a/book/obadiah.html
+++ b/book/obadiah.html
@@ -60,26 +60,26 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>The vision of Obadiah. This is what the Lord Yahweh says about Edom. We have heard news from Yahweh, and an ambassador is sent among the nations, saying, “Arise, and let’s rise up against her in battle. 
+<sup>1&#160;</sup>The vision of Obadiah. This is what the Lord Yahuah says about Edom. We have heard news from Yahuah, and an ambassador is sent among the nations, saying, “Arise, and let’s rise up against her in battle. 
 <sup>2&#160;</sup>Behold, I have made you small among the nations. You are greatly despised. 
 <sup>3&#160;</sup>The pride of your heart has deceived you, you who dwell in the clefts of the rock, whose habitation is high, who says in his heart, ‘Who will bring me down to the ground?’ 
-<sup>4&#160;</sup>Though you mount on high as the eagle, and though your nest is set among the stars, I will bring you down from there,” says Yahweh. 
+<sup>4&#160;</sup>Though you mount on high as the eagle, and though your nest is set among the stars, I will bring you down from there,” says Yahuah. 
 <sup>5&#160;</sup>“If thieves came to you, if robbers by night—oh, what disaster awaits you—wouldn’t they only steal until they had enough? If grape pickers came to you, wouldn’t they leave some gleaning grapes? 
 <sup>6&#160;</sup>How Esau will be ransacked! How his hidden treasures are sought out! 
 <sup>7&#160;</sup>All the men of your alliance have brought you on your way, even to the border. The men who were at peace with you have deceived you, and prevailed against you. Friends who eat your bread lay a snare under you. There is no understanding in him.” 
 </p><p>
-<sup>8&#160;</sup>“Won’t I in that day”, says Yahweh, “destroy the wise men out of Edom, and understanding out of the mountain of Esau? 
+<sup>8&#160;</sup>“Won’t I in that day”, says Yahuah, “destroy the wise men out of Edom, and understanding out of the mountain of Esau? 
 <sup>9&#160;</sup>Your mighty men, Teman, will be dismayed, to the end that everyone may be cut off from the mountain of Esau by slaughter. 
 <sup>10&#160;</sup>For the violence done to your brother Jacob, shame will cover you, and you will be cut off forever. 
 <sup>11&#160;</sup>In the day that you stood on the other side, in the day that strangers carried away his substance and foreigners entered into his gates and cast lots for Jerusalem, even you were like one of them. 
 <sup>12&#160;</sup>But don’t look down on your brother in the day of his disaster, and don’t rejoice over the children of Judah in the day of their destruction. Don’t speak proudly in the day of distress. 
 <sup>13&#160;</sup>Don’t enter into the gate of my people in the day of their calamity. Don’t look down on their affliction in the day of their calamity, neither seize their wealth on the day of their calamity. 
 <sup>14&#160;</sup>Don’t stand in the crossroads to cut off those of his who escape. Don’t deliver up those of his who remain in the day of distress. 
-<sup>15&#160;</sup>For the day of Yahweh is near all the nations! As you have done, it will be done to you. Your deeds will return upon your own head. 
+<sup>15&#160;</sup>For the day of Yahuah is near all the nations! As you have done, it will be done to you. Your deeds will return upon your own head. 
 <sup>16&#160;</sup>For as you have drunk on my set-apart mountain, so all the nations will drink continually. Yes, they will drink, swallow down, and will be as though they had not been. 
 <sup>17&#160;</sup>But in Mount Zion, there will be those who escape, and it will be set-apart. The house of Jacob will possess their possessions. 
-<sup>18&#160;</sup>The house of Jacob will be a fire, the house of Joseph a flame, and the house of Esau for stubble. They will burn among them and devour them. There will not be any remaining to the house of Esau.” Indeed, Yahweh has spoken. 
+<sup>18&#160;</sup>The house of Jacob will be a fire, the house of Joseph a flame, and the house of Esau for stubble. They will burn among them and devour them. There will not be any remaining to the house of Esau.” Indeed, Yahuah has spoken. 
 </p><p>
 <sup>19&#160;</sup>Those of the South will possess the mountain of Esau, and those of the lowland, the Philistines. They will possess the field of Ephraim, and the field of Samaria. Benjamin will possess Gilead. 
 <sup>20&#160;</sup>The captives of this army of the children of Israel, who are among the Canaanites, will possess even to Zarephath; and the captives of Jerusalem, who are in Sepharad, will possess the cities of the Negev. 
-<sup>21&#160;</sup>Saviors will go up on Mount Zion to judge the mountains of Esau, and the kingdom will be Yahweh’s. </p></div><script src="../main.js"></script></body></html>
+<sup>21&#160;</sup>Saviors will go up on Mount Zion to judge the mountains of Esau, and the kingdom will be Yahuah’s. </p></div><script src="../main.js"></script></body></html>

--- a/book/proverbs.html
+++ b/book/proverbs.html
@@ -107,7 +107,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the words and riddles of the wise. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>7&#160;</sup>The fear of Yahweh is the beginning of knowledge, 
+<sup>7&#160;</sup>The fear of Yahuah is the beginning of knowledge, 
 </p><p class="q2">but the foolish despise wisdom and instruction. 
 </p><p class="q1">
 <sup>8&#160;</sup>My son, listen to your father’s instruction, 
@@ -177,7 +177,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They will seek me diligently, but they will not find me, 
 </p><p class="q1">
 <sup>29&#160;</sup>because they hated knowledge, 
-</p><p class="q2">and didn’t choose the fear of Yahweh. 
+</p><p class="q2">and didn’t choose the fear of Yahuah. 
 </p><p class="q1">
 <sup>30&#160;</sup>They wanted none of my counsel. 
 </p><p class="q2">They despised all my reproof. 
@@ -204,10 +204,10 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>if you seek her as silver, 
 </p><p class="q2">and search for her as for hidden treasures; 
 </p><p class="q1">
-<sup>5&#160;</sup>then you will understand the fear of Yahweh, 
+<sup>5&#160;</sup>then you will understand the fear of Yahuah, 
 </p><p class="q2">and find the knowledge of Elohim. 
 </p><p class="q1">
-<sup>6&#160;</sup>For Yahweh gives wisdom. 
+<sup>6&#160;</sup>For Yahuah gives wisdom. 
 </p><p class="q2">Out of his mouth comes knowledge and understanding. 
 </p><p class="q1">
 <sup>7&#160;</sup>He lays up sound wisdom for the upright. 
@@ -272,28 +272,28 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>So you will find favor, 
 </p><p class="q2">and good understanding in the sight of Elohim and man. 
 </p><p class="q1">
-<sup>5&#160;</sup>Trust in Yahweh with all your heart, 
+<sup>5&#160;</sup>Trust in Yahuah with all your heart, 
 </p><p class="q2">and don’t lean on your own understanding. 
 </p><p class="q1">
 <sup>6&#160;</sup>In all your ways acknowledge him, 
 </p><p class="q2">and he will make your paths straight. 
 </p><p class="q1">
 <sup>7&#160;</sup>Don’t be wise in your own eyes. 
-</p><p class="q2">Fear Yahweh, and depart from evil. 
+</p><p class="q2">Fear Yahuah, and depart from evil. 
 </p><p class="q1">
 <sup>8&#160;</sup>It will be health to your body, 
 </p><p class="q2">and nourishment to your bones. 
 </p><p class="q1">
-<sup>9&#160;</sup>Honor Yahweh with your substance, 
+<sup>9&#160;</sup>Honor Yahuah with your substance, 
 </p><p class="q2">with the first fruits of all your increase; 
 </p><p class="q1">
 <sup>10&#160;</sup>so your barns will be filled with plenty, 
 </p><p class="q2">and your vats will overflow with new wine. 
 </p><p class="q1">
-<sup>11&#160;</sup>My son, don’t despise Yahweh’s discipline, 
+<sup>11&#160;</sup>My son, don’t despise Yahuah’s discipline, 
 </p><p class="q2">neither be weary of his correction; 
 </p><p class="q1">
-<sup>12&#160;</sup>for whom Yahweh loves, he corrects, 
+<sup>12&#160;</sup>for whom Yahuah loves, he corrects, 
 </p><p class="q2">even as a father reproves the son in whom he delights. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -315,7 +315,7 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>She is a tree of life to those who lay hold of her. 
 </p><p class="q2">Happy is everyone who retains her. 
 </p><p class="q1">
-<sup>19&#160;</sup>By wisdom Yahweh founded the earth. 
+<sup>19&#160;</sup>By wisdom Yahuah founded the earth. 
 </p><p class="q2">By understanding, he established the heavens. 
 </p><p class="q1">
 <sup>20&#160;</sup>By his knowledge, the depths were broken up, 
@@ -336,7 +336,7 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>Don’t be afraid of sudden fear, 
 </p><p class="q2">neither of the desolation of the wicked, when it comes; 
 </p><p class="q1">
-<sup>26&#160;</sup>for Yahweh will be your confidence, 
+<sup>26&#160;</sup>for Yahuah will be your confidence, 
 </p><p class="q2">and will keep your foot from being taken. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -356,10 +356,10 @@ html[dir=ltr] .q2 {
 <sup>31&#160;</sup>Don’t envy the man of violence. 
 </p><p class="q2">Choose none of his ways. 
 </p><p class="q1">
-<sup>32&#160;</sup>For the perverse is an abomination to Yahweh, 
+<sup>32&#160;</sup>For the perverse is an abomination to Yahuah, 
 </p><p class="q2">but his friendship is with the upright. 
 </p><p class="q1">
-<sup>33&#160;</sup>Yahweh’s curse is in the house of the wicked, 
+<sup>33&#160;</sup>Yahuah’s curse is in the house of the wicked, 
 </p><p class="q2">but he blesses the habitation of the righteous. 
 </p><p class="q1">
 <sup>34&#160;</sup>Surely he mocks the mockers, 
@@ -519,7 +519,7 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>For why should you, my son, be captivated with an adulteress? 
 </p><p class="q2">Why embrace the bosom of another? 
 </p><p class="q1">
-<sup>21&#160;</sup>For the ways of man are before Yahweh’s eyes. 
+<sup>21&#160;</sup>For the ways of man are before Yahuah’s eyes. 
 </p><p class="q2">He examines all his paths. 
 </p><p class="q1">
 <sup>22&#160;</sup>The evil deeds of the wicked ensnare him. 
@@ -578,7 +578,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He will be broken suddenly, and that without remedy. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>16&#160;</sup>There are six things which Yahweh hates; 
+<sup>16&#160;</sup>There are six things which Yahuah hates; 
 </p><p class="q2">yes, seven which are an abomination to him: 
 </p><p class="q1">
 <sup>17&#160;</sup>arrogant eyes, a lying tongue, 
@@ -764,7 +764,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>“I, wisdom, have made prudence my dwelling. 
 </p><p class="q2">Find out knowledge and discretion. 
 </p><p class="q1">
-<sup>13&#160;</sup>The fear of Yahweh is to hate evil. 
+<sup>13&#160;</sup>The fear of Yahuah is to hate evil. 
 </p><p class="q2">I hate pride, arrogance, the evil way, and the perverse mouth. 
 </p><p class="q1">
 <sup>14&#160;</sup>Counsel and sound knowledge are mine. 
@@ -792,7 +792,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I fill their treasuries. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>22&#160;</sup>“Yahweh possessed me in the beginning of his work, 
+<sup>22&#160;</sup>“Yahuah possessed me in the beginning of his work, 
 </p><p class="q2">before his deeds of old. 
 </p><p class="q1">
 <sup>23&#160;</sup>I was set up from everlasting, from the beginning, 
@@ -836,7 +836,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">waiting at my door posts. 
 </p><p class="q1">
 <sup>35&#160;</sup>For whoever finds me finds life, 
-</p><p class="q2">and will obtain favor from Yahweh. 
+</p><p class="q2">and will obtain favor from Yahuah. 
 </p><p class="q1">
 <sup>36&#160;</sup>But he who sins against me wrongs his own soul. 
 </p><p class="q2">All those who hate me love death.” 
@@ -871,7 +871,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Instruct a wise person, and he will be still wiser. 
 </p><p class="q2">Teach a righteous person, and he will increase in learning. 
 </p><p class="q1">
-<sup>10&#160;</sup>The fear of Yahweh is the beginning of wisdom. 
+<sup>10&#160;</sup>The fear of Yahuah is the beginning of wisdom. 
 </p><p class="q2">The knowledge of the Set-Apart One is understanding. 
 </p><p class="q1">
 <sup>11&#160;</sup>For by me your days will be multiplied. 
@@ -907,7 +907,7 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>Treasures of wickedness profit nothing, 
 </p><p class="q2">but righteousness delivers from death. 
 </p><p class="q1">
-<sup>3&#160;</sup>Yahweh will not allow the soul of the righteous to go hungry, 
+<sup>3&#160;</sup>Yahuah will not allow the soul of the righteous to go hungry, 
 </p><p class="q2">but he thrusts away the desire of the wicked. 
 </p><p class="q1">
 <sup>4&#160;</sup>He becomes poor who works with a lazy hand, 
@@ -964,7 +964,7 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>The lips of the righteous feed many, 
 </p><p class="q2">but the foolish die for lack of understanding. 
 </p><p class="q1">
-<sup>22&#160;</sup>Yahweh’s blessing brings wealth, 
+<sup>22&#160;</sup>Yahuah’s blessing brings wealth, 
 </p><p class="q2">and he adds no trouble to it. 
 </p><p class="q1">
 <sup>23&#160;</sup>It is a fool’s pleasure to do wickedness, 
@@ -979,13 +979,13 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>As vinegar to the teeth, and as smoke to the eyes, 
 </p><p class="q2">so is the sluggard to those who send him. 
 </p><p class="q1">
-<sup>27&#160;</sup>The fear of Yahweh prolongs days, 
+<sup>27&#160;</sup>The fear of Yahuah prolongs days, 
 </p><p class="q2">but the years of the wicked shall be shortened. 
 </p><p class="q1">
 <sup>28&#160;</sup>The prospect of the righteous is joy, 
 </p><p class="q2">but the hope of the wicked will perish. 
 </p><p class="q1">
-<sup>29&#160;</sup>The way of Yahweh is a stronghold to the upright, 
+<sup>29&#160;</sup>The way of Yahuah is a stronghold to the upright, 
 </p><p class="q2">but it is a destruction to the workers of iniquity. 
 </p><p class="q1">
 <sup>30&#160;</sup>The righteous will never be removed, 
@@ -998,7 +998,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">but the mouth of the wicked is perverse. 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p class="q1">
-<sup>1&#160;</sup>A false balance is an abomination to Yahweh, 
+<sup>1&#160;</sup>A false balance is an abomination to Yahuah, 
 </p><p class="q2">but accurate weights are his delight. 
 </p><p class="q1">
 <sup>2&#160;</sup>When pride comes, then comes shame, 
@@ -1055,7 +1055,7 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>He who is truly righteous gets life. 
 </p><p class="q2">He who pursues evil gets death. 
 </p><p class="q1">
-<sup>20&#160;</sup>Those who are perverse in heart are an abomination to Yahweh, 
+<sup>20&#160;</sup>Those who are perverse in heart are an abomination to Yahuah, 
 </p><p class="q2">but those whose ways are blameless are his delight. 
 </p><p class="q1">
 <sup>21&#160;</sup>Most certainly, the evil man will not be unpunished, 
@@ -1095,7 +1095,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>Whoever loves correction loves knowledge, 
 </p><p class="q2">but he who hates reproof is stupid. 
 </p><p class="q1">
-<sup>2&#160;</sup>A good man shall obtain favor from Yahweh, 
+<sup>2&#160;</sup>A good man shall obtain favor from Yahuah, 
 </p><p class="q2">but he will condemn a man of wicked plans. 
 </p><p class="q1">
 <sup>3&#160;</sup>A man shall not be established by wickedness, 
@@ -1155,7 +1155,7 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>No mischief shall happen to the righteous, 
 </p><p class="q2">but the wicked shall be filled with evil. 
 </p><p class="q1">
-<sup>22&#160;</sup>Lying lips are an abomination to Yahweh, 
+<sup>22&#160;</sup>Lying lips are an abomination to Yahuah, 
 </p><p class="q2">but those who do the truth are his delight. 
 </p><p class="q1">
 <sup>23&#160;</sup>A prudent man keeps his knowledge, 
@@ -1256,7 +1256,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>Every wise woman builds her house, 
 </p><p class="q2">but the foolish one tears it down with her own hands. 
 </p><p class="q1">
-<sup>2&#160;</sup>He who walks in his uprightness fears Yahweh, 
+<sup>2&#160;</sup>He who walks in his uprightness fears Yahuah, 
 </p><p class="q2">but he who is perverse in his ways despises him. 
 </p><p class="q1">
 <sup>3&#160;</sup>The fool’s talk brings a rod to his back, 
@@ -1328,10 +1328,10 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>A truthful witness saves souls, 
 </p><p class="q2">but a false witness is deceitful. 
 </p><p class="q1">
-<sup>26&#160;</sup>In the fear of Yahweh is a secure fortress, 
+<sup>26&#160;</sup>In the fear of Yahuah is a secure fortress, 
 </p><p class="q2">and he will be a refuge for his children. 
 </p><p class="q1">
-<sup>27&#160;</sup>The fear of Yahweh is a fountain of life, 
+<sup>27&#160;</sup>The fear of Yahuah is a fountain of life, 
 </p><p class="q2">turning people from the snares of death. 
 </p><p class="q1">
 <sup>28&#160;</sup>In the multitude of people is the king’s glory, 
@@ -1365,7 +1365,7 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>The tongue of the wise commends knowledge, 
 </p><p class="q2">but the mouths of fools gush out folly. 
 </p><p class="q1">
-<sup>3&#160;</sup>Yahweh’s eyes are everywhere, 
+<sup>3&#160;</sup>Yahuah’s eyes are everywhere, 
 </p><p class="q2">keeping watch on the evil and the good. 
 </p><p class="q1">
 <sup>4&#160;</sup>A gentle tongue is a tree of life, 
@@ -1380,16 +1380,16 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>The lips of the wise spread knowledge; 
 </p><p class="q2">not so with the heart of fools. 
 </p><p class="q1">
-<sup>8&#160;</sup>The sacrifice made by the wicked is an abomination to Yahweh, 
+<sup>8&#160;</sup>The sacrifice made by the wicked is an abomination to Yahuah, 
 </p><p class="q2">but the prayer of the upright is his delight. 
 </p><p class="q1">
-<sup>9&#160;</sup>The way of the wicked is an abomination to Yahweh, 
+<sup>9&#160;</sup>The way of the wicked is an abomination to Yahuah, 
 </p><p class="q2">but he loves him who follows after righteousness. 
 </p><p class="q1">
 <sup>10&#160;</sup>There is stern discipline for one who forsakes the way. 
 </p><p class="q2">Whoever hates reproof shall die. 
 </p><p class="q1">
-<sup>11&#160;</sup>Sheol and Abaddon are before Yahweh—</p><p class="q2">how much more then the hearts of the children of men! 
+<sup>11&#160;</sup>Sheol and Abaddon are before Yahuah—</p><p class="q2">how much more then the hearts of the children of men! 
 </p><p class="q1">
 <sup>12&#160;</sup>A scoffer doesn’t love to be reproved; 
 </p><p class="q2">he will not go to the wise. 
@@ -1403,7 +1403,7 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>All the days of the afflicted are wretched, 
 </p><p class="q2">but one who has a cheerful heart enjoys a continual feast. 
 </p><p class="q1">
-<sup>16&#160;</sup>Better is little, with the fear of Yahweh, 
+<sup>16&#160;</sup>Better is little, with the fear of Yahuah, 
 </p><p class="q2">than great treasure with trouble. 
 </p><p class="q1">
 <sup>17&#160;</sup>Better is a dinner of herbs, where love is, 
@@ -1430,10 +1430,10 @@ html[dir=ltr] .q2 {
 <sup>24&#160;</sup>The path of life leads upward for the wise, 
 </p><p class="q2">to keep him from going downward to Sheol. 
 </p><p class="q1">
-<sup>25&#160;</sup>Yahweh will uproot the house of the proud, 
+<sup>25&#160;</sup>Yahuah will uproot the house of the proud, 
 </p><p class="q2">but he will keep the widow’s borders intact. 
 </p><p class="q1">
-<sup>26&#160;</sup>Yahweh detests the thoughts of the wicked, 
+<sup>26&#160;</sup>Yahuah detests the thoughts of the wicked, 
 </p><p class="q2">but the thoughts of the pure are pleasing. 
 </p><p class="q1">
 <sup>27&#160;</sup>He who is greedy for gain troubles his own house, 
@@ -1442,7 +1442,7 @@ html[dir=ltr] .q2 {
 <sup>28&#160;</sup>The heart of the righteous weighs answers, 
 </p><p class="q2">but the mouth of the wicked gushes out evil. 
 </p><p class="q1">
-<sup>29&#160;</sup>Yahweh is far from the wicked, 
+<sup>29&#160;</sup>Yahuah is far from the wicked, 
 </p><p class="q2">but he hears the prayer of the righteous. 
 </p><p class="q1">
 <sup>30&#160;</sup>The light of the eyes rejoices the heart. 
@@ -1454,40 +1454,40 @@ html[dir=ltr] .q2 {
 <sup>32&#160;</sup>He who refuses correction despises his own soul, 
 </p><p class="q2">but he who listens to reproof gets understanding. 
 </p><p class="q1">
-<sup>33&#160;</sup>The fear of Yahweh teaches wisdom. 
+<sup>33&#160;</sup>The fear of Yahuah teaches wisdom. 
 </p><p class="q2">Before honor is humility. 
 </p><h2 class="chapterlabel" id="16">16</h2>
 <p class="q1">
 <sup>1&#160;</sup>The plans of the heart belong to man, 
-</p><p class="q2">but the answer of the tongue is from Yahweh. 
+</p><p class="q2">but the answer of the tongue is from Yahuah. 
 </p><p class="q1">
 <sup>2&#160;</sup>All the ways of a man are clean in his own eyes, 
-</p><p class="q2">but Yahweh weighs the motives. 
+</p><p class="q2">but Yahuah weighs the motives. 
 </p><p class="q1">
-<sup>3&#160;</sup>Commit your deeds to Yahweh, 
+<sup>3&#160;</sup>Commit your deeds to Yahuah, 
 </p><p class="q2">and your plans shall succeed. 
 </p><p class="q1">
-<sup>4&#160;</sup>Yahweh has made everything for its own end—</p><p class="q2">yes, even the wicked for the day of evil. 
+<sup>4&#160;</sup>Yahuah has made everything for its own end—</p><p class="q2">yes, even the wicked for the day of evil. 
 </p><p class="q1">
-<sup>5&#160;</sup>Everyone who is proud in heart is an abomination to Yahweh; 
+<sup>5&#160;</sup>Everyone who is proud in heart is an abomination to Yahuah; 
 </p><p class="q2">they shall certainly not be unpunished. 
 </p><p class="q1">
 <sup>6&#160;</sup>By mercy and truth iniquity is atoned for. 
-</p><p class="q2">By the fear of Yahweh men depart from evil. 
+</p><p class="q2">By the fear of Yahuah men depart from evil. 
 </p><p class="q1">
-<sup>7&#160;</sup>When a man’s ways please Yahweh, 
+<sup>7&#160;</sup>When a man’s ways please Yahuah, 
 </p><p class="q2">he makes even his enemies to be at peace with him. 
 </p><p class="q1">
 <sup>8&#160;</sup>Better is a little with righteousness, 
 </p><p class="q2">than great revenues with injustice. 
 </p><p class="q1">
 <sup>9&#160;</sup>A man’s heart plans his course, 
-</p><p class="q2">but Yahweh directs his steps. 
+</p><p class="q2">but Yahuah directs his steps. 
 </p><p class="q1">
 <sup>10&#160;</sup>Inspired judgments are on the lips of the king. 
 </p><p class="q2">He shall not betray his mouth. 
 </p><p class="q1">
-<sup>11&#160;</sup>Honest balances and scales are Yahweh’s; 
+<sup>11&#160;</sup>Honest balances and scales are Yahuah’s; 
 </p><p class="q2">all the weights in the bag are his work. 
 </p><p class="q1">
 <sup>12&#160;</sup>It is an abomination for kings to do wrong, 
@@ -1515,7 +1515,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">than to divide the plunder with the proud. 
 </p><p class="q1">
 <sup>20&#160;</sup>He who heeds the Word finds prosperity. 
-</p><p class="q2">Whoever trusts in Yahweh is blessed. 
+</p><p class="q2">Whoever trusts in Yahuah is blessed. 
 </p><p class="q1">
 <sup>21&#160;</sup>The wise in heart shall be called prudent. 
 </p><p class="q2">Pleasantness of the lips promotes instruction. 
@@ -1554,7 +1554,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">one who rules his spirit, than he who takes a city. 
 </p><p class="q1">
 <sup>33&#160;</sup>The lot is cast into the lap, 
-</p><p class="q2">but its every decision is from Yahweh. 
+</p><p class="q2">but its every decision is from Yahuah. 
 </p><h2 class="chapterlabel" id="17">17</h2>
 <p class="q1">
 <sup>1&#160;</sup>Better is a dry morsel with quietness, 
@@ -1564,7 +1564,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and shall have a part in the inheritance among the brothers. 
 </p><p class="q1">
 <sup>3&#160;</sup>The refining pot is for silver, and the furnace for gold, 
-</p><p class="q2">but Yahweh tests the hearts. 
+</p><p class="q2">but Yahuah tests the hearts. 
 </p><p class="q1">
 <sup>4&#160;</sup>An evildoer heeds wicked lips. 
 </p><p class="q2">A liar gives ear to a mischievous tongue. 
@@ -1600,7 +1600,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">therefore stop contention before quarreling breaks out. 
 </p><p class="q1">
 <sup>15&#160;</sup>He who justifies the wicked, and he who condemns the righteous, 
-</p><p class="q2">both of them alike are an abomination to Yahweh. 
+</p><p class="q2">both of them alike are an abomination to Yahuah. 
 </p><p class="q1">
 <sup>16&#160;</sup>Why is there money in the hand of a fool to buy wisdom, 
 </p><p class="q2">since he has no understanding? 
@@ -1669,7 +1669,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>One who is slack in his work 
 </p><p class="q2">is brother to him who is a master of destruction. 
 </p><p class="q1">
-<sup>10&#160;</sup>Yahweh’s name is a strong tower: 
+<sup>10&#160;</sup>Yahuah’s name is a strong tower: 
 </p><p class="q2">the righteous run to him, and are safe. 
 </p><p class="q1">
 <sup>11&#160;</sup>The rich man’s wealth is his strong city, 
@@ -1705,7 +1705,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">those who love it will eat its fruit. 
 </p><p class="q1">
 <sup>22&#160;</sup>Whoever finds a woman finds a good thing, 
-</p><p class="q2">and obtains favor of Yahweh. 
+</p><p class="q2">and obtains favor of Yahuah. 
 </p><p class="q1">
 <sup>23&#160;</sup>The poor plead for mercy, 
 </p><p class="q2">but the rich answer harshly. 
@@ -1721,7 +1721,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">nor being hasty with one’s feet and missing the way. 
 </p><p class="q1">
 <sup>3&#160;</sup>The foolishness of man subverts his way; 
-</p><p class="q2">his heart rages against Yahweh. 
+</p><p class="q2">his heart rages against Yahuah. 
 </p><p class="q1">
 <sup>4&#160;</sup>Wealth adds many friends, 
 </p><p class="q2">but the poor is separated from his friend. 
@@ -1755,7 +1755,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">A woman’s quarrels are a continual dripping. 
 </p><p class="q1">
 <sup>14&#160;</sup>House and riches are an inheritance from fathers, 
-</p><p class="q2">but a prudent woman is from Yahweh. 
+</p><p class="q2">but a prudent woman is from Yahuah. 
 </p><p class="q1">
 <sup>15&#160;</sup>Slothfulness casts into a deep sleep. 
 </p><p class="q2">The idle soul shall suffer hunger. 
@@ -1763,7 +1763,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>He who keeps the commandment keeps his soul, 
 </p><p class="q2">but he who is contemptuous in his ways shall die. 
 </p><p class="q1">
-<sup>17&#160;</sup>He who has pity on the poor lends to Yahweh; 
+<sup>17&#160;</sup>He who has pity on the poor lends to Yahuah; 
 </p><p class="q2">he will reward him. 
 </p><p class="q1">
 <sup>18&#160;</sup>Discipline your son, for there is hope; 
@@ -1776,12 +1776,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">that you may be wise in your latter end. 
 </p><p class="q1">
 <sup>21&#160;</sup>There are many plans in a man’s heart, 
-</p><p class="q2">but Yahweh’s counsel will prevail. 
+</p><p class="q2">but Yahuah’s counsel will prevail. 
 </p><p class="q1">
 <sup>22&#160;</sup>That which makes a man to be desired is his kindness. 
 </p><p class="q2">A poor man is better than a liar. 
 </p><p class="q1">
-<sup>23&#160;</sup>The fear of Yahweh leads to life, then contentment; 
+<sup>23&#160;</sup>The fear of Yahuah leads to life, then contentment; 
 </p><p class="q2">he rests and will not be touched by trouble. 
 </p><p class="q1">
 <sup>24&#160;</sup>The sluggard buries his hand in the dish; 
@@ -1832,13 +1832,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I am clean and without sin”? 
 </p><p class="q1">
 <sup>10&#160;</sup>Differing weights and differing measures, 
-</p><p class="q2">both of them alike are an abomination to Yahweh. 
+</p><p class="q2">both of them alike are an abomination to Yahuah. 
 </p><p class="q1">
 <sup>11&#160;</sup>Even a child makes himself known by his doings, 
 </p><p class="q2">whether his work is pure, and whether it is right. 
 </p><p class="q1">
 <sup>12&#160;</sup>The hearing ear, and the seeing eye, 
-</p><p class="q2">Yahweh has made even both of them. 
+</p><p class="q2">Yahuah has made even both of them. 
 </p><p class="q1">
 <sup>13&#160;</sup>Don’t love sleep, lest you come to poverty. 
 </p><p class="q2">Open your eyes, and you shall be satisfied with bread. 
@@ -1868,12 +1868,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">won’t be blessed in the end. 
 </p><p class="q1">
 <sup>22&#160;</sup>Don’t say, “I will pay back evil.” 
-</p><p class="q2">Wait for Yahweh, and he will save you. 
+</p><p class="q2">Wait for Yahuah, and he will save you. 
 </p><p class="q1">
-<sup>23&#160;</sup>Yahweh detests differing weights, 
+<sup>23&#160;</sup>Yahuah detests differing weights, 
 </p><p class="q2">and dishonest scales are not pleasing. 
 </p><p class="q1">
-<sup>24&#160;</sup>A man’s steps are from Yahweh; 
+<sup>24&#160;</sup>A man’s steps are from Yahuah; 
 </p><p class="q2">how then can man understand his way? 
 </p><p class="q1">
 <sup>25&#160;</sup>It is a snare to a man to make a rash dedication, 
@@ -1882,7 +1882,7 @@ html[dir=ltr] .q2 {
 <sup>26&#160;</sup>A wise king winnows out the wicked, 
 </p><p class="q2">and drives the threshing wheel over them. 
 </p><p class="q1">
-<sup>27&#160;</sup>The spirit of man is Yahweh’s lamp, 
+<sup>27&#160;</sup>The spirit of man is Yahuah’s lamp, 
 </p><p class="q2">searching all his innermost parts. 
 </p><p class="q1">
 <sup>28&#160;</sup>Love and faithfulness keep the king safe. 
@@ -1896,14 +1896,14 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <h2 class="chapterlabel" id="21">21</h2>
 <p class="q1">
-<sup>1&#160;</sup>The king’s heart is in Yahweh’s hand like the watercourses. 
+<sup>1&#160;</sup>The king’s heart is in Yahuah’s hand like the watercourses. 
 </p><p class="q2">He turns it wherever he desires. 
 </p><p class="q1">
 <sup>2&#160;</sup>Every way of a man is right in his own eyes, 
-</p><p class="q2">but Yahweh weighs the hearts. 
+</p><p class="q2">but Yahuah weighs the hearts. 
 </p><p class="q1">
 <sup>3&#160;</sup>To do righteousness and justice 
-</p><p class="q2">is more acceptable to Yahweh than sacrifice. 
+</p><p class="q2">is more acceptable to Yahuah than sacrifice. 
 </p><p class="q1">
 <sup>4&#160;</sup>A high look and a proud heart, 
 </p><p class="q2">the lamp of the wicked, is sin. 
@@ -1982,10 +1982,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">but as for the upright, he establishes his ways. 
 </p><p class="q1">
 <sup>30&#160;</sup>There is no wisdom nor understanding 
-</p><p class="q2">nor counsel against Yahweh. 
+</p><p class="q2">nor counsel against Yahuah. 
 </p><p class="q1">
 <sup>31&#160;</sup>The horse is prepared for the day of battle; 
-</p><p class="q2">but victory is with Yahweh. 
+</p><p class="q2">but victory is with Yahuah. 
 </p><p class="b"> &#160; </p>
 <h2 class="chapterlabel" id="22">22</h2>
 <p class="q1">
@@ -1993,12 +1993,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and loving favor is better than silver and gold. 
 </p><p class="q1">
 <sup>2&#160;</sup>The rich and the poor have this in common: 
-</p><p class="q2">Yahweh is the maker of them all. 
+</p><p class="q2">Yahuah is the maker of them all. 
 </p><p class="q1">
 <sup>3&#160;</sup>A prudent man sees danger and hides himself; 
 </p><p class="q2">but the simple pass on, and suffer for it. 
 </p><p class="q1">
-<sup>4&#160;</sup>The result of humility and the fear of Yahweh 
+<sup>4&#160;</sup>The result of humility and the fear of Yahuah 
 </p><p class="q2">is wealth, honor, and life. 
 </p><p class="q1">
 <sup>5&#160;</sup>Thorns and snares are in the path of the wicked; 
@@ -2022,14 +2022,14 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>He who loves purity of heart and speaks gracefully 
 </p><p class="q2">is the king’s friend. 
 </p><p class="q1">
-<sup>12&#160;</sup>Yahweh’s eyes watch over knowledge, 
+<sup>12&#160;</sup>Yahuah’s eyes watch over knowledge, 
 </p><p class="q2">but he frustrates the words of the unfaithful. 
 </p><p class="q1">
 <sup>13&#160;</sup>The sluggard says, “There is a lion outside! 
 </p><p class="q2">I will be killed in the streets!” 
 </p><p class="q1">
 <sup>14&#160;</sup>The mouth of an adulteress is a deep pit. 
-</p><p class="q2">He who is under Yahweh’s wrath will fall into it. 
+</p><p class="q2">He who is under Yahuah’s wrath will fall into it. 
 </p><p class="q1">
 <sup>15&#160;</sup>Folly is bound up in the heart of a child; 
 </p><p class="q2">the rod of discipline drives it far from him. 
@@ -2045,7 +2045,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">if all of them are ready on your lips. 
 </p><p class="q1">
 <sup>19&#160;</sup>I teach you today, even you, 
-</p><p class="q2">so that your trust may be in Yahweh. 
+</p><p class="q2">so that your trust may be in Yahuah. 
 </p><p class="q1">
 <sup>20&#160;</sup>Haven’t I written to you thirty excellent things 
 </p><p class="q2">of counsel and knowledge, 
@@ -2057,7 +2057,7 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>Don’t exploit the poor because he is poor; 
 </p><p class="q2">and don’t crush the needy in court; 
 </p><p class="q1">
-<sup>23&#160;</sup>for Yahweh will plead their case, 
+<sup>23&#160;</sup>for Yahuah will plead their case, 
 </p><p class="q2">and plunder the life of those who plunder them. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -2139,7 +2139,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">when your lips speak what is right. 
 </p><p class="q1">
 <sup>17&#160;</sup>Don’t let your heart envy sinners, 
-</p><p class="q2">but rather fear Yahweh all day long. 
+</p><p class="q2">but rather fear Yahuah all day long. 
 </p><p class="q1">
 <sup>18&#160;</sup>Indeed surely there is a future hope, 
 </p><p class="q2">and your hope will not be cut off. 
@@ -2259,7 +2259,7 @@ html[dir=ltr] .q2 {
 <sup>17&#160;</sup>Don’t rejoice when your enemy falls. 
 </p><p class="q2">Don’t let your heart be glad when he is overthrown, 
 </p><p class="q1">
-<sup>18&#160;</sup>lest Yahweh see it, and it displease him, 
+<sup>18&#160;</sup>lest Yahuah see it, and it displease him, 
 </p><p class="q2">and he turn away his wrath from him. 
 </p><p class="q1">
 <sup>19&#160;</sup>Don’t fret yourself because of evildoers, 
@@ -2268,7 +2268,7 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>for there will be no reward to the evil man. 
 </p><p class="q2">The lamp of the wicked will be snuffed out. 
 </p><p class="q1">
-<sup>21&#160;</sup>My son, fear Yahweh and the king. 
+<sup>21&#160;</sup>My son, fear Yahuah and the king. 
 </p><p class="q2">Don’t join those who are rebellious, 
 </p><p class="q1">
 <sup>22&#160;</sup>for their calamity will rise suddenly. 
@@ -2382,7 +2382,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">If he is thirsty, give him water to drink; 
 </p><p class="q1">
 <sup>22&#160;</sup>for you will heap coals of fire on his head, 
-</p><p class="q2">and Yahweh will reward you. 
+</p><p class="q2">and Yahuah will reward you. 
 </p><p class="q1">
 <sup>23&#160;</sup>The north wind produces rain; 
 </p><p class="q2">so a backbiting tongue brings an angry face. 
@@ -2594,7 +2594,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">but those who keep the law contend with them. 
 </p><p class="q1">
 <sup>5&#160;</sup>Evil men don’t understand justice; 
-</p><p class="q2">but those who seek Yahweh understand it fully. 
+</p><p class="q2">but those who seek Yahuah understand it fully. 
 </p><p class="q1">
 <sup>6&#160;</sup>Better is the poor who walks in his integrity 
 </p><p class="q2">than he who is perverse in his ways, and he is rich. 
@@ -2655,7 +2655,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">is a partner with a destroyer. 
 </p><p class="q1">
 <sup>25&#160;</sup>One who is greedy stirs up strife; 
-</p><p class="q2">but one who trusts in Yahweh will prosper. 
+</p><p class="q2">but one who trusts in Yahuah will prosper. 
 </p><p class="q1">
 <sup>26&#160;</sup>One who trusts in himself is a fool; 
 </p><p class="q2">but one who walks in wisdom is kept safe. 
@@ -2704,7 +2704,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">all of his officials are wicked. 
 </p><p class="q1">
 <sup>13&#160;</sup>The poor man and the oppressor have this in common: 
-</p><p class="q2">Yahweh gives sight to the eyes of both. 
+</p><p class="q2">Yahuah gives sight to the eyes of both. 
 </p><p class="q1">
 <sup>14&#160;</sup>The king who fairly judges the poor, 
 </p><p class="q2">his throne shall be established forever. 
@@ -2740,10 +2740,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He takes an oath, but dares not testify. 
 </p><p class="q1">
 <sup>25&#160;</sup>The fear of man proves to be a snare, 
-</p><p class="q2">but whoever puts his trust in Yahweh is kept safe. 
+</p><p class="q2">but whoever puts his trust in Yahuah is kept safe. 
 </p><p class="q1">
 <sup>26&#160;</sup>Many seek the ruler’s favor, 
-</p><p class="q2">but a man’s justice comes from Yahweh. 
+</p><p class="q2">but a man’s justice comes from Yahuah. 
 </p><p class="q1">
 <sup>27&#160;</sup>A dishonest man detests the righteous, 
 </p><p class="q2">and the upright in their ways detest the wicked. 
@@ -2780,7 +2780,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Give me neither poverty nor riches. 
 </p><p class="q2">Feed me with the food that is needful for me, 
 </p><p class="q1">
-<sup>9&#160;</sup>lest I be full, deny you, and say, ‘Who is Yahweh?’ 
+<sup>9&#160;</sup>lest I be full, deny you, and say, ‘Who is Yahuah?’ 
 </p><p class="q2">or lest I be poor, and steal, 
 </p><p class="q2">and so dishonor the name of my Elohim. 
 </p><p class="b"> &#160; </p>
@@ -2973,7 +2973,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">but you excel them all.” 
 </p><p class="q1">
 <sup>30&#160;</sup>Charm is deceitful, and beauty is vain; 
-</p><p class="q2">but a woman who fears Yahweh, she shall be praised. 
+</p><p class="q2">but a woman who fears Yahuah, she shall be praised. 
 </p><p class="q1">
 <sup>31&#160;</sup>Give her of the fruit of her hands! 
 </p><p class="q2">Let her works praise her in the gates! </p></div><script src="../main.js"></script></body></html>

--- a/book/psalms.html
+++ b/book/psalms.html
@@ -214,7 +214,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">nor stand on the path of sinners, 
 </p><p class="q2">nor sit in the seat of scoffers; 
 </p><p class="q1">
-<sup>2&#160;</sup>but his delight is in Yahweh’s law. 
+<sup>2&#160;</sup>but his delight is in Yahuah’s law. 
 </p><p class="q2">On his law he meditates day and night. 
 </p><p class="q1">
 <sup>3&#160;</sup>He will be like a tree planted by the streams of water, 
@@ -228,7 +228,7 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>Therefore the wicked shall not stand in the judgment, 
 </p><p class="q2">nor sinners in the congregation of the righteous. 
 </p><p class="q1">
-<sup>6&#160;</sup>For Yahweh knows the way of the righteous, 
+<sup>6&#160;</sup>For Yahuah knows the way of the righteous, 
 </p><p class="q2">but the way of the wicked shall perish. 
 </p><h2 class="psalmlabel" id="2">2</h2>
 <p class="q1">
@@ -237,7 +237,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>2&#160;</sup>The kings of the earth take a stand, 
 </p><p class="q2">and the rulers take counsel together, 
-</p><p class="q2">against Yahweh, and against his Anointed, saying, 
+</p><p class="q2">against Yahuah, and against his Anointed, saying, 
 </p><p class="q1">
 <sup>3&#160;</sup>“Let’s break their bonds apart, 
 </p><p class="q2">and cast their cords from us.” 
@@ -251,7 +251,7 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>“Yet I have set my King on my set-apart hill of Zion.” 
 </p><p class="q2">
 <sup>7&#160;</sup>I will tell of the decree: 
-</p><p class="q1">Yahweh said to me, “You are my son. 
+</p><p class="q1">Yahuah said to me, “You are my son. 
 </p><p class="q2">Today I have become your father. 
 </p><p class="q1">
 <sup>8&#160;</sup>Ask of me, and I will give the nations for your inheritance, 
@@ -263,7 +263,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>Now therefore be wise, you kings. 
 </p><p class="q2">Be instructed, you judges of the earth. 
 </p><p class="q1">
-<sup>11&#160;</sup>Serve Yahweh with fear, 
+<sup>11&#160;</sup>Serve Yahuah with fear, 
 </p><p class="q2">and rejoice with trembling. 
 </p><p class="q1">
 <sup>12&#160;</sup>Give sincere homage to the Son, lest he be angry, and you perish on the way, 
@@ -272,30 +272,30 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="3">3</h2>
 <p class="d">A Psalm by David, when he fled from Absalom his son. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, how my adversaries have increased! 
+<sup>1&#160;</sup>Yahuah, how my adversaries have increased! 
 </p><p class="q2">Many are those who rise up against me. 
 </p><p class="q1">
 <sup>2&#160;</sup>Many there are who say of my soul, 
 </p><p class="q2">“There is no help for him in Elohim.” </p><p class="qs">Selah. 
 </p><p class="q1">
-<sup>3&#160;</sup>But you, Yahweh, are a shield around me, 
+<sup>3&#160;</sup>But you, Yahuah, are a shield around me, 
 </p><p class="q2">my glory, and the one who lifts up my head. 
 </p><p class="q1">
-<sup>4&#160;</sup>I cry to Yahweh with my voice, 
+<sup>4&#160;</sup>I cry to Yahuah with my voice, 
 </p><p class="q2">and he answers me out of his set-apart hill. </p><p class="qs">Selah. 
 </p><p class="q1">
 <sup>5&#160;</sup>I laid myself down and slept. 
-</p><p class="q2">I awakened, for Yahweh sustains me. 
+</p><p class="q2">I awakened, for Yahuah sustains me. 
 </p><p class="q1">
 <sup>6&#160;</sup>I will not be afraid of tens of thousands of people 
 </p><p class="q2">who have set themselves against me on every side. 
 </p><p class="q1">
-<sup>7&#160;</sup>Arise, Yahweh! 
+<sup>7&#160;</sup>Arise, Yahuah! 
 </p><p class="q2">Save me, my Elohim! 
 </p><p class="q1">For you have struck all of my enemies on the cheek bone. 
 </p><p class="q2">You have broken the teeth of the wicked. 
 </p><p class="q1">
-<sup>8&#160;</sup>Salvation belongs to Yahweh. 
+<sup>8&#160;</sup>Salvation belongs to Yahuah. 
 </p><p class="q2">May your blessing be on your people. </p><p class="qs">Selah. 
 </p><h2 class="psalmlabel" id="4">4</h2>
 <p class="d">For the Chief Musician; on stringed instruments. A Psalm by David. 
@@ -307,33 +307,33 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>You sons of men, how long shall my glory be turned into dishonor? 
 </p><p class="q2">Will you love vanity and seek after falsehood? </p><p class="qs">Selah. 
 </p><p class="q1">
-<sup>3&#160;</sup>But know that Yahweh has set apart for himself him who is elohimly; 
-</p><p class="q2">Yahweh will hear when I call to him. 
+<sup>3&#160;</sup>But know that Yahuah has set apart for himself him who is elohimly; 
+</p><p class="q2">Yahuah will hear when I call to him. 
 </p><p class="q1">
 <sup>4&#160;</sup>Stand in awe, and don’t sin. 
 </p><p class="q2">Search your own heart on your bed, and be still. </p><p class="qs">Selah. 
 </p><p class="q1">
 <sup>5&#160;</sup>Offer the sacrifices of righteousness. 
-</p><p class="q2">Put your trust in Yahweh. 
+</p><p class="q2">Put your trust in Yahuah. 
 </p><p class="q1">
 <sup>6&#160;</sup>Many say, “Who will show us any good?” 
-</p><p class="q2">Yahweh, let the light of your face shine on us. 
+</p><p class="q2">Yahuah, let the light of your face shine on us. 
 </p><p class="q1">
 <sup>7&#160;</sup>You have put gladness in my heart, 
 </p><p class="q2">more than when their grain and their new wine are increased. 
 </p><p class="q1">
 <sup>8&#160;</sup>In peace I will both lay myself down and sleep, 
-</p><p class="q2">for you alone, Yahweh, make me live in safety. 
+</p><p class="q2">for you alone, Yahuah, make me live in safety. 
 </p><h2 class="psalmlabel" id="5">5</h2>
 <p class="d">For the Chief Musician, with the flutes. A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Give ear to my words, Yahweh. 
+<sup>1&#160;</sup>Give ear to my words, Yahuah. 
 </p><p class="q2">Consider my meditation. 
 </p><p class="q1">
 <sup>2&#160;</sup>Listen to the voice of my cry, my King and my Elohim, 
 </p><p class="q2">for I pray to you. 
 </p><p class="q1">
-<sup>3&#160;</sup>Yahweh, in the morning you will hear my voice. 
+<sup>3&#160;</sup>Yahuah, in the morning you will hear my voice. 
 </p><p class="q2">In the morning I will lay my requests before you, and will watch expectantly. 
 </p><p class="q1">
 <sup>4&#160;</sup>For you are not an Elohim who has pleasure in wickedness. 
@@ -343,12 +343,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">You hate all workers of iniquity. 
 </p><p class="q1">
 <sup>6&#160;</sup>You will destroy those who speak lies. 
-</p><p class="q2">Yahweh abhors the bloodthirsty and deceitful man. 
+</p><p class="q2">Yahuah abhors the bloodthirsty and deceitful man. 
 </p><p class="q1">
 <sup>7&#160;</sup>But as for me, in the abundance of your loving kindness I will come into your house. 
 </p><p class="q2">I will bow toward your set-apart temple in reverence of you. 
 </p><p class="q1">
-<sup>8&#160;</sup>Lead me, Yahweh, in your righteousness because of my enemies. 
+<sup>8&#160;</sup>Lead me, Yahuah, in your righteousness because of my enemies. 
 </p><p class="q2">Make your way straight before my face. 
 </p><p class="q1">
 <sup>9&#160;</sup>For there is no faithfulness in their mouth. 
@@ -366,20 +366,20 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Let them also who love your name be joyful in you. 
 </p><p class="q2">
 <sup>12&#160;</sup>For you will bless the righteous. 
-</p><p class="q1">Yahweh, you will surround him with favor as with a shield. 
+</p><p class="q1">Yahuah, you will surround him with favor as with a shield. 
 </p><h2 class="psalmlabel" id="6">6</h2>
 <p class="d">For the Chief Musician; on stringed instruments, upon the eight-stringed lyre. A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, don’t rebuke me in your anger, 
+<sup>1&#160;</sup>Yahuah, don’t rebuke me in your anger, 
 </p><p class="q2">neither discipline me in your wrath. 
 </p><p class="q1">
-<sup>2&#160;</sup>Have mercy on me, Yahweh, for I am faint. 
-</p><p class="q2">Yahweh, heal me, for my bones are troubled. 
+<sup>2&#160;</sup>Have mercy on me, Yahuah, for I am faint. 
+</p><p class="q2">Yahuah, heal me, for my bones are troubled. 
 </p><p class="q1">
 <sup>3&#160;</sup>My soul is also in great anguish. 
-</p><p class="q2">But you, Yahweh—how long? 
+</p><p class="q2">But you, Yahuah—how long? 
 </p><p class="q1">
-<sup>4&#160;</sup>Return, Yahweh. Deliver my soul, 
+<sup>4&#160;</sup>Return, Yahuah. Deliver my soul, 
 </p><p class="q2">and save me for your loving kindness’ sake. 
 </p><p class="q1">
 <sup>5&#160;</sup>For in death there is no memory of you. 
@@ -393,23 +393,23 @@ html[dir=ltr] .q2 {
 </p><p class="q2">It grows old because of all my adversaries. 
 </p><p class="q1">
 <sup>8&#160;</sup>Depart from me, all you workers of iniquity, 
-</p><p class="q2">for Yahweh has heard the voice of my weeping. 
+</p><p class="q2">for Yahuah has heard the voice of my weeping. 
 </p><p class="q1">
-<sup>9&#160;</sup>Yahweh has heard my supplication. 
-</p><p class="q2">Yahweh accepts my prayer. 
+<sup>9&#160;</sup>Yahuah has heard my supplication. 
+</p><p class="q2">Yahuah accepts my prayer. 
 </p><p class="q1">
 <sup>10&#160;</sup>May all my enemies be ashamed and dismayed. 
 </p><p class="q2">They shall turn back, they shall be disgraced suddenly. 
 </p><h2 class="psalmlabel" id="7">7</h2>
-<p class="d">A meditation by David, which he sang to Yahweh, concerning the words of Cush, the Benjamite. 
+<p class="d">A meditation by David, which he sang to Yahuah, concerning the words of Cush, the Benjamite. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, my Elohim, I take refuge in you. 
+<sup>1&#160;</sup>Yahuah, my Elohim, I take refuge in you. 
 </p><p class="q2">Save me from all those who pursue me, and deliver me, 
 </p><p class="q1">
 <sup>2&#160;</sup>lest they tear apart my soul like a lion, 
 </p><p class="q2">ripping it in pieces, while there is no one to deliver. 
 </p><p class="q1">
-<sup>3&#160;</sup>Yahweh, my Elohim, if I have done this, 
+<sup>3&#160;</sup>Yahuah, my Elohim, if I have done this, 
 </p><p class="q2">if there is iniquity in my hands, 
 </p><p class="q1">
 <sup>4&#160;</sup>if I have rewarded evil to him who was at peace with me 
@@ -419,15 +419,15 @@ html[dir=ltr] .q2 {
 </p><p class="q1">yes, let him tread my life down to the earth, 
 </p><p class="q2">and lay my glory in the dust. </p><p class="qs">Selah. 
 </p><p class="q1">
-<sup>6&#160;</sup>Arise, Yahweh, in your anger. 
+<sup>6&#160;</sup>Arise, Yahuah, in your anger. 
 </p><p class="q2">Lift up yourself against the rage of my adversaries. 
 </p><p class="q1">Awake for me. You have commanded judgment. 
 </p><p class="q2">
 <sup>7&#160;</sup>Let the congregation of the peoples surround you. 
 </p><p class="q2">Rule over them on high. 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh administers judgment to the peoples. 
-</p><p class="q2">Judge me, Yahweh, according to my righteousness, 
+<sup>8&#160;</sup>Yahuah administers judgment to the peoples. 
+</p><p class="q2">Judge me, Yahuah, according to my righteousness, 
 </p><p class="q2">and to my integrity that is in me. 
 </p><p class="q1">
 <sup>9&#160;</sup>Oh let the wickedness of the wicked come to an end, 
@@ -456,12 +456,12 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>The trouble he causes shall return to his own head. 
 </p><p class="q2">His violence shall come down on the crown of his own head. 
 </p><p class="q1">
-<sup>17&#160;</sup>I will give thanks to Yahweh according to his righteousness, 
-</p><p class="q2">and will sing praise to the name of Yahweh Most High. 
+<sup>17&#160;</sup>I will give thanks to Yahuah according to his righteousness, 
+</p><p class="q2">and will sing praise to the name of Yahuah Most High. 
 </p><h2 class="psalmlabel" id="8">8</h2>
 <p class="d">For the Chief Musician; on an instrument of Gath. A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, our Lord, how majestic is your name in all the earth! 
+<sup>1&#160;</sup>Yahuah, our Lord, how majestic is your name in all the earth! 
 </p><p class="q2">You have set your glory above the heavens! 
 </p><p class="q1">
 <sup>2&#160;</sup>From the lips of babes and infants you have established strength, 
@@ -485,12 +485,12 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>the birds of the sky, the fish of the sea, 
 </p><p class="q2">and whatever passes through the paths of the seas. 
 </p><p class="q1">
-<sup>9&#160;</sup>Yahweh, our Lord, 
+<sup>9&#160;</sup>Yahuah, our Lord, 
 </p><p class="q2">how majestic is your name in all the earth! 
 </p><h2 class="psalmlabel" id="9">9</h2>
 <p class="d">For the Chief Musician. Set to “The Death of the Son.” A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>I will give thanks to Yahweh with my whole heart. 
+<sup>1&#160;</sup>I will give thanks to Yahuah with my whole heart. 
 </p><p class="q2">I will tell of all your marvelous works. 
 </p><p class="q1">
 <sup>2&#160;</sup>I will be glad and rejoice in you. 
@@ -509,25 +509,25 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>The enemy is overtaken by endless ruin. 
 </p><p class="q2">The very memory of the cities which you have overthrown has perished. 
 </p><p class="q1">
-<sup>7&#160;</sup>But Yahweh reigns forever. 
+<sup>7&#160;</sup>But Yahuah reigns forever. 
 </p><p class="q2">He has prepared his throne for judgment. 
 </p><p class="q1">
 <sup>8&#160;</sup>He will judge the world in righteousness. 
 </p><p class="q2">He will administer judgment to the peoples in uprightness. 
 </p><p class="q1">
-<sup>9&#160;</sup>Yahweh will also be a high tower for the oppressed; 
+<sup>9&#160;</sup>Yahuah will also be a high tower for the oppressed; 
 </p><p class="q2">a high tower in times of trouble. 
 </p><p class="q1">
 <sup>10&#160;</sup>Those who know your name will put their trust in you, 
-</p><p class="q2">for you, Yahweh, have not forsaken those who seek you. 
+</p><p class="q2">for you, Yahuah, have not forsaken those who seek you. 
 </p><p class="q1">
-<sup>11&#160;</sup>Sing praises to Yahweh, who dwells in Zion, 
+<sup>11&#160;</sup>Sing praises to Yahuah, who dwells in Zion, 
 </p><p class="q2">and declare among the people what he has done. 
 </p><p class="q1">
 <sup>12&#160;</sup>For he who avenges blood remembers them. 
 </p><p class="q2">He doesn’t forget the cry of the afflicted. 
 </p><p class="q1">
-<sup>13&#160;</sup>Have mercy on me, Yahweh. 
+<sup>13&#160;</sup>Have mercy on me, Yahuah. 
 </p><p class="q2">See my affliction by those who hate me, 
 </p><p class="q1">and lift me up from the gates of death, 
 </p><p class="q2">
@@ -537,7 +537,7 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>The nations have sunk down in the pit that they made. 
 </p><p class="q2">In the net which they hid, their own foot is taken. 
 </p><p class="q1">
-<sup>16&#160;</sup>Yahweh has made himself known. 
+<sup>16&#160;</sup>Yahuah has made himself known. 
 </p><p class="q2">He has executed judgment. 
 </p><p class="q2">The wicked is snared by the work of his own hands. </p><p class="qs">Meditation. Selah. 
 </p><p class="q1">
@@ -547,21 +547,21 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>For the needy shall not always be forgotten, 
 </p><p class="q2">nor the hope of the poor perish forever. 
 </p><p class="q1">
-<sup>19&#160;</sup>Arise, Yahweh! Don’t let man prevail. 
+<sup>19&#160;</sup>Arise, Yahuah! Don’t let man prevail. 
 </p><p class="q2">Let the nations be judged in your sight. 
 </p><p class="q1">
-<sup>20&#160;</sup>Put them in fear, Yahweh. 
+<sup>20&#160;</sup>Put them in fear, Yahuah. 
 </p><p class="q2">Let the nations know that they are only men. </p><p class="qs">Selah. 
 </p><h2 class="psalmlabel" id="10">10</h2>
 <p class="q1">
-<sup>1&#160;</sup>Why do you stand far off, Yahweh? 
+<sup>1&#160;</sup>Why do you stand far off, Yahuah? 
 </p><p class="q2">Why do you hide yourself in times of trouble? 
 </p><p class="q1">
 <sup>2&#160;</sup>In arrogance, the wicked hunt down the weak. 
 </p><p class="q2">They are caught in the schemes that they devise. 
 </p><p class="q1">
 <sup>3&#160;</sup>For the wicked boasts of his heart’s cravings. 
-</p><p class="q2">He blesses the greedy and condemns Yahweh. 
+</p><p class="q2">He blesses the greedy and condemns Yahuah. 
 </p><p class="q1">
 <sup>4&#160;</sup>The wicked, in the pride of his face, 
 </p><p class="q2">has no room in his thoughts for Elohim. 
@@ -593,7 +593,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He will never see it.” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>12&#160;</sup>Arise, Yahweh! 
+<sup>12&#160;</sup>Arise, Yahuah! 
 </p><p class="q2">Elohim, lift up your hand! 
 </p><p class="q2">Don’t forget the helpless. 
 </p><p class="q1">
@@ -607,10 +607,10 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Break the arm of the wicked. 
 </p><p class="q2">As for the evil man, seek out his wickedness until you find none. 
 </p><p class="q1">
-<sup>16&#160;</sup>Yahweh is King forever and ever! 
+<sup>16&#160;</sup>Yahuah is King forever and ever! 
 </p><p class="q2">The nations will perish out of his land. 
 </p><p class="q1">
-<sup>17&#160;</sup>Yahweh, you have heard the desire of the humble. 
+<sup>17&#160;</sup>Yahuah, you have heard the desire of the humble. 
 </p><p class="q2">You will prepare their heart. 
 </p><p class="q2">You will cause your ear to hear, 
 </p><p class="q2">
@@ -619,7 +619,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="11">11</h2>
 <p class="d">For the Chief Musician. By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>In Yahweh, I take refuge. 
+<sup>1&#160;</sup>In Yahuah, I take refuge. 
 </p><p class="q2">How can you say to my soul, “Flee as a bird to your mountain”? 
 </p><p class="q1">
 <sup>2&#160;</sup>For, behold, the wicked bend their bows. 
@@ -629,30 +629,30 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>If the foundations are destroyed, 
 </p><p class="q2">what can the righteous do? 
 </p><p class="q1">
-<sup>4&#160;</sup>Yahweh is in his set-apart temple. 
-</p><p class="q2">Yahweh is on his throne in heaven. 
+<sup>4&#160;</sup>Yahuah is in his set-apart temple. 
+</p><p class="q2">Yahuah is on his throne in heaven. 
 </p><p class="q1">His eyes observe. 
 </p><p class="q2">His eyes examine the children of men. 
 </p><p class="q1">
-<sup>5&#160;</sup>Yahweh examines the righteous, 
+<sup>5&#160;</sup>Yahuah examines the righteous, 
 </p><p class="q2">but his soul hates the wicked and him who loves violence. 
 </p><p class="q1">
 <sup>6&#160;</sup>On the wicked he will rain blazing coals; 
 </p><p class="q2">fire, sulfur, and scorching wind shall be the portion of their cup. 
 </p><p class="q1">
-<sup>7&#160;</sup>For Yahweh is righteous. 
+<sup>7&#160;</sup>For Yahuah is righteous. 
 </p><p class="q2">He loves righteousness. 
 </p><p class="q2">The upright shall see his face. 
 </p><h2 class="psalmlabel" id="12">12</h2>
 <p class="d">For the Chief Musician; upon an eight-stringed lyre. A Psalm of David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Help, Yahweh; for the elohimly man ceases. 
+<sup>1&#160;</sup>Help, Yahuah; for the elohimly man ceases. 
 </p><p class="q2">For the faithful fail from among the children of men. 
 </p><p class="q1">
 <sup>2&#160;</sup>Everyone lies to his neighbor. 
 </p><p class="q2">They speak with flattering lips, and with a double heart. 
 </p><p class="q1">
-<sup>3&#160;</sup>May Yahweh cut off all flattering lips, 
+<sup>3&#160;</sup>May Yahuah cut off all flattering lips, 
 </p><p class="q2">and the tongue that boasts, 
 </p><p class="q1">
 <sup>4&#160;</sup>who have said, “With our tongue we will prevail. 
@@ -660,13 +660,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Who is lord over us?” 
 </p><p class="q1">
 <sup>5&#160;</sup>“Because of the oppression of the weak and because of the groaning of the needy, 
-</p><p class="q2">I will now arise,” says Yahweh; 
+</p><p class="q2">I will now arise,” says Yahuah; 
 </p><p class="q1">“I will set him in safety from those who malign him.” 
 </p><p class="q1">
-<sup>6&#160;</sup>Yahweh’s words are flawless words, 
+<sup>6&#160;</sup>Yahuah’s words are flawless words, 
 </p><p class="q2">as silver refined in a clay furnace, purified seven times. 
 </p><p class="q1">
-<sup>7&#160;</sup>You will keep them, Yahweh. 
+<sup>7&#160;</sup>You will keep them, Yahuah. 
 </p><p class="q2">You will preserve them from this generation forever. 
 </p><p class="q1">
 <sup>8&#160;</sup>The wicked walk on every side, 
@@ -674,7 +674,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="13">13</h2>
 <p class="d">For the Chief Musician. A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>How long, Yahweh? 
+<sup>1&#160;</sup>How long, Yahuah? 
 </p><p class="q2">Will you forget me forever? 
 </p><p class="q2">How long will you hide your face from me? 
 </p><p class="q1">
@@ -682,7 +682,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">having sorrow in my heart every day? 
 </p><p class="q2">How long shall my enemy triumph over me? 
 </p><p class="q1">
-<sup>3&#160;</sup>Behold, and answer me, Yahweh, my Elohim. 
+<sup>3&#160;</sup>Behold, and answer me, Yahuah, my Elohim. 
 </p><p class="q2">Give light to my eyes, lest I sleep in death; 
 </p><p class="q2">
 <sup>4&#160;</sup>lest my enemy say, “I have prevailed against him;” 
@@ -692,7 +692,7 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>But I trust in your loving kindness. 
 </p><p class="q2">My heart rejoices in your salvation. 
 </p><p class="q1">
-<sup>6&#160;</sup>I will sing to Yahweh, 
+<sup>6&#160;</sup>I will sing to Yahuah, 
 </p><p class="q2">because he has been good to me. 
 </p><h2 class="psalmlabel" id="14">14</h2>
 <p class="d">For the Chief Musician. By David. 
@@ -702,7 +702,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They have done abominable deeds. 
 </p><p class="q2">There is no one who does good. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh looked down from heaven on the children of men, 
+<sup>2&#160;</sup>Yahuah looked down from heaven on the children of men, 
 </p><p class="q2">to see if there were any who understood, 
 </p><p class="q2">who sought after Elohim. 
 </p><p class="q1">
@@ -712,21 +712,21 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>4&#160;</sup>Have all the workers of iniquity no knowledge, 
 </p><p class="q2">who eat up my people as they eat bread, 
-</p><p class="q2">and don’t call on Yahweh? 
+</p><p class="q2">and don’t call on Yahuah? 
 </p><p class="q1">
 <sup>5&#160;</sup>There they were in great fear, 
 </p><p class="q2">for Elohim is in the generation of the righteous. 
 </p><p class="q1">
 <sup>6&#160;</sup>You frustrate the plan of the poor, 
-</p><p class="q2">because Yahweh is his refuge. 
+</p><p class="q2">because Yahuah is his refuge. 
 </p><p class="q1">
 <sup>7&#160;</sup>Oh that the salvation of Israel would come out of Zion! 
-</p><p class="q2">When Yahweh restores the fortunes of his people, 
+</p><p class="q2">When Yahuah restores the fortunes of his people, 
 </p><p class="q2">then Jacob shall rejoice, and Israel shall be glad. 
 </p><h2 class="psalmlabel" id="15">15</h2>
 <p class="d">A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, who shall dwell in your sanctuary? 
+<sup>1&#160;</sup>Yahuah, who shall dwell in your sanctuary? 
 </p><p class="q2">Who shall live on your set-apart hill? 
 </p><p class="q1">
 <sup>2&#160;</sup>He who walks blamelessly and does what is right, 
@@ -737,7 +737,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">nor casts slurs against his fellow man; 
 </p><p class="q1">
 <sup>4&#160;</sup>in whose eyes a vile man is despised, 
-</p><p class="q2">but who honors those who fear Yahweh; 
+</p><p class="q2">but who honors those who fear Yahuah; 
 </p><p class="q2">he who keeps an oath even when it hurts, and doesn’t change; 
 </p><p class="q1">
 <sup>5&#160;</sup>he who doesn’t lend out his money for usury, 
@@ -749,7 +749,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>1&#160;</sup>Preserve me, Elohim, for I take refuge in you. 
 </p><p class="q1">
-<sup>2&#160;</sup>My soul, you have said to Yahweh, “You are my Lord. 
+<sup>2&#160;</sup>My soul, you have said to Yahuah, “You are my Lord. 
 </p><p class="q2">Apart from you I have no good thing.” 
 </p><p class="q1">
 <sup>3&#160;</sup>As for the saints who are in the earth, 
@@ -760,17 +760,17 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Their drink offerings of blood I will not offer, 
 </p><p class="q2">nor take their names on my lips. 
 </p><p class="q1">
-<sup>5&#160;</sup>Yahweh assigned my portion and my cup. 
+<sup>5&#160;</sup>Yahuah assigned my portion and my cup. 
 </p><p class="q2">You made my lot secure. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>6&#160;</sup>The lines have fallen to me in pleasant places. 
 </p><p class="q2">Yes, I have a good inheritance. 
 </p><p class="q1">
-<sup>7&#160;</sup>I will bless Yahweh, who has given me counsel. 
+<sup>7&#160;</sup>I will bless Yahuah, who has given me counsel. 
 </p><p class="q2">Yes, my heart instructs me in the night seasons. 
 </p><p class="q1">
-<sup>8&#160;</sup>I have set Yahweh always before me. 
+<sup>8&#160;</sup>I have set Yahuah always before me. 
 </p><p class="q2">Because he is at my right hand, I shall not be moved. 
 </p><p class="q1">
 <sup>9&#160;</sup>Therefore my heart is glad, and my tongue rejoices. 
@@ -785,7 +785,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="17">17</h2>
 <p class="d">A Prayer by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Hear, Yahweh, my righteous plea. 
+<sup>1&#160;</sup>Hear, Yahuah, my righteous plea. 
 </p><p class="q2">Give ear to my prayer that doesn’t go out of deceitful lips. 
 </p><p class="q1">
 <sup>2&#160;</sup>Let my sentence come out of your presence. 
@@ -824,11 +824,11 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>He is like a lion that is greedy of his prey, 
 </p><p class="q2">as it were a young lion lurking in secret places. 
 </p><p class="q1">
-<sup>13&#160;</sup>Arise, Yahweh, confront him. 
+<sup>13&#160;</sup>Arise, Yahuah, confront him. 
 </p><p class="q2">Cast him down. 
 </p><p class="q1">Deliver my soul from the wicked by your sword, 
 </p><p class="q2">
-<sup>14&#160;</sup>from men by your hand, Yahweh, 
+<sup>14&#160;</sup>from men by your hand, Yahuah, 
 </p><p class="q2">from men of the world, whose portion is in this life. 
 </p><p class="q1">You fill the belly of your cherished ones. 
 </p><p class="q2">Your sons have plenty, 
@@ -837,15 +837,15 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>As for me, I shall see your face in righteousness. 
 </p><p class="q2">I shall be satisfied, when I awake, with seeing your form. 
 </p><h2 class="psalmlabel" id="18">18</h2>
-<p class="d">For the Chief Musician. By David the servant of Yahweh, who spoke to Yahweh the words of this song in the day that Yahweh delivered him from the hand of all his enemies, and from the hand of Saul. He said, 
+<p class="d">For the Chief Musician. By David the servant of Yahuah, who spoke to Yahuah the words of this song in the day that Yahuah delivered him from the hand of all his enemies, and from the hand of Saul. He said, 
 </p><p class="q1">
-<sup>1&#160;</sup>I love you, Yahweh, my strength. 
+<sup>1&#160;</sup>I love you, Yahuah, my strength. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh is my rock, my fortress, and my deliverer; 
+<sup>2&#160;</sup>Yahuah is my rock, my fortress, and my deliverer; 
 </p><p class="q2">my Elohim, my rock, in whom I take refuge; 
 </p><p class="q2">my shield, and the horn of my salvation, my high tower. 
 </p><p class="q1">
-<sup>3&#160;</sup>I call on Yahweh, who is worthy to be praised; 
+<sup>3&#160;</sup>I call on Yahuah, who is worthy to be praised; 
 </p><p class="q2">and I am saved from my enemies. 
 </p><p class="q1">
 <sup>4&#160;</sup>The cords of death surrounded me. 
@@ -854,7 +854,7 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>The cords of Sheol were around me. 
 </p><p class="q2">The snares of death came on me. 
 </p><p class="q1">
-<sup>6&#160;</sup>In my distress I called on Yahweh, 
+<sup>6&#160;</sup>In my distress I called on Yahuah, 
 </p><p class="q2">and cried to my Elohim. 
 </p><p class="q1">He heard my voice out of his temple. 
 </p><p class="q2">My cry before him came into his ears. 
@@ -879,7 +879,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>At the brightness before him his thick clouds passed, 
 </p><p class="q2">hailstones and coals of fire. 
 </p><p class="q1">
-<sup>13&#160;</sup>Yahweh also thundered in the sky. 
+<sup>13&#160;</sup>Yahuah also thundered in the sky. 
 </p><p class="q2">The Most High uttered his voice: 
 </p><p class="q2">hailstones and coals of fire. 
 </p><p class="q1">
@@ -887,7 +887,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He routed them with great lightning bolts. 
 </p><p class="q1">
 <sup>15&#160;</sup>Then the channels of waters appeared. 
-</p><p class="q2">The foundations of the world were laid bare at your rebuke, Yahweh, 
+</p><p class="q2">The foundations of the world were laid bare at your rebuke, Yahuah, 
 </p><p class="q2">at the blast of the breath of your nostrils. 
 </p><p class="q1">
 <sup>16&#160;</sup>He sent from on high. 
@@ -898,15 +898,15 @@ html[dir=ltr] .q2 {
 </p><p class="q2">from those who hated me; for they were too mighty for me. 
 </p><p class="q1">
 <sup>18&#160;</sup>They came on me in the day of my calamity, 
-</p><p class="q2">but Yahweh was my support. 
+</p><p class="q2">but Yahuah was my support. 
 </p><p class="q1">
 <sup>19&#160;</sup>He brought me out also into a large place. 
 </p><p class="q2">He delivered me, because he delighted in me. 
 </p><p class="q1">
-<sup>20&#160;</sup>Yahweh has rewarded me according to my righteousness. 
+<sup>20&#160;</sup>Yahuah has rewarded me according to my righteousness. 
 </p><p class="q2">According to the cleanness of my hands, he has recompensed me. 
 </p><p class="q1">
-<sup>21&#160;</sup>For I have kept the ways of Yahweh, 
+<sup>21&#160;</sup>For I have kept the ways of Yahuah, 
 </p><p class="q2">and have not wickedly departed from my Elohim. 
 </p><p class="q1">
 <sup>22&#160;</sup>For all his ordinances were before me. 
@@ -915,7 +915,7 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>I was also blameless with him. 
 </p><p class="q2">I kept myself from my iniquity. 
 </p><p class="q1">
-<sup>24&#160;</sup>Therefore Yahweh has rewarded me according to my righteousness, 
+<sup>24&#160;</sup>Therefore Yahuah has rewarded me according to my righteousness, 
 </p><p class="q2">according to the cleanness of my hands in his eyesight. 
 </p><p class="q1">
 <sup>25&#160;</sup>With the merciful you will show yourself merciful. 
@@ -927,17 +927,17 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>For you will save the afflicted people, 
 </p><p class="q2">but the arrogant eyes you will bring down. 
 </p><p class="q1">
-<sup>28&#160;</sup>For you will light my lamp, Yahweh. 
+<sup>28&#160;</sup>For you will light my lamp, Yahuah. 
 </p><p class="q2">My Elohim will light up my darkness. 
 </p><p class="q1">
 <sup>29&#160;</sup>For by you, I advance through a troop. 
 </p><p class="q2">By my Elohim, I leap over a wall. 
 </p><p class="q1">
 <sup>30&#160;</sup>As for Elohim, his way is perfect. 
-</p><p class="q2">Yahweh’s word is tried. 
+</p><p class="q2">Yahuah’s word is tried. 
 </p><p class="q2">He is a shield to all those who take refuge in him. 
 </p><p class="q1">
-<sup>31&#160;</sup>For who is Elohim, except Yahweh? 
+<sup>31&#160;</sup>For who is Elohim, except Yahuah? 
 </p><p class="q2">Who is a rock, besides our Elohim, 
 </p><p class="q2">
 <sup>32&#160;</sup>the Elohim who arms me with strength, and makes my way perfect? 
@@ -968,7 +968,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">that I might cut off those who hate me. 
 </p><p class="q1">
 <sup>41&#160;</sup>They cried, but there was no one to save; 
-</p><p class="q2">even to Yahweh, but he didn’t answer them. 
+</p><p class="q2">even to Yahuah, but he didn’t answer them. 
 </p><p class="q1">
 <sup>42&#160;</sup>Then I beat them small as the dust before the wind. 
 </p><p class="q2">I cast them out as the mire of the streets. 
@@ -983,7 +983,7 @@ html[dir=ltr] .q2 {
 <sup>45&#160;</sup>The foreigners shall fade away, 
 </p><p class="q2">and shall come trembling out of their strongholds. 
 </p><p class="q1">
-<sup>46&#160;</sup>Yahweh lives! Blessed be my rock. 
+<sup>46&#160;</sup>Yahuah lives! Blessed be my rock. 
 </p><p class="q2">Exalted be the Elohim of my salvation, 
 </p><p class="q1">
 <sup>47&#160;</sup>even the Elohim who executes vengeance for me, 
@@ -993,7 +993,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Yes, you lift me up above those who rise up against me. 
 </p><p class="q2">You deliver me from the violent man. 
 </p><p class="q1">
-<sup>49&#160;</sup>Therefore I will give thanks to you, Yahweh, among the nations, 
+<sup>49&#160;</sup>Therefore I will give thanks to you, Yahuah, among the nations, 
 </p><p class="q2">and will sing praises to your name. 
 </p><p class="q1">
 <sup>50&#160;</sup>He gives great deliverance to his king, 
@@ -1023,14 +1023,14 @@ html[dir=ltr] .q2 {
 </p><p class="q2">There is nothing hidden from its heat. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>7&#160;</sup>Yahweh’s law is perfect, restoring the soul. 
-</p><p class="q2">Yahweh’s covenant is sure, making wise the simple. 
+<sup>7&#160;</sup>Yahuah’s law is perfect, restoring the soul. 
+</p><p class="q2">Yahuah’s covenant is sure, making wise the simple. 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh’s precepts are right, rejoicing the heart. 
-</p><p class="q2">Yahweh’s commandment is pure, enlightening the eyes. 
+<sup>8&#160;</sup>Yahuah’s precepts are right, rejoicing the heart. 
+</p><p class="q2">Yahuah’s commandment is pure, enlightening the eyes. 
 </p><p class="q1">
-<sup>9&#160;</sup>The fear of Yahweh is clean, enduring forever. 
-</p><p class="q2">Yahweh’s ordinances are true, and righteous altogether. 
+<sup>9&#160;</sup>The fear of Yahuah is clean, enduring forever. 
+</p><p class="q2">Yahuah’s ordinances are true, and righteous altogether. 
 </p><p class="q1">
 <sup>10&#160;</sup>They are more to be desired than gold, yes, than much fine gold, 
 </p><p class="q2">sweeter also than honey and the extract of the honeycomb. 
@@ -1049,11 +1049,11 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>14&#160;</sup>Let the words of my mouth and the meditation of my heart 
 </p><p class="q2">be acceptable in your sight, 
-</p><p class="q2">Yahweh, my rock, and my redeemer. 
+</p><p class="q2">Yahuah, my rock, and my redeemer. 
 </p><h2 class="psalmlabel" id="20">20</h2>
 <p class="d">For the Chief Musician. A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>May Yahweh answer you in the day of trouble. 
+<sup>1&#160;</sup>May Yahuah answer you in the day of trouble. 
 </p><p class="q2">May the name of the Elohim of Jacob set you up on high, 
 </p><p class="q2">
 <sup>2&#160;</sup>send you help from the sanctuary, 
@@ -1067,24 +1067,24 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>5&#160;</sup>We will triumph in your salvation. 
 </p><p class="q2">In the name of our Elohim, we will set up our banners. 
-</p><p class="q2">May Yahweh grant all your requests. 
+</p><p class="q2">May Yahuah grant all your requests. 
 </p><p class="q1">
-<sup>6&#160;</sup>Now I know that Yahweh saves his anointed. 
+<sup>6&#160;</sup>Now I know that Yahuah saves his anointed. 
 </p><p class="q2">He will answer him from his set-apart heaven, 
 </p><p class="q2">with the saving strength of his right hand. 
 </p><p class="q1">
 <sup>7&#160;</sup>Some trust in chariots, and some in horses, 
-</p><p class="q2">but we trust in the name of Yahweh our Elohim. 
+</p><p class="q2">but we trust in the name of Yahuah our Elohim. 
 </p><p class="q1">
 <sup>8&#160;</sup>They are bowed down and fallen, 
 </p><p class="q2">but we rise up, and stand upright. 
 </p><p class="q1">
-<sup>9&#160;</sup>Save, Yahweh! 
+<sup>9&#160;</sup>Save, Yahuah! 
 </p><p class="q2">Let the King answer us when we call! 
 </p><h2 class="psalmlabel" id="21">21</h2>
 <p class="d">For the Chief Musician. A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>The king rejoices in your strength, Yahweh! 
+<sup>1&#160;</sup>The king rejoices in your strength, Yahuah! 
 </p><p class="q2">How greatly he rejoices in your salvation! 
 </p><p class="q1">
 <sup>2&#160;</sup>You have given him his heart’s desire, 
@@ -1102,14 +1102,14 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>For you make him most blessed forever. 
 </p><p class="q2">You make him glad with joy in your presence. 
 </p><p class="q1">
-<sup>7&#160;</sup>For the king trusts in Yahweh. 
+<sup>7&#160;</sup>For the king trusts in Yahuah. 
 </p><p class="q2">Through the loving kindness of the Most High, he shall not be moved. 
 </p><p class="q1">
 <sup>8&#160;</sup>Your hand will find out all of your enemies. 
 </p><p class="q2">Your right hand will find out those who hate you. 
 </p><p class="q1">
 <sup>9&#160;</sup>You will make them as a fiery furnace in the time of your anger. 
-</p><p class="q2">Yahweh will swallow them up in his wrath. 
+</p><p class="q2">Yahuah will swallow them up in his wrath. 
 </p><p class="q2">The fire shall devour them. 
 </p><p class="q1">
 <sup>10&#160;</sup>You will destroy their descendants from the earth, 
@@ -1121,7 +1121,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>For you will make them turn their back, 
 </p><p class="q2">when you aim drawn bows at their face. 
 </p><p class="q1">
-<sup>13&#160;</sup>Be exalted, Yahweh, in your strength, 
+<sup>13&#160;</sup>Be exalted, Yahuah, in your strength, 
 </p><p class="q2">so we will sing and praise your power. 
 </p><h2 class="psalmlabel" id="22">22</h2>
 <p class="d">For the Chief Musician; set to “The Doe of the Morning.” A Psalm by David. 
@@ -1147,7 +1147,7 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>All those who see me mock me. 
 </p><p class="q2">They insult me with their lips. They shake their heads, saying, 
 </p><p class="q2">
-<sup>8&#160;</sup>“He trusts in Yahweh. 
+<sup>8&#160;</sup>“He trusts in Yahuah. 
 </p><p class="q2">Let him deliver him. 
 </p><p class="q2">Let him rescue him, since he delights in him.” 
 </p><p class="q1">
@@ -1186,7 +1186,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They cast lots for my clothing. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>19&#160;</sup>But don’t be far off, Yahweh. 
+<sup>19&#160;</sup>But don’t be far off, Yahuah. 
 </p><p class="q2">You are my help. Hurry to help me! 
 </p><p class="q1">
 <sup>20&#160;</sup>Deliver my soul from the sword, 
@@ -1199,7 +1199,7 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>I will declare your name to my brothers. 
 </p><p class="q2">Among the assembly, I will praise you. 
 </p><p class="q1">
-<sup>23&#160;</sup>You who fear Yahweh, praise him! 
+<sup>23&#160;</sup>You who fear Yahuah, praise him! 
 </p><p class="q2">All you descendants of Jacob, glorify him! 
 </p><p class="q2">Stand in awe of him, all you descendants of Israel! 
 </p><p class="q1">
@@ -1212,13 +1212,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I will pay my vows before those who fear him. 
 </p><p class="q1">
 <sup>26&#160;</sup>The humble shall eat and be satisfied. 
-</p><p class="q2">They shall praise Yahweh who seek after him. 
+</p><p class="q2">They shall praise Yahuah who seek after him. 
 </p><p class="q2">Let your hearts live forever. 
 </p><p class="q1">
-<sup>27&#160;</sup>All the ends of the earth shall remember and turn to Yahweh. 
+<sup>27&#160;</sup>All the ends of the earth shall remember and turn to Yahuah. 
 </p><p class="q2">All the relatives of the nations shall worship before you. 
 </p><p class="q1">
-<sup>28&#160;</sup>For the kingdom is Yahweh’s. 
+<sup>28&#160;</sup>For the kingdom is Yahuah’s. 
 </p><p class="q2">He is the ruler over the nations. 
 </p><p class="q1">
 <sup>29&#160;</sup>All the rich ones of the earth shall eat and worship. 
@@ -1233,7 +1233,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="23">23</h2>
 <p class="d">A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh is my shepherd; 
+<sup>1&#160;</sup>Yahuah is my shepherd; 
 </p><p class="q2">I shall lack nothing. 
 </p><p class="q1">
 <sup>2&#160;</sup>He makes me lie down in green pastures. 
@@ -1253,25 +1253,25 @@ html[dir=ltr] .q2 {
 </p><p class="q2">My cup runs over. 
 </p><p class="q1">
 <sup>6&#160;</sup>Surely goodness and loving kindness shall follow me all the days of my life, 
-</p><p class="q2">and I will dwell in Yahweh’s house forever. 
+</p><p class="q2">and I will dwell in Yahuah’s house forever. 
 </p><h2 class="psalmlabel" id="24">24</h2>
 <p class="d">A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>The earth is Yahweh’s, with its fullness; 
+<sup>1&#160;</sup>The earth is Yahuah’s, with its fullness; 
 </p><p class="q2">the world, and those who dwell in it. 
 </p><p class="q1">
 <sup>2&#160;</sup>For he has founded it on the seas, 
 </p><p class="q2">and established it on the floods. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>3&#160;</sup>Who may ascend to Yahweh’s hill? 
+<sup>3&#160;</sup>Who may ascend to Yahuah’s hill? 
 </p><p class="q2">Who may stand in his set-apart place? 
 </p><p class="q1">
 <sup>4&#160;</sup>He who has clean hands and a pure heart; 
 </p><p class="q2">who has not lifted up his soul to falsehood, 
 </p><p class="q2">and has not sworn deceitfully. 
 </p><p class="q1">
-<sup>5&#160;</sup>He shall receive a blessing from Yahweh, 
+<sup>5&#160;</sup>He shall receive a blessing from Yahuah, 
 </p><p class="q2">righteousness from the Elohim of his salvation. 
 </p><p class="q1">
 <sup>6&#160;</sup>This is the generation of those who seek Him, 
@@ -1283,19 +1283,19 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and the King of glory will come in. 
 </p><p class="q1">
 <sup>8&#160;</sup>Who is the King of glory? 
-</p><p class="q2">Yahweh strong and mighty, 
-</p><p class="q2">Yahweh mighty in battle. 
+</p><p class="q2">Yahuah strong and mighty, 
+</p><p class="q2">Yahuah mighty in battle. 
 </p><p class="q1">
 <sup>9&#160;</sup>Lift up your heads, you gates; 
 </p><p class="q2">yes, lift them up, you everlasting doors, 
 </p><p class="q2">and the King of glory will come in. 
 </p><p class="q1">
 <sup>10&#160;</sup>Who is this King of glory? 
-</p><p class="q2">Yahweh of Armies is the King of glory! </p><p class="qs">Selah. 
+</p><p class="q2">Yahuah of Armies is the King of glory! </p><p class="qs">Selah. 
 </p><h2 class="psalmlabel" id="25">25</h2>
 <p class="d">By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>To you, Yahweh, I lift up my soul. 
+<sup>1&#160;</sup>To you, Yahuah, I lift up my soul. 
 </p><p class="q1">
 <sup>2&#160;</sup>My Elohim, I have trusted in you. 
 </p><p class="q2">Don’t let me be shamed. 
@@ -1305,43 +1305,43 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They will be shamed who deal treacherously without cause. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>4&#160;</sup>Show me your ways, Yahweh. 
+<sup>4&#160;</sup>Show me your ways, Yahuah. 
 </p><p class="q2">Teach me your paths. 
 </p><p class="q1">
 <sup>5&#160;</sup>Guide me in your truth, and teach me, 
 </p><p class="q2">for you are the Elohim of my salvation. 
 </p><p class="q2">I wait for you all day long. 
 </p><p class="q1">
-<sup>6&#160;</sup>Yahweh, remember your tender mercies and your loving kindness, 
+<sup>6&#160;</sup>Yahuah, remember your tender mercies and your loving kindness, 
 </p><p class="q2">for they are from old times. 
 </p><p class="q1">
 <sup>7&#160;</sup>Don’t remember the sins of my youth, nor my transgressions. 
 </p><p class="q2">Remember me according to your loving kindness, 
-</p><p class="q2">for your goodness’ sake, Yahweh. 
+</p><p class="q2">for your goodness’ sake, Yahuah. 
 </p><p class="q1">
-<sup>8&#160;</sup>Good and upright is Yahweh, 
+<sup>8&#160;</sup>Good and upright is Yahuah, 
 </p><p class="q2">therefore he will instruct sinners in the way. 
 </p><p class="q1">
 <sup>9&#160;</sup>He will guide the humble in justice. 
 </p><p class="q2">He will teach the humble his way. 
 </p><p class="q1">
-<sup>10&#160;</sup>All the paths of Yahweh are loving kindness and truth 
+<sup>10&#160;</sup>All the paths of Yahuah are loving kindness and truth 
 </p><p class="q2">to such as keep his covenant and his testimonies. 
 </p><p class="q1">
-<sup>11&#160;</sup>For your name’s sake, Yahweh, 
+<sup>11&#160;</sup>For your name’s sake, Yahuah, 
 </p><p class="q2">pardon my iniquity, for it is great. 
 </p><p class="q1">
-<sup>12&#160;</sup>What man is he who fears Yahweh? 
+<sup>12&#160;</sup>What man is he who fears Yahuah? 
 </p><p class="q2">He shall instruct him in the way that he shall choose. 
 </p><p class="q1">
 <sup>13&#160;</sup>His soul will dwell at ease. 
 </p><p class="q2">His offspring will inherit the land. 
 </p><p class="q1">
-<sup>14&#160;</sup>The friendship of Yahweh is with those who fear him. 
+<sup>14&#160;</sup>The friendship of Yahuah is with those who fear him. 
 </p><p class="q2">He will show them his covenant. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>15&#160;</sup>My eyes are ever on Yahweh, 
+<sup>15&#160;</sup>My eyes are ever on Yahuah, 
 </p><p class="q2">for he will pluck my feet out of the net. 
 </p><p class="q1">
 <sup>16&#160;</sup>Turn to me, and have mercy on me, 
@@ -1367,10 +1367,10 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="26">26</h2>
 <p class="d">By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Judge me, Yahweh, for I have walked in my integrity. 
-</p><p class="q2">I have trusted also in Yahweh without wavering. 
+<sup>1&#160;</sup>Judge me, Yahuah, for I have walked in my integrity. 
+</p><p class="q2">I have trusted also in Yahuah without wavering. 
 </p><p class="q1">
-<sup>2&#160;</sup>Examine me, Yahweh, and prove me. 
+<sup>2&#160;</sup>Examine me, Yahuah, and prove me. 
 </p><p class="q2">Try my heart and my mind. 
 </p><p class="q1">
 <sup>3&#160;</sup>For your loving kindness is before my eyes. 
@@ -1383,12 +1383,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will not sit with the wicked. 
 </p><p class="q1">
 <sup>6&#160;</sup>I will wash my hands in innocence, 
-</p><p class="q2">so I will go about your altar, Yahweh, 
+</p><p class="q2">so I will go about your altar, Yahuah, 
 </p><p class="q2">
 <sup>7&#160;</sup>that I may make the voice of thanksgiving to be heard 
 </p><p class="q2">and tell of all your wondrous deeds. 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh, I love the habitation of your house, 
+<sup>8&#160;</sup>Yahuah, I love the habitation of your house, 
 </p><p class="q2">the place where your glory dwells. 
 </p><p class="q1">
 <sup>9&#160;</sup>Don’t gather my soul with sinners, 
@@ -1402,13 +1402,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Redeem me, and be merciful to me. 
 </p><p class="q1">
 <sup>12&#160;</sup>My foot stands in an even place. 
-</p><p class="q2">In the congregations I will bless Yahweh. 
+</p><p class="q2">In the congregations I will bless Yahuah. 
 </p><h2 class="psalmlabel" id="27">27</h2>
 <p class="d">By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh is my light and my salvation. 
+<sup>1&#160;</sup>Yahuah is my light and my salvation. 
 </p><p class="q2">Whom shall I fear? 
-</p><p class="q1">Yahweh is the strength of my life. 
+</p><p class="q1">Yahuah is the strength of my life. 
 </p><p class="q2">Of whom shall I be afraid? 
 </p><p class="q1">
 <sup>2&#160;</sup>When evildoers came at me to eat up my flesh, 
@@ -1419,9 +1419,9 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Though war should rise against me, 
 </p><p class="q2">even then I will be confident. 
 </p><p class="q1">
-<sup>4&#160;</sup>One thing I have asked of Yahweh, that I will seek after: 
-</p><p class="q2">that I may dwell in Yahweh’s house all the days of my life, 
-</p><p class="q2">to see Yahweh’s beauty, 
+<sup>4&#160;</sup>One thing I have asked of Yahuah, that I will seek after: 
+</p><p class="q2">that I may dwell in Yahuah’s house all the days of my life, 
+</p><p class="q2">to see Yahuah’s beauty, 
 </p><p class="q2">and to inquire in his temple. 
 </p><p class="q1">
 <sup>5&#160;</sup>For in the day of trouble, he will keep me secretly in his pavilion. 
@@ -1430,14 +1430,14 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>6&#160;</sup>Now my head will be lifted up above my enemies around me. 
 </p><p class="q1">I will offer sacrifices of joy in his tent. 
-</p><p class="q2">I will sing, yes, I will sing praises to Yahweh. 
+</p><p class="q2">I will sing, yes, I will sing praises to Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>7&#160;</sup>Hear, Yahweh, when I cry with my voice. 
+<sup>7&#160;</sup>Hear, Yahuah, when I cry with my voice. 
 </p><p class="q2">Have mercy also on me, and answer me. 
 </p><p class="q1">
 <sup>8&#160;</sup>When you said, “Seek my face,” 
-</p><p class="q2">my heart said to you, “I will seek your face, Yahweh.” 
+</p><p class="q2">my heart said to you, “I will seek your face, Yahuah.” 
 </p><p class="q1">
 <sup>9&#160;</sup>Don’t hide your face from me. 
 </p><p class="q2">Don’t put your servant away in anger. 
@@ -1446,9 +1446,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">neither forsake me, Elohim of my salvation. 
 </p><p class="q1">
 <sup>10&#160;</sup>When my father and my mother forsake me, 
-</p><p class="q2">then Yahweh will take me up. 
+</p><p class="q2">then Yahuah will take me up. 
 </p><p class="q1">
-<sup>11&#160;</sup>Teach me your way, Yahweh. 
+<sup>11&#160;</sup>Teach me your way, Yahuah. 
 </p><p class="q2">Lead me in a straight path, because of my enemies. 
 </p><p class="q1">
 <sup>12&#160;</sup>Don’t deliver me over to the desire of my adversaries, 
@@ -1456,15 +1456,15 @@ html[dir=ltr] .q2 {
 </p><p class="q2">such as breathe out cruelty. 
 </p><p class="q1">
 <sup>13&#160;</sup>I am still confident of this: 
-</p><p class="q2">I will see the goodness of Yahweh in the land of the living. 
+</p><p class="q2">I will see the goodness of Yahuah in the land of the living. 
 </p><p class="q1">
-<sup>14&#160;</sup>Wait for Yahweh. 
+<sup>14&#160;</sup>Wait for Yahuah. 
 </p><p class="q2">Be strong, and let your heart take courage. 
-</p><p class="q1">Yes, wait for Yahweh. 
+</p><p class="q1">Yes, wait for Yahuah. 
 </p><h2 class="psalmlabel" id="28">28</h2>
 <p class="d">By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>To you, Yahweh, I call. 
+<sup>1&#160;</sup>To you, Yahuah, I call. 
 </p><p class="q2">My rock, don’t be deaf to me, 
 </p><p class="q2">lest, if you are silent to me, 
 </p><p class="q2">I would become like those who go down into the pit. 
@@ -1480,20 +1480,20 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Give them according to the operation of their hands. 
 </p><p class="q2">Bring back on them what they deserve. 
 </p><p class="q1">
-<sup>5&#160;</sup>Because they don’t respect the works of Yahweh, 
+<sup>5&#160;</sup>Because they don’t respect the works of Yahuah, 
 </p><p class="q2">nor the operation of his hands, 
 </p><p class="q2">he will break them down and not build them up. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>6&#160;</sup>Blessed be Yahweh, 
+<sup>6&#160;</sup>Blessed be Yahuah, 
 </p><p class="q2">because he has heard the voice of my petitions. 
 </p><p class="q1">
-<sup>7&#160;</sup>Yahweh is my strength and my shield. 
+<sup>7&#160;</sup>Yahuah is my strength and my shield. 
 </p><p class="q2">My heart has trusted in him, and I am helped. 
 </p><p class="q1">Therefore my heart greatly rejoices. 
 </p><p class="q2">With my song I will thank him. 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh is their strength. 
+<sup>8&#160;</sup>Yahuah is their strength. 
 </p><p class="q2">He is a stronghold of salvation to his anointed. 
 </p><p class="q1">
 <sup>9&#160;</sup>Save your people, 
@@ -1503,53 +1503,53 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="29">29</h2>
 <p class="d">A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Ascribe to Yahweh, you sons of the mighty, 
-</p><p class="q2">ascribe to Yahweh glory and strength. 
+<sup>1&#160;</sup>Ascribe to Yahuah, you sons of the mighty, 
+</p><p class="q2">ascribe to Yahuah glory and strength. 
 </p><p class="q1">
-<sup>2&#160;</sup>Ascribe to Yahweh the glory due to his name. 
-</p><p class="q2">Worship Yahweh in set-apart array. 
+<sup>2&#160;</sup>Ascribe to Yahuah the glory due to his name. 
+</p><p class="q2">Worship Yahuah in set-apart array. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>3&#160;</sup>Yahweh’s voice is on the waters. 
-</p><p class="q2">The Elohim of glory thunders, even Yahweh on many waters. 
+<sup>3&#160;</sup>Yahuah’s voice is on the waters. 
+</p><p class="q2">The Elohim of glory thunders, even Yahuah on many waters. 
 </p><p class="q1">
-<sup>4&#160;</sup>Yahweh’s voice is powerful. 
-</p><p class="q2">Yahweh’s voice is full of majesty. 
+<sup>4&#160;</sup>Yahuah’s voice is powerful. 
+</p><p class="q2">Yahuah’s voice is full of majesty. 
 </p><p class="q1">
-<sup>5&#160;</sup>Yahweh’s voice breaks the cedars. 
-</p><p class="q2">Yes, Yahweh breaks in pieces the cedars of Lebanon. 
+<sup>5&#160;</sup>Yahuah’s voice breaks the cedars. 
+</p><p class="q2">Yes, Yahuah breaks in pieces the cedars of Lebanon. 
 </p><p class="q1">
 <sup>6&#160;</sup>He makes them also to skip like a calf; 
 </p><p class="q2">Lebanon and Sirion like a young, wild ox. 
 </p><p class="q1">
-<sup>7&#160;</sup>Yahweh’s voice strikes with flashes of lightning. 
+<sup>7&#160;</sup>Yahuah’s voice strikes with flashes of lightning. 
 </p><p class="q2">
-<sup>8&#160;</sup>Yahweh’s voice shakes the wilderness. 
-</p><p class="q2">Yahweh shakes the wilderness of Kadesh. 
+<sup>8&#160;</sup>Yahuah’s voice shakes the wilderness. 
+</p><p class="q2">Yahuah shakes the wilderness of Kadesh. 
 </p><p class="q1">
-<sup>9&#160;</sup>Yahweh’s voice makes the deer calve, 
+<sup>9&#160;</sup>Yahuah’s voice makes the deer calve, 
 </p><p class="q2">and strips the forests bare. 
 </p><p class="q2">In his temple everything says, “Glory!” 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>Yahweh sat enthroned at the Flood. 
-</p><p class="q2">Yes, Yahweh sits as King forever. 
+<sup>10&#160;</sup>Yahuah sat enthroned at the Flood. 
+</p><p class="q2">Yes, Yahuah sits as King forever. 
 </p><p class="q1">
-<sup>11&#160;</sup>Yahweh will give strength to his people. 
-</p><p class="q2">Yahweh will bless his people with peace. 
+<sup>11&#160;</sup>Yahuah will give strength to his people. 
+</p><p class="q2">Yahuah will bless his people with peace. 
 </p><h2 class="psalmlabel" id="30">30</h2>
 <p class="d">A Psalm. A Song for the Dedication of the Temple. By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>I will extol you, Yahweh, for you have raised me up, 
+<sup>1&#160;</sup>I will extol you, Yahuah, for you have raised me up, 
 </p><p class="q2">and have not made my foes to rejoice over me. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh my Elohim, I cried to you, 
+<sup>2&#160;</sup>Yahuah my Elohim, I cried to you, 
 </p><p class="q2">and you have healed me. 
 </p><p class="q1">
-<sup>3&#160;</sup>Yahweh, you have brought up my soul from Sheol. 
+<sup>3&#160;</sup>Yahuah, you have brought up my soul from Sheol. 
 </p><p class="q2">You have kept me alive, that I should not go down to the pit. 
 </p><p class="q1">
-<sup>4&#160;</sup>Sing praise to Yahweh, you saints of his. 
+<sup>4&#160;</sup>Sing praise to Yahuah, you saints of his. 
 </p><p class="q2">Give thanks to his set-apart name. 
 </p><p class="q1">
 <sup>5&#160;</sup>For his anger is but for a moment. 
@@ -1560,28 +1560,28 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>As for me, I said in my prosperity, 
 </p><p class="q2">“I shall never be moved.” 
 </p><p class="q1">
-<sup>7&#160;</sup>You, Yahweh, when you favored me, made my mountain stand strong; 
+<sup>7&#160;</sup>You, Yahuah, when you favored me, made my mountain stand strong; 
 </p><p class="q2">but when you hid your face, I was troubled. 
 </p><p class="q1">
-<sup>8&#160;</sup>I cried to you, Yahweh. 
+<sup>8&#160;</sup>I cried to you, Yahuah. 
 </p><p class="q2">I made supplication to the Lord: 
 </p><p class="q1">
 <sup>9&#160;</sup>“What profit is there in my destruction, if I go down to the pit? 
 </p><p class="q2">Shall the dust praise you? 
 </p><p class="q2">Shall it declare your truth? 
 </p><p class="q1">
-<sup>10&#160;</sup>Hear, Yahweh, and have mercy on me. 
-</p><p class="q2">Yahweh, be my helper.” 
+<sup>10&#160;</sup>Hear, Yahuah, and have mercy on me. 
+</p><p class="q2">Yahuah, be my helper.” 
 </p><p class="q1">
 <sup>11&#160;</sup>You have turned my mourning into dancing for me. 
 </p><p class="q2">You have removed my sackcloth, and clothed me with gladness, 
 </p><p class="q2">
 <sup>12&#160;</sup>to the end that my heart may sing praise to you, and not be silent. 
-</p><p class="q1">Yahweh my Elohim, I will give thanks to you forever! 
+</p><p class="q1">Yahuah my Elohim, I will give thanks to you forever! 
 </p><h2 class="psalmlabel" id="31">31</h2>
 <p class="d">For the Chief Musician. A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>In you, Yahweh, I take refuge. 
+<sup>1&#160;</sup>In you, Yahuah, I take refuge. 
 </p><p class="q2">Let me never be disappointed. 
 </p><p class="q2">Deliver me in your righteousness. 
 </p><p class="q1">
@@ -1597,10 +1597,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for you are my stronghold. 
 </p><p class="q1">
 <sup>5&#160;</sup>Into your hand I commend my spirit. 
-</p><p class="q2">You redeem me, Yahweh, Elohim of truth. 
+</p><p class="q2">You redeem me, Yahuah, Elohim of truth. 
 </p><p class="q1">
 <sup>6&#160;</sup>I hate those who regard lying vanities, 
-</p><p class="q2">but I trust in Yahweh. 
+</p><p class="q2">but I trust in Yahuah. 
 </p><p class="q1">
 <sup>7&#160;</sup>I will be glad and rejoice in your loving kindness, 
 </p><p class="q2">for you have seen my affliction. 
@@ -1609,7 +1609,7 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>You have not shut me up into the hand of the enemy. 
 </p><p class="q2">You have set my feet in a large place. 
 </p><p class="q1">
-<sup>9&#160;</sup>Have mercy on me, Yahweh, for I am in distress. 
+<sup>9&#160;</sup>Have mercy on me, Yahuah, for I am in distress. 
 </p><p class="q2">My eye, my soul, and my body waste away with grief. 
 </p><p class="q1">
 <sup>10&#160;</sup>For my life is spent with sorrow, 
@@ -1628,7 +1628,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">while they conspire together against me, 
 </p><p class="q2">they plot to take away my life. 
 </p><p class="q1">
-<sup>14&#160;</sup>But I trust in you, Yahweh. 
+<sup>14&#160;</sup>But I trust in you, Yahuah. 
 </p><p class="q2">I said, “You are my Elohim.” 
 </p><p class="q1">
 <sup>15&#160;</sup>My times are in your hand. 
@@ -1637,7 +1637,7 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>Make your face to shine on your servant. 
 </p><p class="q2">Save me in your loving kindness. 
 </p><p class="q1">
-<sup>17&#160;</sup>Let me not be disappointed, Yahweh, for I have called on you. 
+<sup>17&#160;</sup>Let me not be disappointed, Yahuah, for I have called on you. 
 </p><p class="q2">Let the wicked be disappointed. 
 </p><p class="q2">Let them be silent in Sheol. 
 </p><p class="q1">
@@ -1652,25 +1652,25 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>In the shelter of your presence you will hide them from the plotting of man. 
 </p><p class="q2">You will keep them secretly in a dwelling away from the strife of tongues. 
 </p><p class="q1">
-<sup>21&#160;</sup>Praise be to Yahweh, 
+<sup>21&#160;</sup>Praise be to Yahuah, 
 </p><p class="q2">for he has shown me his marvelous loving kindness in a strong city. 
 </p><p class="q1">
 <sup>22&#160;</sup>As for me, I said in my haste, “I am cut off from before your eyes.” 
 </p><p class="q2">Nevertheless you heard the voice of my petitions when I cried to you. 
 </p><p class="q1">
-<sup>23&#160;</sup>Oh love Yahweh, all you his saints! 
-</p><p class="q2">Yahweh preserves the faithful, 
+<sup>23&#160;</sup>Oh love Yahuah, all you his saints! 
+</p><p class="q2">Yahuah preserves the faithful, 
 </p><p class="q1">and fully recompenses him who behaves arrogantly. 
 </p><p class="q1">
 <sup>24&#160;</sup>Be strong, and let your heart take courage, 
-</p><p class="q2">all you who hope in Yahweh. 
+</p><p class="q2">all you who hope in Yahuah. 
 </p><h2 class="psalmlabel" id="32">32</h2>
 <p class="d">By David. A contemplative psalm. 
 </p><p class="q1">
 <sup>1&#160;</sup>Blessed is he whose disobedience is forgiven, 
 </p><p class="q2">whose sin is covered. 
 </p><p class="q1">
-<sup>2&#160;</sup>Blessed is the man to whom Yahweh doesn’t impute iniquity, 
+<sup>2&#160;</sup>Blessed is the man to whom Yahuah doesn’t impute iniquity, 
 </p><p class="q2">in whose spirit there is no deceit. 
 </p><p class="q1">
 <sup>3&#160;</sup>When I kept silence, my bones wasted away through my groaning all day long. 
@@ -1680,7 +1680,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>5&#160;</sup>I acknowledged my sin to you. 
 </p><p class="q2">I didn’t hide my iniquity. 
-</p><p class="q1">I said, I will confess my transgressions to Yahweh, 
+</p><p class="q1">I said, I will confess my transgressions to Yahuah, 
 </p><p class="q2">and you forgave the iniquity of my sin. </p><p class="qs">Selah. 
 </p><p class="q1">
 <sup>6&#160;</sup>For this, let everyone who is elohimly pray to you in a time when you may be found. 
@@ -1697,49 +1697,49 @@ html[dir=ltr] .q2 {
 </p><p class="q2">who are controlled by bit and bridle, or else they will not come near to you. 
 </p><p class="q1">
 <sup>10&#160;</sup>Many sorrows come to the wicked, 
-</p><p class="q2">but loving kindness shall surround him who trusts in Yahweh. 
+</p><p class="q2">but loving kindness shall surround him who trusts in Yahuah. 
 </p><p class="q1">
-<sup>11&#160;</sup>Be glad in Yahweh, and rejoice, you righteous! 
+<sup>11&#160;</sup>Be glad in Yahuah, and rejoice, you righteous! 
 </p><p class="q2">Shout for joy, all you who are upright in heart! 
 </p><h2 class="psalmlabel" id="33">33</h2>
 <p class="q1">
-<sup>1&#160;</sup>Rejoice in Yahweh, you righteous! 
+<sup>1&#160;</sup>Rejoice in Yahuah, you righteous! 
 </p><p class="q2">Praise is fitting for the upright. 
 </p><p class="q1">
-<sup>2&#160;</sup>Give thanks to Yahweh with the lyre. 
+<sup>2&#160;</sup>Give thanks to Yahuah with the lyre. 
 </p><p class="q2">Sing praises to him with the harp of ten strings. 
 </p><p class="q1">
 <sup>3&#160;</sup>Sing to him a new song. 
 </p><p class="q2">Play skillfully with a shout of joy! 
 </p><p class="q1">
-<sup>4&#160;</sup>For Yahweh’s word is right. 
+<sup>4&#160;</sup>For Yahuah’s word is right. 
 </p><p class="q2">All his work is done in faithfulness. 
 </p><p class="q1">
 <sup>5&#160;</sup>He loves righteousness and justice. 
-</p><p class="q2">The earth is full of the loving kindness of Yahweh. 
+</p><p class="q2">The earth is full of the loving kindness of Yahuah. 
 </p><p class="q1">
-<sup>6&#160;</sup>By Yahweh’s word, the heavens were made: 
+<sup>6&#160;</sup>By Yahuah’s word, the heavens were made: 
 </p><p class="q2">all their army by the breath of his mouth. 
 </p><p class="q1">
 <sup>7&#160;</sup>He gathers the waters of the sea together as a heap. 
 </p><p class="q2">He lays up the deeps in storehouses. 
 </p><p class="q1">
-<sup>8&#160;</sup>Let all the earth fear Yahweh. 
+<sup>8&#160;</sup>Let all the earth fear Yahuah. 
 </p><p class="q2">Let all the inhabitants of the world stand in awe of him. 
 </p><p class="q1">
 <sup>9&#160;</sup>For he spoke, and it was done. 
 </p><p class="q2">He commanded, and it stood firm. 
 </p><p class="q1">
-<sup>10&#160;</sup>Yahweh brings the counsel of the nations to nothing. 
+<sup>10&#160;</sup>Yahuah brings the counsel of the nations to nothing. 
 </p><p class="q2">He makes the thoughts of the peoples to be of no effect. 
 </p><p class="q1">
-<sup>11&#160;</sup>The counsel of Yahweh stands fast forever, 
+<sup>11&#160;</sup>The counsel of Yahuah stands fast forever, 
 </p><p class="q2">the thoughts of his heart to all generations. 
 </p><p class="q1">
-<sup>12&#160;</sup>Blessed is the nation whose Elohim is Yahweh, 
+<sup>12&#160;</sup>Blessed is the nation whose Elohim is Yahuah, 
 </p><p class="q2">the people whom he has chosen for his own inheritance. 
 </p><p class="q1">
-<sup>13&#160;</sup>Yahweh looks from heaven. 
+<sup>13&#160;</sup>Yahuah looks from heaven. 
 </p><p class="q2">He sees all the sons of men. 
 </p><p class="q1">
 <sup>14&#160;</sup>From the place of his habitation he looks out on all the inhabitants of the earth, 
@@ -1753,56 +1753,56 @@ html[dir=ltr] .q2 {
 <sup>17&#160;</sup>A horse is a vain thing for safety, 
 </p><p class="q2">neither does he deliver any by his great power. 
 </p><p class="q1">
-<sup>18&#160;</sup>Behold, Yahweh’s eye is on those who fear him, 
+<sup>18&#160;</sup>Behold, Yahuah’s eye is on those who fear him, 
 </p><p class="q2">on those who hope in his loving kindness, 
 </p><p class="q2">
 <sup>19&#160;</sup>to deliver their soul from death, 
 </p><p class="q2">to keep them alive in famine. 
 </p><p class="q1">
-<sup>20&#160;</sup>Our soul has waited for Yahweh. 
+<sup>20&#160;</sup>Our soul has waited for Yahuah. 
 </p><p class="q2">He is our help and our shield. 
 </p><p class="q1">
 <sup>21&#160;</sup>For our heart rejoices in him, 
 </p><p class="q2">because we have trusted in his set-apart name. 
 </p><p class="q1">
-<sup>22&#160;</sup>Let your loving kindness be on us, Yahweh, 
+<sup>22&#160;</sup>Let your loving kindness be on us, Yahuah, 
 </p><p class="q2">since we have hoped in you. 
 </p><h2 class="psalmlabel" id="34">34</h2>
 <p class="d">By David; when he pretended to be insane before Abimelech, who drove him away, and he departed. 
 </p><p class="q1">
-<sup>1&#160;</sup> I will bless Yahweh at all times. 
+<sup>1&#160;</sup> I will bless Yahuah at all times. 
 </p><p class="q2">His praise will always be in my mouth. 
 </p><p class="q1">
-<sup>2&#160;</sup>My soul shall boast in Yahweh. 
+<sup>2&#160;</sup>My soul shall boast in Yahuah. 
 </p><p class="q2">The humble shall hear of it and be glad. 
 </p><p class="q1">
-<sup>3&#160;</sup>Oh magnify Yahweh with me. 
+<sup>3&#160;</sup>Oh magnify Yahuah with me. 
 </p><p class="q2">Let’s exalt his name together. 
 </p><p class="q1">
-<sup>4&#160;</sup>I sought Yahweh, and he answered me, 
+<sup>4&#160;</sup>I sought Yahuah, and he answered me, 
 </p><p class="q2">and delivered me from all my fears. 
 </p><p class="q1">
 <sup>5&#160;</sup>They looked to him, and were radiant. 
 </p><p class="q2">Their faces shall never be covered with shame. 
 </p><p class="q1">
-<sup>6&#160;</sup>This poor man cried, and Yahweh heard him, 
+<sup>6&#160;</sup>This poor man cried, and Yahuah heard him, 
 </p><p class="q2">and saved him out of all his troubles. 
 </p><p class="q1">
-<sup>7&#160;</sup>Yahweh’s angel encamps around those who fear him, 
+<sup>7&#160;</sup>Yahuah’s angel encamps around those who fear him, 
 </p><p class="q2">and delivers them. 
 </p><p class="q1">
-<sup>8&#160;</sup>Oh taste and see that Yahweh is good. 
+<sup>8&#160;</sup>Oh taste and see that Yahuah is good. 
 </p><p class="q2">Blessed is the man who takes refuge in him. 
 </p><p class="q1">
-<sup>9&#160;</sup>Oh fear Yahweh, you his saints, 
+<sup>9&#160;</sup>Oh fear Yahuah, you his saints, 
 </p><p class="q2">for there is no lack with those who fear him. 
 </p><p class="q1">
 <sup>10&#160;</sup>The young lions do lack, and suffer hunger, 
-</p><p class="q2">but those who seek Yahweh shall not lack any good thing. 
+</p><p class="q2">but those who seek Yahuah shall not lack any good thing. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>11&#160;</sup>Come, you children, listen to me. 
-</p><p class="q2">I will teach you the fear of Yahweh. 
+</p><p class="q2">I will teach you the fear of Yahuah. 
 </p><p class="q1">
 <sup>12&#160;</sup>Who is someone who desires life, 
 </p><p class="q2">and loves many days, that he may see good? 
@@ -1813,20 +1813,20 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>Depart from evil, and do good. 
 </p><p class="q2">Seek peace, and pursue it. 
 </p><p class="q1">
-<sup>15&#160;</sup>Yahweh’s eyes are toward the righteous. 
+<sup>15&#160;</sup>Yahuah’s eyes are toward the righteous. 
 </p><p class="q2">His ears listen to their cry. 
 </p><p class="q1">
-<sup>16&#160;</sup>Yahweh’s face is against those who do evil, 
+<sup>16&#160;</sup>Yahuah’s face is against those who do evil, 
 </p><p class="q2">to cut off their memory from the earth. 
 </p><p class="q1">
-<sup>17&#160;</sup>The righteous cry, and Yahweh hears, 
+<sup>17&#160;</sup>The righteous cry, and Yahuah hears, 
 </p><p class="q2">and delivers them out of all their troubles. 
 </p><p class="q1">
-<sup>18&#160;</sup>Yahweh is near to those who have a broken heart, 
+<sup>18&#160;</sup>Yahuah is near to those who have a broken heart, 
 </p><p class="q2">and saves those who have a crushed spirit. 
 </p><p class="q1">
 <sup>19&#160;</sup>Many are the afflictions of the righteous, 
-</p><p class="q2">but Yahweh delivers him out of them all. 
+</p><p class="q2">but Yahuah delivers him out of them all. 
 </p><p class="q1">
 <sup>20&#160;</sup>He protects all of his bones. 
 </p><p class="q2">Not one of them is broken. 
@@ -1834,12 +1834,12 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>Evil shall kill the wicked. 
 </p><p class="q2">Those who hate the righteous shall be condemned. 
 </p><p class="q1">
-<sup>22&#160;</sup>Yahweh redeems the soul of his servants. 
+<sup>22&#160;</sup>Yahuah redeems the soul of his servants. 
 </p><p class="q2">None of those who take refuge in him shall be condemned. 
 </p><h2 class="psalmlabel" id="35">35</h2>
 <p class="d">By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Contend, Yahweh, with those who contend with me. 
+<sup>1&#160;</sup>Contend, Yahuah, with those who contend with me. 
 </p><p class="q2">Fight against those who fight against me. 
 </p><p class="q1">
 <sup>2&#160;</sup>Take hold of shield and buckler, 
@@ -1852,10 +1852,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Let those who plot my ruin be turned back and confounded. 
 </p><p class="q1">
 <sup>5&#160;</sup>Let them be as chaff before the wind, 
-</p><p class="q2">Yahweh’s angel driving them on. 
+</p><p class="q2">Yahuah’s angel driving them on. 
 </p><p class="q1">
 <sup>6&#160;</sup>Let their way be dark and slippery, 
-</p><p class="q2">Yahweh’s angel pursuing them. 
+</p><p class="q2">Yahuah’s angel pursuing them. 
 </p><p class="q1">
 <sup>7&#160;</sup>For without cause they have hidden their net in a pit for me. 
 </p><p class="q2">Without cause they have dug a pit for my soul. 
@@ -1865,10 +1865,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Let him fall into that destruction. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>9&#160;</sup>My soul shall be joyful in Yahweh. 
+<sup>9&#160;</sup>My soul shall be joyful in Yahuah. 
 </p><p class="q2">It shall rejoice in his salvation. 
 </p><p class="q1">
-<sup>10&#160;</sup>All my bones shall say, “Yahweh, who is like you, 
+<sup>10&#160;</sup>All my bones shall say, “Yahuah, who is like you, 
 </p><p class="q2">who delivers the poor from him who is too strong for him; 
 </p><p class="q2">yes, the poor and the needy from him who robs him?” 
 </p><p class="q1">
@@ -1909,13 +1909,13 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>Yes, they opened their mouth wide against me. 
 </p><p class="q2">They said, “Aha! Aha! Our eye has seen it!” 
 </p><p class="q1">
-<sup>22&#160;</sup>You have seen it, Yahweh. Don’t keep silent. 
+<sup>22&#160;</sup>You have seen it, Yahuah. Don’t keep silent. 
 </p><p class="q2">Lord, don’t be far from me. 
 </p><p class="q1">
 <sup>23&#160;</sup>Wake up! Rise up to defend me, my Elohim! 
 </p><p class="q2">My Lord, contend for me! 
 </p><p class="q1">
-<sup>24&#160;</sup>Vindicate me, Yahweh my Elohim, according to your righteousness. 
+<sup>24&#160;</sup>Vindicate me, Yahuah my Elohim, according to your righteousness. 
 </p><p class="q2">Don’t let them gloat over me. 
 </p><p class="q1">
 <sup>25&#160;</sup>Don’t let them say in their heart, “Aha! That’s the way we want it!” 
@@ -1926,12 +1926,12 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>27&#160;</sup>Let those who favor my righteous cause shout for joy and be glad. 
-</p><p class="q2">Yes, let them say continually, “May Yahweh be magnified, 
+</p><p class="q2">Yes, let them say continually, “May Yahuah be magnified, 
 </p><p class="q2">who has pleasure in the prosperity of his servant!” 
 </p><p class="q1">
 <sup>28&#160;</sup>My tongue shall talk about your righteousness and about your praise all day long. 
 </p><h2 class="psalmlabel" id="36">36</h2>
-<p class="d">For the Chief Musician. By David, the servant of Yahweh. 
+<p class="d">For the Chief Musician. By David, the servant of Yahuah. 
 </p><p class="q1">
 <sup>1&#160;</sup>A revelation is within my heart about the disobedience of the wicked: 
 </p><p class="q2">There is no fear of Elohim before his eyes. 
@@ -1947,12 +1947,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He doesn’t abhor evil. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>5&#160;</sup>Your loving kindness, Yahweh, is in the heavens. 
+<sup>5&#160;</sup>Your loving kindness, Yahuah, is in the heavens. 
 </p><p class="q2">Your faithfulness reaches to the skies. 
 </p><p class="q1">
 <sup>6&#160;</sup>Your righteousness is like the mountains of Elohim. 
 </p><p class="q2">Your judgments are like a great deep. 
-</p><p class="q2">Yahweh, you preserve man and animal. 
+</p><p class="q2">Yahuah, you preserve man and animal. 
 </p><p class="q1">
 <sup>7&#160;</sup>How precious is your loving kindness, Elohim! 
 </p><p class="q2">The children of men take refuge under the shadow of your wings. 
@@ -1980,19 +1980,19 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>For they shall soon be cut down like the grass, 
 </p><p class="q2">and wither like the green herb. 
 </p><p class="q1">
-<sup>3&#160;</sup>Trust in Yahweh, and do good. 
+<sup>3&#160;</sup>Trust in Yahuah, and do good. 
 </p><p class="q2">Dwell in the land, and enjoy safe pasture. 
 </p><p class="q1">
-<sup>4&#160;</sup>Also delight yourself in Yahweh, 
+<sup>4&#160;</sup>Also delight yourself in Yahuah, 
 </p><p class="q2">and he will give you the desires of your heart. 
 </p><p class="q1">
-<sup>5&#160;</sup>Commit your way to Yahweh. 
+<sup>5&#160;</sup>Commit your way to Yahuah. 
 </p><p class="q2">Trust also in him, and he will do this: 
 </p><p class="q1">
 <sup>6&#160;</sup>he will make your righteousness shine out like light, 
 </p><p class="q2">and your justice as the noon day sun. 
 </p><p class="q1">
-<sup>7&#160;</sup>Rest in Yahweh, and wait patiently for him. 
+<sup>7&#160;</sup>Rest in Yahuah, and wait patiently for him. 
 </p><p class="q2">Don’t fret because of him who prospers in his way, 
 </p><p class="q2">because of the man who makes wicked plots happen. 
 </p><p class="q1">
@@ -2000,7 +2000,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Don’t fret; it leads only to evildoing. 
 </p><p class="q1">
 <sup>9&#160;</sup>For evildoers shall be cut off, 
-</p><p class="q2">but those who wait for Yahweh shall inherit the land. 
+</p><p class="q2">but those who wait for Yahuah shall inherit the land. 
 </p><p class="q1">
 <sup>10&#160;</sup>For yet a little while, and the wicked will be no more. 
 </p><p class="q2">Yes, though you look for his place, he isn’t there. 
@@ -2025,9 +2025,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">than the abundance of many wicked. 
 </p><p class="q1">
 <sup>17&#160;</sup>For the arms of the wicked shall be broken, 
-</p><p class="q2">but Yahweh upholds the righteous. 
+</p><p class="q2">but Yahuah upholds the righteous. 
 </p><p class="q1">
-<sup>18&#160;</sup>Yahweh knows the days of the perfect. 
+<sup>18&#160;</sup>Yahuah knows the days of the perfect. 
 </p><p class="q2">Their inheritance shall be forever. 
 </p><p class="q1">
 <sup>19&#160;</sup>They shall not be disappointed in the time of evil. 
@@ -2035,7 +2035,7 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>20&#160;</sup>But the wicked shall perish. 
-</p><p class="q2">The enemies of Yahweh shall be like the beauty of the fields. 
+</p><p class="q2">The enemies of Yahuah shall be like the beauty of the fields. 
 </p><p class="q2">They will vanish—</p><p class="q2">vanish like smoke. 
 </p><p class="q1">
 <sup>21&#160;</sup>The wicked borrow, and don’t pay back, 
@@ -2044,11 +2044,11 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>For such as are blessed by him shall inherit the land. 
 </p><p class="q2">Those who are cursed by him shall be cut off. 
 </p><p class="q1">
-<sup>23&#160;</sup>A man’s steps are established by Yahweh. 
+<sup>23&#160;</sup>A man’s steps are established by Yahuah. 
 </p><p class="q2">He delights in his way. 
 </p><p class="q1">
 <sup>24&#160;</sup>Though he stumble, he shall not fall, 
-</p><p class="q2">for Yahweh holds him up with his hand. 
+</p><p class="q2">for Yahuah holds him up with his hand. 
 </p><p class="q1">
 <sup>25&#160;</sup>I have been young, and now am old, 
 </p><p class="q2">yet I have not seen the righteous forsaken, 
@@ -2060,7 +2060,7 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>Depart from evil, and do good. 
 </p><p class="q2">Live securely forever. 
 </p><p class="q1">
-<sup>28&#160;</sup>For Yahweh loves justice, 
+<sup>28&#160;</sup>For Yahuah loves justice, 
 </p><p class="q2">and doesn’t forsake his saints. 
 </p><p class="q2">They are preserved forever, 
 </p><p class="q2">but the children of the wicked shall be cut off. 
@@ -2078,10 +2078,10 @@ html[dir=ltr] .q2 {
 <sup>32&#160;</sup>The wicked watch the righteous, 
 </p><p class="q2">and seek to kill him. 
 </p><p class="q1">
-<sup>33&#160;</sup>Yahweh will not leave him in his hand, 
+<sup>33&#160;</sup>Yahuah will not leave him in his hand, 
 </p><p class="q2">nor condemn him when he is judged. 
 </p><p class="q1">
-<sup>34&#160;</sup>Wait for Yahweh, and keep his way, 
+<sup>34&#160;</sup>Wait for Yahuah, and keep his way, 
 </p><p class="q2">and he will exalt you to inherit the land. 
 </p><p class="q2">When the wicked are cut off, you shall see it. 
 </p><p class="b"> &#160; </p>
@@ -2098,16 +2098,16 @@ html[dir=ltr] .q2 {
 <sup>38&#160;</sup>As for transgressors, they shall be destroyed together. 
 </p><p class="q2">The future of the wicked shall be cut off. 
 </p><p class="q1">
-<sup>39&#160;</sup>But the salvation of the righteous is from Yahweh. 
+<sup>39&#160;</sup>But the salvation of the righteous is from Yahuah. 
 </p><p class="q2">He is their stronghold in the time of trouble. 
 </p><p class="q1">
-<sup>40&#160;</sup>Yahweh helps them and rescues them. 
+<sup>40&#160;</sup>Yahuah helps them and rescues them. 
 </p><p class="q2">He rescues them from the wicked and saves them, 
 </p><p class="q2">because they have taken refuge in him. 
 </p><h2 class="psalmlabel" id="38">38</h2>
 <p class="d">A Psalm by David, for a memorial. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, don’t rebuke me in your wrath, 
+<sup>1&#160;</sup>Yahuah, don’t rebuke me in your wrath, 
 </p><p class="q2">neither chasten me in your hot displeasure. 
 </p><p class="q1">
 <sup>2&#160;</sup>For your arrows have pierced me, 
@@ -2151,7 +2151,7 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>Yes, I am as a man who doesn’t hear, 
 </p><p class="q2">in whose mouth are no reproofs. 
 </p><p class="q1">
-<sup>15&#160;</sup>For I hope in you, Yahweh. 
+<sup>15&#160;</sup>For I hope in you, Yahuah. 
 </p><p class="q2">You will answer, Lord my Elohim. 
 </p><p class="q1">
 <sup>16&#160;</sup>For I said, “Don’t let them gloat over me, 
@@ -2169,7 +2169,7 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>They who render evil for good are also adversaries to me, 
 </p><p class="q2">because I follow what is good. 
 </p><p class="q1">
-<sup>21&#160;</sup>Don’t forsake me, Yahweh. 
+<sup>21&#160;</sup>Don’t forsake me, Yahuah. 
 </p><p class="q2">My Elohim, don’t be far from me. 
 </p><p class="q1">
 <sup>22&#160;</sup>Hurry to help me, 
@@ -2188,7 +2188,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">While I meditated, the fire burned. 
 </p><p class="q1">I spoke with my tongue: 
 </p><p class="q2">
-<sup>4&#160;</sup>“Yahweh, show me my end, 
+<sup>4&#160;</sup>“Yahuah, show me my end, 
 </p><p class="q2">what is the measure of my days. 
 </p><p class="q2">Let me know how frail I am. 
 </p><p class="q1">
@@ -2217,7 +2217,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">you consume his wealth like a moth. 
 </p><p class="q1">Surely every man is but a breath.” </p><p class="qs">Selah. 
 </p><p class="q1">
-<sup>12&#160;</sup>“Hear my prayer, Yahweh, and give ear to my cry. 
+<sup>12&#160;</sup>“Hear my prayer, Yahuah, and give ear to my cry. 
 </p><p class="q2">Don’t be silent at my tears. 
 </p><p class="q1">For I am a stranger with you, 
 </p><p class="q2">a foreigner, as all my fathers were. 
@@ -2227,7 +2227,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="40">40</h2>
 <p class="d">For the Chief Musician. A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>I waited patiently for Yahweh. 
+<sup>1&#160;</sup>I waited patiently for Yahuah. 
 </p><p class="q2">He turned to me, and heard my cry. 
 </p><p class="q1">
 <sup>2&#160;</sup>He brought me up also out of a horrible pit, 
@@ -2236,12 +2236,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and gave me a firm place to stand. 
 </p><p class="q1">
 <sup>3&#160;</sup>He has put a new song in my mouth, even praise to our Elohim. 
-</p><p class="q2">Many shall see it, and fear, and shall trust in Yahweh. 
+</p><p class="q2">Many shall see it, and fear, and shall trust in Yahuah. 
 </p><p class="q1">
-<sup>4&#160;</sup>Blessed is the man who makes Yahweh his trust, 
+<sup>4&#160;</sup>Blessed is the man who makes Yahuah his trust, 
 </p><p class="q2">and doesn’t respect the proud, nor such as turn away to lies. 
 </p><p class="q1">
-<sup>5&#160;</sup>Many, Yahweh, my Elohim, are the wonderful works which you have done, 
+<sup>5&#160;</sup>Many, Yahuah, my Elohim, are the wonderful works which you have done, 
 </p><p class="q2">and your thoughts which are toward us. 
 </p><p class="q1">They can’t be declared back to you. 
 </p><p class="q2">If I would declare and speak of them, they are more than can be counted. 
@@ -2257,13 +2257,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Yes, your law is within my heart.” 
 </p><p class="q1">
 <sup>9&#160;</sup>I have proclaimed glad news of righteousness in the great assembly. 
-</p><p class="q2">Behold, I will not seal my lips, Yahweh, you know. 
+</p><p class="q2">Behold, I will not seal my lips, Yahuah, you know. 
 </p><p class="q1">
 <sup>10&#160;</sup>I have not hidden your righteousness within my heart. 
 </p><p class="q2">I have declared your faithfulness and your salvation. 
 </p><p class="q2">I have not concealed your loving kindness and your truth from the great assembly. 
 </p><p class="q1">
-<sup>11&#160;</sup>Don’t withhold your tender mercies from me, Yahweh. 
+<sup>11&#160;</sup>Don’t withhold your tender mercies from me, Yahuah. 
 </p><p class="q2">Let your loving kindness and your truth continually preserve me. 
 </p><p class="q1">
 <sup>12&#160;</sup>For innumerable evils have surrounded me. 
@@ -2271,8 +2271,8 @@ html[dir=ltr] .q2 {
 </p><p class="q1">They are more than the hairs of my head. 
 </p><p class="q2">My heart has failed me. 
 </p><p class="q1">
-<sup>13&#160;</sup>Be pleased, Yahweh, to deliver me. 
-</p><p class="q2">Hurry to help me, Yahweh. 
+<sup>13&#160;</sup>Be pleased, Yahuah, to deliver me. 
+</p><p class="q2">Hurry to help me, Yahuah. 
 </p><p class="q1">
 <sup>14&#160;</sup>Let them be disappointed and confounded together who seek after my soul to destroy it. 
 </p><p class="q2">Let them be turned backward and brought to dishonor who delight in my hurt. 
@@ -2280,7 +2280,7 @@ html[dir=ltr] .q2 {
 <sup>15&#160;</sup>Let them be desolate by reason of their shame that tell me, “Aha! Aha!” 
 </p><p class="q1">
 <sup>16&#160;</sup>Let all those who seek you rejoice and be glad in you. 
-</p><p class="q2">Let such as love your salvation say continually, “Let Yahweh be exalted!” 
+</p><p class="q2">Let such as love your salvation say continually, “Let Yahuah be exalted!” 
 </p><p class="q1">
 <sup>17&#160;</sup>But I am poor and needy. 
 </p><p class="q2">May the Lord think about me. 
@@ -2290,16 +2290,16 @@ html[dir=ltr] .q2 {
 <p class="d">For the Chief Musician. A Psalm by David. 
 </p><p class="q1">
 <sup>1&#160;</sup>Blessed is he who considers the poor. 
-</p><p class="q2">Yahweh will deliver him in the day of evil. 
+</p><p class="q2">Yahuah will deliver him in the day of evil. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh will preserve him, and keep him alive. 
+<sup>2&#160;</sup>Yahuah will preserve him, and keep him alive. 
 </p><p class="q2">He shall be blessed on the earth, 
 </p><p class="q2">and he will not surrender him to the will of his enemies. 
 </p><p class="q1">
-<sup>3&#160;</sup>Yahweh will sustain him on his sickbed, 
+<sup>3&#160;</sup>Yahuah will sustain him on his sickbed, 
 </p><p class="q2">and restore him from his bed of illness. 
 </p><p class="q1">
-<sup>4&#160;</sup>I said, “Yahweh, have mercy on me! 
+<sup>4&#160;</sup>I said, “Yahuah, have mercy on me! 
 </p><p class="q2">Heal me, for I have sinned against you.” 
 </p><p class="q1">
 <sup>5&#160;</sup>My enemies speak evil against me: 
@@ -2320,7 +2320,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">has lifted up his heel against me. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>10&#160;</sup>But you, Yahweh, have mercy on me, and raise me up, 
+<sup>10&#160;</sup>But you, Yahuah, have mercy on me, and raise me up, 
 </p><p class="q2">that I may repay them. 
 </p><p class="q1">
 <sup>11&#160;</sup>By this I know that you delight in me, 
@@ -2330,7 +2330,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and set me in your presence forever. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>13&#160;</sup>Blessed be Yahweh, the Elohim of Israel, 
+<sup>13&#160;</sup>Blessed be Yahuah, the Elohim of Israel, 
 </p><p class="q2">from everlasting and to everlasting! 
 </p><p class="q1">Amen and amen. 
 </p><h2 class="ms1">BOOK 2</h2>
@@ -2363,7 +2363,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">All your waves and your billows have swept over me. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>8&#160;</sup>Yahweh will command his loving kindness in the daytime. 
+<sup>8&#160;</sup>Yahuah will command his loving kindness in the daytime. 
 </p><p class="q2">In the night his song shall be with me: 
 </p><p class="q2">a prayer to the Elohim of my life. 
 </p><p class="q1">
@@ -2565,11 +2565,11 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>The nations raged. The kingdoms were moved. 
 </p><p class="q2">He lifted his voice and the earth melted. 
 </p><p class="q1">
-<sup>7&#160;</sup>Yahweh of Armies is with us. 
+<sup>7&#160;</sup>Yahuah of Armies is with us. 
 </p><p class="q2">The Elohim of Jacob is our refuge. </p><p class="qs">Selah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>8&#160;</sup>Come, see Yahweh’s works, 
+<sup>8&#160;</sup>Come, see Yahuah’s works, 
 </p><p class="q2">what desolations he has made in the earth. 
 </p><p class="q1">
 <sup>9&#160;</sup>He makes wars cease to the end of the earth. 
@@ -2580,7 +2580,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I will be exalted among the nations. 
 </p><p class="q2">I will be exalted in the earth.” 
 </p><p class="q1">
-<sup>11&#160;</sup>Yahweh of Armies is with us. 
+<sup>11&#160;</sup>Yahuah of Armies is with us. 
 </p><p class="q2">The Elohim of Jacob is our refuge. </p><p class="qs">Selah. 
 </p><p class="b"> &#160; </p>
 <h2 class="psalmlabel" id="47">47</h2>
@@ -2589,7 +2589,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>Oh clap your hands, all you nations. 
 </p><p class="q2">Shout to Elohim with the voice of triumph! 
 </p><p class="q1">
-<sup>2&#160;</sup>For Yahweh Most High is awesome. 
+<sup>2&#160;</sup>For Yahuah Most High is awesome. 
 </p><p class="q2">He is a great King over all the earth. 
 </p><p class="q1">
 <sup>3&#160;</sup>He subdues nations under us, 
@@ -2599,7 +2599,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the glory of Jacob whom he loved. </p><p class="qs">Selah. 
 </p><p class="q1">
 <sup>5&#160;</sup>Elohim has gone up with a shout, 
-</p><p class="q2">Yahweh with the sound of a trumpet. 
+</p><p class="q2">Yahuah with the sound of a trumpet. 
 </p><p class="q1">
 <sup>6&#160;</sup>Sing praises to Elohim! Sing praises! 
 </p><p class="q2">Sing praises to our King! Sing praises! 
@@ -2617,7 +2617,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="48">48</h2>
 <p class="d">A Song. A Psalm by the sons of Korah. 
 </p><p class="q1">
-<sup>1&#160;</sup>Great is Yahweh, and greatly to be praised, 
+<sup>1&#160;</sup>Great is Yahuah, and greatly to be praised, 
 </p><p class="q2">in the city of our Elohim, in his set-apart mountain. 
 </p><p class="q1">
 <sup>2&#160;</sup>Beautiful in elevation, the joy of the whole earth, 
@@ -2639,7 +2639,7 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>With the east wind, you break the ships of Tarshish. 
 </p><p class="q1">
 <sup>8&#160;</sup>As we have heard, so we have seen, 
-</p><p class="q2">in the city of Yahweh of Armies, in the city of our Elohim. 
+</p><p class="q2">in the city of Yahuah of Armies, in the city of our Elohim. 
 </p><p class="q1">Elohim will establish it forever. </p><p class="qs">Selah. 
 </p><p class="q1">
 <sup>9&#160;</sup>We have thought about your loving kindness, Elohim, 
@@ -2729,7 +2729,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="50">50</h2>
 <p class="d">A Psalm by Asaph. 
 </p><p class="q1">
-<sup>1&#160;</sup>The Mighty One, Elohim, Yahweh, speaks, 
+<sup>1&#160;</sup>The Mighty One, Elohim, Yahuah, speaks, 
 </p><p class="q2">and calls the earth from sunrise to sunset. 
 </p><p class="q1">
 <sup>2&#160;</sup>Out of Zion, the perfection of beauty, 
@@ -2947,7 +2947,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Destroy them in your truth. 
 </p><p class="q1">
 <sup>6&#160;</sup>With a free will offering, I will sacrifice to you. 
-</p><p class="q2">I will give thanks to your name, Yahweh, for it is good. 
+</p><p class="q2">I will give thanks to your name, Yahuah, for it is good. 
 </p><p class="q1">
 <sup>7&#160;</sup>For he has delivered me out of all trouble. 
 </p><p class="q2">My eye has seen triumph over my enemies. 
@@ -3004,7 +3004,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">For wickedness is among them, in their dwelling. 
 </p><p class="q1">
 <sup>16&#160;</sup>As for me, I will call on Elohim. 
-</p><p class="q2">Yahweh will save me. 
+</p><p class="q2">Yahuah will save me. 
 </p><p class="q1">
 <sup>17&#160;</sup>Evening, morning, and at noon, I will cry out in distress. 
 </p><p class="q2">He will hear my voice. 
@@ -3027,7 +3027,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">yet they were drawn swords. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>22&#160;</sup>Cast your burden on Yahweh and he will sustain you. 
+<sup>22&#160;</sup>Cast your burden on Yahuah and he will sustain you. 
 </p><p class="q2">He will never allow the righteous to be moved. 
 </p><p class="q1">
 <sup>23&#160;</sup>But you, Elohim, will bring them down into the pit of destruction. 
@@ -3068,7 +3068,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I know this: that Elohim is for me. 
 </p><p class="q1">
 <sup>10&#160;</sup>In Elohim, I will praise his word. 
-</p><p class="q2">In Yahweh, I will praise his word. 
+</p><p class="q2">In Yahuah, I will praise his word. 
 </p><p class="q1">
 <sup>11&#160;</sup>I have put my trust in Elohim. 
 </p><p class="q2">I will not be afraid. 
@@ -3143,7 +3143,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">no matter how skillful the charmer may be. 
 </p><p class="q1">
 <sup>6&#160;</sup>Break their teeth, Elohim, in their mouth. 
-</p><p class="q2">Break out the great teeth of the young lions, Yahweh. 
+</p><p class="q2">Break out the great teeth of the young lions, Yahuah. 
 </p><p class="q1">
 <sup>7&#160;</sup>Let them vanish like water that flows away. 
 </p><p class="q2">When they draw the bow, let their arrows be made blunt. 
@@ -3170,12 +3170,12 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>3&#160;</sup>For, behold, they lie in wait for my soul. 
 </p><p class="q2">The mighty gather themselves together against me, 
-</p><p class="q2">not for my disobedience, nor for my sin, Yahweh. 
+</p><p class="q2">not for my disobedience, nor for my sin, Yahuah. 
 </p><p class="q1">
 <sup>4&#160;</sup>I have done no wrong, yet they are ready to attack me. 
 </p><p class="q2">Rise up, behold, and help me! 
 </p><p class="q1">
-<sup>5&#160;</sup>You, Yahweh Elohim of Armies, the Elohim of Israel, 
+<sup>5&#160;</sup>You, Yahuah Elohim of Armies, the Elohim of Israel, 
 </p><p class="q2">rouse yourself to punish the nations. 
 </p><p class="q2">Show no mercy to the wicked traitors. </p><p class="qs">Selah. 
 </p><p class="q1">
@@ -3186,7 +3186,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Swords are in their lips, 
 </p><p class="q2">“For”, they say, “who hears us?” 
 </p><p class="q1">
-<sup>8&#160;</sup>But you, Yahweh, laugh at them. 
+<sup>8&#160;</sup>But you, Yahuah, laugh at them. 
 </p><p class="q2">You scoff at all the nations. 
 </p><p class="q1">
 <sup>9&#160;</sup>Oh, my Strength, I watch for you, 
@@ -3412,7 +3412,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They shall declare the work of Elohim, 
 </p><p class="q2">and shall wisely ponder what he has done. 
 </p><p class="q1">
-<sup>10&#160;</sup>The righteous shall be glad in Yahweh, 
+<sup>10&#160;</sup>The righteous shall be glad in Yahuah, 
 </p><p class="q2">and shall take refuge in him. 
 </p><p class="q2">All the upright in heart shall praise him! 
 </p><h2 class="psalmlabel" id="65">65</h2>
@@ -3614,7 +3614,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>16&#160;</sup>Why do you look in envy, you rugged mountains, 
 </p><p class="q2">at the mountain where Elohim chooses to reign? 
-</p><p class="q2">Yes, Yahweh will dwell there forever. 
+</p><p class="q2">Yes, Yahuah will dwell there forever. 
 </p><p class="q1">
 <sup>17&#160;</sup>The chariots of Elohim are tens of thousands and thousands of thousands. 
 </p><p class="q2">The Lord is among them, from Sinai, into the sanctuary. 
@@ -3629,7 +3629,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">even the Elohim who is our salvation. </p><p class="qs">Selah. 
 </p><p class="q1">
 <sup>20&#160;</sup>Elohim is to us an Elohim of deliverance. 
-</p><p class="q2">To Yahweh, the Lord, belongs escape from death. 
+</p><p class="q2">To Yahuah, the Lord, belongs escape from death. 
 </p><p class="q1">
 <sup>21&#160;</sup>But Elohim will strike through the head of his enemies, 
 </p><p class="q2">the hairy scalp of such a one as still continues in his guiltiness. 
@@ -3699,7 +3699,7 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>Elohim, you know my foolishness. 
 </p><p class="q2">My sins aren’t hidden from you. 
 </p><p class="q1">
-<sup>6&#160;</sup>Don’t let those who wait for you be shamed through me, Lord Yahweh of Armies. 
+<sup>6&#160;</sup>Don’t let those who wait for you be shamed through me, Lord Yahuah of Armies. 
 </p><p class="q2">Don’t let those who seek you be brought to dishonor through me, Elohim of Israel. 
 </p><p class="q1">
 <sup>7&#160;</sup>Because for your sake, I have borne reproach. 
@@ -3720,7 +3720,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Those who sit in the gate talk about me. 
 </p><p class="q2">I am the song of the drunkards. 
 </p><p class="q1">
-<sup>13&#160;</sup>But as for me, my prayer is to you, Yahweh, in an acceptable time. 
+<sup>13&#160;</sup>But as for me, my prayer is to you, Yahuah, in an acceptable time. 
 </p><p class="q2">Elohim, in the abundance of your loving kindness, answer me in the truth of your salvation. 
 </p><p class="q1">
 <sup>14&#160;</sup>Deliver me out of the mire, and don’t let me sink. 
@@ -3730,7 +3730,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">neither let the deep swallow me up. 
 </p><p class="q2">Don’t let the pit shut its mouth on me. 
 </p><p class="q1">
-<sup>16&#160;</sup>Answer me, Yahweh, for your loving kindness is good. 
+<sup>16&#160;</sup>Answer me, Yahuah, for your loving kindness is good. 
 </p><p class="q2">According to the multitude of your tender mercies, turn to me. 
 </p><p class="q1">
 <sup>17&#160;</sup>Don’t hide your face from your servant, 
@@ -3777,13 +3777,13 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>I will praise the name of Elohim with a song, 
 </p><p class="q2">and will magnify him with thanksgiving. 
 </p><p class="q1">
-<sup>31&#160;</sup>It will please Yahweh better than an ox, 
+<sup>31&#160;</sup>It will please Yahuah better than an ox, 
 </p><p class="q2">or a bull that has horns and hoofs. 
 </p><p class="q1">
 <sup>32&#160;</sup>The humble have seen it, and are glad. 
 </p><p class="q2">You who seek after Elohim, let your heart live. 
 </p><p class="q1">
-<sup>33&#160;</sup>For Yahweh hears the needy, 
+<sup>33&#160;</sup>For Yahuah hears the needy, 
 </p><p class="q2">and doesn’t despise his captive people. 
 </p><p class="q1">
 <sup>34&#160;</sup>Let heaven and earth praise him; 
@@ -3798,7 +3798,7 @@ html[dir=ltr] .q2 {
 <p class="d">For the Chief Musician. By David. A reminder. 
 </p><p class="q1">
 <sup>1&#160;</sup>Hurry, Elohim, to deliver me. 
-</p><p class="q2">Come quickly to help me, Yahweh. 
+</p><p class="q2">Come quickly to help me, Yahuah. 
 </p><p class="q1">
 <sup>2&#160;</sup>Let them be disappointed and confounded who seek my soul. 
 </p><p class="q2">Let those who desire my ruin be turned back in disgrace. 
@@ -3813,11 +3813,11 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>But I am poor and needy. 
 </p><p class="q2">Come to me quickly, Elohim. 
 </p><p class="q1">You are my help and my deliverer. 
-</p><p class="q2">Yahweh, don’t delay. 
+</p><p class="q2">Yahuah, don’t delay. 
 </p><p class="b"> &#160; </p>
 <h2 class="psalmlabel" id="71">71</h2>
 <p class="q1">
-<sup>1&#160;</sup>In you, Yahweh, I take refuge. 
+<sup>1&#160;</sup>In you, Yahuah, I take refuge. 
 </p><p class="q2">Never let me be disappointed. 
 </p><p class="q1">
 <sup>2&#160;</sup>Deliver me in your righteousness, and rescue me. 
@@ -3830,7 +3830,7 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>Rescue me, my Elohim, from the hand of the wicked, 
 </p><p class="q2">from the hand of the unrighteous and cruel man. 
 </p><p class="q1">
-<sup>5&#160;</sup>For you are my hope, Lord Yahweh, 
+<sup>5&#160;</sup>For you are my hope, Lord Yahuah, 
 </p><p class="q2">my confidence from my youth. 
 </p><p class="q1">
 <sup>6&#160;</sup>I have relied on you from the womb. 
@@ -3865,7 +3865,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and of your salvation all day, 
 </p><p class="q2">though I don’t know its full measure. 
 </p><p class="q1">
-<sup>16&#160;</sup>I will come with the mighty acts of the Lord Yahweh. 
+<sup>16&#160;</sup>I will come with the mighty acts of the Lord Yahuah. 
 </p><p class="q2">I will make mention of your righteousness, even of yours alone. 
 </p><p class="q1">
 <sup>17&#160;</sup>Elohim, you have taught me from my youth. 
@@ -3955,7 +3955,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">All nations will call him blessed. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>18&#160;</sup>Praise be to Yahweh Elohim, the Elohim of Israel, 
+<sup>18&#160;</sup>Praise be to Yahuah Elohim, the Elohim of Israel, 
 </p><p class="q2">who alone does marvelous deeds. 
 </p><p class="q1">
 <sup>19&#160;</sup>Blessed be his glorious name forever! 
@@ -4049,7 +4049,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">You have destroyed all those who are unfaithful to you. 
 </p><p class="q1">
 <sup>28&#160;</sup>But it is good for me to come close to Elohim. 
-</p><p class="q2">I have made the Lord Yahweh my refuge, 
+</p><p class="q2">I have made the Lord Yahuah my refuge, 
 </p><p class="q2">that I may tell of all your works. 
 </p><p class="b"> &#160; </p>
 <h2 class="psalmlabel" id="74">74</h2>
@@ -4109,7 +4109,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">You have made summer and winter. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>18&#160;</sup>Remember this, that the enemy has mocked you, Yahweh. 
+<sup>18&#160;</sup>Remember this, that the enemy has mocked you, Yahuah. 
 </p><p class="q2">Foolish people have blasphemed your name. 
 </p><p class="q1">
 <sup>19&#160;</sup>Don’t deliver the soul of your dove to wild beasts. 
@@ -4153,7 +4153,7 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>But Elohim is the judge. 
 </p><p class="q2">He puts down one, and lifts up another. 
 </p><p class="q1">
-<sup>8&#160;</sup>For in Yahweh’s hand there is a cup, 
+<sup>8&#160;</sup>For in Yahuah’s hand there is a cup, 
 </p><p class="q2">full of foaming wine mixed with spices. 
 </p><p class="q1">He pours it out. 
 </p><p class="q2">Indeed the wicked of the earth drink and drink it to its very dregs. 
@@ -4199,7 +4199,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>Surely the wrath of man praises you. 
 </p><p class="q2">The survivors of your wrath are restrained. 
 </p><p class="q1">
-<sup>11&#160;</sup>Make vows to Yahweh your Elohim, and fulfill them! 
+<sup>11&#160;</sup>Make vows to Yahuah your Elohim, and fulfill them! 
 </p><p class="q2">Let all of his neighbors bring presents to him who is to be feared. 
 </p><p class="q1">
 <sup>12&#160;</sup>He will cut off the spirit of princes. 
@@ -4289,7 +4289,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and our fathers have told us. 
 </p><p class="q1">
 <sup>4&#160;</sup>We will not hide them from their children, 
-</p><p class="q2">telling to the generation to come the praises of Yahweh, 
+</p><p class="q2">telling to the generation to come the praises of Yahuah, 
 </p><p class="q2">his strength, and his wondrous deeds that he has done. 
 </p><p class="q1">
 <sup>5&#160;</sup>For he established a covenant in Jacob, 
@@ -4346,7 +4346,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Can he give bread also? 
 </p><p class="q2">Will he provide meat for his people?” 
 </p><p class="q1">
-<sup>21&#160;</sup>Therefore Yahweh heard, and was angry. 
+<sup>21&#160;</sup>Therefore Yahuah heard, and was angry. 
 </p><p class="q2">A fire was kindled against Jacob, 
 </p><p class="q2">anger also went up against Israel, 
 </p><p class="q1">
@@ -4525,7 +4525,7 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>We have become a reproach to our neighbors, 
 </p><p class="q2">a scoffing and derision to those who are around us. 
 </p><p class="q1">
-<sup>5&#160;</sup>How long, Yahweh? 
+<sup>5&#160;</sup>How long, Yahuah? 
 </p><p class="q2">Will you be angry forever? 
 </p><p class="q2">Will your jealousy burn like fire? 
 </p><p class="q1">
@@ -4571,7 +4571,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and we will be saved. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>4&#160;</sup>Yahweh Elohim of Armies, 
+<sup>4&#160;</sup>Yahuah Elohim of Armies, 
 </p><p class="q2">how long will you be angry against the prayer of your people? 
 </p><p class="q1">
 <sup>5&#160;</sup>You have fed them with the bread of tears, 
@@ -4619,7 +4619,7 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>So we will not turn away from you. 
 </p><p class="q2">Revive us, and we will call on your name. 
 </p><p class="q1">
-<sup>19&#160;</sup>Turn us again, Yahweh Elohim of Armies. 
+<sup>19&#160;</sup>Turn us again, Yahuah Elohim of Armies. 
 </p><p class="q2">Cause your face to shine, and we will be saved. 
 </p><h2 class="psalmlabel" id="81">81</h2>
 <p class="d">For the Chief Musician. On an instrument of Gath. By Asaph. 
@@ -4654,7 +4654,7 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>There shall be no strange elohim in you, 
 </p><p class="q2">neither shall you worship any foreign elohim. 
 </p><p class="q1">
-<sup>10&#160;</sup>I am Yahweh, your Elohim, 
+<sup>10&#160;</sup>I am Yahuah, your Elohim, 
 </p><p class="q2">who brought you up out of the land of Egypt. 
 </p><p class="q2">Open your mouth wide, and I will fill it. 
 </p><p class="q1">
@@ -4670,7 +4670,7 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>I would soon subdue their enemies, 
 </p><p class="q2">and turn my hand against their adversaries. 
 </p><p class="q1">
-<sup>15&#160;</sup>The haters of Yahweh would cringe before him, 
+<sup>15&#160;</sup>The haters of Yahuah would cringe before him, 
 </p><p class="q2">and their punishment would last forever. 
 </p><p class="q1">
 <sup>16&#160;</sup>But he would have also fed them with the finest of the wheat. 
@@ -4752,25 +4752,25 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and terrify them with your storm. 
 </p><p class="q1">
 <sup>16&#160;</sup>Fill their faces with confusion, 
-</p><p class="q2">that they may seek your name, Yahweh. 
+</p><p class="q2">that they may seek your name, Yahuah. 
 </p><p class="q1">
 <sup>17&#160;</sup>Let them be disappointed and dismayed forever. 
 </p><p class="q2">Yes, let them be confounded and perish; 
 </p><p class="q1">
-<sup>18&#160;</sup>that they may know that you alone, whose name is Yahweh, 
+<sup>18&#160;</sup>that they may know that you alone, whose name is Yahuah, 
 </p><p class="q2">are the Most High over all the earth. 
 </p><h2 class="psalmlabel" id="84">84</h2>
 <p class="d">For the Chief Musician. On an instrument of Gath. A Psalm by the sons of Korah. 
 </p><p class="q1">
 <sup>1&#160;</sup>How lovely are your dwellings, 
-</p><p class="q2">Yahweh of Armies! 
+</p><p class="q2">Yahuah of Armies! 
 </p><p class="q1">
-<sup>2&#160;</sup>My soul longs, and even faints for the courts of Yahweh. 
+<sup>2&#160;</sup>My soul longs, and even faints for the courts of Yahuah. 
 </p><p class="q2">My heart and my flesh cry out for the living Elohim. 
 </p><p class="q1">
 <sup>3&#160;</sup>Yes, the sparrow has found a home, 
 </p><p class="q2">and the swallow a nest for herself, where she may have her young, 
-</p><p class="q2">near your altars, Yahweh of Armies, my King, and my Elohim. 
+</p><p class="q2">near your altars, Yahuah of Armies, my King, and my Elohim. 
 </p><p class="q1">
 <sup>4&#160;</sup>Blessed are those who dwell in your house. 
 </p><p class="q2">They are always praising you. </p><p class="qs">Selah. 
@@ -4784,7 +4784,7 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>They go from strength to strength. 
 </p><p class="q2">Every one of them appears before Elohim in Zion. 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh, Elohim of Armies, hear my prayer. 
+<sup>8&#160;</sup>Yahuah, Elohim of Armies, hear my prayer. 
 </p><p class="q2">Listen, Elohim of Jacob. </p><p class="qs">Selah. 
 </p><p class="q1">
 <sup>9&#160;</sup>Behold, Elohim our shield, 
@@ -4794,16 +4794,16 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I would rather be a doorkeeper in the house of my Elohim, 
 </p><p class="q2">than to dwell in the tents of wickedness. 
 </p><p class="q1">
-<sup>11&#160;</sup>For Yahweh Elohim is a sun and a shield. 
-</p><p class="q2">Yahweh will give grace and glory. 
+<sup>11&#160;</sup>For Yahuah Elohim is a sun and a shield. 
+</p><p class="q2">Yahuah will give grace and glory. 
 </p><p class="q2">He withholds no good thing from those who walk blamelessly. 
 </p><p class="q1">
-<sup>12&#160;</sup>Yahweh of Armies, 
+<sup>12&#160;</sup>Yahuah of Armies, 
 </p><p class="q2">blessed is the man who trusts in you. 
 </p><h2 class="psalmlabel" id="85">85</h2>
 <p class="d">For the Chief Musician. A Psalm by the sons of Korah. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, you have been favorable to your land. 
+<sup>1&#160;</sup>Yahuah, you have been favorable to your land. 
 </p><p class="q2">You have restored the fortunes of Jacob. 
 </p><p class="q1">
 <sup>2&#160;</sup>You have forgiven the iniquity of your people. 
@@ -4821,10 +4821,10 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>Won’t you revive us again, 
 </p><p class="q2">that your people may rejoice in you? 
 </p><p class="q1">
-<sup>7&#160;</sup>Show us your loving kindness, Yahweh. 
+<sup>7&#160;</sup>Show us your loving kindness, Yahuah. 
 </p><p class="q2">Grant us your salvation. 
 </p><p class="q1">
-<sup>8&#160;</sup>I will hear what Elohim, Yahweh, will speak, 
+<sup>8&#160;</sup>I will hear what Elohim, Yahuah, will speak, 
 </p><p class="q2">for he will speak peace to his people, his saints; 
 </p><p class="q2">but let them not turn again to folly. 
 </p><p class="q1">
@@ -4837,7 +4837,7 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>Truth springs out of the earth. 
 </p><p class="q2">Righteousness has looked down from heaven. 
 </p><p class="q1">
-<sup>12&#160;</sup>Yes, Yahweh will give that which is good. 
+<sup>12&#160;</sup>Yes, Yahuah will give that which is good. 
 </p><p class="q2">Our land will yield its increase. 
 </p><p class="q1">
 <sup>13&#160;</sup>Righteousness goes before him, 
@@ -4845,7 +4845,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="86">86</h2>
 <p class="d">A Prayer by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Hear, Yahweh, and answer me, 
+<sup>1&#160;</sup>Hear, Yahuah, and answer me, 
 </p><p class="q2">for I am poor and needy. 
 </p><p class="q1">
 <sup>2&#160;</sup>Preserve my soul, for I am elohimly. 
@@ -4860,7 +4860,7 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>For you, Lord, are good, and ready to forgive, 
 </p><p class="q2">abundant in loving kindness to all those who call on you. 
 </p><p class="q1">
-<sup>6&#160;</sup>Hear, Yahweh, my prayer. 
+<sup>6&#160;</sup>Hear, Yahuah, my prayer. 
 </p><p class="q2">Listen to the voice of my petitions. 
 </p><p class="q1">
 <sup>7&#160;</sup>In the day of my trouble I will call on you, 
@@ -4875,7 +4875,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>For you are great, and do wondrous things. 
 </p><p class="q2">You are Elohim alone. 
 </p><p class="q1">
-<sup>11&#160;</sup>Teach me your way, Yahweh. 
+<sup>11&#160;</sup>Teach me your way, Yahuah. 
 </p><p class="q2">I will walk in your truth. 
 </p><p class="q2">Make my heart undivided to fear your name. 
 </p><p class="q1">
@@ -4898,13 +4898,13 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>17&#160;</sup>Show me a sign of your goodness, 
 </p><p class="q2">that those who hate me may see it, and be shamed, 
-</p><p class="q2">because you, Yahweh, have helped me, and comforted me. 
+</p><p class="q2">because you, Yahuah, have helped me, and comforted me. 
 </p><h2 class="psalmlabel" id="87">87</h2>
 <p class="d">A Psalm by the sons of Korah; a Song. 
 </p><p class="q1">
 <sup>1&#160;</sup>His foundation is in the set-apart mountains. 
 </p><p class="q2">
-<sup>2&#160;</sup>Yahweh loves the gates of Zion more than all the dwellings of Jacob. 
+<sup>2&#160;</sup>Yahuah loves the gates of Zion more than all the dwellings of Jacob. 
 </p><p class="q1">
 <sup>3&#160;</sup>Glorious things are spoken about you, city of Elohim. </p><p class="qs">Selah. 
 </p><p class="q1">
@@ -4915,7 +4915,7 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>Yes, of Zion it will be said, “This one and that one was born in her;” 
 </p><p class="q2">the Most High himself will establish her. 
 </p><p class="q1">
-<sup>6&#160;</sup>Yahweh will count, when he writes up the peoples, 
+<sup>6&#160;</sup>Yahuah will count, when he writes up the peoples, 
 </p><p class="q2">“This one was born there.” </p><p class="qs">Selah. 
 </p><p class="q1">
 <sup>7&#160;</sup>Those who sing as well as those who dance say, 
@@ -4923,7 +4923,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="88">88</h2>
 <p class="d">A Song. A Psalm by the sons of Korah. For the Chief Musician. To the tune of “The Suffering of Affliction.” A contemplation by Heman, the Ezrahite. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, the Elohim of my salvation, 
+<sup>1&#160;</sup>Yahuah, the Elohim of my salvation, 
 </p><p class="q2">I have cried day and night before you. 
 </p><p class="q1">
 <sup>2&#160;</sup>Let my prayer enter into your presence. 
@@ -4951,7 +4951,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I am confined, and I can’t escape. 
 </p><p class="q1">
 <sup>9&#160;</sup>My eyes are dim from grief. 
-</p><p class="q2">I have called on you daily, Yahweh. 
+</p><p class="q2">I have called on you daily, Yahuah. 
 </p><p class="q2">I have spread out my hands to you. 
 </p><p class="q1">
 <sup>10&#160;</sup>Do you show wonders to the dead? 
@@ -4963,10 +4963,10 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Are your wonders made known in the dark? 
 </p><p class="q2">Or your righteousness in the land of forgetfulness? 
 </p><p class="q1">
-<sup>13&#160;</sup>But to you, Yahweh, I have cried. 
+<sup>13&#160;</sup>But to you, Yahuah, I have cried. 
 </p><p class="q2">In the morning, my prayer comes before you. 
 </p><p class="q1">
-<sup>14&#160;</sup>Yahweh, why do you reject my soul? 
+<sup>14&#160;</sup>Yahuah, why do you reject my soul? 
 </p><p class="q2">Why do you hide your face from me? 
 </p><p class="q1">
 <sup>15&#160;</sup>I am afflicted and ready to die from my youth up. 
@@ -4983,7 +4983,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="89">89</h2>
 <p class="d">A contemplation by Ethan, the Ezrahite. 
 </p><p class="q1">
-<sup>1&#160;</sup>I will sing of the loving kindness of Yahweh forever. 
+<sup>1&#160;</sup>I will sing of the loving kindness of Yahuah forever. 
 </p><p class="q2">With my mouth, I will make known your faithfulness to all generations. 
 </p><p class="q1">
 <sup>2&#160;</sup>I indeed declare, “Love stands firm forever. 
@@ -4997,16 +4997,16 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>‘I will establish your offspring forever, 
 </p><p class="q2">and build up your throne to all generations.’&#160;” </p><p class="qs">Selah. 
 </p><p class="q1">
-<sup>5&#160;</sup>The heavens will praise your wonders, Yahweh, 
+<sup>5&#160;</sup>The heavens will praise your wonders, Yahuah, 
 </p><p class="q2">your faithfulness also in the assembly of the set-apart ones. 
 </p><p class="q1">
-<sup>6&#160;</sup>For who in the skies can be compared to Yahweh? 
-</p><p class="q2">Who among the sons of the heavenly beings is like Yahweh, 
+<sup>6&#160;</sup>For who in the skies can be compared to Yahuah? 
+</p><p class="q2">Who among the sons of the heavenly beings is like Yahuah, 
 </p><p class="q1">
 <sup>7&#160;</sup>a very awesome Elohim in the council of the set-apart ones, 
 </p><p class="q2">to be feared above all those who are around him? 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh, Elohim of Armies, who is a mighty one, like you? 
+<sup>8&#160;</sup>Yahuah, Elohim of Armies, who is a mighty one, like you? 
 </p><p class="q2">Yah, your faithfulness is around you. 
 </p><p class="q1">
 <sup>9&#160;</sup>You rule the pride of the sea. 
@@ -5030,7 +5030,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Loving kindness and truth go before your face. 
 </p><p class="q1">
 <sup>15&#160;</sup>Blessed are the people who learn to acclaim you. 
-</p><p class="q2">They walk in the light of your presence, Yahweh. 
+</p><p class="q2">They walk in the light of your presence, Yahuah. 
 </p><p class="q1">
 <sup>16&#160;</sup>In your name they rejoice all day. 
 </p><p class="q2">In your righteousness, they are exalted. 
@@ -5038,7 +5038,7 @@ html[dir=ltr] .q2 {
 <sup>17&#160;</sup>For you are the glory of their strength. 
 </p><p class="q2">In your favor, our horn will be exalted. 
 </p><p class="q1">
-<sup>18&#160;</sup>For our shield belongs to Yahweh, 
+<sup>18&#160;</sup>For our shield belongs to Yahuah, 
 </p><p class="q2">our king to the Set-Apart One of Israel. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -5125,7 +5125,7 @@ html[dir=ltr] .q2 {
 <sup>45&#160;</sup>You have shortened the days of his youth. 
 </p><p class="q2">You have covered him with shame. </p><p class="qs">Selah. 
 </p><p class="q1">
-<sup>46&#160;</sup>How long, Yahweh? 
+<sup>46&#160;</sup>How long, Yahuah? 
 </p><p class="q2">Will you hide yourself forever? 
 </p><p class="q2">Will your wrath burn like fire? 
 </p><p class="q1">
@@ -5141,11 +5141,11 @@ html[dir=ltr] .q2 {
 <sup>50&#160;</sup>Remember, Lord, the reproach of your servants, 
 </p><p class="q2">how I bear in my heart the taunts of all the mighty peoples, 
 </p><p class="q1">
-<sup>51&#160;</sup>With which your enemies have mocked, Yahweh, 
+<sup>51&#160;</sup>With which your enemies have mocked, Yahuah, 
 </p><p class="q2">with which they have mocked the footsteps of your anointed one. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>52&#160;</sup>Blessed be Yahweh forever more. 
+<sup>52&#160;</sup>Blessed be Yahuah forever more. 
 </p><p class="q1">Amen, and Amen. 
 </p><h2 class="ms1">BOOK 4</h2>
 <h2 class="psalmlabel" id="90">90</h2>
@@ -5189,7 +5189,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>So teach us to count our days, 
 </p><p class="q2">that we may gain a heart of wisdom. 
 </p><p class="q1">
-<sup>13&#160;</sup>Relent, Yahweh! 
+<sup>13&#160;</sup>Relent, Yahuah! 
 </p><p class="q2">How long? 
 </p><p class="q2">Have compassion on your servants! 
 </p><p class="q1">
@@ -5210,7 +5210,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>He who dwells in the secret place of the Most High 
 </p><p class="q2">will rest in the shadow of the Almighty. 
 </p><p class="q1">
-<sup>2&#160;</sup>I will say of Yahweh, “He is my refuge and my fortress; 
+<sup>2&#160;</sup>I will say of Yahuah, “He is my refuge and my fortress; 
 </p><p class="q2">my Elohim, in whom I trust.” 
 </p><p class="q1">
 <sup>3&#160;</sup>For he will deliver you from the snare of the fowler, 
@@ -5233,7 +5233,7 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>You will only look with your eyes, 
 </p><p class="q2">and see the recompense of the wicked. 
 </p><p class="q1">
-<sup>9&#160;</sup>Because you have made Yahweh your refuge, 
+<sup>9&#160;</sup>Because you have made Yahuah your refuge, 
 </p><p class="q2">and the Most High your dwelling place, 
 </p><p class="q1">
 <sup>10&#160;</sup>no evil shall happen to you, 
@@ -5260,7 +5260,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="92">92</h2>
 <p class="d">A Psalm. A song for the Sabbath day. 
 </p><p class="q1">
-<sup>1&#160;</sup>It is a good thing to give thanks to Yahweh, 
+<sup>1&#160;</sup>It is a good thing to give thanks to Yahuah, 
 </p><p class="q2">to sing praises to your name, Most High, 
 </p><p class="q1">
 <sup>2&#160;</sup>to proclaim your loving kindness in the morning, 
@@ -5269,10 +5269,10 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>with the ten-stringed lute, with the harp, 
 </p><p class="q2">and with the melody of the lyre. 
 </p><p class="q1">
-<sup>4&#160;</sup>For you, Yahweh, have made me glad through your work. 
+<sup>4&#160;</sup>For you, Yahuah, have made me glad through your work. 
 </p><p class="q2">I will triumph in the works of your hands. 
 </p><p class="q1">
-<sup>5&#160;</sup>How great are your works, Yahweh! 
+<sup>5&#160;</sup>How great are your works, Yahuah! 
 </p><p class="q2">Your thoughts are very deep. 
 </p><p class="q1">
 <sup>6&#160;</sup>A senseless man doesn’t know, 
@@ -5282,9 +5282,9 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and all the evildoers flourish, 
 </p><p class="q2">they will be destroyed forever. 
 </p><p class="q1">
-<sup>8&#160;</sup>But you, Yahweh, are on high forever more. 
+<sup>8&#160;</sup>But you, Yahuah, are on high forever more. 
 </p><p class="q1">
-<sup>9&#160;</sup>For behold, your enemies, Yahweh, 
+<sup>9&#160;</sup>For behold, your enemies, Yahuah, 
 </p><p class="q2">for behold, your enemies shall perish. 
 </p><p class="q2">All the evildoers will be scattered. 
 </p><p class="q1">
@@ -5297,52 +5297,52 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>The righteous shall flourish like the palm tree. 
 </p><p class="q2">He will grow like a cedar in Lebanon. 
 </p><p class="q1">
-<sup>13&#160;</sup>They are planted in Yahweh’s house. 
+<sup>13&#160;</sup>They are planted in Yahuah’s house. 
 </p><p class="q2">They will flourish in our Elohim’s courts. 
 </p><p class="q1">
 <sup>14&#160;</sup>They will still produce fruit in old age. 
 </p><p class="q2">They will be full of sap and green, 
 </p><p class="q2">
-<sup>15&#160;</sup>to show that Yahweh is upright. 
+<sup>15&#160;</sup>to show that Yahuah is upright. 
 </p><p class="q1">He is my rock, 
 </p><p class="q2">and there is no unrighteousness in him. 
 </p><h2 class="psalmlabel" id="93">93</h2>
 <p class="q1">
-<sup>1&#160;</sup>Yahweh reigns! 
+<sup>1&#160;</sup>Yahuah reigns! 
 </p><p class="q2">He is clothed with majesty! 
-</p><p class="q2">Yahweh is armed with strength. 
+</p><p class="q2">Yahuah is armed with strength. 
 </p><p class="q1">The world also is established. 
 </p><p class="q2">It can’t be moved. 
 </p><p class="q1">
 <sup>2&#160;</sup>Your throne is established from long ago. 
 </p><p class="q2">You are from everlasting. 
 </p><p class="q1">
-<sup>3&#160;</sup>The floods have lifted up, Yahweh, 
+<sup>3&#160;</sup>The floods have lifted up, Yahuah, 
 </p><p class="q2">the floods have lifted up their voice. 
 </p><p class="q2">The floods lift up their waves. 
 </p><p class="q1">
 <sup>4&#160;</sup>Above the voices of many waters, 
 </p><p class="q2">the mighty breakers of the sea, 
-</p><p class="q2">Yahweh on high is mighty. 
+</p><p class="q2">Yahuah on high is mighty. 
 </p><p class="q1">
 <sup>5&#160;</sup>Your statutes stand firm. 
 </p><p class="q2">Set-Apartness adorns your house, 
-</p><p class="q2">Yahweh, forever more. 
+</p><p class="q2">Yahuah, forever more. 
 </p><h2 class="psalmlabel" id="94">94</h2>
 <p class="q1">
-<sup>1&#160;</sup>Yahweh, you Elohim to whom vengeance belongs, 
+<sup>1&#160;</sup>Yahuah, you Elohim to whom vengeance belongs, 
 </p><p class="q2">you Elohim to whom vengeance belongs, shine out. 
 </p><p class="q1">
 <sup>2&#160;</sup>Rise up, you judge of the earth. 
 </p><p class="q2">Pay back the proud what they deserve. 
 </p><p class="q1">
-<sup>3&#160;</sup>Yahweh, how long will the wicked, 
+<sup>3&#160;</sup>Yahuah, how long will the wicked, 
 </p><p class="q2">how long will the wicked triumph? 
 </p><p class="q1">
 <sup>4&#160;</sup>They pour out arrogant words. 
 </p><p class="q2">All the evildoers boast. 
 </p><p class="q1">
-<sup>5&#160;</sup>They break your people in pieces, Yahweh, 
+<sup>5&#160;</sup>They break your people in pieces, Yahuah, 
 </p><p class="q2">and afflict your heritage. 
 </p><p class="q1">
 <sup>6&#160;</sup>They kill the widow and the alien, 
@@ -5360,7 +5360,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>He who disciplines the nations, won’t he punish? 
 </p><p class="q2">He who teaches man knows. 
 </p><p class="q1">
-<sup>11&#160;</sup>Yahweh knows the thoughts of man, 
+<sup>11&#160;</sup>Yahuah knows the thoughts of man, 
 </p><p class="q2">that they are futile. 
 </p><p class="q1">
 <sup>12&#160;</sup>Blessed is the man whom you discipline, Yah, 
@@ -5369,7 +5369,7 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>that you may give him rest from the days of adversity, 
 </p><p class="q2">until the pit is dug for the wicked. 
 </p><p class="q1">
-<sup>14&#160;</sup>For Yahweh won’t reject his people, 
+<sup>14&#160;</sup>For Yahuah won’t reject his people, 
 </p><p class="q2">neither will he forsake his inheritance. 
 </p><p class="q1">
 <sup>15&#160;</sup>For judgment will return to righteousness. 
@@ -5378,11 +5378,11 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>Who will rise up for me against the wicked? 
 </p><p class="q2">Who will stand up for me against the evildoers? 
 </p><p class="q1">
-<sup>17&#160;</sup>Unless Yahweh had been my help, 
+<sup>17&#160;</sup>Unless Yahuah had been my help, 
 </p><p class="q2">my soul would have soon lived in silence. 
 </p><p class="q1">
 <sup>18&#160;</sup>When I said, “My foot is slipping!” 
-</p><p class="q2">Your loving kindness, Yahweh, held me up. 
+</p><p class="q2">Your loving kindness, Yahuah, held me up. 
 </p><p class="q1">
 <sup>19&#160;</sup>In the multitude of my thoughts within me, 
 </p><p class="q2">your comforts delight my soul. 
@@ -5393,21 +5393,21 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>They gather themselves together against the soul of the righteous, 
 </p><p class="q2">and condemn the innocent blood. 
 </p><p class="q1">
-<sup>22&#160;</sup>But Yahweh has been my high tower, 
+<sup>22&#160;</sup>But Yahuah has been my high tower, 
 </p><p class="q2">my Elohim, the rock of my refuge. 
 </p><p class="q1">
 <sup>23&#160;</sup>He has brought on them their own iniquity, 
 </p><p class="q2">and will cut them off in their own wickedness. 
-</p><p class="q2">Yahweh, our Elohim, will cut them off. 
+</p><p class="q2">Yahuah, our Elohim, will cut them off. 
 </p><h2 class="psalmlabel" id="95">95</h2>
 <p class="q1">
-<sup>1&#160;</sup>Oh come, let’s sing to Yahweh. 
+<sup>1&#160;</sup>Oh come, let’s sing to Yahuah. 
 </p><p class="q2">Let’s shout aloud to the rock of our salvation! 
 </p><p class="q1">
 <sup>2&#160;</sup>Let’s come before his presence with thanksgiving. 
 </p><p class="q2">Let’s extol him with songs! 
 </p><p class="q1">
-<sup>3&#160;</sup>For Yahweh is a great Elohim, 
+<sup>3&#160;</sup>For Yahuah is a great Elohim, 
 </p><p class="q2">a great King above all elohims. 
 </p><p class="q1">
 <sup>4&#160;</sup>In his hand are the deep places of the earth. 
@@ -5417,7 +5417,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">His hands formed the dry land. 
 </p><p class="q1">
 <sup>6&#160;</sup>Oh come, let’s worship and bow down. 
-</p><p class="q2">Let’s kneel before Yahweh, our Maker, 
+</p><p class="q2">Let’s kneel before Yahuah, our Maker, 
 </p><p class="q2">
 <sup>7&#160;</sup>for he is our Elohim. 
 </p><p class="q1">We are the people of his pasture, 
@@ -5438,35 +5438,35 @@ html[dir=ltr] .q2 {
 </p><p class="q2">“They won’t enter into my rest.” 
 </p><h2 class="psalmlabel" id="96">96</h2>
 <p class="q1">
-<sup>1&#160;</sup>Sing to Yahweh a new song! 
-</p><p class="q2">Sing to Yahweh, all the earth. 
+<sup>1&#160;</sup>Sing to Yahuah a new song! 
+</p><p class="q2">Sing to Yahuah, all the earth. 
 </p><p class="q1">
-<sup>2&#160;</sup>Sing to Yahweh! 
+<sup>2&#160;</sup>Sing to Yahuah! 
 </p><p class="q2">Bless his name! 
 </p><p class="q2">Proclaim his salvation from day to day! 
 </p><p class="q1">
 <sup>3&#160;</sup>Declare his glory among the nations, 
 </p><p class="q2">his marvelous works among all the peoples. 
 </p><p class="q1">
-<sup>4&#160;</sup>For Yahweh is great, and greatly to be praised! 
+<sup>4&#160;</sup>For Yahuah is great, and greatly to be praised! 
 </p><p class="q2">He is to be feared above all elohims. 
 </p><p class="q1">
 <sup>5&#160;</sup>For all the elohims of the peoples are idols, 
-</p><p class="q2">but Yahweh made the heavens. 
+</p><p class="q2">but Yahuah made the heavens. 
 </p><p class="q1">
 <sup>6&#160;</sup>Honor and majesty are before him. 
 </p><p class="q2">Strength and beauty are in his sanctuary. 
 </p><p class="q1">
-<sup>7&#160;</sup>Ascribe to Yahweh, you families of nations, 
-</p><p class="q2">ascribe to Yahweh glory and strength. 
+<sup>7&#160;</sup>Ascribe to Yahuah, you families of nations, 
+</p><p class="q2">ascribe to Yahuah glory and strength. 
 </p><p class="q1">
-<sup>8&#160;</sup>Ascribe to Yahweh the glory due to his name. 
+<sup>8&#160;</sup>Ascribe to Yahuah the glory due to his name. 
 </p><p class="q2">Bring an offering, and come into his courts. 
 </p><p class="q1">
-<sup>9&#160;</sup>Worship Yahweh in set-apart array. 
+<sup>9&#160;</sup>Worship Yahuah in set-apart array. 
 </p><p class="q2">Tremble before him, all the earth. 
 </p><p class="q1">
-<sup>10&#160;</sup>Say among the nations, “Yahweh reigns.” 
+<sup>10&#160;</sup>Say among the nations, “Yahuah reigns.” 
 </p><p class="q2">The world is also established. 
 </p><p class="q2">It can’t be moved. 
 </p><p class="q2">He will judge the peoples with equity. 
@@ -5477,13 +5477,13 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Let the field and all that is in it exult! 
 </p><p class="q2">Then all the trees of the woods shall sing for joy 
 </p><p class="q2">
-<sup>13&#160;</sup>before Yahweh; for he comes, 
+<sup>13&#160;</sup>before Yahuah; for he comes, 
 </p><p class="q2">for he comes to judge the earth. 
 </p><p class="q1">He will judge the world with righteousness, 
 </p><p class="q2">the peoples with his truth. 
 </p><h2 class="psalmlabel" id="97">97</h2>
 <p class="q1">
-<sup>1&#160;</sup>Yahweh reigns! 
+<sup>1&#160;</sup>Yahuah reigns! 
 </p><p class="q2">Let the earth rejoice! 
 </p><p class="q2">Let the multitude of islands be glad! 
 </p><p class="q1">
@@ -5496,7 +5496,7 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>His lightning lights up the world. 
 </p><p class="q2">The earth sees, and trembles. 
 </p><p class="q1">
-<sup>5&#160;</sup>The mountains melt like wax at the presence of Yahweh, 
+<sup>5&#160;</sup>The mountains melt like wax at the presence of Yahuah, 
 </p><p class="q2">at the presence of the Lord of the whole earth. 
 </p><p class="q1">
 <sup>6&#160;</sup>The heavens declare his righteousness. 
@@ -5508,41 +5508,41 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>8&#160;</sup>Zion heard and was glad. 
 </p><p class="q2">The daughters of Judah rejoiced 
-</p><p class="q2">because of your judgments, Yahweh. 
+</p><p class="q2">because of your judgments, Yahuah. 
 </p><p class="q1">
-<sup>9&#160;</sup>For you, Yahweh, are most high above all the earth. 
+<sup>9&#160;</sup>For you, Yahuah, are most high above all the earth. 
 </p><p class="q2">You are exalted far above all elohims. 
 </p><p class="q1">
-<sup>10&#160;</sup>You who love Yahweh, hate evil! 
+<sup>10&#160;</sup>You who love Yahuah, hate evil! 
 </p><p class="q2">He preserves the souls of his saints. 
 </p><p class="q2">He delivers them out of the hand of the wicked. 
 </p><p class="q1">
 <sup>11&#160;</sup>Light is sown for the righteous, 
 </p><p class="q2">and gladness for the upright in heart. 
 </p><p class="q1">
-<sup>12&#160;</sup>Be glad in Yahweh, you righteous people! 
+<sup>12&#160;</sup>Be glad in Yahuah, you righteous people! 
 </p><p class="q2">Give thanks to his set-apart Name. 
 </p><h2 class="psalmlabel" id="98">98</h2>
 <p class="d">A Psalm. 
 </p><p class="q1">
-<sup>1&#160;</sup>Sing to Yahweh a new song, 
+<sup>1&#160;</sup>Sing to Yahuah a new song, 
 </p><p class="q2">for he has done marvelous things! 
 </p><p class="q2">His right hand and his set-apart arm have worked salvation for him. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh has made known his salvation. 
+<sup>2&#160;</sup>Yahuah has made known his salvation. 
 </p><p class="q2">He has openly shown his righteousness in the sight of the nations. 
 </p><p class="q1">
 <sup>3&#160;</sup>He has remembered his loving kindness and his faithfulness toward the house of Israel. 
 </p><p class="q2">All the ends of the earth have seen the salvation of our Elohim. 
 </p><p class="q1">
-<sup>4&#160;</sup>Make a joyful noise to Yahweh, all the earth! 
+<sup>4&#160;</sup>Make a joyful noise to Yahuah, all the earth! 
 </p><p class="q2">Burst out and sing for joy, yes, sing praises! 
 </p><p class="q1">
-<sup>5&#160;</sup>Sing praises to Yahweh with the harp, 
+<sup>5&#160;</sup>Sing praises to Yahuah with the harp, 
 </p><p class="q2">with the harp and the voice of melody. 
 </p><p class="q1">
 <sup>6&#160;</sup>With trumpets and sound of the ram’s horn, 
-</p><p class="q2">make a joyful noise before the King, Yahweh. 
+</p><p class="q2">make a joyful noise before the King, Yahuah. 
 </p><p class="q1">
 <sup>7&#160;</sup>Let the sea roar with its fullness; 
 </p><p class="q2">the world, and those who dwell therein. 
@@ -5550,17 +5550,17 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>Let the rivers clap their hands. 
 </p><p class="q2">Let the mountains sing for joy together. 
 </p><p class="q1">
-<sup>9&#160;</sup>Let them sing before Yahweh, 
+<sup>9&#160;</sup>Let them sing before Yahuah, 
 </p><p class="q2">for he comes to judge the earth. 
 </p><p class="q1">He will judge the world with righteousness, 
 </p><p class="q2">and the peoples with equity. 
 </p><h2 class="psalmlabel" id="99">99</h2>
 <p class="q1">
-<sup>1&#160;</sup>Yahweh reigns! Let the peoples tremble. 
+<sup>1&#160;</sup>Yahuah reigns! Let the peoples tremble. 
 </p><p class="q2">He sits enthroned among the cherubim. 
 </p><p class="q2">Let the earth be moved. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh is great in Zion. 
+<sup>2&#160;</sup>Yahuah is great in Zion. 
 </p><p class="q2">He is high above all the peoples. 
 </p><p class="q1">
 <sup>3&#160;</sup>Let them praise your great and awesome name. 
@@ -5571,35 +5571,35 @@ html[dir=ltr] .q2 {
 </p><p class="q2">You establish equity. 
 </p><p class="q2">You execute justice and righteousness in Jacob. 
 </p><p class="q1">
-<sup>5&#160;</sup>Exalt Yahweh our Elohim. 
+<sup>5&#160;</sup>Exalt Yahuah our Elohim. 
 </p><p class="q2">Worship at his footstool. 
 </p><p class="q2">He is Set-Apart! 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>6&#160;</sup>Moses and Aaron were among his priests, 
 </p><p class="q2">Samuel was among those who call on his name. 
-</p><p class="q2">They called on Yahweh, and he answered them. 
+</p><p class="q2">They called on Yahuah, and he answered them. 
 </p><p class="q1">
 <sup>7&#160;</sup>He spoke to them in the pillar of cloud. 
 </p><p class="q2">They kept his testimonies, 
 </p><p class="q2">the statute that he gave them. 
 </p><p class="q1">
-<sup>8&#160;</sup>You answered them, Yahweh our Elohim. 
+<sup>8&#160;</sup>You answered them, Yahuah our Elohim. 
 </p><p class="q2">You are an Elohim who forgave them, 
 </p><p class="q2">although you took vengeance for their doings. 
 </p><p class="q1">
-<sup>9&#160;</sup>Exalt Yahweh, our Elohim. 
+<sup>9&#160;</sup>Exalt Yahuah, our Elohim. 
 </p><p class="q2">Worship at his set-apart hill, 
-</p><p class="q2">for Yahweh, our Elohim, is set-apart! 
+</p><p class="q2">for Yahuah, our Elohim, is set-apart! 
 </p><h2 class="psalmlabel" id="100">100</h2>
 <p class="d">A Psalm of thanksgiving. 
 </p><p class="q1">
-<sup>1&#160;</sup>Shout for joy to Yahweh, all you lands! 
+<sup>1&#160;</sup>Shout for joy to Yahuah, all you lands! 
 </p><p class="q2">
-<sup>2&#160;</sup>Serve Yahweh with gladness. 
+<sup>2&#160;</sup>Serve Yahuah with gladness. 
 </p><p class="q2">Come before his presence with singing. 
 </p><p class="q1">
-<sup>3&#160;</sup>Know that Yahweh, he is Elohim. 
+<sup>3&#160;</sup>Know that Yahuah, he is Elohim. 
 </p><p class="q2">It is he who has made us, and we are his. 
 </p><p class="q2">We are his people, and the sheep of his pasture. 
 </p><p class="q1">
@@ -5607,14 +5607,14 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and into his courts with praise. 
 </p><p class="q2">Give thanks to him, and bless his name. 
 </p><p class="q1">
-<sup>5&#160;</sup>For Yahweh is good. 
+<sup>5&#160;</sup>For Yahuah is good. 
 </p><p class="q2">His loving kindness endures forever, 
 </p><p class="q2">his faithfulness to all generations. 
 </p><h2 class="psalmlabel" id="101">101</h2>
 <p class="d">A Psalm by David. 
 </p><p class="q1">
 <sup>1&#160;</sup>I will sing of loving kindness and justice. 
-</p><p class="q2">To you, Yahweh, I will sing praises. 
+</p><p class="q2">To you, Yahuah, I will sing praises. 
 </p><p class="q1">
 <sup>2&#160;</sup>I will be careful to live a blameless life. 
 </p><p class="q2">When will you come to me? 
@@ -5639,11 +5639,11 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He who speaks falsehood won’t be established before my eyes. 
 </p><p class="q1">
 <sup>8&#160;</sup>Morning by morning, I will destroy all the wicked of the land, 
-</p><p class="q2">to cut off all the workers of iniquity from Yahweh’s city. 
+</p><p class="q2">to cut off all the workers of iniquity from Yahuah’s city. 
 </p><h2 class="psalmlabel" id="102">102</h2>
-<p class="d">A Prayer of the afflicted, when he is overwhelmed and pours out his complaint before Yahweh. 
+<p class="d">A Prayer of the afflicted, when he is overwhelmed and pours out his complaint before Yahuah. 
 </p><p class="q1">
-<sup>1&#160;</sup>Hear my prayer, Yahweh! 
+<sup>1&#160;</sup>Hear my prayer, Yahuah! 
 </p><p class="q2">Let my cry come to you. 
 </p><p class="q1">
 <sup>2&#160;</sup>Don’t hide your face from me in the day of my distress. 
@@ -5677,7 +5677,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I have withered like grass. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>12&#160;</sup>But you, Yahweh, will remain forever; 
+<sup>12&#160;</sup>But you, Yahuah, will remain forever; 
 </p><p class="q2">your renown endures to all generations. 
 </p><p class="q1">
 <sup>13&#160;</sup>You will arise and have mercy on Zion, 
@@ -5687,10 +5687,10 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>For your servants take pleasure in her stones, 
 </p><p class="q2">and have pity on her dust. 
 </p><p class="q1">
-<sup>15&#160;</sup>So the nations will fear Yahweh’s name, 
+<sup>15&#160;</sup>So the nations will fear Yahuah’s name, 
 </p><p class="q2">all the kings of the earth your glory. 
 </p><p class="q1">
-<sup>16&#160;</sup>For Yahweh has built up Zion. 
+<sup>16&#160;</sup>For Yahuah has built up Zion. 
 </p><p class="q2">He has appeared in his glory. 
 </p><p class="q1">
 <sup>17&#160;</sup>He has responded to the prayer of the destitute, 
@@ -5700,16 +5700,16 @@ html[dir=ltr] .q2 {
 </p><p class="q2">A people which will be created will praise Yah, 
 </p><p class="q1">
 <sup>19&#160;</sup>for he has looked down from the height of his sanctuary. 
-</p><p class="q2">From heaven, Yahweh saw the earth, 
+</p><p class="q2">From heaven, Yahuah saw the earth, 
 </p><p class="q1">
 <sup>20&#160;</sup>to hear the groans of the prisoner, 
 </p><p class="q2">to free those who are condemned to death, 
 </p><p class="q1">
-<sup>21&#160;</sup>that men may declare Yahweh’s name in Zion, 
+<sup>21&#160;</sup>that men may declare Yahuah’s name in Zion, 
 </p><p class="q2">and his praise in Jerusalem, 
 </p><p class="q1">
 <sup>22&#160;</sup>when the peoples are gathered together, 
-</p><p class="q2">the kingdoms, to serve Yahweh. 
+</p><p class="q2">the kingdoms, to serve Yahuah. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>23&#160;</sup>He weakened my strength along the course. 
@@ -5733,10 +5733,10 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="103">103</h2>
 <p class="d">By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Praise Yahweh, my soul! 
+<sup>1&#160;</sup>Praise Yahuah, my soul! 
 </p><p class="q2">All that is within me, praise his set-apart name! 
 </p><p class="q1">
-<sup>2&#160;</sup>Praise Yahweh, my soul, 
+<sup>2&#160;</sup>Praise Yahuah, my soul, 
 </p><p class="q2">and don’t forget all his benefits, 
 </p><p class="q1">
 <sup>3&#160;</sup>who forgives all your sins, 
@@ -5748,13 +5748,13 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>who satisfies your desire with good things, 
 </p><p class="q2">so that your youth is renewed like the eagle’s. 
 </p><p class="q1">
-<sup>6&#160;</sup>Yahweh executes righteous acts, 
+<sup>6&#160;</sup>Yahuah executes righteous acts, 
 </p><p class="q2">and justice for all who are oppressed. 
 </p><p class="q1">
 <sup>7&#160;</sup>He made known his ways to Moses, 
 </p><p class="q2">his deeds to the children of Israel. 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh is merciful and gracious, 
+<sup>8&#160;</sup>Yahuah is merciful and gracious, 
 </p><p class="q2">slow to anger, and abundant in loving kindness. 
 </p><p class="q1">
 <sup>9&#160;</sup>He will not always accuse; 
@@ -5770,7 +5770,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">so far has he removed our transgressions from us. 
 </p><p class="q1">
 <sup>13&#160;</sup>Like a father has compassion on his children, 
-</p><p class="q2">so Yahweh has compassion on those who fear him. 
+</p><p class="q2">so Yahuah has compassion on those who fear him. 
 </p><p class="q1">
 <sup>14&#160;</sup>For he knows how we are made. 
 </p><p class="q2">He remembers that we are dust. 
@@ -5781,29 +5781,29 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>For the wind passes over it, and it is gone. 
 </p><p class="q2">Its place remembers it no more. 
 </p><p class="q1">
-<sup>17&#160;</sup>But Yahweh’s loving kindness is from everlasting to everlasting with those who fear him, 
+<sup>17&#160;</sup>But Yahuah’s loving kindness is from everlasting to everlasting with those who fear him, 
 </p><p class="q2">his righteousness to children’s children, 
 </p><p class="q1">
 <sup>18&#160;</sup>to those who keep his covenant, 
 </p><p class="q2">to those who remember to obey his precepts. 
 </p><p class="q1">
-<sup>19&#160;</sup>Yahweh has established his throne in the heavens. 
+<sup>19&#160;</sup>Yahuah has established his throne in the heavens. 
 </p><p class="q2">His kingdom rules over all. 
 </p><p class="q1">
-<sup>20&#160;</sup>Praise Yahweh, you angels of his, 
+<sup>20&#160;</sup>Praise Yahuah, you angels of his, 
 </p><p class="q2">who are mighty in strength, who fulfill his word, 
 </p><p class="q2">obeying the voice of his word. 
 </p><p class="q1">
-<sup>21&#160;</sup>Praise Yahweh, all you armies of his, 
+<sup>21&#160;</sup>Praise Yahuah, all you armies of his, 
 </p><p class="q2">you servants of his, who do his pleasure. 
 </p><p class="q1">
-<sup>22&#160;</sup>Praise Yahweh, all you works of his, 
+<sup>22&#160;</sup>Praise Yahuah, all you works of his, 
 </p><p class="q2">in all places of his dominion. 
-</p><p class="q2">Praise Yahweh, my soul! 
+</p><p class="q2">Praise Yahuah, my soul! 
 </p><h2 class="psalmlabel" id="104">104</h2>
 <p class="q1">
-<sup>1&#160;</sup>Bless Yahweh, my soul. 
-</p><p class="q2">Yahweh, my Elohim, you are very great. 
+<sup>1&#160;</sup>Bless Yahuah, my soul. 
+</p><p class="q2">Yahuah, my Elohim, you are very great. 
 </p><p class="q2">You are clothed with honor and majesty. 
 </p><p class="q1">
 <sup>2&#160;</sup>He covers himself with light as with a garment. 
@@ -5852,7 +5852,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">oil to make his face to shine, 
 </p><p class="q2">and bread that strengthens man’s heart. 
 </p><p class="q1">
-<sup>16&#160;</sup>Yahweh’s trees are well watered, 
+<sup>16&#160;</sup>Yahuah’s trees are well watered, 
 </p><p class="q2">the cedars of Lebanon, which he has planted, 
 </p><p class="q1">
 <sup>17&#160;</sup>where the birds make their nests. 
@@ -5876,7 +5876,7 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>Man goes out to his work, 
 </p><p class="q2">to his labor until the evening. 
 </p><p class="q1">
-<sup>24&#160;</sup>Yahweh, how many are your works! 
+<sup>24&#160;</sup>Yahuah, how many are your works! 
 </p><p class="q2">In wisdom, you have made them all. 
 </p><p class="q2">The earth is full of your riches. 
 </p><p class="q1">
@@ -5899,34 +5899,34 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>You send out your Spirit and they are created. 
 </p><p class="q2">You renew the face of the ground. 
 </p><p class="q1">
-<sup>31&#160;</sup>Let Yahweh’s glory endure forever. 
-</p><p class="q2">Let Yahweh rejoice in his works. 
+<sup>31&#160;</sup>Let Yahuah’s glory endure forever. 
+</p><p class="q2">Let Yahuah rejoice in his works. 
 </p><p class="q1">
 <sup>32&#160;</sup>He looks at the earth, and it trembles. 
 </p><p class="q2">He touches the mountains, and they smoke. 
 </p><p class="q1">
-<sup>33&#160;</sup>I will sing to Yahweh as long as I live. 
+<sup>33&#160;</sup>I will sing to Yahuah as long as I live. 
 </p><p class="q2">I will sing praise to my Elohim while I have any being. 
 </p><p class="q1">
 <sup>34&#160;</sup>Let my meditation be sweet to him. 
-</p><p class="q2">I will rejoice in Yahweh. 
+</p><p class="q2">I will rejoice in Yahuah. 
 </p><p class="q1">
 <sup>35&#160;</sup>Let sinners be consumed out of the earth. 
 </p><p class="q2">Let the wicked be no more. 
-</p><p class="q2">Bless Yahweh, my soul. 
+</p><p class="q2">Bless Yahuah, my soul. 
 </p><p class="q2">Praise Yah! 
 </p><h2 class="psalmlabel" id="105">105</h2>
 <p class="q1">
-<sup>1&#160;</sup>Give thanks to Yahweh! Call on his name! 
+<sup>1&#160;</sup>Give thanks to Yahuah! Call on his name! 
 </p><p class="q2">Make his doings known among the peoples. 
 </p><p class="q1">
 <sup>2&#160;</sup>Sing to him, sing praises to him! 
 </p><p class="q2">Tell of all his marvelous works. 
 </p><p class="q1">
 <sup>3&#160;</sup>Glory in his set-apart name. 
-</p><p class="q2">Let the heart of those who seek Yahweh rejoice. 
+</p><p class="q2">Let the heart of those who seek Yahuah rejoice. 
 </p><p class="q1">
-<sup>4&#160;</sup>Seek Yahweh and his strength. 
+<sup>4&#160;</sup>Seek Yahuah and his strength. 
 </p><p class="q2">Seek his face forever more. 
 </p><p class="q1">
 <sup>5&#160;</sup>Remember his marvelous works that he has done: 
@@ -5935,7 +5935,7 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>you offspring of Abraham, his servant, 
 </p><p class="q2">you children of Jacob, his chosen ones. 
 </p><p class="q1">
-<sup>7&#160;</sup>He is Yahweh, our Elohim. 
+<sup>7&#160;</sup>He is Yahuah, our Elohim. 
 </p><p class="q2">His judgments are in all the earth. 
 </p><p class="q1">
 <sup>8&#160;</sup>He has remembered his covenant forever, 
@@ -5972,7 +5972,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">His neck was locked in irons, 
 </p><p class="q1">
 <sup>19&#160;</sup>until the time that his word happened, 
-</p><p class="q2">and Yahweh’s word proved him true. 
+</p><p class="q2">and Yahuah’s word proved him true. 
 </p><p class="q1">
 <sup>20&#160;</sup>The king sent and freed him, 
 </p><p class="q2">even the ruler of peoples, and let him go free. 
@@ -6054,17 +6054,17 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Praise Yah! 
 </p><h2 class="psalmlabel" id="106">106</h2>
 <p class="q1">
-<sup>1&#160;</sup>Praise Yahweh! 
-</p><p class="q2">Give thanks to Yahweh, for he is good, 
+<sup>1&#160;</sup>Praise Yahuah! 
+</p><p class="q2">Give thanks to Yahuah, for he is good, 
 </p><p class="q2">for his loving kindness endures forever. 
 </p><p class="q1">
-<sup>2&#160;</sup>Who can utter the mighty acts of Yahweh, 
+<sup>2&#160;</sup>Who can utter the mighty acts of Yahuah, 
 </p><p class="q2">or fully declare all his praise? 
 </p><p class="q1">
 <sup>3&#160;</sup>Blessed are those who keep justice. 
 </p><p class="q2">Blessed is one who does what is right at all times. 
 </p><p class="q1">
-<sup>4&#160;</sup>Remember me, Yahweh, with the favor that you show to your people. 
+<sup>4&#160;</sup>Remember me, Yahuah, with the favor that you show to your people. 
 </p><p class="q2">Visit me with your salvation, 
 </p><p class="q1">
 <sup>5&#160;</sup>that I may see the prosperity of your chosen, 
@@ -6106,7 +6106,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">but sent leanness into their soul. 
 </p><p class="q1">
 <sup>16&#160;</sup>They envied Moses also in the camp, 
-</p><p class="q2">and Aaron, Yahweh’s saint. 
+</p><p class="q2">and Aaron, Yahuah’s saint. 
 </p><p class="q1">
 <sup>17&#160;</sup>The earth opened and swallowed up Dathan, 
 </p><p class="q2">and covered the company of Abiram. 
@@ -6134,7 +6134,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">They didn’t believe his word, 
 </p><p class="q2">
 <sup>25&#160;</sup>but murmured in their tents, 
-</p><p class="q2">and didn’t listen to Yahweh’s voice. 
+</p><p class="q2">and didn’t listen to Yahuah’s voice. 
 </p><p class="q1">
 <sup>26&#160;</sup>Therefore he swore to them 
 </p><p class="q2">that he would overthrow them in the wilderness, 
@@ -6161,7 +6161,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">he spoke rashly with his lips. 
 </p><p class="q1">
 <sup>34&#160;</sup>They didn’t destroy the peoples, 
-</p><p class="q2">as Yahweh commanded them, 
+</p><p class="q2">as Yahuah commanded them, 
 </p><p class="q2">
 <sup>35&#160;</sup>but mixed themselves with the nations, 
 </p><p class="q2">and learned their works. 
@@ -6179,7 +6179,7 @@ html[dir=ltr] .q2 {
 <sup>39&#160;</sup>Thus they were defiled with their works, 
 </p><p class="q2">and prostituted themselves in their deeds. 
 </p><p class="q1">
-<sup>40&#160;</sup>Therefore Yahweh burned with anger against his people. 
+<sup>40&#160;</sup>Therefore Yahuah burned with anger against his people. 
 </p><p class="q2">He abhorred his inheritance. 
 </p><p class="q1">
 <sup>41&#160;</sup>He gave them into the hand of the nations. 
@@ -6202,23 +6202,23 @@ html[dir=ltr] .q2 {
 </p><p class="q2">by all those who carried them captive. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>47&#160;</sup>Save us, Yahweh, our Elohim, 
+<sup>47&#160;</sup>Save us, Yahuah, our Elohim, 
 </p><p class="q2">gather us from among the nations, 
 </p><p class="q2">to give thanks to your set-apart name, 
 </p><p class="q2">to triumph in your praise! 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>48&#160;</sup>Blessed be Yahweh, the Elohim of Israel, 
+<sup>48&#160;</sup>Blessed be Yahuah, the Elohim of Israel, 
 </p><p class="q2">from everlasting even to everlasting! 
 </p><p class="q1">Let all the people say, “Amen.” 
 </p><p class="q2">Praise Yah! 
 </p><h2 class="ms1">BOOK 5</h2>
 <h2 class="psalmlabel" id="107">107</h2>
 <p class="q1">
-<sup>1&#160;</sup>Give thanks to Yahweh, for he is good, 
+<sup>1&#160;</sup>Give thanks to Yahuah, for he is good, 
 </p><p class="q2">for his loving kindness endures forever. 
 </p><p class="q1">
-<sup>2&#160;</sup>Let the redeemed by Yahweh say so, 
+<sup>2&#160;</sup>Let the redeemed by Yahuah say so, 
 </p><p class="q2">whom he has redeemed from the hand of the adversary, 
 </p><p class="q2">
 <sup>3&#160;</sup>and gathered out of the lands, 
@@ -6232,13 +6232,13 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>Hungry and thirsty, 
 </p><p class="q2">their soul fainted in them. 
 </p><p class="q1">
-<sup>6&#160;</sup>Then they cried to Yahweh in their trouble, 
+<sup>6&#160;</sup>Then they cried to Yahuah in their trouble, 
 </p><p class="q2">and he delivered them out of their distresses. 
 </p><p class="q1">
 <sup>7&#160;</sup>He led them also by a straight way, 
 </p><p class="q2">that they might go to a city to live in. 
 </p><p class="q1">
-<sup>8&#160;</sup>Let them praise Yahweh for his loving kindness, 
+<sup>8&#160;</sup>Let them praise Yahuah for his loving kindness, 
 </p><p class="q2">for his wonderful deeds to the children of men! 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -6255,13 +6255,13 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Therefore he brought down their heart with labor. 
 </p><p class="q2">They fell down, and there was no one to help. 
 </p><p class="q1">
-<sup>13&#160;</sup>Then they cried to Yahweh in their trouble, 
+<sup>13&#160;</sup>Then they cried to Yahuah in their trouble, 
 </p><p class="q2">and he saved them out of their distresses. 
 </p><p class="q1">
 <sup>14&#160;</sup>He brought them out of darkness and the shadow of death, 
 </p><p class="q2">and broke away their chains. 
 </p><p class="q1">
-<sup>15&#160;</sup>Let them praise Yahweh for his loving kindness, 
+<sup>15&#160;</sup>Let them praise Yahuah for his loving kindness, 
 </p><p class="q2">for his wonderful deeds to the children of men! 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -6275,13 +6275,13 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>Their soul abhors all kinds of food. 
 </p><p class="q2">They draw near to the gates of death. 
 </p><p class="q1">
-<sup>19&#160;</sup>Then they cry to Yahweh in their trouble, 
+<sup>19&#160;</sup>Then they cry to Yahuah in their trouble, 
 </p><p class="q2">and he saves them out of their distresses. 
 </p><p class="q1">
 <sup>20&#160;</sup>He sends his word, and heals them, 
 </p><p class="q2">and delivers them from their graves. 
 </p><p class="q1">
-<sup>21&#160;</sup>Let them praise Yahweh for his loving kindness, 
+<sup>21&#160;</sup>Let them praise Yahuah for his loving kindness, 
 </p><p class="q2">for his wonderful deeds to the children of men! 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -6292,7 +6292,7 @@ html[dir=ltr] .q2 {
 <sup>23&#160;</sup>Those who go down to the sea in ships, 
 </p><p class="q2">who do business in great waters, 
 </p><p class="q2">
-<sup>24&#160;</sup>these see Yahweh’s deeds, 
+<sup>24&#160;</sup>these see Yahuah’s deeds, 
 </p><p class="q2">and his wonders in the deep. 
 </p><p class="q1">
 <sup>25&#160;</sup>For he commands, and raises the stormy wind, 
@@ -6304,7 +6304,7 @@ html[dir=ltr] .q2 {
 <sup>27&#160;</sup>They reel back and forth, and stagger like a drunken man, 
 </p><p class="q2">and are at their wits’ end. 
 </p><p class="q1">
-<sup>28&#160;</sup>Then they cry to Yahweh in their trouble, 
+<sup>28&#160;</sup>Then they cry to Yahuah in their trouble, 
 </p><p class="q2">and he brings them out of their distress. 
 </p><p class="q1">
 <sup>29&#160;</sup>He makes the storm a calm, 
@@ -6313,7 +6313,7 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>Then they are glad because it is calm, 
 </p><p class="q2">so he brings them to their desired haven. 
 </p><p class="q1">
-<sup>31&#160;</sup>Let them praise Yahweh for his loving kindness, 
+<sup>31&#160;</sup>Let them praise Yahuah for his loving kindness, 
 </p><p class="q2">for his wonderful deeds for the children of men! 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -6352,7 +6352,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">All the wicked will shut their mouths. 
 </p><p class="q1">
 <sup>43&#160;</sup>Whoever is wise will pay attention to these things. 
-</p><p class="q2">They will consider the loving kindnesses of Yahweh. 
+</p><p class="q2">They will consider the loving kindnesses of Yahuah. 
 </p><h2 class="psalmlabel" id="108">108</h2>
 <p class="d">A Song. A Psalm by David. 
 </p><p class="q1">
@@ -6362,7 +6362,7 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>Wake up, harp and lyre! 
 </p><p class="q2">I will wake up the dawn. 
 </p><p class="q1">
-<sup>3&#160;</sup>I will give thanks to you, Yahweh, among the nations. 
+<sup>3&#160;</sup>I will give thanks to you, Yahuah, among the nations. 
 </p><p class="q2">I will sing praises to you among the peoples. 
 </p><p class="q1">
 <sup>4&#160;</sup>For your loving kindness is great above the heavens. 
@@ -6437,10 +6437,10 @@ html[dir=ltr] .q2 {
 <sup>13&#160;</sup>Let his posterity be cut off. 
 </p><p class="q2">In the generation following let their name be blotted out. 
 </p><p class="q1">
-<sup>14&#160;</sup>Let the iniquity of his fathers be remembered by Yahweh. 
+<sup>14&#160;</sup>Let the iniquity of his fathers be remembered by Yahuah. 
 </p><p class="q2">Don’t let the sin of his mother be blotted out. 
 </p><p class="q1">
-<sup>15&#160;</sup>Let them be before Yahweh continually, 
+<sup>15&#160;</sup>Let them be before Yahuah continually, 
 </p><p class="q2">that he may cut off their memory from the earth; 
 </p><p class="q1">
 <sup>16&#160;</sup>because he didn’t remember to show kindness, 
@@ -6457,11 +6457,11 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>Let it be to him as the clothing with which he covers himself, 
 </p><p class="q2">for the belt that is always around him. 
 </p><p class="q1">
-<sup>20&#160;</sup>This is the reward of my adversaries from Yahweh, 
+<sup>20&#160;</sup>This is the reward of my adversaries from Yahuah, 
 </p><p class="q2">of those who speak evil against my soul. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>21&#160;</sup>But deal with me, Yahweh the Lord, for your name’s sake, 
+<sup>21&#160;</sup>But deal with me, Yahuah the Lord, for your name’s sake, 
 </p><p class="q2">because your loving kindness is good, deliver me; 
 </p><p class="q2">
 <sup>22&#160;</sup>for I am poor and needy. 
@@ -6476,11 +6476,11 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>I have also become a reproach to them. 
 </p><p class="q2">When they see me, they shake their head. 
 </p><p class="q1">
-<sup>26&#160;</sup>Help me, Yahweh, my Elohim. 
+<sup>26&#160;</sup>Help me, Yahuah, my Elohim. 
 </p><p class="q2">Save me according to your loving kindness; 
 </p><p class="q1">
 <sup>27&#160;</sup>that they may know that this is your hand; 
-</p><p class="q2">that you, Yahweh, have done it. 
+</p><p class="q2">that you, Yahuah, have done it. 
 </p><p class="q1">
 <sup>28&#160;</sup>They may curse, but you bless. 
 </p><p class="q2">When they arise, they will be shamed, 
@@ -6489,7 +6489,7 @@ html[dir=ltr] .q2 {
 <sup>29&#160;</sup>Let my adversaries be clothed with dishonor. 
 </p><p class="q2">Let them cover themselves with their own shame as with a robe. 
 </p><p class="q1">
-<sup>30&#160;</sup>I will give great thanks to Yahweh with my mouth. 
+<sup>30&#160;</sup>I will give great thanks to Yahuah with my mouth. 
 </p><p class="q2">Yes, I will praise him among the multitude. 
 </p><p class="q1">
 <sup>31&#160;</sup>For he will stand at the right hand of the needy, 
@@ -6497,16 +6497,16 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="110">110</h2>
 <p class="d">A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh says to my Lord, “Sit at my right hand, 
+<sup>1&#160;</sup>Yahuah says to my Lord, “Sit at my right hand, 
 </p><p class="q2">until I make your enemies your footstool for your feet.” 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh will send out the rod of your strength out of Zion. 
+<sup>2&#160;</sup>Yahuah will send out the rod of your strength out of Zion. 
 </p><p class="q2">Rule among your enemies. 
 </p><p class="q1">
 <sup>3&#160;</sup>Your people offer themselves willingly in the day of your power, in set-apart array. 
 </p><p class="q2">Out of the womb of the morning, you have the dew of your youth. 
 </p><p class="q1">
-<sup>4&#160;</sup>Yahweh has sworn, and will not change his mind: 
+<sup>4&#160;</sup>Yahuah has sworn, and will not change his mind: 
 </p><p class="q2">“You are a priest forever in the order of Melchizedek.” 
 </p><p class="q1">
 <sup>5&#160;</sup>The Lord is at your right hand. 
@@ -6521,17 +6521,17 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="111">111</h2>
 <p class="q1">
 <sup>1&#160;</sup>Praise Yah! 
-</p><p class="q2">I will give thanks to Yahweh with my whole heart, 
+</p><p class="q2">I will give thanks to Yahuah with my whole heart, 
 </p><p class="q2">in the council of the upright, and in the congregation. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh’s works are great, 
+<sup>2&#160;</sup>Yahuah’s works are great, 
 </p><p class="q2">pondered by all those who delight in them. 
 </p><p class="q1">
 <sup>3&#160;</sup>His work is honor and majesty. 
 </p><p class="q2">His righteousness endures forever. 
 </p><p class="q1">
 <sup>4&#160;</sup>He has caused his wonderful works to be remembered. 
-</p><p class="q2">Yahweh is gracious and merciful. 
+</p><p class="q2">Yahuah is gracious and merciful. 
 </p><p class="q1">
 <sup>5&#160;</sup>He has given food to those who fear him. 
 </p><p class="q2">He always remembers his covenant. 
@@ -6549,13 +6549,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">He has ordained his covenant forever. 
 </p><p class="q2">His name is set-apart and awesome! 
 </p><p class="q1">
-<sup>10&#160;</sup>The fear of Yahweh is the beginning of wisdom. 
+<sup>10&#160;</sup>The fear of Yahuah is the beginning of wisdom. 
 </p><p class="q2">All those who do his work have a good understanding. 
 </p><p class="q1">His praise endures forever! 
 </p><h2 class="psalmlabel" id="112">112</h2>
 <p class="q1">
 <sup>1&#160;</sup>Praise Yah! 
-</p><p class="q2">Blessed is the man who fears Yahweh, 
+</p><p class="q2">Blessed is the man who fears Yahuah, 
 </p><p class="q2">who delights greatly in his commandments. 
 </p><p class="q1">
 <sup>2&#160;</sup>His offspring will be mighty in the land. 
@@ -6574,7 +6574,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">The righteous will be remembered forever. 
 </p><p class="q1">
 <sup>7&#160;</sup>He will not be afraid of evil news. 
-</p><p class="q2">His heart is steadfast, trusting in Yahweh. 
+</p><p class="q2">His heart is steadfast, trusting in Yahuah. 
 </p><p class="q1">
 <sup>8&#160;</sup>His heart is established. 
 </p><p class="q2">He will not be afraid in the end when he sees his adversaries. 
@@ -6589,19 +6589,19 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="113">113</h2>
 <p class="q1">
 <sup>1&#160;</sup>Praise Yah! 
-</p><p class="q2">Praise, you servants of Yahweh, 
-</p><p class="q2">praise Yahweh’s name. 
+</p><p class="q2">Praise, you servants of Yahuah, 
+</p><p class="q2">praise Yahuah’s name. 
 </p><p class="q1">
-<sup>2&#160;</sup>Blessed be Yahweh’s name, 
+<sup>2&#160;</sup>Blessed be Yahuah’s name, 
 </p><p class="q2">from this time forward and forever more. 
 </p><p class="q1">
 <sup>3&#160;</sup>From the rising of the sun to its going down, 
-</p><p class="q2">Yahweh’s name is to be praised. 
+</p><p class="q2">Yahuah’s name is to be praised. 
 </p><p class="q1">
-<sup>4&#160;</sup>Yahweh is high above all nations, 
+<sup>4&#160;</sup>Yahuah is high above all nations, 
 </p><p class="q2">his glory above the heavens. 
 </p><p class="q1">
-<sup>5&#160;</sup>Who is like Yahweh, our Elohim, 
+<sup>5&#160;</sup>Who is like Yahuah, our Elohim, 
 </p><p class="q2">who has his seat on high, 
 </p><p class="q2">
 <sup>6&#160;</sup>who stoops down to see in heaven and in the earth? 
@@ -6642,7 +6642,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the flint into a spring of waters. 
 </p><h2 class="psalmlabel" id="115">115</h2>
 <p class="q1">
-<sup>1&#160;</sup>Not to us, Yahweh, not to us, 
+<sup>1&#160;</sup>Not to us, Yahuah, not to us, 
 </p><p class="q2">but to your name give glory, 
 </p><p class="q2">for your loving kindness, and for your truth’s sake. 
 </p><p class="q1">
@@ -6668,29 +6668,29 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>Those who make them will be like them; 
 </p><p class="q2">yes, everyone who trusts in them. 
 </p><p class="q1">
-<sup>9&#160;</sup>Israel, trust in Yahweh! 
+<sup>9&#160;</sup>Israel, trust in Yahuah! 
 </p><p class="q2">He is their help and their shield. 
 </p><p class="q1">
-<sup>10&#160;</sup>House of Aaron, trust in Yahweh! 
+<sup>10&#160;</sup>House of Aaron, trust in Yahuah! 
 </p><p class="q2">He is their help and their shield. 
 </p><p class="q1">
-<sup>11&#160;</sup>You who fear Yahweh, trust in Yahweh! 
+<sup>11&#160;</sup>You who fear Yahuah, trust in Yahuah! 
 </p><p class="q2">He is their help and their shield. 
 </p><p class="q1">
-<sup>12&#160;</sup>Yahweh remembers us. He will bless us. 
+<sup>12&#160;</sup>Yahuah remembers us. He will bless us. 
 </p><p class="q2">He will bless the house of Israel. 
 </p><p class="q2">He will bless the house of Aaron. 
 </p><p class="q1">
-<sup>13&#160;</sup>He will bless those who fear Yahweh, 
+<sup>13&#160;</sup>He will bless those who fear Yahuah, 
 </p><p class="q2">both small and great. 
 </p><p class="q1">
-<sup>14&#160;</sup>May Yahweh increase you more and more, 
+<sup>14&#160;</sup>May Yahuah increase you more and more, 
 </p><p class="q2">you and your children. 
 </p><p class="q1">
-<sup>15&#160;</sup>Blessed are you by Yahweh, 
+<sup>15&#160;</sup>Blessed are you by Yahuah, 
 </p><p class="q2">who made heaven and earth. 
 </p><p class="q1">
-<sup>16&#160;</sup>The heavens are Yahweh’s heavens, 
+<sup>16&#160;</sup>The heavens are Yahuah’s heavens, 
 </p><p class="q2">but he has given the earth to the children of men. 
 </p><p class="q1">
 <sup>17&#160;</sup>The dead don’t praise Yah, 
@@ -6701,7 +6701,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Praise Yah! 
 </p><h2 class="psalmlabel" id="116">116</h2>
 <p class="q1">
-<sup>1&#160;</sup>I love Yahweh, because he listens to my voice, 
+<sup>1&#160;</sup>I love Yahuah, because he listens to my voice, 
 </p><p class="q2">and my cries for mercy. 
 </p><p class="q1">
 <sup>2&#160;</sup>Because he has turned his ear to me, 
@@ -6711,23 +6711,23 @@ html[dir=ltr] .q2 {
 </p><p class="q2">the pains of Sheol got a hold of me. 
 </p><p class="q2">I found trouble and sorrow. 
 </p><p class="q1">
-<sup>4&#160;</sup>Then I called on Yahweh’s name: 
-</p><p class="q2">“Yahweh, I beg you, deliver my soul.” 
+<sup>4&#160;</sup>Then I called on Yahuah’s name: 
+</p><p class="q2">“Yahuah, I beg you, deliver my soul.” 
 </p><p class="q1">
-<sup>5&#160;</sup>Yahweh is gracious and righteous. 
+<sup>5&#160;</sup>Yahuah is gracious and righteous. 
 </p><p class="q2">Yes, our Elohim is merciful. 
 </p><p class="q1">
-<sup>6&#160;</sup>Yahweh preserves the simple. 
+<sup>6&#160;</sup>Yahuah preserves the simple. 
 </p><p class="q2">I was brought low, and he saved me. 
 </p><p class="q1">
 <sup>7&#160;</sup>Return to your rest, my soul, 
-</p><p class="q2">for Yahweh has dealt bountifully with you. 
+</p><p class="q2">for Yahuah has dealt bountifully with you. 
 </p><p class="q1">
 <sup>8&#160;</sup>For you have delivered my soul from death, 
 </p><p class="q2">my eyes from tears, 
 </p><p class="q2">and my feet from falling. 
 </p><p class="q1">
-<sup>9&#160;</sup>I will walk before Yahweh in the land of the living. 
+<sup>9&#160;</sup>I will walk before Yahuah in the land of the living. 
 </p><p class="q1">
 <sup>10&#160;</sup>I believed, therefore I said, 
 </p><p class="q2">“I was greatly afflicted.” 
@@ -6735,39 +6735,39 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>I said in my haste, 
 </p><p class="q2">“All people are liars.” 
 </p><p class="q1">
-<sup>12&#160;</sup>What will I give to Yahweh for all his benefits toward me? 
+<sup>12&#160;</sup>What will I give to Yahuah for all his benefits toward me? 
 </p><p class="q2">
-<sup>13&#160;</sup>I will take the cup of salvation, and call on Yahweh’s name. 
+<sup>13&#160;</sup>I will take the cup of salvation, and call on Yahuah’s name. 
 </p><p class="q1">
-<sup>14&#160;</sup>I will pay my vows to Yahweh, 
+<sup>14&#160;</sup>I will pay my vows to Yahuah, 
 </p><p class="q2">yes, in the presence of all his people. 
 </p><p class="q1">
-<sup>15&#160;</sup>Precious in Yahweh’s sight is the death of his saints. 
+<sup>15&#160;</sup>Precious in Yahuah’s sight is the death of his saints. 
 </p><p class="q1">
-<sup>16&#160;</sup>Yahweh, truly I am your servant. 
+<sup>16&#160;</sup>Yahuah, truly I am your servant. 
 </p><p class="q2">I am your servant, the son of your servant girl. 
 </p><p class="q2">You have freed me from my chains. 
 </p><p class="q1">
 <sup>17&#160;</sup>I will offer to you the sacrifice of thanksgiving, 
-</p><p class="q2">and will call on Yahweh’s name. 
+</p><p class="q2">and will call on Yahuah’s name. 
 </p><p class="q1">
-<sup>18&#160;</sup>I will pay my vows to Yahweh, 
+<sup>18&#160;</sup>I will pay my vows to Yahuah, 
 </p><p class="q2">yes, in the presence of all his people, 
 </p><p class="q1">
-<sup>19&#160;</sup>in the courts of Yahweh’s house, 
+<sup>19&#160;</sup>in the courts of Yahuah’s house, 
 </p><p class="q2">in the middle of you, Jerusalem. 
 </p><p class="q1">Praise Yah! 
 </p><h2 class="psalmlabel" id="117">117</h2>
 <p class="q1">
-<sup>1&#160;</sup>Praise Yahweh, all you nations! 
+<sup>1&#160;</sup>Praise Yahuah, all you nations! 
 </p><p class="q2">Extol him, all you peoples! 
 </p><p class="q1">
 <sup>2&#160;</sup>For his loving kindness is great toward us. 
-</p><p class="q2">Yahweh’s faithfulness endures forever. 
+</p><p class="q2">Yahuah’s faithfulness endures forever. 
 </p><p class="q1">Praise Yah! 
 </p><h2 class="psalmlabel" id="118">118</h2>
 <p class="q1">
-<sup>1&#160;</sup>Give thanks to Yahweh, for he is good, 
+<sup>1&#160;</sup>Give thanks to Yahuah, for he is good, 
 </p><p class="q2">for his loving kindness endures forever. 
 </p><p class="q1">
 <sup>2&#160;</sup>Let Israel now say 
@@ -6776,45 +6776,45 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>Let the house of Aaron now say 
 </p><p class="q2">that his loving kindness endures forever. 
 </p><p class="q1">
-<sup>4&#160;</sup>Now let those who fear Yahweh say 
+<sup>4&#160;</sup>Now let those who fear Yahuah say 
 </p><p class="q2">that his loving kindness endures forever. 
 </p><p class="q1">
 <sup>5&#160;</sup>Out of my distress, I called on Yah. 
 </p><p class="q2">Yah answered me with freedom. 
 </p><p class="q1">
-<sup>6&#160;</sup>Yahweh is on my side. I will not be afraid. 
+<sup>6&#160;</sup>Yahuah is on my side. I will not be afraid. 
 </p><p class="q2">What can man do to me? 
 </p><p class="q1">
-<sup>7&#160;</sup>Yahweh is on my side among those who help me. 
+<sup>7&#160;</sup>Yahuah is on my side among those who help me. 
 </p><p class="q2">Therefore I will look in triumph at those who hate me. 
 </p><p class="q1">
-<sup>8&#160;</sup>It is better to take refuge in Yahweh, 
+<sup>8&#160;</sup>It is better to take refuge in Yahuah, 
 </p><p class="q2">than to put confidence in man. 
 </p><p class="q1">
-<sup>9&#160;</sup>It is better to take refuge in Yahweh, 
+<sup>9&#160;</sup>It is better to take refuge in Yahuah, 
 </p><p class="q2">than to put confidence in princes. 
 </p><p class="q1">
 <sup>10&#160;</sup>All the nations surrounded me, 
-</p><p class="q2">but in Yahweh’s name I cut them off. 
+</p><p class="q2">but in Yahuah’s name I cut them off. 
 </p><p class="q1">
 <sup>11&#160;</sup>They surrounded me, yes, they surrounded me. 
-</p><p class="q2">In Yahweh’s name I indeed cut them off. 
+</p><p class="q2">In Yahuah’s name I indeed cut them off. 
 </p><p class="q1">
 <sup>12&#160;</sup>They surrounded me like bees. 
 </p><p class="q2">They are quenched like the burning thorns. 
-</p><p class="q2">In Yahweh’s name I cut them off. 
+</p><p class="q2">In Yahuah’s name I cut them off. 
 </p><p class="q1">
 <sup>13&#160;</sup>You pushed me back hard, to make me fall, 
-</p><p class="q2">but Yahweh helped me. 
+</p><p class="q2">but Yahuah helped me. 
 </p><p class="q1">
 <sup>14&#160;</sup>Yah is my strength and song. 
 </p><p class="q2">He has become my salvation. 
 </p><p class="q1">
 <sup>15&#160;</sup>The voice of rejoicing and salvation is in the tents of the righteous. 
-</p><p class="q2">“The right hand of Yahweh does valiantly. 
+</p><p class="q2">“The right hand of Yahuah does valiantly. 
 </p><p class="q1">
-<sup>16&#160;</sup>The right hand of Yahweh is exalted! 
-</p><p class="q2">The right hand of Yahweh does valiantly!” 
+<sup>16&#160;</sup>The right hand of Yahuah is exalted! 
+</p><p class="q2">The right hand of Yahuah does valiantly!” 
 </p><p class="q1">
 <sup>17&#160;</sup>I will not die, but live, 
 </p><p class="q2">and declare Yah’s works. 
@@ -6826,7 +6826,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">I will enter into them. 
 </p><p class="q2">I will give thanks to Yah. 
 </p><p class="q1">
-<sup>20&#160;</sup>This is the gate of Yahweh; 
+<sup>20&#160;</sup>This is the gate of Yahuah; 
 </p><p class="q2">the righteous will enter into it. 
 </p><p class="q1">
 <sup>21&#160;</sup>I will give thanks to you, for you have answered me, 
@@ -6835,31 +6835,31 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>The stone which the builders rejected 
 </p><p class="q2">has become the cornerstone. 
 </p><p class="q1">
-<sup>23&#160;</sup>This is Yahweh’s doing. 
+<sup>23&#160;</sup>This is Yahuah’s doing. 
 </p><p class="q2">It is marvelous in our eyes. 
 </p><p class="q1">
-<sup>24&#160;</sup>This is the day that Yahweh has made. 
+<sup>24&#160;</sup>This is the day that Yahuah has made. 
 </p><p class="q2">We will rejoice and be glad in it! 
 </p><p class="q1">
-<sup>25&#160;</sup>Save us now, we beg you, Yahweh! 
-</p><p class="q2">Yahweh, we beg you, send prosperity now. 
+<sup>25&#160;</sup>Save us now, we beg you, Yahuah! 
+</p><p class="q2">Yahuah, we beg you, send prosperity now. 
 </p><p class="q1">
-<sup>26&#160;</sup>Blessed is he who comes in Yahweh’s name! 
-</p><p class="q2">We have blessed you out of Yahweh’s house. 
+<sup>26&#160;</sup>Blessed is he who comes in Yahuah’s name! 
+</p><p class="q2">We have blessed you out of Yahuah’s house. 
 </p><p class="q1">
-<sup>27&#160;</sup>Yahweh is Elohim, and he has given us light. 
+<sup>27&#160;</sup>Yahuah is Elohim, and he has given us light. 
 </p><p class="q2">Bind the sacrifice with cords, even to the horns of the altar. 
 </p><p class="q1">
 <sup>28&#160;</sup>You are my Elohim, and I will give thanks to you. 
 </p><p class="q2">You are my Elohim, I will exalt you. 
 </p><p class="q1">
-<sup>29&#160;</sup>Oh give thanks to Yahweh, for he is good, 
+<sup>29&#160;</sup>Oh give thanks to Yahuah, for he is good, 
 </p><p class="q2">for his loving kindness endures forever. 
 </p><h2 class="psalmlabel" id="119">119</h2>
 <p class="d">ALEPH 
 </p><p class="q1">
 <sup>1&#160;</sup>Blessed are those whose ways are blameless, 
-</p><p class="q2">who walk according to Yahweh’s law. 
+</p><p class="q2">who walk according to Yahuah’s law. 
 </p><p class="q1">
 <sup>2&#160;</sup>Blessed are those who keep his statutes, 
 </p><p class="q2">who seek him with their whole heart. 
@@ -6892,7 +6892,7 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>I have hidden your word in my heart, 
 </p><p class="q2">that I might not sin against you. 
 </p><p class="q1">
-<sup>12&#160;</sup>Blessed are you, Yahweh. 
+<sup>12&#160;</sup>Blessed are you, Yahuah. 
 </p><p class="q2">Teach me your statutes. 
 </p><p class="q1">
 <sup>13&#160;</sup>With my lips, 
@@ -6950,14 +6950,14 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup>I have chosen the way of truth. 
 </p><p class="q2">I have set your ordinances before me. 
 </p><p class="q1">
-<sup>31&#160;</sup>I cling to your statutes, Yahweh. 
+<sup>31&#160;</sup>I cling to your statutes, Yahuah. 
 </p><p class="q2">Don’t let me be disappointed. 
 </p><p class="q1">
 <sup>32&#160;</sup>I run in the path of your commandments, 
 </p><p class="q2">for you have set my heart free. 
 </p><p class="d">HE 
 </p><p class="q1">
-<sup>33&#160;</sup>Teach me, Yahweh, the way of your statutes. 
+<sup>33&#160;</sup>Teach me, Yahuah, the way of your statutes. 
 </p><p class="q2">I will keep them to the end. 
 </p><p class="q1">
 <sup>34&#160;</sup>Give me understanding, and I will keep your law. 
@@ -6982,7 +6982,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Revive me in your righteousness. 
 </p><p class="d">VAV 
 </p><p class="q1">
-<sup>41&#160;</sup>Let your loving kindness also come to me, Yahweh, 
+<sup>41&#160;</sup>Let your loving kindness also come to me, Yahuah, 
 </p><p class="q2">your salvation, according to your word. 
 </p><p class="q1">
 <sup>42&#160;</sup>So I will have an answer for him who reproaches me, 
@@ -7016,7 +7016,7 @@ html[dir=ltr] .q2 {
 <sup>51&#160;</sup>The arrogant mock me excessively, 
 </p><p class="q2">but I don’t swerve from your law. 
 </p><p class="q1">
-<sup>52&#160;</sup>I remember your ordinances of old, Yahweh, 
+<sup>52&#160;</sup>I remember your ordinances of old, Yahuah, 
 </p><p class="q2">and have comforted myself. 
 </p><p class="q1">
 <sup>53&#160;</sup>Indignation has taken hold on me, 
@@ -7025,14 +7025,14 @@ html[dir=ltr] .q2 {
 <sup>54&#160;</sup>Your statutes have been my songs 
 </p><p class="q2">in the house where I live. 
 </p><p class="q1">
-<sup>55&#160;</sup>I have remembered your name, Yahweh, in the night, 
+<sup>55&#160;</sup>I have remembered your name, Yahuah, in the night, 
 </p><p class="q2">and I obey your law. 
 </p><p class="q1">
 <sup>56&#160;</sup>This is my way, 
 </p><p class="q2">that I keep your precepts. 
 </p><p class="d">HETH 
 </p><p class="q1">
-<sup>57&#160;</sup>Yahweh is my portion. 
+<sup>57&#160;</sup>Yahuah is my portion. 
 </p><p class="q2">I promised to obey your words. 
 </p><p class="q1">
 <sup>58&#160;</sup>I sought your favor with my whole heart. 
@@ -7053,12 +7053,12 @@ html[dir=ltr] .q2 {
 <sup>63&#160;</sup>I am a friend of all those who fear you, 
 </p><p class="q2">of those who observe your precepts. 
 </p><p class="q1">
-<sup>64&#160;</sup>The earth is full of your loving kindness, Yahweh. 
+<sup>64&#160;</sup>The earth is full of your loving kindness, Yahuah. 
 </p><p class="q2">Teach me your statutes. 
 </p><p class="d">TETH 
 </p><p class="q1">
 <sup>65&#160;</sup>You have treated your servant well, 
-</p><p class="q2">according to your word, Yahweh. 
+</p><p class="q2">according to your word, Yahuah. 
 </p><p class="q1">
 <sup>66&#160;</sup>Teach me good judgment and knowledge, 
 </p><p class="q2">for I believe in your commandments. 
@@ -7087,7 +7087,7 @@ html[dir=ltr] .q2 {
 <sup>74&#160;</sup>Those who fear you will see me and be glad, 
 </p><p class="q2">because I have put my hope in your word. 
 </p><p class="q1">
-<sup>75&#160;</sup>Yahweh, I know that your judgments are righteous, 
+<sup>75&#160;</sup>Yahuah, I know that your judgments are righteous, 
 </p><p class="q2">that in faithfulness you have afflicted me. 
 </p><p class="q1">
 <sup>76&#160;</sup>Please let your loving kindness be for my comfort, 
@@ -7132,7 +7132,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">so I will obey the statutes of your mouth. 
 </p><p class="d">LAMEDH 
 </p><p class="q1">
-<sup>89&#160;</sup>Yahweh, your word is settled in heaven forever. 
+<sup>89&#160;</sup>Yahuah, your word is settled in heaven forever. 
 </p><p class="q1">
 <sup>90&#160;</sup>Your faithfulness is to all generations. 
 </p><p class="q2">You have established the earth, and it remains. 
@@ -7188,10 +7188,10 @@ html[dir=ltr] .q2 {
 </p><p class="q2">that I will obey your righteous ordinances. 
 </p><p class="q1">
 <sup>107&#160;</sup>I am afflicted very much. 
-</p><p class="q2">Revive me, Yahweh, according to your word. 
+</p><p class="q2">Revive me, Yahuah, according to your word. 
 </p><p class="q1">
 <sup>108&#160;</sup>Accept, I beg you, the willing offerings of my mouth. 
-</p><p class="q2">Yahweh, teach me your ordinances. 
+</p><p class="q2">Yahuah, teach me your ordinances. 
 </p><p class="q1">
 <sup>109&#160;</sup>My soul is continually in my hand, 
 </p><p class="q2">yet I won’t forget your law. 
@@ -7246,7 +7246,7 @@ html[dir=ltr] .q2 {
 <sup>125&#160;</sup>I am your servant. Give me understanding, 
 </p><p class="q2">that I may know your testimonies. 
 </p><p class="q1">
-<sup>126&#160;</sup>It is time to act, Yahweh, 
+<sup>126&#160;</sup>It is time to act, Yahuah, 
 </p><p class="q2">for they break your law. 
 </p><p class="q1">
 <sup>127&#160;</sup>Therefore I love your commandments more than gold, 
@@ -7281,7 +7281,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">because they don’t observe your law. 
 </p><p class="d">TZADHE 
 </p><p class="q1">
-<sup>137&#160;</sup>You are righteous, Yahweh. 
+<sup>137&#160;</sup>You are righteous, Yahuah. 
 </p><p class="q2">Your judgments are upright. 
 </p><p class="q1">
 <sup>138&#160;</sup>You have commanded your statutes in righteousness. 
@@ -7307,7 +7307,7 @@ html[dir=ltr] .q2 {
 </p><p class="d">QOPH 
 </p><p class="q1">
 <sup>145&#160;</sup>I have called with my whole heart. 
-</p><p class="q2">Answer me, Yahweh! 
+</p><p class="q2">Answer me, Yahuah! 
 </p><p class="q2">I will keep your statutes. 
 </p><p class="q1">
 <sup>146&#160;</sup>I have called to you. Save me! 
@@ -7320,12 +7320,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">that I might meditate on your word. 
 </p><p class="q1">
 <sup>149&#160;</sup>Hear my voice according to your loving kindness. 
-</p><p class="q2">Revive me, Yahweh, according to your ordinances. 
+</p><p class="q2">Revive me, Yahuah, according to your ordinances. 
 </p><p class="q1">
 <sup>150&#160;</sup>They draw near who follow after wickedness. 
 </p><p class="q2">They are far from your law. 
 </p><p class="q1">
-<sup>151&#160;</sup>You are near, Yahweh. 
+<sup>151&#160;</sup>You are near, Yahuah. 
 </p><p class="q2">All your commandments are truth. 
 </p><p class="q1">
 <sup>152&#160;</sup>Of old I have known from your testimonies, 
@@ -7341,7 +7341,7 @@ html[dir=ltr] .q2 {
 <sup>155&#160;</sup>Salvation is far from the wicked, 
 </p><p class="q2">for they don’t seek your statutes. 
 </p><p class="q1">
-<sup>156&#160;</sup>Great are your tender mercies, Yahweh. 
+<sup>156&#160;</sup>Great are your tender mercies, Yahuah. 
 </p><p class="q2">Revive me according to your ordinances. 
 </p><p class="q1">
 <sup>157&#160;</sup>Many are my persecutors and my adversaries. 
@@ -7351,7 +7351,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">because they don’t observe your word. 
 </p><p class="q1">
 <sup>159&#160;</sup>Consider how I love your precepts. 
-</p><p class="q2">Revive me, Yahweh, according to your loving kindness. 
+</p><p class="q2">Revive me, Yahuah, according to your loving kindness. 
 </p><p class="q1">
 <sup>160&#160;</sup>All of your words are truth. 
 </p><p class="q2">Every one of your righteous ordinances endures forever. 
@@ -7372,7 +7372,7 @@ html[dir=ltr] .q2 {
 <sup>165&#160;</sup>Those who love your law have great peace. 
 </p><p class="q2">Nothing causes them to stumble. 
 </p><p class="q1">
-<sup>166&#160;</sup>I have hoped for your salvation, Yahweh. 
+<sup>166&#160;</sup>I have hoped for your salvation, Yahuah. 
 </p><p class="q2">I have done your commandments. 
 </p><p class="q1">
 <sup>167&#160;</sup>My soul has observed your testimonies. 
@@ -7382,7 +7382,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for all my ways are before you. 
 </p><p class="d">TAV 
 </p><p class="q1">
-<sup>169&#160;</sup>Let my cry come before you, Yahweh. 
+<sup>169&#160;</sup>Let my cry come before you, Yahuah. 
 </p><p class="q2">Give me understanding according to your word. 
 </p><p class="q1">
 <sup>170&#160;</sup>Let my supplication come before you. 
@@ -7397,7 +7397,7 @@ html[dir=ltr] .q2 {
 <sup>173&#160;</sup>Let your hand be ready to help me, 
 </p><p class="q2">for I have chosen your precepts. 
 </p><p class="q1">
-<sup>174&#160;</sup>I have longed for your salvation, Yahweh. 
+<sup>174&#160;</sup>I have longed for your salvation, Yahuah. 
 </p><p class="q2">Your law is my delight. 
 </p><p class="q1">
 <sup>175&#160;</sup>Let my soul live, that I may praise you. 
@@ -7408,10 +7408,10 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="120">120</h2>
 <p class="d">A Song of Ascents. 
 </p><p class="q1">
-<sup>1&#160;</sup>In my distress, I cried to Yahweh. 
+<sup>1&#160;</sup>In my distress, I cried to Yahuah. 
 </p><p class="q2">He answered me. 
 </p><p class="q1">
-<sup>2&#160;</sup>Deliver my soul, Yahweh, from lying lips, 
+<sup>2&#160;</sup>Deliver my soul, Yahuah, from lying lips, 
 </p><p class="q2">from a deceitful tongue. 
 </p><p class="q1">
 <sup>3&#160;</sup>What will be given to you, and what will be done more to you, 
@@ -7434,7 +7434,7 @@ html[dir=ltr] .q2 {
 <sup>1&#160;</sup>I will lift up my eyes to the hills. 
 </p><p class="q2">Where does my help come from? 
 </p><p class="q1">
-<sup>2&#160;</sup>My help comes from Yahweh, 
+<sup>2&#160;</sup>My help comes from Yahuah, 
 </p><p class="q2">who made heaven and earth. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -7444,22 +7444,22 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>Behold, he who keeps Israel 
 </p><p class="q2">will neither slumber nor sleep. 
 </p><p class="q1">
-<sup>5&#160;</sup>Yahweh is your keeper. 
-</p><p class="q2">Yahweh is your shade on your right hand. 
+<sup>5&#160;</sup>Yahuah is your keeper. 
+</p><p class="q2">Yahuah is your shade on your right hand. 
 </p><p class="q1">
 <sup>6&#160;</sup>The sun will not harm you by day, 
 </p><p class="q2">nor the moon by night. 
 </p><p class="q1">
-<sup>7&#160;</sup>Yahweh will keep you from all evil. 
+<sup>7&#160;</sup>Yahuah will keep you from all evil. 
 </p><p class="q2">He will keep your soul. 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh will keep your going out and your coming in, 
+<sup>8&#160;</sup>Yahuah will keep your going out and your coming in, 
 </p><p class="q2">from this time forward, and forever more. 
 </p><h2 class="psalmlabel" id="122">122</h2>
 <p class="d">A Song of Ascents. By David. 
 </p><p class="q1">
 <sup>1&#160;</sup>I was glad when they said to me, 
-</p><p class="q2">“Let’s go to Yahweh’s house!” 
+</p><p class="q2">“Let’s go to Yahuah’s house!” 
 </p><p class="q1">
 <sup>2&#160;</sup>Our feet are standing within your gates, Jerusalem! 
 </p><p class="q2">
@@ -7467,7 +7467,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>4&#160;</sup>where the tribes go up, even Yah’s tribes, 
 </p><p class="q2">according to an ordinance for Israel, 
-</p><p class="q2">to give thanks to Yahweh’s name. 
+</p><p class="q2">to give thanks to Yahuah’s name. 
 </p><p class="q1">
 <sup>5&#160;</sup>For there are set thrones for judgment, 
 </p><p class="q2">the thrones of David’s house. 
@@ -7481,7 +7481,7 @@ html[dir=ltr] .q2 {
 <sup>8&#160;</sup>For my brothers’ and companions’ sakes, 
 </p><p class="q2">I will now say, “Peace be within you.” 
 </p><p class="q1">
-<sup>9&#160;</sup>For the sake of the house of Yahweh our Elohim, 
+<sup>9&#160;</sup>For the sake of the house of Yahuah our Elohim, 
 </p><p class="q2">I will seek your good. 
 </p><h2 class="psalmlabel" id="123">123</h2>
 <p class="d">A Song of Ascents. 
@@ -7491,10 +7491,10 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>2&#160;</sup>Behold, as the eyes of servants look to the hand of their master, 
 </p><p class="q2">as the eyes of a maid to the hand of her mistress, 
-</p><p class="q2">so our eyes look to Yahweh, our Elohim, 
+</p><p class="q2">so our eyes look to Yahuah, our Elohim, 
 </p><p class="q2">until he has mercy on us. 
 </p><p class="q1">
-<sup>3&#160;</sup>Have mercy on us, Yahweh, have mercy on us, 
+<sup>3&#160;</sup>Have mercy on us, Yahuah, have mercy on us, 
 </p><p class="q2">for we have endured much contempt. 
 </p><p class="q1">
 <sup>4&#160;</sup>Our soul is exceedingly filled with the scoffing of those who are at ease, 
@@ -7502,10 +7502,10 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="124">124</h2>
 <p class="d">A Song of Ascents. By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>If it had not been Yahweh who was on our side, 
+<sup>1&#160;</sup>If it had not been Yahuah who was on our side, 
 </p><p class="q2">let Israel now say, 
 </p><p class="q1">
-<sup>2&#160;</sup>if it had not been Yahweh who was on our side, 
+<sup>2&#160;</sup>if it had not been Yahuah who was on our side, 
 </p><p class="q2">when men rose up against us, 
 </p><p class="q1">
 <sup>3&#160;</sup>then they would have swallowed us up alive, 
@@ -7516,47 +7516,47 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>5&#160;</sup>Then the proud waters would have gone over our soul. 
 </p><p class="q1">
-<sup>6&#160;</sup>Blessed be Yahweh, 
+<sup>6&#160;</sup>Blessed be Yahuah, 
 </p><p class="q2">who has not given us as a prey to their teeth. 
 </p><p class="q1">
 <sup>7&#160;</sup>Our soul has escaped like a bird out of the fowler’s snare. 
 </p><p class="q2">The snare is broken, and we have escaped. 
 </p><p class="q1">
-<sup>8&#160;</sup>Our help is in Yahweh’s name, 
+<sup>8&#160;</sup>Our help is in Yahuah’s name, 
 </p><p class="q2">who made heaven and earth. 
 </p><h2 class="psalmlabel" id="125">125</h2>
 <p class="d">A Song of Ascents. 
 </p><p class="q1">
-<sup>1&#160;</sup>Those who trust in Yahweh are as Mount Zion, 
+<sup>1&#160;</sup>Those who trust in Yahuah are as Mount Zion, 
 </p><p class="q2">which can’t be moved, but remains forever. 
 </p><p class="q1">
 <sup>2&#160;</sup>As the mountains surround Jerusalem, 
-</p><p class="q2">so Yahweh surrounds his people from this time forward and forever more. 
+</p><p class="q2">so Yahuah surrounds his people from this time forward and forever more. 
 </p><p class="q1">
 <sup>3&#160;</sup>For the scepter of wickedness won’t remain over the allotment of the righteous, 
 </p><p class="q2">so that the righteous won’t use their hands to do evil. 
 </p><p class="q1">
-<sup>4&#160;</sup>Do good, Yahweh, to those who are good, 
+<sup>4&#160;</sup>Do good, Yahuah, to those who are good, 
 </p><p class="q2">to those who are upright in their hearts. 
 </p><p class="q1">
 <sup>5&#160;</sup>But as for those who turn away to their crooked ways, 
-</p><p class="q2">Yahweh will lead them away with the workers of iniquity. 
+</p><p class="q2">Yahuah will lead them away with the workers of iniquity. 
 </p><p class="q1">Peace be on Israel. 
 </p><h2 class="psalmlabel" id="126">126</h2>
 <p class="d">A Song of Ascents. 
 </p><p class="q1">
-<sup>1&#160;</sup>When Yahweh brought back those who returned to Zion, 
+<sup>1&#160;</sup>When Yahuah brought back those who returned to Zion, 
 </p><p class="q2">we were like those who dream. 
 </p><p class="q1">
 <sup>2&#160;</sup>Then our mouth was filled with laughter, 
 </p><p class="q2">and our tongue with singing. 
 </p><p class="q1">Then they said among the nations, 
-</p><p class="q2">“Yahweh has done great things for them.” 
+</p><p class="q2">“Yahuah has done great things for them.” 
 </p><p class="q1">
-<sup>3&#160;</sup>Yahweh has done great things for us, 
+<sup>3&#160;</sup>Yahuah has done great things for us, 
 </p><p class="q2">and we are glad. 
 </p><p class="q1">
-<sup>4&#160;</sup>Restore our fortunes again, Yahweh, 
+<sup>4&#160;</sup>Restore our fortunes again, Yahuah, 
 </p><p class="q2">like the streams in the Negev. 
 </p><p class="q1">
 <sup>5&#160;</sup>Those who sow in tears will reap in joy. 
@@ -7566,9 +7566,9 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="127">127</h2>
 <p class="d">A Song of Ascents. By Solomon. 
 </p><p class="q1">
-<sup>1&#160;</sup>Unless Yahweh builds the house, 
+<sup>1&#160;</sup>Unless Yahuah builds the house, 
 </p><p class="q2">they who build it labor in vain. 
-</p><p class="q1">Unless Yahweh watches over the city, 
+</p><p class="q1">Unless Yahuah watches over the city, 
 </p><p class="q2">the watchman guards it in vain. 
 </p><p class="q1">
 <sup>2&#160;</sup>It is vain for you to rise up early, 
@@ -7576,7 +7576,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">eating the bread of toil, 
 </p><p class="q2">for he gives sleep to his loved ones. 
 </p><p class="q1">
-<sup>3&#160;</sup>Behold, children are a heritage of Yahweh. 
+<sup>3&#160;</sup>Behold, children are a heritage of Yahuah. 
 </p><p class="q2">The fruit of the womb is his reward. 
 </p><p class="q1">
 <sup>4&#160;</sup>As arrows in the hand of a mighty man, 
@@ -7587,7 +7587,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="128">128</h2>
 <p class="d">A Song of Ascents. 
 </p><p class="q1">
-<sup>1&#160;</sup>Blessed is everyone who fears Yahweh, 
+<sup>1&#160;</sup>Blessed is everyone who fears Yahuah, 
 </p><p class="q2">who walks in his ways. 
 </p><p class="q1">
 <sup>2&#160;</sup>For you will eat the labor of your hands. 
@@ -7596,9 +7596,9 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>Your woman will be as a fruitful vine in the innermost parts of your house, 
 </p><p class="q2">your children like olive shoots around your table. 
 </p><p class="q1">
-<sup>4&#160;</sup>Behold, this is how the man who fears Yahweh is blessed. 
+<sup>4&#160;</sup>Behold, this is how the man who fears Yahuah is blessed. 
 </p><p class="q2">
-<sup>5&#160;</sup>May Yahweh bless you out of Zion, 
+<sup>5&#160;</sup>May Yahuah bless you out of Zion, 
 </p><p class="q2">and may you see the good of Jerusalem all the days of your life. 
 </p><p class="q1">
 <sup>6&#160;</sup>Yes, may you see your children’s children. 
@@ -7615,7 +7615,7 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>The plowers plowed on my back. 
 </p><p class="q2">They made their furrows long. 
 </p><p class="q1">
-<sup>4&#160;</sup>Yahweh is righteous. 
+<sup>4&#160;</sup>Yahuah is righteous. 
 </p><p class="q2">He has cut apart the cords of the wicked. 
 </p><p class="q1">
 <sup>5&#160;</sup>Let them be disappointed and turned backward, 
@@ -7628,12 +7628,12 @@ html[dir=ltr] .q2 {
 </p><p class="q2">nor he who binds sheaves, his bosom. 
 </p><p class="q1">
 <sup>8&#160;</sup>Neither do those who go by say, 
-</p><p class="q2">“The blessing of Yahweh be on you. 
-</p><p class="q2">We bless you in Yahweh’s name.” 
+</p><p class="q2">“The blessing of Yahuah be on you. 
+</p><p class="q2">We bless you in Yahuah’s name.” 
 </p><h2 class="psalmlabel" id="130">130</h2>
 <p class="d">A Song of Ascents. 
 </p><p class="q1">
-<sup>1&#160;</sup>Out of the depths I have cried to you, Yahweh. 
+<sup>1&#160;</sup>Out of the depths I have cried to you, Yahuah. 
 </p><p class="q1">
 <sup>2&#160;</sup>Lord, hear my voice. 
 </p><p class="q2">Let your ears be attentive to the voice of my petitions. 
@@ -7644,22 +7644,22 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>But there is forgiveness with you, 
 </p><p class="q2">therefore you are feared. 
 </p><p class="q1">
-<sup>5&#160;</sup>I wait for Yahweh. 
+<sup>5&#160;</sup>I wait for Yahuah. 
 </p><p class="q2">My soul waits. 
 </p><p class="q2">I hope in his word. 
 </p><p class="q1">
 <sup>6&#160;</sup>My soul longs for the Lord more than watchmen long for the morning, 
 </p><p class="q2">more than watchmen for the morning. 
 </p><p class="q1">
-<sup>7&#160;</sup>Israel, hope in Yahweh, 
-</p><p class="q2">for there is loving kindness with Yahweh. 
+<sup>7&#160;</sup>Israel, hope in Yahuah, 
+</p><p class="q2">for there is loving kindness with Yahuah. 
 </p><p class="q2">Abundant redemption is with him. 
 </p><p class="q1">
 <sup>8&#160;</sup>He will redeem Israel from all their sins. 
 </p><h2 class="psalmlabel" id="131">131</h2>
 <p class="d">A Song of Ascents. By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, my heart isn’t arrogant, nor my eyes lofty; 
+<sup>1&#160;</sup>Yahuah, my heart isn’t arrogant, nor my eyes lofty; 
 </p><p class="q2">nor do I concern myself with great matters, 
 </p><p class="q2">or things too wonderful for me. 
 </p><p class="q1">
@@ -7667,14 +7667,14 @@ html[dir=ltr] .q2 {
 </p><p class="q2">like a weaned child with his mother, 
 </p><p class="q2">like a weaned child is my soul within me. 
 </p><p class="q1">
-<sup>3&#160;</sup>Israel, hope in Yahweh, 
+<sup>3&#160;</sup>Israel, hope in Yahuah, 
 </p><p class="q2">from this time forward and forever more. 
 </p><h2 class="psalmlabel" id="132">132</h2>
 <p class="d">A Song of Ascents. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, remember David and all his affliction, 
+<sup>1&#160;</sup>Yahuah, remember David and all his affliction, 
 </p><p class="q1">
-<sup>2&#160;</sup>how he swore to Yahweh, 
+<sup>2&#160;</sup>how he swore to Yahuah, 
 </p><p class="q2">and vowed to the Mighty One of Jacob: 
 </p><p class="q1">
 <sup>3&#160;</sup>“Surely I will not come into the structure of my house, 
@@ -7683,7 +7683,7 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>I will not give sleep to my eyes, 
 </p><p class="q2">or slumber to my eyelids, 
 </p><p class="q1">
-<sup>5&#160;</sup>until I find out a place for Yahweh, 
+<sup>5&#160;</sup>until I find out a place for Yahuah, 
 </p><p class="q2">a dwelling for the Mighty One of Jacob.” 
 </p><p class="q1">
 <sup>6&#160;</sup>Behold, we heard of it in Ephrathah. 
@@ -7692,7 +7692,7 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>“We will go into his dwelling place. 
 </p><p class="q2">We will worship at his footstool.” 
 </p><p class="q1">
-<sup>8&#160;</sup>Arise, Yahweh, into your resting place, 
+<sup>8&#160;</sup>Arise, Yahuah, into your resting place, 
 </p><p class="q2">you, and the ark of your strength. 
 </p><p class="q1">
 <sup>9&#160;</sup>Let your priests be clothed with righteousness. 
@@ -7701,7 +7701,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>For your servant David’s sake, 
 </p><p class="q2">don’t turn away the face of your anointed one. 
 </p><p class="q1">
-<sup>11&#160;</sup>Yahweh has sworn to David in truth. 
+<sup>11&#160;</sup>Yahuah has sworn to David in truth. 
 </p><p class="q2">He will not turn from it: 
 </p><p class="q2">“I will set the fruit of your body on your throne. 
 </p><p class="q1">
@@ -7709,7 +7709,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">my testimony that I will teach them, 
 </p><p class="q2">their children also will sit on your throne forever more.” 
 </p><p class="q1">
-<sup>13&#160;</sup>For Yahweh has chosen Zion. 
+<sup>13&#160;</sup>For Yahuah has chosen Zion. 
 </p><p class="q2">He has desired it for his habitation. 
 </p><p class="q1">
 <sup>14&#160;</sup>“This is my resting place forever. 
@@ -7739,38 +7739,38 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>3&#160;</sup>like the dew of Hermon, 
 </p><p class="q2">that comes down on the hills of Zion; 
-</p><p class="q2">for there Yahweh gives the blessing, 
+</p><p class="q2">for there Yahuah gives the blessing, 
 </p><p class="q2">even life forever more. 
 </p><h2 class="psalmlabel" id="134">134</h2>
 <p class="d">A Song of Ascents. 
 </p><p class="q1">
-<sup>1&#160;</sup>Look! Praise Yahweh, all you servants of Yahweh, 
-</p><p class="q2">who stand by night in Yahweh’s house! 
+<sup>1&#160;</sup>Look! Praise Yahuah, all you servants of Yahuah, 
+</p><p class="q2">who stand by night in Yahuah’s house! 
 </p><p class="q1">
 <sup>2&#160;</sup>Lift up your hands in the sanctuary. 
-</p><p class="q2">Praise Yahweh! 
+</p><p class="q2">Praise Yahuah! 
 </p><p class="q1">
-<sup>3&#160;</sup>May Yahweh bless you from Zion, 
+<sup>3&#160;</sup>May Yahuah bless you from Zion, 
 </p><p class="q2">even he who made heaven and earth. 
 </p><h2 class="psalmlabel" id="135">135</h2>
 <p class="q1">
 <sup>1&#160;</sup>Praise Yah! 
-</p><p class="q2">Praise Yahweh’s name! 
-</p><p class="q2">Praise him, you servants of Yahweh, 
+</p><p class="q2">Praise Yahuah’s name! 
+</p><p class="q2">Praise him, you servants of Yahuah, 
 </p><p class="q1">
-<sup>2&#160;</sup>you who stand in Yahweh’s house, 
+<sup>2&#160;</sup>you who stand in Yahuah’s house, 
 </p><p class="q2">in the courts of our Elohim’s house. 
 </p><p class="q1">
-<sup>3&#160;</sup>Praise Yah, for Yahweh is good. 
+<sup>3&#160;</sup>Praise Yah, for Yahuah is good. 
 </p><p class="q2">Sing praises to his name, for that is pleasant. 
 </p><p class="q1">
 <sup>4&#160;</sup>For Yah has chosen Jacob for himself, 
 </p><p class="q2">Israel for his own possession. 
 </p><p class="q1">
-<sup>5&#160;</sup>For I know that Yahweh is great, 
+<sup>5&#160;</sup>For I know that Yahuah is great, 
 </p><p class="q2">that our Lord is above all elohims. 
 </p><p class="q1">
-<sup>6&#160;</sup>Whatever Yahweh pleased, that he has done, 
+<sup>6&#160;</sup>Whatever Yahuah pleased, that he has done, 
 </p><p class="q2">in heaven and in earth, in the seas and in all deeps. 
 </p><p class="q1">
 <sup>7&#160;</sup>He causes the clouds to rise from the ends of the earth. 
@@ -7791,10 +7791,10 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>and gave their land for a heritage, 
 </p><p class="q2">a heritage to Israel, his people. 
 </p><p class="q1">
-<sup>13&#160;</sup>Your name, Yahweh, endures forever; 
-</p><p class="q2">your renown, Yahweh, throughout all generations. 
+<sup>13&#160;</sup>Your name, Yahuah, endures forever; 
+</p><p class="q2">your renown, Yahuah, throughout all generations. 
 </p><p class="q1">
-<sup>14&#160;</sup>For Yahweh will judge his people 
+<sup>14&#160;</sup>For Yahuah will judge his people 
 </p><p class="q2">and have compassion on his servants. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -7810,18 +7810,18 @@ html[dir=ltr] .q2 {
 <sup>18&#160;</sup>Those who make them will be like them, 
 </p><p class="q2">yes, everyone who trusts in them. 
 </p><p class="q1">
-<sup>19&#160;</sup>House of Israel, praise Yahweh! 
-</p><p class="q2">House of Aaron, praise Yahweh! 
+<sup>19&#160;</sup>House of Israel, praise Yahuah! 
+</p><p class="q2">House of Aaron, praise Yahuah! 
 </p><p class="q1">
-<sup>20&#160;</sup>House of Levi, praise Yahweh! 
-</p><p class="q2">You who fear Yahweh, praise Yahweh! 
+<sup>20&#160;</sup>House of Levi, praise Yahuah! 
+</p><p class="q2">You who fear Yahuah, praise Yahuah! 
 </p><p class="q1">
-<sup>21&#160;</sup>Blessed be Yahweh from Zion, 
+<sup>21&#160;</sup>Blessed be Yahuah from Zion, 
 </p><p class="q2">who dwells in Jerusalem. 
 </p><p class="q1">Praise Yah! 
 </p><h2 class="psalmlabel" id="136">136</h2>
 <p class="q1">
-<sup>1&#160;</sup>Give thanks to Yahweh, for he is good, 
+<sup>1&#160;</sup>Give thanks to Yahuah, for he is good, 
 </p><p class="q2">for his loving kindness endures forever. 
 </p><p class="q1">
 <sup>2&#160;</sup>Give thanks to the Elohim of elohims, 
@@ -7910,7 +7910,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Those who tormented us demanded songs of joy: 
 </p><p class="q2">“Sing us one of the songs of Zion!” 
 </p><p class="q1">
-<sup>4&#160;</sup>How can we sing Yahweh’s song in a foreign land? 
+<sup>4&#160;</sup>How can we sing Yahuah’s song in a foreign land? 
 </p><p class="q1">
 <sup>5&#160;</sup>If I forget you, Jerusalem, 
 </p><p class="q2">let my right hand forget its skill. 
@@ -7918,7 +7918,7 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>Let my tongue stick to the roof of my mouth if I don’t remember you, 
 </p><p class="q2">if I don’t prefer Jerusalem above my chief joy. 
 </p><p class="q1">
-<sup>7&#160;</sup>Remember, Yahweh, against the children of Edom in the day of Jerusalem, 
+<sup>7&#160;</sup>Remember, Yahuah, against the children of Edom in the day of Jerusalem, 
 </p><p class="q2">who said, “Raze it! 
 </p><p class="q2">Raze it even to its foundation!” 
 </p><p class="q1">
@@ -7941,26 +7941,26 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>In the day that I called, you answered me. 
 </p><p class="q2">You encouraged me with strength in my soul. 
 </p><p class="q1">
-<sup>4&#160;</sup>All the kings of the earth will give you thanks, Yahweh, 
+<sup>4&#160;</sup>All the kings of the earth will give you thanks, Yahuah, 
 </p><p class="q2">for they have heard the words of your mouth. 
 </p><p class="q1">
-<sup>5&#160;</sup>Yes, they will sing of the ways of Yahweh, 
-</p><p class="q2">for Yahweh’s glory is great! 
+<sup>5&#160;</sup>Yes, they will sing of the ways of Yahuah, 
+</p><p class="q2">for Yahuah’s glory is great! 
 </p><p class="q1">
-<sup>6&#160;</sup>For though Yahweh is high, yet he looks after the lowly; 
+<sup>6&#160;</sup>For though Yahuah is high, yet he looks after the lowly; 
 </p><p class="q2">but he knows the proud from afar. 
 </p><p class="q1">
 <sup>7&#160;</sup>Though I walk in the middle of trouble, you will revive me. 
 </p><p class="q2">You will stretch out your hand against the wrath of my enemies. 
 </p><p class="q2">Your right hand will save me. 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh will fulfill that which concerns me. 
-</p><p class="q2">Your loving kindness, Yahweh, endures forever. 
+<sup>8&#160;</sup>Yahuah will fulfill that which concerns me. 
+</p><p class="q2">Your loving kindness, Yahuah, endures forever. 
 </p><p class="q2">Don’t forsake the works of your own hands. 
 </p><h2 class="psalmlabel" id="139">139</h2>
 <p class="d">For the Chief Musician. A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, you have searched me, 
+<sup>1&#160;</sup>Yahuah, you have searched me, 
 </p><p class="q2">and you know me. 
 </p><p class="q1">
 <sup>2&#160;</sup>You know my sitting down and my rising up. 
@@ -7970,7 +7970,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and are acquainted with all my ways. 
 </p><p class="q1">
 <sup>4&#160;</sup>For there is not a word on my tongue, 
-</p><p class="q2">but behold, Yahweh, you know it altogether. 
+</p><p class="q2">but behold, Yahuah, you know it altogether. 
 </p><p class="q1">
 <sup>5&#160;</sup>You hem me in behind and before. 
 </p><p class="q2">You laid your hand on me. 
@@ -8027,7 +8027,7 @@ html[dir=ltr] .q2 {
 <sup>20&#160;</sup>For they speak against you wickedly. 
 </p><p class="q2">Your enemies take your name in vain. 
 </p><p class="q1">
-<sup>21&#160;</sup>Yahweh, don’t I hate those who hate you? 
+<sup>21&#160;</sup>Yahuah, don’t I hate those who hate you? 
 </p><p class="q2">Am I not grieved with those who rise up against you? 
 </p><p class="q1">
 <sup>22&#160;</sup>I hate them with perfect hatred. 
@@ -8041,7 +8041,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="140">140</h2>
 <p class="d">For the Chief Musician. A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Deliver me, Yahweh, from evil men. 
+<sup>1&#160;</sup>Deliver me, Yahuah, from evil men. 
 </p><p class="q2">Preserve me from violent men: 
 </p><p class="q1">
 <sup>2&#160;</sup>those who devise mischief in their hearts. 
@@ -8050,20 +8050,20 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>They have sharpened their tongues like a serpent. 
 </p><p class="q2">Viper’s poison is under their lips. </p><p class="qs">Selah. 
 </p><p class="q1">
-<sup>4&#160;</sup>Yahweh, keep me from the hands of the wicked. 
+<sup>4&#160;</sup>Yahuah, keep me from the hands of the wicked. 
 </p><p class="q2">Preserve me from the violent men who have determined to trip my feet. 
 </p><p class="q1">
 <sup>5&#160;</sup>The proud have hidden a snare for me, 
 </p><p class="q2">they have spread the cords of a net by the path. 
 </p><p class="q2">They have set traps for me. </p><p class="qs">Selah. 
 </p><p class="q1">
-<sup>6&#160;</sup>I said to Yahweh, “You are my Elohim.” 
-</p><p class="q2">Listen to the cry of my petitions, Yahweh. 
+<sup>6&#160;</sup>I said to Yahuah, “You are my Elohim.” 
+</p><p class="q2">Listen to the cry of my petitions, Yahuah. 
 </p><p class="q1">
-<sup>7&#160;</sup>Yahweh, the Lord, the strength of my salvation, 
+<sup>7&#160;</sup>Yahuah, the Lord, the strength of my salvation, 
 </p><p class="q2">you have covered my head in the day of battle. 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh, don’t grant the desires of the wicked. 
+<sup>8&#160;</sup>Yahuah, don’t grant the desires of the wicked. 
 </p><p class="q2">Don’t let their evil plans succeed, or they will become proud. </p><p class="qs">Selah. 
 </p><p class="q1">
 <sup>9&#160;</sup>As for the head of those who surround me, 
@@ -8076,7 +8076,7 @@ html[dir=ltr] .q2 {
 <sup>11&#160;</sup>An evil speaker won’t be established in the earth. 
 </p><p class="q2">Evil will hunt the violent man to overthrow him. 
 </p><p class="q1">
-<sup>12&#160;</sup>I know that Yahweh will maintain the cause of the afflicted, 
+<sup>12&#160;</sup>I know that Yahuah will maintain the cause of the afflicted, 
 </p><p class="q2">and justice for the needy. 
 </p><p class="q1">
 <sup>13&#160;</sup>Surely the righteous will give thanks to your name. 
@@ -8084,14 +8084,14 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="141">141</h2>
 <p class="d">A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Yahweh, I have called on you. 
+<sup>1&#160;</sup>Yahuah, I have called on you. 
 </p><p class="q2">Come to me quickly! 
 </p><p class="q2">Listen to my voice when I call to you. 
 </p><p class="q1">
 <sup>2&#160;</sup>Let my prayer be set before you like incense; 
 </p><p class="q2">the lifting up of my hands like the evening sacrifice. 
 </p><p class="q1">
-<sup>3&#160;</sup>Set a watch, Yahweh, before my mouth. 
+<sup>3&#160;</sup>Set a watch, Yahuah, before my mouth. 
 </p><p class="q2">Keep the door of my lips. 
 </p><p class="q1">
 <sup>4&#160;</sup>Don’t incline my heart to any evil thing, 
@@ -8109,7 +8109,7 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>“As when one plows and breaks up the earth, 
 </p><p class="q2">our bones are scattered at the mouth of Sheol.” 
 </p><p class="q1">
-<sup>8&#160;</sup>For my eyes are on you, Yahweh, the Lord. 
+<sup>8&#160;</sup>For my eyes are on you, Yahuah, the Lord. 
 </p><p class="q2">I take refuge in you. 
 </p><p class="q2">Don’t leave my soul destitute. 
 </p><p class="q1">
@@ -8121,8 +8121,8 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="142">142</h2>
 <p class="d">A contemplation by David, when he was in the cave. A Prayer. 
 </p><p class="q1">
-<sup>1&#160;</sup>I cry with my voice to Yahweh. 
-</p><p class="q2">With my voice, I ask Yahweh for mercy. 
+<sup>1&#160;</sup>I cry with my voice to Yahuah. 
+</p><p class="q2">With my voice, I ask Yahuah for mercy. 
 </p><p class="q1">
 <sup>2&#160;</sup>I pour out my complaint before him. 
 </p><p class="q2">I tell him my troubles. 
@@ -8137,7 +8137,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">Refuge has fled from me. 
 </p><p class="q2">No one cares for my soul. 
 </p><p class="q1">
-<sup>5&#160;</sup>I cried to you, Yahweh. 
+<sup>5&#160;</sup>I cried to you, Yahuah. 
 </p><p class="q2">I said, “You are my refuge, 
 </p><p class="q2">my portion in the land of the living.” 
 </p><p class="q1">
@@ -8153,7 +8153,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="143">143</h2>
 <p class="d">A Psalm by David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Hear my prayer, Yahweh. 
+<sup>1&#160;</sup>Hear my prayer, Yahuah. 
 </p><p class="q2">Listen to my petitions. 
 </p><p class="q2">In your faithfulness and righteousness, relieve me. 
 </p><p class="q1">
@@ -8174,7 +8174,7 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>I spread out my hands to you. 
 </p><p class="q2">My soul thirsts for you, like a parched land. </p><p class="qs">Selah. 
 </p><p class="q1">
-<sup>7&#160;</sup>Hurry to answer me, Yahweh. 
+<sup>7&#160;</sup>Hurry to answer me, Yahuah. 
 </p><p class="q2">My spirit fails. 
 </p><p class="q1">Don’t hide your face from me, 
 </p><p class="q2">so that I don’t become like those who go down into the pit. 
@@ -8184,7 +8184,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Cause me to know the way in which I should walk, 
 </p><p class="q2">for I lift up my soul to you. 
 </p><p class="q1">
-<sup>9&#160;</sup>Deliver me, Yahweh, from my enemies. 
+<sup>9&#160;</sup>Deliver me, Yahuah, from my enemies. 
 </p><p class="q2">I flee to you to hide me. 
 </p><p class="q1">
 <sup>10&#160;</sup>Teach me to do your will, 
@@ -8192,7 +8192,7 @@ html[dir=ltr] .q2 {
 </p><p class="q1">Your Spirit is good. 
 </p><p class="q2">Lead me in the land of uprightness. 
 </p><p class="q1">
-<sup>11&#160;</sup>Revive me, Yahweh, for your name’s sake. 
+<sup>11&#160;</sup>Revive me, Yahuah, for your name’s sake. 
 </p><p class="q2">In your righteousness, bring my soul out of trouble. 
 </p><p class="q1">
 <sup>12&#160;</sup>In your loving kindness, cut off my enemies, 
@@ -8201,7 +8201,7 @@ html[dir=ltr] .q2 {
 </p><h2 class="psalmlabel" id="144">144</h2>
 <p class="d">By David. 
 </p><p class="q1">
-<sup>1&#160;</sup>Blessed be Yahweh, my rock, 
+<sup>1&#160;</sup>Blessed be Yahuah, my rock, 
 </p><p class="q2">who trains my hands to war, 
 </p><p class="q2">and my fingers to battle—</p><p class="q1">
 <sup>2&#160;</sup>my loving kindness, my fortress, 
@@ -8209,13 +8209,13 @@ html[dir=ltr] .q2 {
 </p><p class="q2">my shield, and he in whom I take refuge, 
 </p><p class="q2">who subdues my people under me. 
 </p><p class="q1">
-<sup>3&#160;</sup>Yahweh, what is man, that you care for him? 
+<sup>3&#160;</sup>Yahuah, what is man, that you care for him? 
 </p><p class="q2">Or the son of man, that you think of him? 
 </p><p class="q1">
 <sup>4&#160;</sup>Man is like a breath. 
 </p><p class="q2">His days are like a shadow that passes away. 
 </p><p class="q1">
-<sup>5&#160;</sup>Part your heavens, Yahweh, and come down. 
+<sup>5&#160;</sup>Part your heavens, Yahuah, and come down. 
 </p><p class="q2">Touch the mountains, and they will smoke. 
 </p><p class="q1">
 <sup>6&#160;</sup>Throw out lightning, and scatter them. 
@@ -8250,7 +8250,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and no outcry in our streets. 
 </p><p class="q1">
 <sup>15&#160;</sup>Happy are the people who are in such a situation. 
-</p><p class="q2">Happy are the people whose Elohim is Yahweh. 
+</p><p class="q2">Happy are the people whose Elohim is Yahuah. 
 </p><h2 class="psalmlabel" id="145">145</h2>
 <p class="d">A praise psalm by David. 
 </p><p class="q1">
@@ -8260,7 +8260,7 @@ html[dir=ltr] .q2 {
 <sup>2&#160;</sup>Every day I will praise you. 
 </p><p class="q2">I will extol your name forever and ever. 
 </p><p class="q1">
-<sup>3&#160;</sup>Great is Yahweh, and greatly to be praised! 
+<sup>3&#160;</sup>Great is Yahuah, and greatly to be praised! 
 </p><p class="q2">His greatness is unsearchable. 
 </p><p class="q1">
 <sup>4&#160;</sup>One generation will commend your works to another, 
@@ -8275,13 +8275,13 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>They will utter the memory of your great goodness, 
 </p><p class="q2">and will sing of your righteousness. 
 </p><p class="q1">
-<sup>8&#160;</sup>Yahweh is gracious, merciful, 
+<sup>8&#160;</sup>Yahuah is gracious, merciful, 
 </p><p class="q2">slow to anger, and of great loving kindness. 
 </p><p class="q1">
-<sup>9&#160;</sup>Yahweh is good to all. 
+<sup>9&#160;</sup>Yahuah is good to all. 
 </p><p class="q2">His tender mercies are over all his works. 
 </p><p class="q1">
-<sup>10&#160;</sup>All your works will give thanks to you, Yahweh. 
+<sup>10&#160;</sup>All your works will give thanks to you, Yahuah. 
 </p><p class="q2">Your saints will extol you. 
 </p><p class="q1">
 <sup>11&#160;</sup>They will speak of the glory of your kingdom, 
@@ -8292,10 +8292,10 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>13&#160;</sup>Your kingdom is an everlasting kingdom. 
 </p><p class="q2">Your dominion endures throughout all generations. 
-</p><p class="q1">Yahweh is faithful in all his words, 
+</p><p class="q1">Yahuah is faithful in all his words, 
 </p><p class="q2">and loving in all his deeds. 
 </p><p class="q1">
-<sup>14&#160;</sup>Yahweh upholds all who fall, 
+<sup>14&#160;</sup>Yahuah upholds all who fall, 
 </p><p class="q2">and raises up all those who are bowed down. 
 </p><p class="q1">
 <sup>15&#160;</sup>The eyes of all wait for you. 
@@ -8304,27 +8304,27 @@ html[dir=ltr] .q2 {
 <sup>16&#160;</sup>You open your hand, 
 </p><p class="q2">and satisfy the desire of every living thing. 
 </p><p class="q1">
-<sup>17&#160;</sup>Yahweh is righteous in all his ways, 
+<sup>17&#160;</sup>Yahuah is righteous in all his ways, 
 </p><p class="q2">and gracious in all his works. 
 </p><p class="q1">
-<sup>18&#160;</sup>Yahweh is near to all those who call on him, 
+<sup>18&#160;</sup>Yahuah is near to all those who call on him, 
 </p><p class="q2">to all who call on him in truth. 
 </p><p class="q1">
 <sup>19&#160;</sup>He will fulfill the desire of those who fear him. 
 </p><p class="q2">He also will hear their cry, and will save them. 
 </p><p class="q1">
-<sup>20&#160;</sup>Yahweh preserves all those who love him, 
+<sup>20&#160;</sup>Yahuah preserves all those who love him, 
 </p><p class="q2">but he will destroy all the wicked. 
 </p><p class="q1">
-<sup>21&#160;</sup>My mouth will speak the praise of Yahweh. 
+<sup>21&#160;</sup>My mouth will speak the praise of Yahuah. 
 </p><p class="q2">Let all flesh bless his set-apart name forever and ever. 
 </p><p class="b"> &#160; </p>
 <h2 class="psalmlabel" id="146">146</h2>
 <p class="q1">
 <sup>1&#160;</sup>Praise Yah! 
-</p><p class="q2">Praise Yahweh, my soul. 
+</p><p class="q2">Praise Yahuah, my soul. 
 </p><p class="q1">
-<sup>2&#160;</sup>While I live, I will praise Yahweh. 
+<sup>2&#160;</sup>While I live, I will praise Yahuah. 
 </p><p class="q2">I will sing praises to my Elohim as long as I exist. 
 </p><p class="q1">
 <sup>3&#160;</sup>Don’t put your trust in princes, 
@@ -8334,7 +8334,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">In that very day, his thoughts perish. 
 </p><p class="q1">
 <sup>5&#160;</sup>Happy is he who has the Elohim of Jacob for his help, 
-</p><p class="q2">whose hope is in Yahweh, his Elohim, 
+</p><p class="q2">whose hope is in Yahuah, his Elohim, 
 </p><p class="q1">
 <sup>6&#160;</sup>who made heaven and earth, 
 </p><p class="q2">the sea, and all that is in them; 
@@ -8342,17 +8342,17 @@ html[dir=ltr] .q2 {
 </p><p class="q1">
 <sup>7&#160;</sup>who executes justice for the oppressed; 
 </p><p class="q2">who gives food to the hungry. 
-</p><p class="q1">Yahweh frees the prisoners. 
+</p><p class="q1">Yahuah frees the prisoners. 
 </p><p class="q2">
-<sup>8&#160;</sup>Yahweh opens the eyes of the blind. 
-</p><p class="q2">Yahweh raises up those who are bowed down. 
-</p><p class="q2">Yahweh loves the righteous. 
+<sup>8&#160;</sup>Yahuah opens the eyes of the blind. 
+</p><p class="q2">Yahuah raises up those who are bowed down. 
+</p><p class="q2">Yahuah loves the righteous. 
 </p><p class="q1">
-<sup>9&#160;</sup>Yahweh preserves the foreigners. 
+<sup>9&#160;</sup>Yahuah preserves the foreigners. 
 </p><p class="q2">He upholds the fatherless and widow, 
 </p><p class="q2">but he turns the way of the wicked upside down. 
 </p><p class="q1">
-<sup>10&#160;</sup>Yahweh will reign forever; 
+<sup>10&#160;</sup>Yahuah will reign forever; 
 </p><p class="q2">your Elohim, O Zion, to all generations. 
 </p><p class="q1">Praise Yah! 
 </p><p class="b"> &#160; </p>
@@ -8362,7 +8362,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">for it is good to sing praises to our Elohim; 
 </p><p class="q2">for it is pleasant and fitting to praise him. 
 </p><p class="q1">
-<sup>2&#160;</sup>Yahweh builds up Jerusalem. 
+<sup>2&#160;</sup>Yahuah builds up Jerusalem. 
 </p><p class="q2">He gathers together the outcasts of Israel. 
 </p><p class="q1">
 <sup>3&#160;</sup>He heals the broken in heart, 
@@ -8374,10 +8374,10 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>Great is our Lord, and mighty in power. 
 </p><p class="q2">His understanding is infinite. 
 </p><p class="q1">
-<sup>6&#160;</sup>Yahweh upholds the humble. 
+<sup>6&#160;</sup>Yahuah upholds the humble. 
 </p><p class="q2">He brings the wicked down to the ground. 
 </p><p class="q1">
-<sup>7&#160;</sup>Sing to Yahweh with thanksgiving. 
+<sup>7&#160;</sup>Sing to Yahuah with thanksgiving. 
 </p><p class="q2">Sing praises on the harp to our Elohim, 
 </p><p class="q1">
 <sup>8&#160;</sup>who covers the sky with clouds, 
@@ -8390,10 +8390,10 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>He doesn’t delight in the strength of the horse. 
 </p><p class="q2">He takes no pleasure in the legs of a man. 
 </p><p class="q1">
-<sup>11&#160;</sup>Yahweh takes pleasure in those who fear him, 
+<sup>11&#160;</sup>Yahuah takes pleasure in those who fear him, 
 </p><p class="q2">in those who hope in his loving kindness. 
 </p><p class="q1">
-<sup>12&#160;</sup>Praise Yahweh, Jerusalem! 
+<sup>12&#160;</sup>Praise Yahuah, Jerusalem! 
 </p><p class="q2">Praise your Elohim, Zion! 
 </p><p class="q1">
 <sup>13&#160;</sup>For he has strengthened the bars of your gates. 
@@ -8424,7 +8424,7 @@ html[dir=ltr] .q2 {
 <h2 class="psalmlabel" id="148">148</h2>
 <p class="q1">
 <sup>1&#160;</sup>Praise Yah! 
-</p><p class="q2">Praise Yahweh from the heavens! 
+</p><p class="q2">Praise Yahuah from the heavens! 
 </p><p class="q2">Praise him in the heights! 
 </p><p class="q1">
 <sup>2&#160;</sup>Praise him, all his angels! 
@@ -8436,13 +8436,13 @@ html[dir=ltr] .q2 {
 <sup>4&#160;</sup>Praise him, you heavens of heavens, 
 </p><p class="q2">you waters that are above the heavens. 
 </p><p class="q1">
-<sup>5&#160;</sup>Let them praise Yahweh’s name, 
+<sup>5&#160;</sup>Let them praise Yahuah’s name, 
 </p><p class="q2">for he commanded, and they were created. 
 </p><p class="q1">
 <sup>6&#160;</sup>He has also established them forever and ever. 
 </p><p class="q2">He has made a decree which will not pass away. 
 </p><p class="q1">
-<sup>7&#160;</sup>Praise Yahweh from the earth, 
+<sup>7&#160;</sup>Praise Yahuah from the earth, 
 </p><p class="q2">you great sea creatures, and all depths, 
 </p><p class="q1">
 <sup>8&#160;</sup>lightning and hail, snow and clouds, 
@@ -8460,7 +8460,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>both young men and maidens, 
 </p><p class="q2">old men and children. 
 </p><p class="q1">
-<sup>13&#160;</sup>Let them praise Yahweh’s name, 
+<sup>13&#160;</sup>Let them praise Yahuah’s name, 
 </p><p class="q2">for his name alone is exalted. 
 </p><p class="q2">His glory is above the earth and the heavens. 
 </p><p class="q1">
@@ -8471,8 +8471,8 @@ html[dir=ltr] .q2 {
 </p><p class="b"> &#160; </p>
 <h2 class="psalmlabel" id="149">149</h2>
 <p class="q1">
-<sup>1&#160;</sup>Praise Yahweh! 
-</p><p class="q2">Sing to Yahweh a new song, 
+<sup>1&#160;</sup>Praise Yahuah! 
+</p><p class="q2">Sing to Yahuah a new song, 
 </p><p class="q2">his praise in the assembly of the saints. 
 </p><p class="q1">
 <sup>2&#160;</sup>Let Israel rejoice in him who made them. 
@@ -8481,7 +8481,7 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>Let them praise his name in the dance! 
 </p><p class="q2">Let them sing praises to him with tambourine and harp! 
 </p><p class="q1">
-<sup>4&#160;</sup>For Yahweh takes pleasure in his people. 
+<sup>4&#160;</sup>For Yahuah takes pleasure in his people. 
 </p><p class="q2">He crowns the humble with salvation. 
 </p><p class="q1">
 <sup>5&#160;</sup>Let the saints rejoice in honor. 

--- a/book/ruth.html
+++ b/book/ruth.html
@@ -68,29 +68,29 @@ html[dir=ltr] .q2 {
 <sup>3&#160;</sup>Elimelech, Naomi’s man, died; and she was left with her two sons. 
 <sup>4&#160;</sup>They took for themselves women of the women of Moab. The name of the one was Orpah, and the name of the other was Ruth. They lived there about ten years. 
 <sup>5&#160;</sup>Mahlon and Chilion both died, and the woman was bereaved of her two children and of her man. 
-<sup>6&#160;</sup>Then she arose with her daughters-in-law, that she might return from the country of Moab; for she had heard in the country of Moab how Yahweh had visited his people in giving them bread. 
+<sup>6&#160;</sup>Then she arose with her daughters-in-law, that she might return from the country of Moab; for she had heard in the country of Moab how Yahuah had visited his people in giving them bread. 
 <sup>7&#160;</sup>She went out of the place where she was, and her two daughters-in-law with her. They went on the way to return to the land of Judah. 
-<sup>8&#160;</sup>Naomi said to her two daughters-in-law, “Go, return each of you to her mother’s house. May Yahweh deal kindly with you, as you have dealt with the dead and with me. 
-<sup>9&#160;</sup>May Yahweh grant you that you may find rest, each of you in the house of her man.” 
+<sup>8&#160;</sup>Naomi said to her two daughters-in-law, “Go, return each of you to her mother’s house. May Yahuah deal kindly with you, as you have dealt with the dead and with me. 
+<sup>9&#160;</sup>May Yahuah grant you that you may find rest, each of you in the house of her man.” 
 </p><p>Then she kissed them, and they lifted up their voices, and wept. 
 <sup>10&#160;</sup>They said to her, “No, but we will return with you to your people.” 
 </p><p>
 <sup>11&#160;</sup>Naomi said, “Go back, my daughters. Why do you want to go with me? Do I still have sons in my womb, that they may be your men? 
 <sup>12&#160;</sup>Go back, my daughters, go your way; for I am too old to have a man. If I should say, ‘I have hope,’ if I should even have a man tonight, and should also bear sons, 
-<sup>13&#160;</sup>would you then wait until they were grown? Would you then refrain from having men? No, my daughters, for it grieves me seriously for your sakes, for Yahweh’s hand has gone out against me.” 
+<sup>13&#160;</sup>would you then wait until they were grown? Would you then refrain from having men? No, my daughters, for it grieves me seriously for your sakes, for Yahuah’s hand has gone out against me.” 
 </p><p>
 <sup>14&#160;</sup>They lifted up their voices and wept again; then Orpah kissed her mother-in-law, but Ruth stayed with her. 
 <sup>15&#160;</sup>She said, “Behold, your sister-in-law has gone back to her people and to her elohim. Follow your sister-in-law.” 
 </p><p>
 <sup>16&#160;</sup>Ruth said, “Don’t urge me to leave you, and to return from following you, for where you go, I will go; and where you stay, I will stay. Your people will be my people, and your Elohim my Elohim. 
-<sup>17&#160;</sup>Where you die, I will die, and there I will be buried. May Yahweh do so to me, and more also, if anything but death parts you and me.” 
+<sup>17&#160;</sup>Where you die, I will die, and there I will be buried. May Yahuah do so to me, and more also, if anything but death parts you and me.” 
 </p><p>
 <sup>18&#160;</sup>When Naomi saw that she was determined to go with her, she stopped urging her. 
 </p><p>
 <sup>19&#160;</sup>So they both went until they came to Bethlehem. When they had come to Bethlehem, all the city was excited about them, and they asked, “Is this Naomi?” 
 </p><p>
 <sup>20&#160;</sup>She said to them, “Don’t call me Naomi. Call me Mara, for the Almighty has dealt very bitterly with me. 
-<sup>21&#160;</sup>I went out full, and Yahweh has brought me home again empty. Why do you call me Naomi, since Yahweh has testified against me, and the Almighty has afflicted me?” 
+<sup>21&#160;</sup>I went out full, and Yahuah has brought me home again empty. Why do you call me Naomi, since Yahuah has testified against me, and the Almighty has afflicted me?” 
 <sup>22&#160;</sup>So Naomi returned, and Ruth the Moabitess, her daughter-in-law, with her, who returned out of the country of Moab. They came to Bethlehem in the beginning of barley harvest. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
@@ -99,8 +99,8 @@ html[dir=ltr] .q2 {
 </p><p>She said to her, “Go, my daughter.” 
 <sup>3&#160;</sup>She went, and came and gleaned in the field after the reapers; and she happened to come to the portion of the field belonging to Boaz, who was of the family of Elimelech. 
 </p><p>
-<sup>4&#160;</sup>Behold, Boaz came from Bethlehem, and said to the reapers, “May Yahweh be with you.” 
-</p><p>They answered him, “May Yahweh bless you.” 
+<sup>4&#160;</sup>Behold, Boaz came from Bethlehem, and said to the reapers, “May Yahuah be with you.” 
+</p><p>They answered him, “May Yahuah bless you.” 
 </p><p>
 <sup>5&#160;</sup>Then Boaz said to his servant who was set over the reapers, “Whose young lady is this?” 
 </p><p>
@@ -113,7 +113,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>Then she fell on her face and bowed herself to the ground, and said to him, “Why have I found favor in your sight, that you should take knowledge of me, since I am a foreigner?” 
 </p><p>
 <sup>11&#160;</sup>Boaz answered her, “I have been told all about what you have done for your mother-in-law since the death of your man, and how you have left your father, your mother, and the land of your birth, and have come to a people that you didn’t know before. 
-<sup>12&#160;</sup>May Yahweh repay your work, and a full reward be given to you from Yahweh, the Elohim of Israel, under whose wings you have come to take refuge.” 
+<sup>12&#160;</sup>May Yahuah repay your work, and a full reward be given to you from Yahuah, the Elohim of Israel, under whose wings you have come to take refuge.” 
 </p><p>
 <sup>13&#160;</sup>Then she said, “Let me find favor in your sight, my lord, because you have comforted me, and because you have spoken kindly to your servant, though I am not as one of your servants.” 
 </p><p>
@@ -127,7 +127,7 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>19&#160;</sup>Her mother-in-law said to her, “Where have you gleaned today? Where have you worked? Blessed be he who noticed you.” 
 </p><p>She told her mother-in-law with whom she had worked, “The man’s name with whom I worked today is Boaz.” 
-<sup>20&#160;</sup>Naomi said to her daughter-in-law, “May he be blessed by Yahweh, who has not abandoned his kindness to the living and to the dead.” Naomi said to her, “The man is a close relative to us, one of our near kinsmen.” 
+<sup>20&#160;</sup>Naomi said to her daughter-in-law, “May he be blessed by Yahuah, who has not abandoned his kindness to the living and to the dead.” Naomi said to her, “The man is a close relative to us, one of our near kinsmen.” 
 </p><p>
 <sup>21&#160;</sup>Ruth the Moabitess said, “Yes, he said to me, ‘You shall stay close to my young men until they have finished all my harvest.’&#160;” 
 </p><p>
@@ -147,10 +147,10 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>He said, “Who are you?” 
 </p><p>She answered, “I am Ruth your servant. Therefore spread the corner of your garment over your servant; for you are a near kinsman.” 
 </p><p>
-<sup>10&#160;</sup>He said, “You are blessed by Yahweh, my daughter. You have shown more kindness in the latter end than at the beginning, because you didn’t follow young men, whether poor or rich. 
+<sup>10&#160;</sup>He said, “You are blessed by Yahuah, my daughter. You have shown more kindness in the latter end than at the beginning, because you didn’t follow young men, whether poor or rich. 
 <sup>11&#160;</sup>Now, my daughter, don’t be afraid. I will do to you all that you say; for all the city of my people knows that you are a worthy woman. 
 <sup>12&#160;</sup>Now it is true that I am a near kinsman. However, there is a kinsman nearer than I. 
-<sup>13&#160;</sup>Stay this night, and in the morning, if he will perform for you the part of a kinsman, good. Let him do the kinsman’s duty. But if he will not do the duty of a kinsman for you, then I will do the duty of a kinsman for you, as Yahweh lives. Lie down until the morning.” 
+<sup>13&#160;</sup>Stay this night, and in the morning, if he will perform for you the part of a kinsman, good. Let him do the kinsman’s duty. But if he will not do the duty of a kinsman for you, then I will do the duty of a kinsman for you, as Yahuah lives. Lie down until the morning.” 
 </p><p>
 <sup>14&#160;</sup>She lay at his feet until the morning, then she rose up before one could discern another. For he said, “Let it not be known that the woman came to the threshing floor.” 
 <sup>15&#160;</sup>He said, “Bring the mantle that is on you, and hold it.” She held it; and he measured six measures of barley, and laid it on her; then he went into the city. 
@@ -178,11 +178,11 @@ html[dir=ltr] .q2 {
 <sup>9&#160;</sup>Boaz said to the elders and to all the people, “You are witnesses today, that I have bought all that was Elimelech’s, and all that was Chilion’s and Mahlon’s, from the hand of Naomi. 
 <sup>10&#160;</sup>Moreover, Ruth the Moabitess, the woman of Mahlon, I have purchased to be my woman, to raise up the name of the dead on his inheritance, that the name of the dead may not be cut off from among his brothers and from the gate of his place. You are witnesses today.” 
 </p><p>
-<sup>11&#160;</sup>All the people who were in the gate, and the elders, said, “We are witnesses. May Yahweh make the woman who has come into your house like Rachel and like Leah, which both built the house of Israel; and treat you worthily in Ephrathah, and be famous in Bethlehem. 
-<sup>12&#160;</sup>Let your house be like the house of Perez, whom Tamar bore to Judah, of the offspring which Yahweh will give you by this young woman.” 
+<sup>11&#160;</sup>All the people who were in the gate, and the elders, said, “We are witnesses. May Yahuah make the woman who has come into your house like Rachel and like Leah, which both built the house of Israel; and treat you worthily in Ephrathah, and be famous in Bethlehem. 
+<sup>12&#160;</sup>Let your house be like the house of Perez, whom Tamar bore to Judah, of the offspring which Yahuah will give you by this young woman.” 
 </p><p>
-<sup>13&#160;</sup>So Boaz took Ruth and she became his woman; and he went in to her, and Yahweh enabled her to conceive, and she bore a son. 
-<sup>14&#160;</sup>The women said to Naomi, “Blessed be Yahweh, who has not left you today without a near kinsman. Let his name be famous in Israel. 
+<sup>13&#160;</sup>So Boaz took Ruth and she became his woman; and he went in to her, and Yahuah enabled her to conceive, and she bore a son. 
+<sup>14&#160;</sup>The women said to Naomi, “Blessed be Yahuah, who has not left you today without a near kinsman. Let his name be famous in Israel. 
 <sup>15&#160;</sup>He shall be to you a restorer of life and sustain you in your old age; for your daughter-in-law, who loves you, who is better to you than seven sons, has given birth to him.” 
 <sup>16&#160;</sup>Naomi took the child, laid him in her bosom, and became nurse to him. 
 <sup>17&#160;</sup>The women, her neighbors, gave him a name, saying, “A son is born to Naomi”. They named him Obed. He is the father of Jesse, the father of David. 

--- a/book/zechariah.html
+++ b/book/zechariah.html
@@ -73,37 +73,37 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>In the eighth month, in the second year of Darius, Yahweh’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
-<sup>2&#160;</sup>“Yahweh was very displeased with your fathers. 
-<sup>3&#160;</sup>Therefore tell them, Yahweh of Armies says: ‘Return to me,’ says Yahweh of Armies, ‘and I will return to you,’ says Yahweh of Armies. 
-<sup>4&#160;</sup>Don’t you be like your fathers, to whom the former prophets proclaimed, saying: Yahweh of Armies says, ‘Return now from your evil ways and from your evil doings;’ but they didn’t hear nor listen to me, says Yahweh. 
+<sup>1&#160;</sup>In the eighth month, in the second year of Darius, Yahuah’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
+<sup>2&#160;</sup>“Yahuah was very displeased with your fathers. 
+<sup>3&#160;</sup>Therefore tell them, Yahuah of Armies says: ‘Return to me,’ says Yahuah of Armies, ‘and I will return to you,’ says Yahuah of Armies. 
+<sup>4&#160;</sup>Don’t you be like your fathers, to whom the former prophets proclaimed, saying: Yahuah of Armies says, ‘Return now from your evil ways and from your evil doings;’ but they didn’t hear nor listen to me, says Yahuah. 
 <sup>5&#160;</sup>Your fathers, where are they? And the prophets, do they live forever? 
 <sup>6&#160;</sup>But my words and my decrees, which I commanded my servants the prophets, didn’t they overtake your fathers? 
-</p><p>“Then they repented and said, ‘Just as Yahweh of Armies determined to do to us, according to our ways and according to our practices, so he has dealt with us.’&#160;” 
+</p><p>“Then they repented and said, ‘Just as Yahuah of Armies determined to do to us, according to our ways and according to our practices, so he has dealt with us.’&#160;” 
 </p><p>
-<sup>7&#160;</sup>On the twenty-fourth day of the eleventh month, which is the month Shebat, in the second year of Darius, Yahweh’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
+<sup>7&#160;</sup>On the twenty-fourth day of the eleventh month, which is the month Shebat, in the second year of Darius, Yahuah’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
 <sup>8&#160;</sup>“I had a vision in the night, and behold, a man riding on a red horse, and he stood among the myrtle trees that were in a ravine; and behind him there were red, brown, and white horses. 
 <sup>9&#160;</sup>Then I asked, ‘My lord, what are these?’&#160;” 
 </p><p>The angel who talked with me said to me, “I will show you what these are.” 
 </p><p>
-<sup>10&#160;</sup>The man who stood among the myrtle trees answered, “They are the ones Yahweh has sent to go back and forth through the earth.” 
+<sup>10&#160;</sup>The man who stood among the myrtle trees answered, “They are the ones Yahuah has sent to go back and forth through the earth.” 
 </p><p>
-<sup>11&#160;</sup>They reported to Yahweh’s angel who stood among the myrtle trees, and said, “We have walked back and forth through the earth, and behold, all the earth is at rest and in peace.” 
+<sup>11&#160;</sup>They reported to Yahuah’s angel who stood among the myrtle trees, and said, “We have walked back and forth through the earth, and behold, all the earth is at rest and in peace.” 
 </p><p>
-<sup>12&#160;</sup>Then Yahweh’s angel replied, “O Yahweh of Armies, how long will you not have mercy on Jerusalem and on the cities of Judah, against which you have had indignation these seventy years?” 
+<sup>12&#160;</sup>Then Yahuah’s angel replied, “O Yahuah of Armies, how long will you not have mercy on Jerusalem and on the cities of Judah, against which you have had indignation these seventy years?” 
 </p><p>
-<sup>13&#160;</sup>Yahweh answered the angel who talked with me with kind and comforting words. 
-<sup>14&#160;</sup>So the angel who talked with me said to me, “Proclaim, saying, ‘Yahweh of Armies says: “I am jealous for Jerusalem and for Zion with a great jealousy. 
+<sup>13&#160;</sup>Yahuah answered the angel who talked with me with kind and comforting words. 
+<sup>14&#160;</sup>So the angel who talked with me said to me, “Proclaim, saying, ‘Yahuah of Armies says: “I am jealous for Jerusalem and for Zion with a great jealousy. 
 <sup>15&#160;</sup>I am very angry with the nations that are at ease; for I was but a little displeased, but they added to the calamity.” 
-<sup>16&#160;</sup>Therefore Yahweh says: “I have returned to Jerusalem with mercy. My house shall be built in it,” says Yahweh of Armies, “and a line shall be stretched out over Jerusalem.”&#160;’ 
+<sup>16&#160;</sup>Therefore Yahuah says: “I have returned to Jerusalem with mercy. My house shall be built in it,” says Yahuah of Armies, “and a line shall be stretched out over Jerusalem.”&#160;’ 
 </p><p>
-<sup>17&#160;</sup>“Proclaim further, saying, ‘Yahweh of Armies says: “My cities will again overflow with prosperity, and Yahweh will again comfort Zion, and will again choose Jerusalem.”&#160;’&#160;” 
+<sup>17&#160;</sup>“Proclaim further, saying, ‘Yahuah of Armies says: “My cities will again overflow with prosperity, and Yahuah will again comfort Zion, and will again choose Jerusalem.”&#160;’&#160;” 
 </p><p>
 <sup>18&#160;</sup>I lifted up my eyes and saw, and behold, four horns. 
 <sup>19&#160;</sup>I asked the angel who talked with me, “What are these?” 
 </p><p>He answered me, “These are the horns which have scattered Judah, Israel, and Jerusalem.” 
 </p><p>
-<sup>20&#160;</sup>Yahweh showed me four craftsmen. 
+<sup>20&#160;</sup>Yahuah showed me four craftsmen. 
 <sup>21&#160;</sup>Then I asked, “What are these coming to do?” 
 </p><p>He said, “These are the horns which scattered Judah, so that no man lifted up his head; but these have come to terrify them, to cast down the horns of the nations that lifted up their horn against the land of Judah to scatter it.” 
 </p><h2 class="chapterlabel" id="2">2</h2>
@@ -114,32 +114,32 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>3&#160;</sup>Behold, the angel who talked with me went out, and another angel went out to meet him, 
 <sup>4&#160;</sup>and said to him, “Run, speak to this young man, saying, ‘Jerusalem will be inhabited as villages without walls, because of the multitude of men and livestock in it. 
-<sup>5&#160;</sup>For I,’ says Yahweh, ‘will be to her a wall of fire around it, and I will be the glory in the middle of her. 
+<sup>5&#160;</sup>For I,’ says Yahuah, ‘will be to her a wall of fire around it, and I will be the glory in the middle of her. 
 </p><p>
-<sup>6&#160;</sup>Come! Come! Flee from the land of the north,’ says Yahweh; ‘for I have spread you abroad as the four winds of the sky,’ says Yahweh. 
+<sup>6&#160;</sup>Come! Come! Flee from the land of the north,’ says Yahuah; ‘for I have spread you abroad as the four winds of the sky,’ says Yahuah. 
 <sup>7&#160;</sup>‘Come, Zion! Escape, you who dwell with the daughter of Babylon.’ 
-<sup>8&#160;</sup>For Yahweh of Armies says: ‘For honor he has sent me to the nations which plundered you; for he who touches you touches the apple of his eye. 
-<sup>9&#160;</sup>For, behold, I will shake my hand over them, and they will be a plunder to those who served them; and you will know that Yahweh of Armies has sent me. 
-<sup>10&#160;</sup>Sing and rejoice, daughter of Zion! For behold, I come and I will dwell within you,’ says Yahweh. 
-<sup>11&#160;</sup>Many nations shall join themselves to Yahweh in that day, and shall be my people; and I will dwell among you, and you shall know that Yahweh of Armies has sent me to you. 
-<sup>12&#160;</sup>Yahweh will inherit Judah as his portion in the set-apart land, and will again choose Jerusalem. 
-<sup>13&#160;</sup>Be silent, all flesh, before Yahweh; for he has roused himself from his set-apart habitation!” 
+<sup>8&#160;</sup>For Yahuah of Armies says: ‘For honor he has sent me to the nations which plundered you; for he who touches you touches the apple of his eye. 
+<sup>9&#160;</sup>For, behold, I will shake my hand over them, and they will be a plunder to those who served them; and you will know that Yahuah of Armies has sent me. 
+<sup>10&#160;</sup>Sing and rejoice, daughter of Zion! For behold, I come and I will dwell within you,’ says Yahuah. 
+<sup>11&#160;</sup>Many nations shall join themselves to Yahuah in that day, and shall be my people; and I will dwell among you, and you shall know that Yahuah of Armies has sent me to you. 
+<sup>12&#160;</sup>Yahuah will inherit Judah as his portion in the set-apart land, and will again choose Jerusalem. 
+<sup>13&#160;</sup>Be silent, all flesh, before Yahuah; for he has roused himself from his set-apart habitation!” 
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
-<sup>1&#160;</sup>He showed me Joshua the high priest standing before Yahweh’s angel, and Satan standing at his right hand to be his adversary. 
-<sup>2&#160;</sup>Yahweh said to Satan, “Yahweh rebuke you, Satan! Yes, Yahweh who has chosen Jerusalem rebuke you! Isn’t this a burning stick plucked out of the fire?” 
+<sup>1&#160;</sup>He showed me Joshua the high priest standing before Yahuah’s angel, and Satan standing at his right hand to be his adversary. 
+<sup>2&#160;</sup>Yahuah said to Satan, “Yahuah rebuke you, Satan! Yes, Yahuah who has chosen Jerusalem rebuke you! Isn’t this a burning stick plucked out of the fire?” 
 </p><p>
 <sup>3&#160;</sup>Now Joshua was clothed with filthy garments, and was standing before the angel. 
 <sup>4&#160;</sup>He answered and spoke to those who stood before him, saying, “Take the filthy garments off him.” To him he said, “Behold, I have caused your iniquity to pass from you, and I will clothe you with rich clothing.” 
 </p><p>
 <sup>5&#160;</sup>I said, “Let them set a clean turban on his head.” 
-</p><p>So they set a clean turban on his head, and clothed him; and Yahweh’s angel was standing by. 
+</p><p>So they set a clean turban on his head, and clothed him; and Yahuah’s angel was standing by. 
 </p><p>
-<sup>6&#160;</sup>Yahweh’s angel solemnly assured Joshua, saying, 
-<sup>7&#160;</sup>“Yahweh of Armies says: ‘If you will walk in my ways, and if you will follow my instructions, then you also shall judge my house, and shall also keep my courts, and I will give you a place of access among these who stand by. 
+<sup>6&#160;</sup>Yahuah’s angel solemnly assured Joshua, saying, 
+<sup>7&#160;</sup>“Yahuah of Armies says: ‘If you will walk in my ways, and if you will follow my instructions, then you also shall judge my house, and shall also keep my courts, and I will give you a place of access among these who stand by. 
 <sup>8&#160;</sup>Hear now, Joshua the high priest, you and your fellows who sit before you, for they are men who are a sign; for, behold, I will bring out my servant, the Branch. 
-<sup>9&#160;</sup>For, behold, the stone that I have set before Joshua: on one stone are seven eyes; behold, I will engrave its inscription,’ says Yahweh of Armies, ‘and I will remove the iniquity of that land in one day. 
-<sup>10&#160;</sup>In that day,’ says Yahweh of Armies, ‘you will invite every man his neighbor under the vine and under the fig tree.’&#160;” 
+<sup>9&#160;</sup>For, behold, the stone that I have set before Joshua: on one stone are seven eyes; behold, I will engrave its inscription,’ says Yahuah of Armies, ‘and I will remove the iniquity of that land in one day. 
+<sup>10&#160;</sup>In that day,’ says Yahuah of Armies, ‘you will invite every man his neighbor under the vine and under the fig tree.’&#160;” 
 </p><h2 class="chapterlabel" id="4">4</h2>
 <p>
 <sup>1&#160;</sup>The angel who talked with me came again and wakened me, as a man who is wakened out of his sleep. 
@@ -152,12 +152,12 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>Then the angel who talked with me answered me, “Don’t you know what these are?” 
 </p><p>I said, “No, my lord.” 
 </p><p>
-<sup>6&#160;</sup>Then he answered and spoke to me, saying, “This is Yahweh’s word to Zerubbabel, saying, ‘Not by might, nor by power, but by my Spirit,’ says Yahweh of Armies. 
+<sup>6&#160;</sup>Then he answered and spoke to me, saying, “This is Yahuah’s word to Zerubbabel, saying, ‘Not by might, nor by power, but by my Spirit,’ says Yahuah of Armies. 
 <sup>7&#160;</sup>Who are you, great mountain? Before Zerubbabel you are a plain; and he will bring out the capstone with shouts of ‘Grace, grace, to it!’&#160;” 
 </p><p>
-<sup>8&#160;</sup>Moreover Yahweh’s word came to me, saying, 
-<sup>9&#160;</sup>“The hands of Zerubbabel have laid the foundation of this house. His hands shall also finish it; and you will know that Yahweh of Armies has sent me to you. 
-<sup>10&#160;</sup>Indeed, who despises the day of small things? For these seven shall rejoice, and shall see the plumb line in the hand of Zerubbabel. These are Yahweh’s eyes, which run back and forth through the whole earth.” 
+<sup>8&#160;</sup>Moreover Yahuah’s word came to me, saying, 
+<sup>9&#160;</sup>“The hands of Zerubbabel have laid the foundation of this house. His hands shall also finish it; and you will know that Yahuah of Armies has sent me to you. 
+<sup>10&#160;</sup>Indeed, who despises the day of small things? For these seven shall rejoice, and shall see the plumb line in the hand of Zerubbabel. These are Yahuah’s eyes, which run back and forth through the whole earth.” 
 </p><p>
 <sup>11&#160;</sup>Then I asked him, “What are these two olive trees on the right side of the lamp stand and on the left side of it?” 
 </p><p>
@@ -174,7 +174,7 @@ html[dir=ltr] .q2 {
 </p><p>I answered, “I see a flying scroll; its length is twenty cubits, and its width ten cubits.” 
 </p><p>
 <sup>3&#160;</sup>Then he said to me, “This is the curse that goes out over the surface of the whole land, for everyone who steals shall be cut off according to it on the one side; and everyone who swears falsely shall be cut off according to it on the other side. 
-<sup>4&#160;</sup>I will cause it to go out,” says Yahweh of Armies, “and it will enter into the house of the thief, and into the house of him who swears falsely by my name; and it will remain in the middle of his house, and will destroy it with its timber and its stones.” 
+<sup>4&#160;</sup>I will cause it to go out,” says Yahuah of Armies, “and it will enter into the house of the thief, and into the house of him who swears falsely by my name; and it will remain in the middle of his house, and will destroy it with its timber and its stones.” 
 </p><p>
 <sup>5&#160;</sup>Then the angel who talked with me came forward and said to me, “Lift up now your eyes and see what this is that is appearing.” 
 </p><p>
@@ -199,71 +199,71 @@ html[dir=ltr] .q2 {
 </p><p>
 <sup>8&#160;</sup>Then he called to me, and spoke to me, saying, “Behold, those who go toward the north country have quieted my spirit in the north country.” 
 </p><p>
-<sup>9&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>9&#160;</sup>Yahuah’s word came to me, saying, 
 <sup>10&#160;</sup>“Take of them of the captivity, even of Heldai, of Tobijah, and of Jedaiah; and come the same day, and go into the house of Josiah the son of Zephaniah, where they have come from Babylon. 
 <sup>11&#160;</sup>Yes, take silver and gold, and make crowns, and set them on the head of Joshua the son of Jehozadak, the high priest; 
-<sup>12&#160;</sup>and speak to him, saying, ‘Yahweh of Armies says, “Behold, the man whose name is the Branch! He will grow up out of his place; and he will build Yahweh’s temple. 
-<sup>13&#160;</sup>He will build Yahweh’s temple. He will bear the glory, and will sit and rule on his throne. He will be a priest on his throne. The counsel of peace will be between them both. 
-<sup>14&#160;</sup>The crowns shall be to Helem, to Tobijah, to Jedaiah, and to Hen the son of Zephaniah, for a memorial in Yahweh’s temple. 
+<sup>12&#160;</sup>and speak to him, saying, ‘Yahuah of Armies says, “Behold, the man whose name is the Branch! He will grow up out of his place; and he will build Yahuah’s temple. 
+<sup>13&#160;</sup>He will build Yahuah’s temple. He will bear the glory, and will sit and rule on his throne. He will be a priest on his throne. The counsel of peace will be between them both. 
+<sup>14&#160;</sup>The crowns shall be to Helem, to Tobijah, to Jedaiah, and to Hen the son of Zephaniah, for a memorial in Yahuah’s temple. 
 </p><p>
-<sup>15&#160;</sup>Those who are far off shall come and build in Yahweh’s temple; and you shall know that Yahweh of Armies has sent me to you. This will happen, if you will diligently obey Yahweh your Elohim’s voice.”&#160;’&#160;” 
+<sup>15&#160;</sup>Those who are far off shall come and build in Yahuah’s temple; and you shall know that Yahuah of Armies has sent me to you. This will happen, if you will diligently obey Yahuah your Elohim’s voice.”&#160;’&#160;” 
 </p><h2 class="chapterlabel" id="7">7</h2>
 <p>
-<sup>1&#160;</sup>In the fourth year of King Darius, Yahweh’s word came to Zechariah in the fourth day of the ninth month, the month of Chislev. 
-<sup>2&#160;</sup>The people of Bethel sent Sharezer and Regem Melech and their men to entreat Yahweh’s favor, 
-<sup>3&#160;</sup>and to speak to the priests of the house of Yahweh of Armies and to the prophets, saying, “Should I weep in the fifth month, separating myself, as I have done these so many years?” 
+<sup>1&#160;</sup>In the fourth year of King Darius, Yahuah’s word came to Zechariah in the fourth day of the ninth month, the month of Chislev. 
+<sup>2&#160;</sup>The people of Bethel sent Sharezer and Regem Melech and their men to entreat Yahuah’s favor, 
+<sup>3&#160;</sup>and to speak to the priests of the house of Yahuah of Armies and to the prophets, saying, “Should I weep in the fifth month, separating myself, as I have done these so many years?” 
 </p><p>
-<sup>4&#160;</sup>Then the word of Yahweh of Armies came to me, saying, 
+<sup>4&#160;</sup>Then the word of Yahuah of Armies came to me, saying, 
 <sup>5&#160;</sup>“Speak to all the people of the land and to the priests, saying, ‘When you fasted and mourned in the fifth and in the seventh month for these seventy years, did you at all fast to me, really to me? 
 <sup>6&#160;</sup>When you eat and when you drink, don’t you eat for yourselves and drink for yourselves? 
-<sup>7&#160;</sup>Aren’t these the words which Yahweh proclaimed by the former prophets when Jerusalem was inhabited and in prosperity, and its cities around her, and the South and the lowland were inhabited?’&#160;” 
+<sup>7&#160;</sup>Aren’t these the words which Yahuah proclaimed by the former prophets when Jerusalem was inhabited and in prosperity, and its cities around her, and the South and the lowland were inhabited?’&#160;” 
 </p><p>
-<sup>8&#160;</sup>Yahweh’s word came to Zechariah, saying, 
-<sup>9&#160;</sup>“Thus has Yahweh of Armies spoken, saying, ‘Execute true judgment, and show kindness and compassion every man to his brother. 
+<sup>8&#160;</sup>Yahuah’s word came to Zechariah, saying, 
+<sup>9&#160;</sup>“Thus has Yahuah of Armies spoken, saying, ‘Execute true judgment, and show kindness and compassion every man to his brother. 
 <sup>10&#160;</sup>Don’t oppress the widow, the fatherless, the foreigner, nor the poor; and let none of you devise evil against his brother in your heart.’ 
 <sup>11&#160;</sup>But they refused to listen, and turned their backs, and stopped their ears, that they might not hear. 
-<sup>12&#160;</sup>Yes, they made their hearts as hard as flint, lest they might hear the law and the words which Yahweh of Armies had sent by his Spirit by the former prophets. Therefore great wrath came from Yahweh of Armies. 
-<sup>13&#160;</sup>It has come to pass that, as he called and they refused to listen, so they will call and I will not listen,” said Yahweh of Armies; 
+<sup>12&#160;</sup>Yes, they made their hearts as hard as flint, lest they might hear the law and the words which Yahuah of Armies had sent by his Spirit by the former prophets. Therefore great wrath came from Yahuah of Armies. 
+<sup>13&#160;</sup>It has come to pass that, as he called and they refused to listen, so they will call and I will not listen,” said Yahuah of Armies; 
 <sup>14&#160;</sup>“but I will scatter them with a whirlwind among all the nations which they have not known. Thus the land was desolate after them, so that no man passed through nor returned; for they made the pleasant land desolate.” 
 </p><h2 class="chapterlabel" id="8">8</h2>
 <p>
-<sup>1&#160;</sup>The word of Yahweh of Armies came to me. 
-<sup>2&#160;</sup>Yahweh of Armies says: “I am jealous for Zion with great jealousy, and I am jealous for her with great wrath.” 
+<sup>1&#160;</sup>The word of Yahuah of Armies came to me. 
+<sup>2&#160;</sup>Yahuah of Armies says: “I am jealous for Zion with great jealousy, and I am jealous for her with great wrath.” 
 </p><p>
-<sup>3&#160;</sup>Yahweh says: “I have returned to Zion, and will dwell in the middle of Jerusalem. Jerusalem shall be called ‘The City of Truth;’ and the mountain of Yahweh of Armies, ‘The Set-Apart Mountain.’&#160;” 
+<sup>3&#160;</sup>Yahuah says: “I have returned to Zion, and will dwell in the middle of Jerusalem. Jerusalem shall be called ‘The City of Truth;’ and the mountain of Yahuah of Armies, ‘The Set-Apart Mountain.’&#160;” 
 </p><p>
-<sup>4&#160;</sup>Yahweh of Armies says: “Old men and old women will again dwell in the streets of Jerusalem, every man with his staff in his hand because of their old age. 
+<sup>4&#160;</sup>Yahuah of Armies says: “Old men and old women will again dwell in the streets of Jerusalem, every man with his staff in his hand because of their old age. 
 <sup>5&#160;</sup>The streets of the city will be full of boys and girls playing in its streets.” 
 </p><p>
-<sup>6&#160;</sup>Yahweh of Armies says: “If it is marvelous in the eyes of the remnant of this people in those days, should it also be marvelous in my eyes?” says Yahweh of Armies. 
+<sup>6&#160;</sup>Yahuah of Armies says: “If it is marvelous in the eyes of the remnant of this people in those days, should it also be marvelous in my eyes?” says Yahuah of Armies. 
 </p><p>
-<sup>7&#160;</sup>Yahweh of Armies says: “Behold, I will save my people from the east country and from the west country. 
+<sup>7&#160;</sup>Yahuah of Armies says: “Behold, I will save my people from the east country and from the west country. 
 <sup>8&#160;</sup>I will bring them, and they will dwell within Jerusalem. They will be my people, and I will be their Elohim, in truth and in righteousness.” 
 </p><p>
-<sup>9&#160;</sup>Yahweh of Armies says: “Let your hands be strong, you who hear in these days these words from the mouth of the prophets who were in the day that the foundation of the house of Yahweh of Armies was laid, even the temple, that it might be built. 
+<sup>9&#160;</sup>Yahuah of Armies says: “Let your hands be strong, you who hear in these days these words from the mouth of the prophets who were in the day that the foundation of the house of Yahuah of Armies was laid, even the temple, that it might be built. 
 <sup>10&#160;</sup>For before those days there was no wages for man nor any wages for an animal, neither was there any peace to him who went out or came in, because of the adversary. For I set all men everyone against his neighbor. 
-<sup>11&#160;</sup>But now I will not be to the remnant of this people as in the former days,” says Yahweh of Armies. 
+<sup>11&#160;</sup>But now I will not be to the remnant of this people as in the former days,” says Yahuah of Armies. 
 <sup>12&#160;</sup>“For the seed of peace and the vine will yield its fruit, and the ground will give its increase, and the heavens will give their dew. I will cause the remnant of this people to inherit all these things. 
 <sup>13&#160;</sup>It shall come to pass that, as you were a curse among the nations, house of Judah and house of Israel, so I will save you, and you shall be a blessing. Don’t be afraid. Let your hands be strong.” 
 </p><p>
-<sup>14&#160;</sup>For Yahweh of Armies says: “As I thought to do evil to you when your fathers provoked me to wrath,” says Yahweh of Armies, “and I didn’t repent, 
+<sup>14&#160;</sup>For Yahuah of Armies says: “As I thought to do evil to you when your fathers provoked me to wrath,” says Yahuah of Armies, “and I didn’t repent, 
 <sup>15&#160;</sup>so again I have thought in these days to do good to Jerusalem and to the house of Judah. Don’t be afraid. 
 <sup>16&#160;</sup>These are the things that you shall do: speak every man the truth with his neighbor. Execute the judgment of truth and peace in your gates, 
-<sup>17&#160;</sup>and let none of you devise evil in your hearts against his neighbor, and love no false oath; for all these are things that I hate,” says Yahweh. 
+<sup>17&#160;</sup>and let none of you devise evil in your hearts against his neighbor, and love no false oath; for all these are things that I hate,” says Yahuah. 
 </p><p>
-<sup>18&#160;</sup>The word of Yahweh of Armies came to me. 
-<sup>19&#160;</sup>Yahweh of Armies says: “The fasts of the fourth, fifth, seventh, and tenth months shall be for the house of Judah joy, gladness, and cheerful feasts. Therefore love truth and peace.” 
+<sup>18&#160;</sup>The word of Yahuah of Armies came to me. 
+<sup>19&#160;</sup>Yahuah of Armies says: “The fasts of the fourth, fifth, seventh, and tenth months shall be for the house of Judah joy, gladness, and cheerful feasts. Therefore love truth and peace.” 
 </p><p>
-<sup>20&#160;</sup>Yahweh of Armies says: “Many peoples and the inhabitants of many cities will yet come. 
-<sup>21&#160;</sup>The inhabitants of one will go to another, saying, ‘Let’s go speedily to entreat the favor of Yahweh, and to seek Yahweh of Armies. I will go also.’ 
-<sup>22&#160;</sup>Yes, many peoples and strong nations will come to seek Yahweh of Armies in Jerusalem and to entreat the favor of Yahweh.” 
-<sup>23&#160;</sup>Yahweh of Armies says: “In those days, ten men out of all the languages of the nations will take hold of the skirt of him who is a Jew, saying, ‘We will go with you, for we have heard that Elohim is with you.’&#160;” 
+<sup>20&#160;</sup>Yahuah of Armies says: “Many peoples and the inhabitants of many cities will yet come. 
+<sup>21&#160;</sup>The inhabitants of one will go to another, saying, ‘Let’s go speedily to entreat the favor of Yahuah, and to seek Yahuah of Armies. I will go also.’ 
+<sup>22&#160;</sup>Yes, many peoples and strong nations will come to seek Yahuah of Armies in Jerusalem and to entreat the favor of Yahuah.” 
+<sup>23&#160;</sup>Yahuah of Armies says: “In those days, ten men out of all the languages of the nations will take hold of the skirt of him who is a Jew, saying, ‘We will go with you, for we have heard that Elohim is with you.’&#160;” 
 </p><h2 class="chapterlabel" id="9">9</h2>
 <p>
 <sup>1&#160;</sup>A revelation. 
-</p><p class="q1">Yahweh’s word is against the land of Hadrach, 
+</p><p class="q1">Yahuah’s word is against the land of Hadrach, 
 </p><p class="q2">and will rest upon Damascus—</p><p class="q1">for the eye of man 
-</p><p class="q2">and of all the tribes of Israel is toward Yahweh—</p><p class="q1">
+</p><p class="q2">and of all the tribes of Israel is toward Yahuah—</p><p class="q1">
 <sup>2&#160;</sup>and Hamath, also, which borders on it, 
 </p><p class="q2">Tyre and Sidon, because they are very wise. 
 </p><p class="q1">
@@ -326,19 +326,19 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will make you like the sword of a mighty man. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>14&#160;</sup>Yahweh will be seen over them. 
+<sup>14&#160;</sup>Yahuah will be seen over them. 
 </p><p class="q2">His arrow will flash like lightning. 
-</p><p class="q1">The Lord Yahweh will blow the trumpet, 
+</p><p class="q1">The Lord Yahuah will blow the trumpet, 
 </p><p class="q2">and will go with whirlwinds of the south. 
 </p><p class="q1">
-<sup>15&#160;</sup>Yahweh of Armies will defend them. 
+<sup>15&#160;</sup>Yahuah of Armies will defend them. 
 </p><p class="q2">They will destroy and overcome with sling stones. 
 </p><p class="q1">They will drink, and roar as through wine. 
 </p><p class="q2">They will be filled like bowls, 
 </p><p class="q2">like the corners of the altar. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
-<sup>16&#160;</sup>Yahweh their Elohim will save them in that day as the flock of his people; 
+<sup>16&#160;</sup>Yahuah their Elohim will save them in that day as the flock of his people; 
 </p><p class="q2">for they are like the jewels of a crown, 
 </p><p class="q2">lifted on high over his land. 
 </p><p class="q1">
@@ -348,8 +348,8 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and new wine the virgins. 
 </p><h2 class="chapterlabel" id="10">10</h2>
 <p class="q1">
-<sup>1&#160;</sup>Ask of Yahweh rain in the spring time, 
-</p><p class="q2">Yahweh who makes storm clouds, 
+<sup>1&#160;</sup>Ask of Yahuah rain in the spring time, 
+</p><p class="q2">Yahuah who makes storm clouds, 
 </p><p class="q2">and he gives rain showers to everyone for the plants in the field. 
 </p><p class="q1">
 <sup>2&#160;</sup>For the teraphim have spoken vanity, 
@@ -362,7 +362,7 @@ html[dir=ltr] .q2 {
 <p class="q1">
 <sup>3&#160;</sup>My anger is kindled against the shepherds, 
 </p><p class="q2">and I will punish the male goats, 
-</p><p class="q2">for Yahweh of Armies has visited his flock, the house of Judah, 
+</p><p class="q2">for Yahuah of Armies has visited his flock, the house of Judah, 
 </p><p class="q2">and will make them as his majestic horse in the battle. 
 </p><p class="q1">
 <sup>4&#160;</sup>From him will come the cornerstone, 
@@ -372,7 +372,7 @@ html[dir=ltr] .q2 {
 </p><p class="q2">
 <sup>5&#160;</sup>They will be as mighty men, 
 </p><p class="q2">treading down muddy streets in the battle. 
-</p><p class="q1">They will fight, because Yahweh is with them. 
+</p><p class="q1">They will fight, because Yahuah is with them. 
 </p><p class="q2">The riders on horses will be confounded. 
 </p><p class="b"> &#160; </p>
 <p class="q1">
@@ -381,12 +381,12 @@ html[dir=ltr] .q2 {
 </p><p class="q1">I will bring them back, 
 </p><p class="q2">for I have mercy on them. 
 </p><p class="q1">They will be as though I had not cast them off, 
-</p><p class="q2">for I am Yahweh their Elohim, and I will hear them. 
+</p><p class="q2">for I am Yahuah their Elohim, and I will hear them. 
 </p><p class="q1">
 <sup>7&#160;</sup>Ephraim will be like a mighty man, 
 </p><p class="q2">and their heart will rejoice as through wine. 
 </p><p class="q1">Yes, their children will see it and rejoice. 
-</p><p class="q2">Their heart will be glad in Yahweh. 
+</p><p class="q2">Their heart will be glad in Yahuah. 
 </p><p class="q1">
 <sup>8&#160;</sup>I will signal for them and gather them, 
 </p><p class="q2">for I have redeemed them. 
@@ -407,8 +407,8 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and the pride of Assyria will be brought down, 
 </p><p class="q2">and the scepter of Egypt will depart. 
 </p><p class="q1">
-<sup>12&#160;</sup>I will strengthen them in Yahweh. 
-</p><p class="q2">They will walk up and down in his name,” says Yahweh. 
+<sup>12&#160;</sup>I will strengthen them in Yahuah. 
+</p><p class="q2">They will walk up and down in his name,” says Yahuah. 
 </p><h2 class="chapterlabel" id="11">11</h2>
 <p class="q1">
 <sup>1&#160;</sup>Open your doors, Lebanon, 
@@ -423,34 +423,34 @@ html[dir=ltr] .q2 {
 </p><p class="q2">For their glory is destroyed—a voice of the roaring of young lions! 
 </p><p class="q2">For the pride of the Jordan is ruined. 
 </p><p>
-<sup>4&#160;</sup>Yahweh my Elohim says: “Feed the flock of slaughter. 
-<sup>5&#160;</sup>Their buyers slaughter them and go unpunished. Those who sell them say, ‘Blessed be Yahweh, for I am rich;’ and their own shepherds don’t pity them. 
-<sup>6&#160;</sup>For I will no more pity the inhabitants of the land,” says Yahweh; “but, behold, I will deliver every one of the men into his neighbor’s hand and into the hand of his king. They will strike the land, and out of their hand I will not deliver them.” 
+<sup>4&#160;</sup>Yahuah my Elohim says: “Feed the flock of slaughter. 
+<sup>5&#160;</sup>Their buyers slaughter them and go unpunished. Those who sell them say, ‘Blessed be Yahuah, for I am rich;’ and their own shepherds don’t pity them. 
+<sup>6&#160;</sup>For I will no more pity the inhabitants of the land,” says Yahuah; “but, behold, I will deliver every one of the men into his neighbor’s hand and into the hand of his king. They will strike the land, and out of their hand I will not deliver them.” 
 </p><p>
 <sup>7&#160;</sup>So I fed the flock to be slaughtered, especially the oppressed of the flock. I took for myself two staffs. The one I called “Favor” and the other I called “Union”, and I fed the flock. 
 <sup>8&#160;</sup>I cut off the three shepherds in one month; for my soul was weary of them, and their soul also loathed me. 
 <sup>9&#160;</sup>Then I said, “I will not feed you. That which dies, let it die; and that which is to be cut off, let it be cut off; and let those who are left eat each other’s flesh.” 
 <sup>10&#160;</sup>I took my staff Favor and cut it apart, that I might break my covenant that I had made with all the peoples. 
-<sup>11&#160;</sup>It was broken in that day; and thus the poor of the flock that listened to me knew that it was Yahweh’s word. 
+<sup>11&#160;</sup>It was broken in that day; and thus the poor of the flock that listened to me knew that it was Yahuah’s word. 
 <sup>12&#160;</sup>I said to them, “If you think it best, give me my wages; and if not, keep them.” So they weighed for my wages thirty pieces of silver. 
-<sup>13&#160;</sup>Yahweh said to me, “Throw it to the potter—the handsome price that I was valued at by them!” I took the thirty pieces of silver and threw them to the potter in Yahweh’s house. 
+<sup>13&#160;</sup>Yahuah said to me, “Throw it to the potter—the handsome price that I was valued at by them!” I took the thirty pieces of silver and threw them to the potter in Yahuah’s house. 
 <sup>14&#160;</sup>Then I cut apart my other staff, Union, that I might break the brotherhood between Judah and Israel. 
 </p><p>
-<sup>15&#160;</sup>Yahweh said to me, “Take for yourself yet again the equipment of a foolish shepherd. 
+<sup>15&#160;</sup>Yahuah said to me, “Take for yourself yet again the equipment of a foolish shepherd. 
 <sup>16&#160;</sup>For, behold, I will raise up a shepherd in the land who will not visit those who are cut off, neither will seek those who are scattered, nor heal that which is broken, nor feed that which is sound; but he will eat the meat of the fat sheep, and will tear their hoofs in pieces. 
 <sup>17&#160;</sup>Woe to the worthless shepherd who leaves the flock! The sword will strike his arm and his right eye. His arm will be completely withered, and his right eye will be totally blinded!” 
 </p><h2 class="chapterlabel" id="12">12</h2>
 <p>
-<sup>1&#160;</sup>A revelation of Yahweh’s word concerning Israel: Yahweh, who stretches out the heavens and lays the foundation of the earth, and forms the spirit of man within him says: 
+<sup>1&#160;</sup>A revelation of Yahuah’s word concerning Israel: Yahuah, who stretches out the heavens and lays the foundation of the earth, and forms the spirit of man within him says: 
 <sup>2&#160;</sup>“Behold, I will make Jerusalem a cup of reeling to all the surrounding peoples, and it will also be on Judah in the siege against Jerusalem. 
 <sup>3&#160;</sup>It will happen in that day that I will make Jerusalem a burdensome stone for all the peoples. All who burden themselves with it will be severely wounded, and all the nations of the earth will be gathered together against it. 
-<sup>4&#160;</sup>In that day,” says Yahweh, “I will strike every horse with terror and his rider with madness. I will open my eyes on the house of Judah, and will strike every horse of the peoples with blindness. 
-<sup>5&#160;</sup>The chieftains of Judah will say in their heart, ‘The inhabitants of Jerusalem are my strength in Yahweh of Armies their Elohim.’ 
+<sup>4&#160;</sup>In that day,” says Yahuah, “I will strike every horse with terror and his rider with madness. I will open my eyes on the house of Judah, and will strike every horse of the peoples with blindness. 
+<sup>5&#160;</sup>The chieftains of Judah will say in their heart, ‘The inhabitants of Jerusalem are my strength in Yahuah of Armies their Elohim.’ 
 </p><p>
 <sup>6&#160;</sup>In that day I will make the chieftains of Judah like a pan of fire among wood, and like a flaming torch among sheaves. They will devour all the surrounding peoples on the right hand and on the left; and Jerusalem will yet again dwell in their own place, even in Jerusalem. 
 </p><p>
-<sup>7&#160;</sup>Yahweh also will save the tents of Judah first, that the glory of David’s house and the glory of the inhabitants of Jerusalem not be magnified above Judah. 
-<sup>8&#160;</sup>In that day Yahweh will defend the inhabitants of Jerusalem. He who is feeble among them at that day will be like David, and David’s house will be like Elohim, like Yahweh’s angel before them. 
+<sup>7&#160;</sup>Yahuah also will save the tents of Judah first, that the glory of David’s house and the glory of the inhabitants of Jerusalem not be magnified above Judah. 
+<sup>8&#160;</sup>In that day Yahuah will defend the inhabitants of Jerusalem. He who is feeble among them at that day will be like David, and David’s house will be like Elohim, like Yahuah’s angel before them. 
 <sup>9&#160;</sup>It will happen in that day, that I will seek to destroy all the nations that come against Jerusalem. 
 </p><p>
 <sup>10&#160;</sup>I will pour on David’s house and on the inhabitants of Jerusalem the spirit of grace and of supplication. They will look to me whom they have pierced; and they shall mourn for him as one mourns for his only son, and will grieve bitterly for him as one grieves for his firstborn. 
@@ -462,19 +462,19 @@ html[dir=ltr] .q2 {
 <p>
 <sup>1&#160;</sup>“In that day there will be a fountain opened to David’s house and to the inhabitants of Jerusalem, for sin and for uncleanness. 
 </p><p>
-<sup>2&#160;</sup>It will come to pass in that day, says Yahweh of Armies, that I will cut off the names of the idols out of the land, and they will be remembered no more. I will also cause the prophets and the spirit of impurity to pass out of the land. 
-<sup>3&#160;</sup>It will happen that when anyone still prophesies, then his father and his mother who bore him will tell him, ‘You must die, because you speak lies in Yahweh’s name;’ and his father and his mother who bore him will stab him when he prophesies. 
+<sup>2&#160;</sup>It will come to pass in that day, says Yahuah of Armies, that I will cut off the names of the idols out of the land, and they will be remembered no more. I will also cause the prophets and the spirit of impurity to pass out of the land. 
+<sup>3&#160;</sup>It will happen that when anyone still prophesies, then his father and his mother who bore him will tell him, ‘You must die, because you speak lies in Yahuah’s name;’ and his father and his mother who bore him will stab him when he prophesies. 
 <sup>4&#160;</sup>It will happen in that day that the prophets will each be ashamed of his vision when he prophesies; they won’t wear a hairy mantle to deceive, 
 <sup>5&#160;</sup>but he will say, ‘I am no prophet, I am a tiller of the ground; for I have been made a bondservant from my youth.’ 
 <sup>6&#160;</sup>One will say to him, ‘What are these wounds between your arms?’ Then he will answer, ‘Those with which I was wounded in the house of my friends.’ 
 </p><p class="b"> &#160; </p>
 <p class="q1">
 <sup>7&#160;</sup>“Awake, sword, against my shepherd, 
-</p><p class="q2">and against the man who is close to me,” says Yahweh of Armies. 
+</p><p class="q2">and against the man who is close to me,” says Yahuah of Armies. 
 </p><p class="q1">“Strike the shepherd, and the sheep will be scattered; 
 </p><p class="q2">and I will turn my hand against the little ones. 
 </p><p class="q1">
-<sup>8&#160;</sup>It shall happen that in all the land,” says Yahweh, 
+<sup>8&#160;</sup>It shall happen that in all the land,” says Yahuah, 
 </p><p class="q2">“two parts in it will be cut off and die; 
 </p><p class="q2">but the third will be left in it. 
 </p><p class="q1">
@@ -483,35 +483,35 @@ html[dir=ltr] .q2 {
 </p><p class="q2">and will test them like gold is tested. 
 </p><p class="q1">They will call on my name, and I will hear them. 
 </p><p class="q2">I will say, ‘It is my people;’ 
-</p><p class="q2">and they will say, ‘Yahweh is my Elohim.’&#160;” 
+</p><p class="q2">and they will say, ‘Yahuah is my Elohim.’&#160;” 
 </p><h2 class="chapterlabel" id="14">14</h2>
 <p>
-<sup>1&#160;</sup>Behold, a day of Yahweh comes, when your plunder will be divided within you. 
+<sup>1&#160;</sup>Behold, a day of Yahuah comes, when your plunder will be divided within you. 
 <sup>2&#160;</sup>For I will gather all nations against Jerusalem to battle; and the city will be taken, the houses rifled, and the women ravished. Half of the city will go out into captivity, and the rest of the people will not be cut off from the city. 
-<sup>3&#160;</sup>Then Yahweh will go out and fight against those nations, as when he fought in the day of battle. 
+<sup>3&#160;</sup>Then Yahuah will go out and fight against those nations, as when he fought in the day of battle. 
 <sup>4&#160;</sup>His feet will stand in that day on the Mount of Olives, which is before Jerusalem on the east; and the Mount of Olives will be split in two from east to west, making a very great valley. Half of the mountain will move toward the north, and half of it toward the south. 
-<sup>5&#160;</sup>You shall flee by the valley of my mountains, for the valley of the mountains shall reach to Azel. Yes, you shall flee, just like you fled from before the earthquake in the days of Uzziah king of Judah. Yahweh my Elohim will come, and all the set-apart ones with you. 
+<sup>5&#160;</sup>You shall flee by the valley of my mountains, for the valley of the mountains shall reach to Azel. Yes, you shall flee, just like you fled from before the earthquake in the days of Uzziah king of Judah. Yahuah my Elohim will come, and all the set-apart ones with you. 
 </p><p>
 <sup>6&#160;</sup>It will happen in that day that there will not be light, cold, or frost. 
-<sup>7&#160;</sup>It will be a unique day which is known to Yahweh—not day, and not night; but it will come to pass that at evening time there will be light. 
+<sup>7&#160;</sup>It will be a unique day which is known to Yahuah—not day, and not night; but it will come to pass that at evening time there will be light. 
 </p><p>
 <sup>8&#160;</sup>It will happen in that day that living waters will go out from Jerusalem, half of them toward the eastern sea, and half of them toward the western sea. It will be so in summer and in winter. 
 </p><p>
-<sup>9&#160;</sup>Yahweh will be King over all the earth. In that day Yahweh will be one, and his name one. 
+<sup>9&#160;</sup>Yahuah will be King over all the earth. In that day Yahuah will be one, and his name one. 
 </p><p>
 <sup>10&#160;</sup>All the land will be made like the Arabah, from Geba to Rimmon south of Jerusalem; and she will be lifted up and will dwell in her place, from Benjamin’s gate to the place of the first gate, to the corner gate, and from the tower of Hananel to the king’s wine presses. 
 <sup>11&#160;</sup>Men will dwell therein, and there will be no more curse; but Jerusalem will dwell safely. 
 </p><p>
-<sup>12&#160;</sup>This will be the plague with which Yahweh will strike all the peoples who have fought against Jerusalem: their flesh will consume away while they stand on their feet, and their eyes will consume away in their sockets, and their tongue will consume away in their mouth. 
-<sup>13&#160;</sup>It will happen in that day that a great panic from Yahweh will be among them; and they will each seize the hand of his neighbor, and his hand will rise up against the hand of his neighbor. 
+<sup>12&#160;</sup>This will be the plague with which Yahuah will strike all the peoples who have fought against Jerusalem: their flesh will consume away while they stand on their feet, and their eyes will consume away in their sockets, and their tongue will consume away in their mouth. 
+<sup>13&#160;</sup>It will happen in that day that a great panic from Yahuah will be among them; and they will each seize the hand of his neighbor, and his hand will rise up against the hand of his neighbor. 
 <sup>14&#160;</sup>Judah also will fight at Jerusalem; and the wealth of all the surrounding nations will be gathered together: gold, silver, and clothing, in great abundance. 
 </p><p>
 <sup>15&#160;</sup>A plague like this will fall on the horse, on the mule, on the camel, on the donkey, and on all the animals that will be in those camps. 
 </p><p>
-<sup>16&#160;</sup>It will happen that everyone who is left of all the nations that came against Jerusalem will go up from year to year to worship the King, Yahweh of Armies, and to keep the feast of booths. 
-<sup>17&#160;</sup>It will be that whoever of all the families of the earth doesn’t go up to Jerusalem to worship the King, Yahweh of Armies, on them there will be no rain. 
-<sup>18&#160;</sup>If the family of Egypt doesn’t go up and doesn’t come, neither will it rain on them. This will be the plague with which Yahweh will strike the nations that don’t go up to keep the feast of booths. 
+<sup>16&#160;</sup>It will happen that everyone who is left of all the nations that came against Jerusalem will go up from year to year to worship the King, Yahuah of Armies, and to keep the feast of booths. 
+<sup>17&#160;</sup>It will be that whoever of all the families of the earth doesn’t go up to Jerusalem to worship the King, Yahuah of Armies, on them there will be no rain. 
+<sup>18&#160;</sup>If the family of Egypt doesn’t go up and doesn’t come, neither will it rain on them. This will be the plague with which Yahuah will strike the nations that don’t go up to keep the feast of booths. 
 <sup>19&#160;</sup>This will be the punishment of Egypt and the punishment of all the nations that don’t go up to keep the feast of booths. 
 </p><p>
-<sup>20&#160;</sup>In that day there will be inscribed on the bells of the horses, “SET-APART TO YAHWEH”; and the pots in Yahweh’s house will be like the bowls before the altar. 
-<sup>21&#160;</sup>Yes, every pot in Jerusalem and in Judah will be set-apart to Yahweh of Armies; and all those who sacrifice will come and take of them, and cook in them. In that day there will no longer be a Canaanite in the house of Yahweh of Armies. </p></div><script src="../main.js"></script></body></html>
+<sup>20&#160;</sup>In that day there will be inscribed on the bells of the horses, “SET-APART TO YAHUAH”; and the pots in Yahuah’s house will be like the bowls before the altar. 
+<sup>21&#160;</sup>Yes, every pot in Jerusalem and in Judah will be set-apart to Yahuah of Armies; and all those who sacrifice will come and take of them, and cook in them. In that day there will no longer be a Canaanite in the house of Yahuah of Armies. </p></div><script src="../main.js"></script></body></html>

--- a/book/zephaniah.html
+++ b/book/zephaniah.html
@@ -62,41 +62,41 @@ html[dir=ltr] .q2 {
 </div>
 <h2 class="chapterlabel" id="1">1</h2>
 <p class="p1">
-<sup>1&#160;</sup>Yahweh’s word which came to Zephaniah, the son of Cushi, the son of Gedaliah, the son of Amariah, the son of Hezekiah, in the days of Josiah, the son of Amon, king of Judah. 
+<sup>1&#160;</sup>Yahuah’s word which came to Zephaniah, the son of Cushi, the son of Gedaliah, the son of Amariah, the son of Hezekiah, in the days of Josiah, the son of Amon, king of Judah. 
 </p><p>
-<sup>2&#160;</sup>I will utterly sweep away everything from the surface of the earth, says Yahweh. 
-<sup>3&#160;</sup>I will sweep away man and animal. I will sweep away the birds of the sky, the fish of the sea, and the heaps of rubble with the wicked. I will cut off man from the surface of the earth, says Yahweh. 
+<sup>2&#160;</sup>I will utterly sweep away everything from the surface of the earth, says Yahuah. 
+<sup>3&#160;</sup>I will sweep away man and animal. I will sweep away the birds of the sky, the fish of the sea, and the heaps of rubble with the wicked. I will cut off man from the surface of the earth, says Yahuah. 
 <sup>4&#160;</sup>I will stretch out my hand against Judah and against all the inhabitants of Jerusalem. I will cut off the remnant of Baal from this place—the name of the idolatrous and pagan priests, 
-<sup>5&#160;</sup>those who worship the army of the sky on the housetops, those who worship and swear by Yahweh and also swear by Malcam, 
-<sup>6&#160;</sup>those who have turned back from following Yahweh, and those who haven’t sought Yahweh nor inquired after him. 
+<sup>5&#160;</sup>those who worship the army of the sky on the housetops, those who worship and swear by Yahuah and also swear by Malcam, 
+<sup>6&#160;</sup>those who have turned back from following Yahuah, and those who haven’t sought Yahuah nor inquired after him. 
 </p><p>
-<sup>7&#160;</sup>Be silent at the presence of the Lord Yahweh, for the day of Yahweh is at hand. For Yahweh has prepared a sacrifice. He has consecrated his guests. 
-<sup>8&#160;</sup>It will happen in the day of Yahweh’s sacrifice that I will punish the princes, the king’s sons, and all those who are clothed with foreign clothing. 
+<sup>7&#160;</sup>Be silent at the presence of the Lord Yahuah, for the day of Yahuah is at hand. For Yahuah has prepared a sacrifice. He has consecrated his guests. 
+<sup>8&#160;</sup>It will happen in the day of Yahuah’s sacrifice that I will punish the princes, the king’s sons, and all those who are clothed with foreign clothing. 
 <sup>9&#160;</sup>In that day, I will punish all those who leap over the threshold, who fill their master’s house with violence and deceit. 
 </p><p>
-<sup>10&#160;</sup>In that day, says Yahweh, there will be the noise of a cry from the fish gate, a wailing from the second quarter, and a great crashing from the hills. 
+<sup>10&#160;</sup>In that day, says Yahuah, there will be the noise of a cry from the fish gate, a wailing from the second quarter, and a great crashing from the hills. 
 <sup>11&#160;</sup>Wail, you inhabitants of Maktesh, for all the people of Canaan are undone! All those who were loaded with silver are cut off. 
-<sup>12&#160;</sup>It will happen at that time, that I will search Jerusalem with lamps, and I will punish the men who are settled on their dregs, who say in their heart, “Yahweh will not do good, neither will he do evil.” 
+<sup>12&#160;</sup>It will happen at that time, that I will search Jerusalem with lamps, and I will punish the men who are settled on their dregs, who say in their heart, “Yahuah will not do good, neither will he do evil.” 
 <sup>13&#160;</sup>Their wealth will become a plunder, and their houses a desolation. Yes, they will build houses, but won’t inhabit them. They will plant vineyards, but won’t drink their wine. 
 </p><p>
-<sup>14&#160;</sup>The great day of Yahweh is near. It is near and hurries greatly, the voice of the day of Yahweh. The mighty man cries there bitterly. 
+<sup>14&#160;</sup>The great day of Yahuah is near. It is near and hurries greatly, the voice of the day of Yahuah. The mighty man cries there bitterly. 
 <sup>15&#160;</sup>That day is a day of wrath, a day of distress and anguish, a day of trouble and ruin, a day of darkness and gloom, a day of clouds and blackness, 
 <sup>16&#160;</sup>a day of the trumpet and alarm against the fortified cities and against the high battlements. 
-<sup>17&#160;</sup>I will bring such distress on men that they will walk like blind men because they have sinned against Yahweh. Their blood will be poured out like dust and their flesh like dung. 
-<sup>18&#160;</sup>Neither their silver nor their gold will be able to deliver them in the day of Yahweh’s wrath, but the whole land will be devoured by the fire of his jealousy; for he will make an end, yes, a terrible end, of all those who dwell in the land. 
+<sup>17&#160;</sup>I will bring such distress on men that they will walk like blind men because they have sinned against Yahuah. Their blood will be poured out like dust and their flesh like dung. 
+<sup>18&#160;</sup>Neither their silver nor their gold will be able to deliver them in the day of Yahuah’s wrath, but the whole land will be devoured by the fire of his jealousy; for he will make an end, yes, a terrible end, of all those who dwell in the land. 
 </p><h2 class="chapterlabel" id="2">2</h2>
 <p>
 <sup>1&#160;</sup>Gather yourselves together, yes, gather together, you nation that has no shame, 
-<sup>2&#160;</sup>before the appointed time when the day passes as the chaff, before the fierce anger of Yahweh comes on you, before the day of Yahweh’s anger comes on you. 
-<sup>3&#160;</sup>Seek Yahweh, all you humble of the land, who have kept his ordinances. Seek righteousness. Seek humility. It may be that you will be hidden in the day of Yahweh’s anger. 
+<sup>2&#160;</sup>before the appointed time when the day passes as the chaff, before the fierce anger of Yahuah comes on you, before the day of Yahuah’s anger comes on you. 
+<sup>3&#160;</sup>Seek Yahuah, all you humble of the land, who have kept his ordinances. Seek righteousness. Seek humility. It may be that you will be hidden in the day of Yahuah’s anger. 
 <sup>4&#160;</sup>For Gaza will be forsaken, and Ashkelon a desolation. They will drive out Ashdod at noonday, and Ekron will be rooted up. 
-<sup>5&#160;</sup>Woe to the inhabitants of the sea coast, the nation of the Cherethites! Yahweh’s word is against you, Canaan, the land of the Philistines. I will destroy you until there is no inhabitant. 
+<sup>5&#160;</sup>Woe to the inhabitants of the sea coast, the nation of the Cherethites! Yahuah’s word is against you, Canaan, the land of the Philistines. I will destroy you until there is no inhabitant. 
 <sup>6&#160;</sup>The sea coast will be pastures, with cottages for shepherds and folds for flocks. 
-<sup>7&#160;</sup>The coast will be for the remnant of the house of Judah. They will find pasture. In the houses of Ashkelon, they will lie down in the evening, for Yahweh, their Elohim, will visit them and restore them. 
+<sup>7&#160;</sup>The coast will be for the remnant of the house of Judah. They will find pasture. In the houses of Ashkelon, they will lie down in the evening, for Yahuah, their Elohim, will visit them and restore them. 
 <sup>8&#160;</sup>I have heard the reproach of Moab and the insults of the children of Ammon, with which they have reproached my people and magnified themselves against their border. 
-<sup>9&#160;</sup>Therefore, as I live, says Yahweh of Armies, the Elohim of Israel, surely Moab will be as Sodom, and the children of Ammon as Gomorrah, a possession of nettles and salt pits, and a perpetual desolation. The remnant of my people will plunder them, and the survivors of my nation will inherit them. 
-<sup>10&#160;</sup>This they will have for their pride, because they have reproached and magnified themselves against the people of Yahweh of Armies. 
-<sup>11&#160;</sup>Yahweh will be awesome to them, for he will famish all the elohims of the land. Men will worship him, everyone from his place, even all the shores of the nations. 
+<sup>9&#160;</sup>Therefore, as I live, says Yahuah of Armies, the Elohim of Israel, surely Moab will be as Sodom, and the children of Ammon as Gomorrah, a possession of nettles and salt pits, and a perpetual desolation. The remnant of my people will plunder them, and the survivors of my nation will inherit them. 
+<sup>10&#160;</sup>This they will have for their pride, because they have reproached and magnified themselves against the people of Yahuah of Armies. 
+<sup>11&#160;</sup>Yahuah will be awesome to them, for he will famish all the elohims of the land. Men will worship him, everyone from his place, even all the shores of the nations. 
 </p><p>
 <sup>12&#160;</sup>You Cushites also, you will be killed by my sword. 
 </p><p>
@@ -106,27 +106,27 @@ html[dir=ltr] .q2 {
 </p><h2 class="chapterlabel" id="3">3</h2>
 <p>
 <sup>1&#160;</sup>Woe to her who is rebellious and polluted, the oppressing city! 
-<sup>2&#160;</sup>She didn’t obey the voice. She didn’t receive correction. She didn’t trust in Yahweh. She didn’t draw near to her Elohim. 
+<sup>2&#160;</sup>She didn’t obey the voice. She didn’t receive correction. She didn’t trust in Yahuah. She didn’t draw near to her Elohim. 
 </p><p>
 <sup>3&#160;</sup>Her princes within her are roaring lions. Her judges are evening wolves. They leave nothing until the next day. 
 <sup>4&#160;</sup>Her prophets are arrogant and treacherous people. Her priests have profaned the sanctuary. They have done violence to the law. 
-<sup>5&#160;</sup>Yahweh, within her, is righteous. He will do no wrong. Every morning he brings his justice to light. He doesn’t fail, but the unjust know no shame. 
+<sup>5&#160;</sup>Yahuah, within her, is righteous. He will do no wrong. Every morning he brings his justice to light. He doesn’t fail, but the unjust know no shame. 
 </p><p>
 <sup>6&#160;</sup>I have cut off nations. Their battlements are desolate. I have made their streets waste, so that no one passes by. Their cities are destroyed, so that there is no man, so that there is no inhabitant. 
 <sup>7&#160;</sup>I said, “Just fear me. Receive correction,” so that her dwelling won’t be cut off, according to all that I have appointed concerning her. But they rose early and corrupted all their doings. 
 </p><p>
-<sup>8&#160;</sup>“Therefore wait for me”, says Yahweh, “until the day that I rise up to the prey, for my determination is to gather the nations, that I may assemble the kingdoms to pour on them my indignation, even all my fierce anger, for all the earth will be devoured with the fire of my jealousy. 
+<sup>8&#160;</sup>“Therefore wait for me”, says Yahuah, “until the day that I rise up to the prey, for my determination is to gather the nations, that I may assemble the kingdoms to pour on them my indignation, even all my fierce anger, for all the earth will be devoured with the fire of my jealousy. 
 </p><p>
-<sup>9&#160;</sup>For then I will purify the lips of the peoples, that they may all call on Yahweh’s name, to serve him shoulder to shoulder. 
+<sup>9&#160;</sup>For then I will purify the lips of the peoples, that they may all call on Yahuah’s name, to serve him shoulder to shoulder. 
 <sup>10&#160;</sup>From beyond the rivers of Cush, my worshipers, even the daughter of my dispersed people, will bring my offering. 
 <sup>11&#160;</sup>In that day you will not be disappointed for all your doings in which you have transgressed against me; for then I will take away out from among you your proudly exulting ones, and you will no more be arrogant in my set-apart mountain. 
-<sup>12&#160;</sup>But I will leave among you an afflicted and poor people, and they will take refuge in Yahweh’s name. 
+<sup>12&#160;</sup>But I will leave among you an afflicted and poor people, and they will take refuge in Yahuah’s name. 
 <sup>13&#160;</sup>The remnant of Israel will not do iniquity nor speak lies, neither will a deceitful tongue be found in their mouth, for they will feed and lie down, and no one will make them afraid.” 
 </p><p>
 <sup>14&#160;</sup>Sing, daughter of Zion! Shout, Israel! Be glad and rejoice with all your heart, daughter of Jerusalem. 
-<sup>15&#160;</sup>Yahweh has taken away your judgments. He has thrown out your enemy. The King of Israel, Yahweh, is among you. You will not be afraid of evil any more. 
+<sup>15&#160;</sup>Yahuah has taken away your judgments. He has thrown out your enemy. The King of Israel, Yahuah, is among you. You will not be afraid of evil any more. 
 <sup>16&#160;</sup>In that day, it will be said to Jerusalem, “Don’t be afraid, Zion. Don’t let your hands be weak.” 
-<sup>17&#160;</sup>Yahweh, your Elohim, is among you, a mighty one who will save. He will rejoice over you with joy. He will calm you in his love. He will rejoice over you with singing. 
+<sup>17&#160;</sup>Yahuah, your Elohim, is among you, a mighty one who will save. He will rejoice over you with joy. He will calm you in his love. He will rejoice over you with singing. 
 <sup>18&#160;</sup>I will remove those who grieve about the appointed feasts from you. They are a burden and a reproach to you. 
 <sup>19&#160;</sup>Behold, at that time I will deal with all those who afflict you; and I will save those who are lame and gather those who were driven away. I will give them praise and honor, whose shame has been in all the earth. 
-<sup>20&#160;</sup>At that time I will bring you in, and at that time I will gather you; for I will give you honor and praise among all the peoples of the earth when I restore your fortunes before your eyes, says Yahweh. </p></div><script src="../main.js"></script></body></html>
+<sup>20&#160;</sup>At that time I will bring you in, and at that time I will gather you; for I will give you honor and praise among all the peoples of the earth when I restore your fortunes before your eyes, says Yahuah. </p></div><script src="../main.js"></script></body></html>

--- a/setup.sh
+++ b/setup.sh
@@ -1797,6 +1797,14 @@ printf .
 # 4x
 #sed -i 's/YAHWEH/YEHOVAH/g' *.usfm
 
+# update to best known transliteration
+# this transliteration is more compatible with the transliteration of yahushua's
+# name, and is derived from a straightforward, natural, and consistent way to
+# pronounce hebrew characters, rather than forcing an inflection that is similar
+# to the vowels of 'adonai'.
+sed -i 's/Yahweh/Yahuah/g' *.usfm
+sed -i 's/YAHWEH/YAHUAH/g' *.usfm
+
 
 
 

--- a/usfm/1chronicles.usfm
+++ b/usfm/1chronicles.usfm
@@ -70,7 +70,7 @@
 \v 1 These are the sons of Israel: Reuben, Simeon, Levi, Judah, Issachar, Zebulun, 
 \v 2 Dan, Joseph, Benjamin, Naphtali, Gad, and Asher. 
 \p
-\v 3 The sons of Judah: Er, Onan, and Shelah, which three were born to him of Shua’s daughter the Canaanitess. Er, Judah’s firstborn, was wicked in Yahweh’s sight; and he killed him. 
+\v 3 The sons of Judah: Er, Onan, and Shelah, which three were born to him of Shua’s daughter the Canaanitess. Er, Judah’s firstborn, was wicked in Yahuah’s sight; and he killed him. 
 \v 4 Tamar his daughter-in-law bore him Perez and Zerah. All the sons of Judah were five. 
 \p
 \v 5 The sons of Perez: Hezron and Hamul. 
@@ -254,7 +254,7 @@
 \v 12 Ahitub brought forth Zadok. Zadok brought forth Shallum. 
 \v 13 Shallum brought forth Hilkiah. Hilkiah brought forth Azariah. 
 \v 14 Azariah brought forth Seraiah. Seraiah brought forth Jehozadak. 
-\v 15 Jehozadak went into captivity when Yahweh carried Judah and Jerusalem away by the hand of Nebuchadnezzar. 
+\v 15 Jehozadak went into captivity when Yahuah carried Judah and Jerusalem away by the hand of Nebuchadnezzar. 
 \p
 \v 16 The sons of Levi: Gershom, Kohath, and Merari. 
 \v 17 These are the names of the sons of Gershom: Libni and Shimei. 
@@ -272,8 +272,8 @@
 \v 29 The sons of Merari: Mahli, Libni his son, Shimei his son, Uzzah his son, 
 \v 30 Shimea his son, Haggiah his son, Asaiah his son. 
 \p
-\v 31 These are they whom David set over the service of song in Yahweh’s house after the ark came to rest there. 
-\v 32 They ministered with song before the tabernacle of the Tent of Meeting until Solomon had built Yahweh’s house in Jerusalem. They performed the duties of their office according to their order. 
+\v 31 These are they whom David set over the service of song in Yahuah’s house after the ark came to rest there. 
+\v 32 They ministered with song before the tabernacle of the Tent of Meeting until Solomon had built Yahuah’s house in Jerusalem. They performed the duties of their office according to their order. 
 \v 33 These are those who served, and their sons. Of the sons of the Kohathites: Heman the singer, the son of Joel, the son of Samuel, 
 \v 34 the son of Elkanah, the son of Jeroham, the son of Eliel, the son of Toah, 
 \v 35 the son of Zuph, the son of Elkanah, the son of Mahath, the son of Amasai, 
@@ -442,11 +442,11 @@
 \p
 \v 17 The gatekeepers: Shallum, Akkub, Talmon, Ahiman, and their brothers (Shallum was the chief), 
 \v 18 who previously served in the king’s gate eastward. They were the gatekeepers for the camp of the children of Levi. 
-\v 19 Shallum was the son of Kore, the son of Ebiasaph, the son of Korah, and his brothers, of his father’s house, the Korahites, were over the work of the service, keepers of the thresholds of the tent. Their fathers had been over Yahweh’s camp, keepers of the entry. 
-\v 20 Phinehas the son of Eleazar was ruler over them in time past, and Yahweh was with him. 
+\v 19 Shallum was the son of Kore, the son of Ebiasaph, the son of Korah, and his brothers, of his father’s house, the Korahites, were over the work of the service, keepers of the thresholds of the tent. Their fathers had been over Yahuah’s camp, keepers of the entry. 
+\v 20 Phinehas the son of Eleazar was ruler over them in time past, and Yahuah was with him. 
 \v 21 Zechariah the son of Meshelemiah was gatekeeper of the door of the Tent of Meeting. 
 \v 22 All these who were chosen to be gatekeepers in the thresholds were two hundred twelve. These were listed by genealogy in their villages, whom David and Samuel the seer ordained in their office of trust. 
-\v 23 So they and their children had the oversight of the gates of Yahweh’s house, even the house of the tent, as guards. 
+\v 23 So they and their children had the oversight of the gates of Yahuah’s house, even the house of the tent, as guards. 
 \v 24 On the four sides were the gatekeepers, toward the east, west, north, and south. 
 \v 25 Their brothers, in their villages, were to come in every seven days from time to time to be with them, 
 \v 26 for the four chief gatekeepers, who were Levites, were in an office of trust, and were over the rooms and over the treasuries in Elohim’s house. 
@@ -489,34 +489,34 @@
 \v 11 When all Jabesh Gilead heard all that the Philistines had done to Saul, 
 \v 12 all the valiant men arose and took away the body of Saul and the bodies of his sons, and brought them to Jabesh, and buried their bones under the oak in Jabesh, and fasted seven days. 
 \p
-\v 13 So Saul died for his trespass which he committed against Yahweh, because of Yahweh’s word, which he didn’t keep, and also because he asked counsel of one who had a familiar spirit, to inquire, 
-\v 14 and didn’t inquire of Yahweh. Therefore he killed him, and turned the kingdom over to David the son of Jesse. 
+\v 13 So Saul died for his trespass which he committed against Yahuah, because of Yahuah’s word, which he didn’t keep, and also because he asked counsel of one who had a familiar spirit, to inquire, 
+\v 14 and didn’t inquire of Yahuah. Therefore he killed him, and turned the kingdom over to David the son of Jesse. 
 \c 11
 \p
 \v 1 Then all Israel gathered themselves to David to Hebron, saying, “Behold, we are your bone and your flesh. 
-\v 2 In times past, even when Saul was king, it was you who led out and brought in Israel. Yahweh your Elohim said to you, ‘You shall be shepherd of my people Israel, and you shall be prince over my people Israel.’ ” 
+\v 2 In times past, even when Saul was king, it was you who led out and brought in Israel. Yahuah your Elohim said to you, ‘You shall be shepherd of my people Israel, and you shall be prince over my people Israel.’ ” 
 \p
-\v 3 So all the elders of Israel came to the king to Hebron; and David made a covenant with them in Hebron before Yahweh. They anointed David king over Israel, according to Yahweh’s word by Samuel. 
+\v 3 So all the elders of Israel came to the king to Hebron; and David made a covenant with them in Hebron before Yahuah. They anointed David king over Israel, according to Yahuah’s word by Samuel. 
 \p
 \v 4 David and all Israel went to Jerusalem (also called Jebus); and the Jebusites, the inhabitants of the land, were there. 
 \v 5 The inhabitants of Jebus said to David, “You will not come in here!” Nevertheless David took the stronghold of Zion. The same is David’s city. 
 \v 6 David had said, “Whoever strikes the Jebusites first shall be chief and captain.” Joab the son of Zeruiah went up first, and was made chief. 
 \v 7 David lived in the stronghold; therefore they called it David’s city. 
 \v 8 He built the city all around, from Millo even around; and Joab repaired the rest of the city. 
-\v 9 David grew greater and greater, for Yahweh of Armies was with him. 
+\v 9 David grew greater and greater, for Yahuah of Armies was with him. 
 \p
-\v 10 Now these are the chief of the mighty men whom David had, who showed themselves strong with him in his kingdom, together with all Israel, to make him king, according to Yahweh’s word concerning Israel. 
+\v 10 Now these are the chief of the mighty men whom David had, who showed themselves strong with him in his kingdom, together with all Israel, to make him king, according to Yahuah’s word concerning Israel. 
 \p
 \v 11 This is the number of the mighty men whom David had: Jashobeam, the son of a Hachmonite, the chief of the thirty; he lifted up his spear against three hundred and killed them at one time. 
 \v 12 After him was Eleazar the son of Dodo, the Ahohite, who was one of the three mighty men. 
 \v 13 He was with David at Pasdammim, and there the Philistines were gathered together to battle, where there was a plot of ground full of barley; and the people fled from before the Philistines. 
-\v 14 They stood in the middle of the plot, defended it, and killed the Philistines; and Yahweh saved them by a great victory. 
+\v 14 They stood in the middle of the plot, defended it, and killed the Philistines; and Yahuah saved them by a great victory. 
 \p
 \v 15 Three of the thirty chief men went down to the rock to David, into the cave of Adullam; and the army of the Philistines were encamped in the valley of Rephaim. 
 \v 16 David was then in the stronghold, and the garrison of the Philistines was in Bethlehem at that time. 
 \v 17 David longed, and said, “Oh, that someone would give me water to drink from the well of Bethlehem, which is by the gate!” 
 \p
-\v 18 The three broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate, took it, and brought it to David; but David would not drink any of it, but poured it out to Yahweh, 
+\v 18 The three broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate, took it, and brought it to David; but David would not drink any of it, but poured it out to Yahuah, 
 \v 19 and said, “My Elohim forbid me, that I should do this! Shall I drink the blood of these men who have put their lives in jeopardy?” For they risked their lives to bring it. Therefore he would not drink it. The three mighty men did these things. 
 \p
 \v 20 Abishai, the brother of Joab, was chief of the three; for he lifted up his spear against three hundred and killed them, and had a name among the three. 
@@ -578,7 +578,7 @@
 \v 21 They helped David against the band of raiders, for they were all mighty men of valor and were captains in the army. 
 \v 22 For from day to day men came to David to help him, until there was a great army, like Elohim’s army. 
 \p
-\v 23 These are the numbers of the heads of those who were armed for war, who came to David to Hebron to turn the kingdom of Saul to him, according to Yahweh’s word. 
+\v 23 These are the numbers of the heads of those who were armed for war, who came to David to Hebron to turn the kingdom of Saul to him, according to Yahuah’s word. 
 \v 24 The children of Judah who bore shield and spear were six thousand eight hundred, armed for war. 
 \v 25 Of the children of Simeon, mighty men of valor for the war: seven thousand one hundred. 
 \v 26 Of the children of Levi: four thousand six hundred. 
@@ -600,26 +600,26 @@
 \c 13
 \p
 \v 1 David consulted with the captains of thousands and of hundreds, even with every leader. 
-\v 2 David said to all the assembly of Israel, “If it seems good to you, and if it is of Yahweh our Elohim, let’s send word everywhere to our brothers who are left in all the land of Israel, with whom the priests and Levites are in their cities that have pasture lands, that they may gather themselves to us. 
+\v 2 David said to all the assembly of Israel, “If it seems good to you, and if it is of Yahuah our Elohim, let’s send word everywhere to our brothers who are left in all the land of Israel, with whom the priests and Levites are in their cities that have pasture lands, that they may gather themselves to us. 
 \v 3 Also, let’s bring the ark of our Elohim back to us again, for we didn’t seek it in the days of Saul.” 
 \p
 \v 4 All the assembly said that they would do so, for the thing was right in the eyes of all the people. 
 \v 5 So David assembled all Israel together, from the Shihor River of Egypt even to the entrance of Hamath, to bring Elohim’s ark from Kiriath Jearim. 
 \p
-\v 6 David went up with all Israel to Baalah, that is, to Kiriath Jearim, which belonged to Judah, to bring up from there Elohim Yahweh’s ark that sits above the cherubim, that is called by the Name. 
+\v 6 David went up with all Israel to Baalah, that is, to Kiriath Jearim, which belonged to Judah, to bring up from there Elohim Yahuah’s ark that sits above the cherubim, that is called by the Name. 
 \v 7 They carried Elohim’s ark on a new cart, and brought it out of Abinadab’s house; and Uzza and Ahio drove the cart. 
 \v 8 David and all Israel played before Elohim with all their might, even with songs, with harps, with stringed instruments, with tambourines, with cymbals, and with trumpets. 
 \p
 \v 9 When they came to Chidon’s threshing floor, Uzza put out his hand to hold the ark, for the oxen stumbled. 
-\v 10 Yahweh’s anger burned against Uzza, and he struck him because he put his hand on the ark; and he died there before Elohim. 
-\v 11 David was displeased, because Yahweh had broken out against Uzza. He called that place Perez Uzza, to this day. 
+\v 10 Yahuah’s anger burned against Uzza, and he struck him because he put his hand on the ark; and he died there before Elohim. 
+\v 11 David was displeased, because Yahuah had broken out against Uzza. He called that place Perez Uzza, to this day. 
 \v 12 David was afraid of Elohim that day, saying, “How can I bring Elohim’s ark home to me?” 
 \v 13 So David didn’t move the ark with him into David’s city, but carried it aside into Obed-Edom the Gittite’s house. 
-\v 14 Elohim’s ark remained with the family of Obed-Edom in his house three months; and Yahweh blessed Obed-Edom’s house and all that he had. 
+\v 14 Elohim’s ark remained with the family of Obed-Edom in his house three months; and Yahuah blessed Obed-Edom’s house and all that he had. 
 \c 14
 \p
 \v 1 Hiram king of Tyre sent messengers to David with cedar trees, masons, and carpenters, to build him a house. 
-\v 2 David perceived that Yahweh had established him king over Israel, for his kingdom was highly exalted, for his people Israel’s sake. 
+\v 2 David perceived that Yahuah had established him king over Israel, for his kingdom was highly exalted, for his people Israel’s sake. 
 \p
 \v 3 David took more women in Jerusalem, and David brought forth more sons and daughters. 
 \v 4 These are the names of the children whom he had in Jerusalem: Shammua, Shobab, Nathan, Solomon, 
@@ -630,7 +630,7 @@
 \v 8 When the Philistines heard that David was anointed king over all Israel, all the Philistines went up to seek David; and David heard of it, and went out against them. 
 \v 9 Now the Philistines had come and made a raid in the valley of Rephaim. 
 \v 10 David inquired of Elohim, saying, “Shall I go up against the Philistines? Will you deliver them into my hand?” 
-\p Yahweh said to him, “Go up; for I will deliver them into your hand.” 
+\p Yahuah said to him, “Go up; for I will deliver them into your hand.” 
 \p
 \v 11 So they came up to Baal Perazim, and David defeated them there. David said, Elohim has broken my enemies by my hand, like waters breaking out. Therefore they called the name of that place Baal Perazim. 
 \v 12 They left their elohims there; and David gave a command, and they were burned with fire. 
@@ -640,13 +640,13 @@
 \v 15 When you hear the sound of marching in the tops of the mulberry trees, then go out to battle; for Elohim has gone out before you to strike the army of the Philistines.” 
 \p
 \v 16 David did as Elohim commanded him; and they attacked the army of the Philistines from Gibeon even to Gezer. 
-\v 17 The fame of David went out into all lands; and Yahweh brought the fear of him on all nations. 
+\v 17 The fame of David went out into all lands; and Yahuah brought the fear of him on all nations. 
 \c 15
 \p
 \v 1 David made himself houses in David’s city; and he prepared a place for Elohim’s ark, and pitched a tent for it. 
-\v 2 Then David said, “No one ought to carry Elohim’s ark but the Levites. For Yahweh has chosen them to carry Elohim’s ark, and to minister to him forever.” 
+\v 2 Then David said, “No one ought to carry Elohim’s ark but the Levites. For Yahuah has chosen them to carry Elohim’s ark, and to minister to him forever.” 
 \p
-\v 3 David assembled all Israel at Jerusalem, to bring up Yahweh’s ark to its place, which he had prepared for it. 
+\v 3 David assembled all Israel at Jerusalem, to bring up Yahuah’s ark to its place, which he had prepared for it. 
 \v 4 David gathered together the sons of Aaron and the Levites: 
 \v 5 of the sons of Kohath, Uriel the chief, and his brothers one hundred twenty; 
 \v 6 of the sons of Merari, Asaiah the chief, and his brothers two hundred twenty; 
@@ -656,11 +656,11 @@
 \v 10 of the sons of Uzziel, Amminadab the chief, and his brothers one hundred twelve. 
 \p
 \v 11 David called for Zadok and Abiathar the priests, and for the Levites: for Uriel, Asaiah, Joel, Shemaiah, Eliel, and Amminadab, 
-\v 12 and said to them, “You are the heads of the fathers’ households of the Levites. Sanctify yourselves, both you and your brothers, that you may bring the ark of Yahweh, the Elohim of Israel, up to the place that I have prepared for it. 
-\v 13 For because you didn’t carry it at first, Yahweh our Elohim broke out in anger against us, because we didn’t seek him according to the ordinance.” 
+\v 12 and said to them, “You are the heads of the fathers’ households of the Levites. Sanctify yourselves, both you and your brothers, that you may bring the ark of Yahuah, the Elohim of Israel, up to the place that I have prepared for it. 
+\v 13 For because you didn’t carry it at first, Yahuah our Elohim broke out in anger against us, because we didn’t seek him according to the ordinance.” 
 \p
-\v 14 So the priests and the Levites sanctified themselves to bring up the ark of Yahweh, the Elohim of Israel. 
-\v 15 The children of the Levites bore Elohim’s ark on their shoulders with its poles, as Moses commanded according to Yahweh’s word. 
+\v 14 So the priests and the Levites sanctified themselves to bring up the ark of Yahuah, the Elohim of Israel. 
+\v 15 The children of the Levites bore Elohim’s ark on their shoulders with its poles, as Moses commanded according to Yahuah’s word. 
 \p
 \v 16 David spoke to the chief of the Levites to appoint their brothers as singers with instruments of music, stringed instruments, harps, and cymbals, sounding aloud and lifting up their voices with joy. 
 \v 17 So the Levites appointed Heman the son of Joel; and of his brothers, Asaph the son of Berechiah; and of the sons of Merari their brothers, Ethan the son of Kushaiah; 
@@ -672,24 +672,24 @@
 \v 23 Berechiah and Elkanah were doorkeepers for the ark. 
 \v 24 Shebaniah, Joshaphat, Nethanel, Amasai, Zechariah, Benaiah, and Eliezer, the priests, blew the trumpets before Elohim’s ark; and Obed-Edom and Jehiah were doorkeepers for the ark. 
 \p
-\v 25 So David, the elders of Israel, and the captains over thousands went to bring the ark of Yahweh’s covenant up out of the house of Obed-Edom with joy. 
-\v 26 When Elohim helped the Levites who bore the ark of Yahweh’s covenant, they sacrificed seven bulls and seven rams. 
+\v 25 So David, the elders of Israel, and the captains over thousands went to bring the ark of Yahuah’s covenant up out of the house of Obed-Edom with joy. 
+\v 26 When Elohim helped the Levites who bore the ark of Yahuah’s covenant, they sacrificed seven bulls and seven rams. 
 \v 27 David was clothed with a robe of fine linen, as were all the Levites who bore the ark, the singers, and Chenaniah the choir master with the singers; and David had an ephod of linen on him. 
-\v 28 Thus all Israel brought the ark of Yahweh’s covenant up with shouting, with sound of the cornet, with trumpets, and with cymbals, sounding aloud with stringed instruments and harps. 
-\v 29 As the ark of Yahweh’s covenant came to David’s city, Michal the daughter of Saul looked out at the window, and saw king David dancing and playing; and she despised him in her heart. 
+\v 28 Thus all Israel brought the ark of Yahuah’s covenant up with shouting, with sound of the cornet, with trumpets, and with cymbals, sounding aloud with stringed instruments and harps. 
+\v 29 As the ark of Yahuah’s covenant came to David’s city, Michal the daughter of Saul looked out at the window, and saw king David dancing and playing; and she despised him in her heart. 
 \c 16
 \p
 \v 1 They brought in Elohim’s ark, and set it in the middle of the tent that David had pitched for it; and they offered burnt offerings and peace offerings before Elohim. 
-\v 2 When David had finished offering the burnt offering and the peace offerings, he blessed the people in Yahweh’s name. 
+\v 2 When David had finished offering the burnt offering and the peace offerings, he blessed the people in Yahuah’s name. 
 \v 3 He gave to everyone of Israel, both man and woman, to everyone a loaf of bread, a portion of meat, and a cake of raisins. 
 \p
-\v 4 He appointed some of the Levites to minister before Yahweh’s ark, and to commemorate, to thank, and to praise Yahweh, the Elohim of Israel: 
+\v 4 He appointed some of the Levites to minister before Yahuah’s ark, and to commemorate, to thank, and to praise Yahuah, the Elohim of Israel: 
 \v 5 Asaph the chief, and second to him Zechariah, then Jeiel, Shemiramoth, Jehiel, Mattithiah, Eliab, Benaiah, Obed-Edom, and Jeiel, with stringed instruments and with harps; and Asaph with cymbals, sounding aloud; 
 \v 6 with Benaiah and Jahaziel the priests with trumpets continually, before the ark of the covenant of Elohim. 
 \p
-\v 7 Then on that day David first ordained giving of thanks to Yahweh by the hand of Asaph and his brothers. 
+\v 7 Then on that day David first ordained giving of thanks to Yahuah by the hand of Asaph and his brothers. 
 \q1
-\v 8 Oh give thanks to Yahweh. 
+\v 8 Oh give thanks to Yahuah. 
 \q2 Call on his name. 
 \q2 Make what he has done known among the peoples. 
 \q1
@@ -698,9 +698,9 @@
 \q2 Tell of all his marvelous works. 
 \q1
 \v 10 Glory in his set-apart name. 
-\q2 Let the heart of those who seek Yahweh rejoice. 
+\q2 Let the heart of those who seek Yahuah rejoice. 
 \q1
-\v 11 Seek Yahweh and his strength. 
+\v 11 Seek Yahuah and his strength. 
 \q2 Seek his face forever more. 
 \q1
 \v 12 Remember his marvelous works that he has done, 
@@ -710,7 +710,7 @@
 \q2 you children of Jacob, his chosen ones. 
 \b
 \q1
-\v 14 He is Yahweh our Elohim. 
+\v 14 He is Yahuah our Elohim. 
 \q2 His judgments are in all the earth. 
 \q1
 \v 15 Remember his covenant forever, 
@@ -738,43 +738,43 @@
 \q2 Do my prophets no harm!” 
 \b
 \q1
-\v 23 Sing to Yahweh, all the earth! 
+\v 23 Sing to Yahuah, all the earth! 
 \q2 Display his salvation from day to day. 
 \q1
 \v 24 Declare his glory among the nations, 
 \q2 and his marvelous works among all the peoples. 
 \q1
-\v 25 For great is Yahweh, and greatly to be praised. 
+\v 25 For great is Yahuah, and greatly to be praised. 
 \q2 He also is to be feared above all elohims. 
 \q1
 \v 26 For all the elohims of the peoples are idols, 
-\q2 but Yahweh made the heavens. 
+\q2 but Yahuah made the heavens. 
 \q1
 \v 27 Honor and majesty are before him. 
 \q2 Strength and gladness are in his place. 
 \b
 \q1
-\v 28 Ascribe to Yahweh, you families of the peoples, 
-\q2 ascribe to Yahweh glory and strength! 
+\v 28 Ascribe to Yahuah, you families of the peoples, 
+\q2 ascribe to Yahuah glory and strength! 
 \q1
-\v 29 Ascribe to Yahweh the glory due to his name. 
+\v 29 Ascribe to Yahuah the glory due to his name. 
 \q2 Bring an offering, and come before him. 
-\q2 Worship Yahweh in set-apart array. 
+\q2 Worship Yahuah in set-apart array. 
 \q1
 \v 30 Tremble before him, all the earth. 
 \q2 The world also is established that it can’t be moved. 
 \q1
 \v 31 Let the heavens be glad, 
 \q2 and let the earth rejoice! 
-\q2 Let them say among the nations, “Yahweh reigns!” 
+\q2 Let them say among the nations, “Yahuah reigns!” 
 \q1
 \v 32 Let the sea roar, and its fullness! 
 \q2 Let the field exult, and all that is in it! 
 \q1
-\v 33 Then the trees of the forest will sing for joy before Yahweh, 
+\v 33 Then the trees of the forest will sing for joy before Yahuah, 
 \q2 for he comes to judge the earth. 
 \q1
-\v 34 Oh give thanks to Yahweh, for he is good, 
+\v 34 Oh give thanks to Yahuah, for he is good, 
 \q2 for his loving kindness endures forever. 
 \q1
 \v 35 Say, “Save us, Elohim of our salvation! 
@@ -782,50 +782,50 @@
 \q2 to give thanks to your set-apart name, 
 \q2 to triumph in your praise.” 
 \q1
-\v 36 Blessed be Yahweh, the Elohim of Israel, 
+\v 36 Blessed be Yahuah, the Elohim of Israel, 
 \q2 from everlasting even to everlasting. 
-\p All the people said, “Amen,” and praised Yahweh. 
+\p All the people said, “Amen,” and praised Yahuah. 
 \p
-\v 37 So he left Asaph and his brothers there before the ark of Yahweh’s covenant, to minister before the ark continually, as every day’s work required; 
+\v 37 So he left Asaph and his brothers there before the ark of Yahuah’s covenant, to minister before the ark continually, as every day’s work required; 
 \v 38 and Obed-Edom with their sixty-eight relatives; Obed-Edom also the son of Jeduthun and Hosah to be doorkeepers; 
-\v 39 and Zadok the priest and his brothers the priests, before Yahweh’s tabernacle in the high place that was at Gibeon, 
-\v 40 to offer burnt offerings to Yahweh on the altar of burnt offering continually morning and evening, even according to all that is written in Yahweh’s law, which he commanded to Israel; 
-\v 41 and with them Heman and Jeduthun and the rest who were chosen, who were mentioned by name, to give thanks to Yahweh, because his loving kindness endures forever; 
+\v 39 and Zadok the priest and his brothers the priests, before Yahuah’s tabernacle in the high place that was at Gibeon, 
+\v 40 to offer burnt offerings to Yahuah on the altar of burnt offering continually morning and evening, even according to all that is written in Yahuah’s law, which he commanded to Israel; 
+\v 41 and with them Heman and Jeduthun and the rest who were chosen, who were mentioned by name, to give thanks to Yahuah, because his loving kindness endures forever; 
 \v 42 and with them Heman and Jeduthun with trumpets and cymbals for those that should sound aloud, and with instruments for the songs of Elohim, and the sons of Jeduthun to be at the gate. 
 \v 43 All the people departed, each man to his house; and David returned to bless his house. 
 \c 17
 \p
-\v 1 When David was living in his house, David said to Nathan the prophet, “Behold, I live in a cedar house, but the ark of Yahweh’s covenant is in a tent.” 
+\v 1 When David was living in his house, David said to Nathan the prophet, “Behold, I live in a cedar house, but the ark of Yahuah’s covenant is in a tent.” 
 \p
 \v 2 Nathan said to David, “Do all that is in your heart; for Elohim is with you.” 
 \p
 \v 3 That same night, the word of Elohim came to Nathan, saying, 
-\v 4 “Go and tell David my servant, ‘Yahweh says, “You shall not build me a house to dwell in; 
+\v 4 “Go and tell David my servant, ‘Yahuah says, “You shall not build me a house to dwell in; 
 \v 5 for I have not lived in a house since the day that I brought up Israel to this day, but have gone from tent to tent, and from one tent to another. 
 \v 6 In all places in which I have walked with all Israel, did I speak a word with any of the judges of Israel, whom I commanded to be shepherd of my people, saying, ‘Why have you not built me a house of cedar?’ ” ’ 
 \p
-\v 7 “Now therefore, you shall tell my servant David, ‘Yahweh of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people Israel. 
+\v 7 “Now therefore, you shall tell my servant David, ‘Yahuah of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people Israel. 
 \v 8 I have been with you wherever you have gone, and have cut off all your enemies from before you. I will make you a name like the name of the great ones who are in the earth. 
 \v 9 I will appoint a place for my people Israel, and will plant them, that they may dwell in their own place, and be moved no more. The children of wickedness will not waste them any more, as at the first, 
-\v 10 and from the day that I commanded judges to be over my people Israel. I will subdue all your enemies. Moreover I tell you that Yahweh will build you a house. 
+\v 10 and from the day that I commanded judges to be over my people Israel. I will subdue all your enemies. Moreover I tell you that Yahuah will build you a house. 
 \v 11 It will happen, when your days are fulfilled that you must go to be with your fathers, that I will set up your offspring after you, who will be of your sons; and I will establish his kingdom. 
 \v 12 He will build me a house, and I will establish his throne forever. 
 \v 13 I will be his father, and he will be my son. I will not take my loving kindness away from him, as I took it from him who was before you; 
 \v 14 but I will settle him in my house and in my kingdom forever. His throne will be established forever.” ’ ” 
 \v 15 According to all these words, and according to all this vision, so Nathan spoke to David. 
 \p
-\v 16 Then David the king went in and sat before Yahweh; and he said, “Who am I, Yahweh Elohim, and what is my house, that you have brought me this far? 
-\v 17 This was a small thing in your eyes, O Elohim, but you have spoken of your servant’s house for a great while to come, and have respected me according to the standard of a man of high degree, Yahweh Elohim. 
+\v 16 Then David the king went in and sat before Yahuah; and he said, “Who am I, Yahuah Elohim, and what is my house, that you have brought me this far? 
+\v 17 This was a small thing in your eyes, O Elohim, but you have spoken of your servant’s house for a great while to come, and have respected me according to the standard of a man of high degree, Yahuah Elohim. 
 \v 18 What can David say yet more to you concerning the honor which is done to your servant? For you know your servant. 
-\v 19 Yahweh, for your servant’s sake, and according to your own heart, you have done all this greatness, to make known all these great things. 
-\v 20 Yahweh, there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
+\v 19 Yahuah, for your servant’s sake, and according to your own heart, you have done all this greatness, to make known all these great things. 
+\v 20 Yahuah, there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
 \v 21 What one nation in the earth is like your people Israel, whom Elohim went to redeem to himself for a people, to make you a name by great and awesome things, in driving out nations from before your people whom you redeemed out of Egypt? 
-\v 22 For you made your people Israel your own people forever; and you, Yahweh, became their Elohim. 
-\v 23 Now, Yahweh, let the word that you have spoken concerning your servant, and concerning his house, be established forever, and do as you have spoken. 
-\v 24 Let your name be established and magnified forever, saying, ‘Yahweh of Armies is the Elohim of Israel, even an Elohim to Israel. The house of David your servant is established before you.’ 
+\v 22 For you made your people Israel your own people forever; and you, Yahuah, became their Elohim. 
+\v 23 Now, Yahuah, let the word that you have spoken concerning your servant, and concerning his house, be established forever, and do as you have spoken. 
+\v 24 Let your name be established and magnified forever, saying, ‘Yahuah of Armies is the Elohim of Israel, even an Elohim to Israel. The house of David your servant is established before you.’ 
 \v 25 For you, my Elohim, have revealed to your servant that you will build him a house. Therefore your servant has found courage to pray before you. 
-\v 26 Now, Yahweh, you are Elohim, and have promised this good thing to your servant. 
-\v 27 Now it has pleased you to bless the house of your servant, that it may continue forever before you; for you, Yahweh, have blessed, and it is blessed forever.” 
+\v 26 Now, Yahuah, you are Elohim, and have promised this good thing to your servant. 
+\v 27 Now it has pleased you to bless the house of your servant, that it may continue forever before you; for you, Yahuah, have blessed, and it is blessed forever.” 
 \c 18
 \p
 \v 1 After this, David defeated the Philistines and subdued them, and took Gath and its towns out of the hand of the Philistines. 
@@ -834,16 +834,16 @@
 \v 3 David defeated Hadadezer king of Zobah, toward Hamath, as he went to establish his dominion by the river Euphrates. 
 \v 4 David took from him one thousand chariots, seven thousand horsemen, and twenty thousand footmen; and David hamstrung all the chariot horses, but reserved of them enough for one hundred chariots. 
 \v 5 When the Syrians of Damascus came to help Hadadezer king of Zobah, David struck twenty-two thousand men of the Syrians. 
-\v 6 Then David put garrisons in Syria of Damascus; and the Syrians became servants to David and brought tribute. Yahweh gave victory to David wherever he went. 
+\v 6 Then David put garrisons in Syria of Damascus; and the Syrians became servants to David and brought tribute. Yahuah gave victory to David wherever he went. 
 \v 7 David took the shields of gold that were on the servants of Hadadezer, and brought them to Jerusalem. 
 \v 8 From Tibhath and from Cun, cities of Hadadezer, David took very much bronze, with which Solomon made the bronze sea, the pillars, and the vessels of bronze. 
 \p
 \v 9 When Tou king of Hamath heard that David had struck all the army of Hadadezer king of Zobah, 
 \v 10 he sent Hadoram his son to King David to greet him and to bless him, because he had fought against Hadadezer and struck him (for Hadadezer had wars with Tou); and he had with him all kinds of vessels of gold and silver and bronze. 
-\v 11 King David also dedicated these to Yahweh, with the silver and the gold that he carried away from all the nations: from Edom, from Moab, from the children of Ammon, from the Philistines, and from Amalek. 
+\v 11 King David also dedicated these to Yahuah, with the silver and the gold that he carried away from all the nations: from Edom, from Moab, from the children of Ammon, from the Philistines, and from Amalek. 
 \p
 \v 12 Moreover Abishai the son of Zeruiah struck eighteen thousand of the Edomites in the Valley of Salt. 
-\v 13 He put garrisons in Edom; and all the Edomites became servants to David. Yahweh gave victory to David wherever he went. 
+\v 13 He put garrisons in Edom; and all the Edomites became servants to David. Yahuah gave victory to David wherever he went. 
 \p
 \v 14 David reigned over all Israel; and he executed justice and righteousness for all his people. 
 \v 15 Joab the son of Zeruiah was over the army; Jehoshaphat the son of Ahilud was recorder; 
@@ -866,7 +866,7 @@
 \v 10 Now when Joab saw that the battle was set against him before and behind, he chose some of all the choice men of Israel, and put them in array against the Syrians. 
 \v 11 The rest of the people he committed into the hand of Abishai his brother; and they put themselves in array against the children of Ammon. 
 \v 12 He said, “If the Syrians are too strong for me, then you are to help me; but if the children of Ammon are too strong for you, then I will help you. 
-\v 13 Be courageous, and let’s be strong for our people and for the cities of our Elohim. May Yahweh do that which seems good to him.” 
+\v 13 Be courageous, and let’s be strong for our people and for the cities of our Elohim. May Yahuah do that which seems good to him.” 
 \p
 \v 14 So Joab and the people who were with him came near to the front of the Syrians to the battle; and they fled before him. 
 \v 15 When the children of Ammon saw that the Syrians had fled, they likewise fled before Abishai his brother, and entered into the city. Then Joab came to Jerusalem. 
@@ -892,7 +892,7 @@
 \v 1 Satan stood up against Israel, and moved David to take a census of Israel. 
 \v 2 David said to Joab and to the princes of the people, “Go, count Israel from Beersheba even to Dan; and bring me word, that I may know how many there are.” 
 \p
-\v 3 Joab said, “May Yahweh make his people a hundred times as many as they are. But, my lord the king, aren’t they all my lord’s servants? Why does my lord require this thing? Why will he be a cause of guilt to Israel?” 
+\v 3 Joab said, “May Yahuah make his people a hundred times as many as they are. But, my lord the king, aren’t they all my lord’s servants? Why does my lord require this thing? Why will he be a cause of guilt to Israel?” 
 \p
 \v 4 Nevertheless the king’s word prevailed against Joab. Therefore Joab departed and went throughout all Israel, then came to Jerusalem. 
 \v 5 Joab gave the sum of the census of the people to David. All those of Israel were one million one hundred thousand men who drew a sword; and in Judah were four hundred seventy thousand men who drew a sword. 
@@ -901,70 +901,70 @@
 \v 7 Elohim was displeased with this thing; therefore he struck Israel. 
 \v 8 David said to Elohim, “I have sinned greatly, in that I have done this thing. But now put away, I beg you, the iniquity of your servant, for I have done very foolishly.” 
 \p
-\v 9 Yahweh spoke to Gad, David’s seer, saying, 
-\v 10 “Go and speak to David, saying, ‘Yahweh says, “I offer you three things. Choose one of them, that I may do it to you.” ’ ” 
+\v 9 Yahuah spoke to Gad, David’s seer, saying, 
+\v 10 “Go and speak to David, saying, ‘Yahuah says, “I offer you three things. Choose one of them, that I may do it to you.” ’ ” 
 \p
-\v 11 So Gad came to David and said to him, “Yahweh says, ‘Take your choice: 
-\v 12 either three years of famine; or three months to be consumed before your foes, while the sword of your enemies overtakes you; or else three days of the sword of Yahweh, even pestilence in the land, and Yahweh’s angel destroying throughout all the borders of Israel. Now therefore consider what answer I shall return to him who sent me.’ ” 
+\v 11 So Gad came to David and said to him, “Yahuah says, ‘Take your choice: 
+\v 12 either three years of famine; or three months to be consumed before your foes, while the sword of your enemies overtakes you; or else three days of the sword of Yahuah, even pestilence in the land, and Yahuah’s angel destroying throughout all the borders of Israel. Now therefore consider what answer I shall return to him who sent me.’ ” 
 \p
-\v 13 David said to Gad, “I am in distress. Let me fall, I pray, into Yahweh’s hand, for his mercies are very great. Don’t let me fall into man’s hand.” 
+\v 13 David said to Gad, “I am in distress. Let me fall, I pray, into Yahuah’s hand, for his mercies are very great. Don’t let me fall into man’s hand.” 
 \p
-\v 14 So Yahweh sent a pestilence on Israel, and seventy thousand men of Israel fell. 
-\v 15 Elohim sent an angel to Jerusalem to destroy it. As he was about to destroy, Yahweh saw, and he relented of the disaster, and said to the destroying angel, “It is enough. Now withdraw your hand.” Yahweh’s angel was standing by the threshing floor of Ornan the Jebusite. 
-\v 16 David lifted up his eyes, and saw Yahweh’s angel standing between earth and the sky, having a drawn sword in his hand stretched out over Jerusalem. 
+\v 14 So Yahuah sent a pestilence on Israel, and seventy thousand men of Israel fell. 
+\v 15 Elohim sent an angel to Jerusalem to destroy it. As he was about to destroy, Yahuah saw, and he relented of the disaster, and said to the destroying angel, “It is enough. Now withdraw your hand.” Yahuah’s angel was standing by the threshing floor of Ornan the Jebusite. 
+\v 16 David lifted up his eyes, and saw Yahuah’s angel standing between earth and the sky, having a drawn sword in his hand stretched out over Jerusalem. 
 \p Then David and the elders, clothed in sackcloth, fell on their faces. 
-\v 17 David said to Elohim, “Isn’t it I who commanded the people to be counted? It is even I who have sinned and done very wickedly; but these sheep, what have they done? Please let your hand, O Yahweh my Elohim, be against me and against my father’s house; but not against your people, that they should be plagued.” 
+\v 17 David said to Elohim, “Isn’t it I who commanded the people to be counted? It is even I who have sinned and done very wickedly; but these sheep, what have they done? Please let your hand, O Yahuah my Elohim, be against me and against my father’s house; but not against your people, that they should be plagued.” 
 \p
-\v 18 Then Yahweh’s angel commanded Gad to tell David that David should go up and raise an altar to Yahweh on the threshing floor of Ornan the Jebusite. 
-\v 19 David went up at the saying of Gad, which he spoke in Yahweh’s name. 
+\v 18 Then Yahuah’s angel commanded Gad to tell David that David should go up and raise an altar to Yahuah on the threshing floor of Ornan the Jebusite. 
+\v 19 David went up at the saying of Gad, which he spoke in Yahuah’s name. 
 \p
 \v 20 Ornan turned back and saw the angel; and his four sons who were with him hid themselves. Now Ornan was threshing wheat. 
 \v 21 As David came to Ornan, Ornan looked and saw David, and went out of the threshing floor, and bowed himself to David with his face to the ground. 
 \p
-\v 22 Then David said to Ornan, “Sell me the place of this threshing floor, that I may build an altar to Yahweh on it. You shall sell it to me for the full price, that the plague may be stopped from afflicting the people.” 
+\v 22 Then David said to Ornan, “Sell me the place of this threshing floor, that I may build an altar to Yahuah on it. You shall sell it to me for the full price, that the plague may be stopped from afflicting the people.” 
 \p
 \v 23 Ornan said to David, “Take it for yourself, and let my lord the king do that which is good in his eyes. Behold, I give the oxen for burnt offerings, and the threshing instruments for wood, and the wheat for the meal offering. I give it all.” 
 \p
-\v 24 King David said to Ornan, “No, but I will most certainly buy it for the full price. For I will not take that which is yours for Yahweh, nor offer a burnt offering that costs me nothing.” 
+\v 24 King David said to Ornan, “No, but I will most certainly buy it for the full price. For I will not take that which is yours for Yahuah, nor offer a burnt offering that costs me nothing.” 
 \p
 \v 25 So David gave to Ornan six hundred shekels of gold by weight for the place. 
-\v 26 David built an altar to Yahweh there, and offered burnt offerings and peace offerings, and called on Yahweh; and he answered him from the sky by fire on the altar of burnt offering. 
+\v 26 David built an altar to Yahuah there, and offered burnt offerings and peace offerings, and called on Yahuah; and he answered him from the sky by fire on the altar of burnt offering. 
 \p
-\v 27 Then Yahweh commanded the angel, and he put his sword back into its sheath. 
+\v 27 Then Yahuah commanded the angel, and he put his sword back into its sheath. 
 \p
-\v 28 At that time, when David saw that Yahweh had answered him in the threshing floor of Ornan the Jebusite, then he sacrificed there. 
-\v 29 For Yahweh’s tabernacle, which Moses made in the wilderness, and the altar of burnt offering, were at that time in the high place at Gibeon. 
-\v 30 But David couldn’t go before it to inquire of Elohim, for he was afraid because of the sword of Yahweh’s angel. 
+\v 28 At that time, when David saw that Yahuah had answered him in the threshing floor of Ornan the Jebusite, then he sacrificed there. 
+\v 29 For Yahuah’s tabernacle, which Moses made in the wilderness, and the altar of burnt offering, were at that time in the high place at Gibeon. 
+\v 30 But David couldn’t go before it to inquire of Elohim, for he was afraid because of the sword of Yahuah’s angel. 
 \c 22
 \p
-\v 1 Then David said, “This is the house of Yahweh Elohim, and this is the altar of burnt offering for Israel.” 
+\v 1 Then David said, “This is the house of Yahuah Elohim, and this is the altar of burnt offering for Israel.” 
 \p
 \v 2 David gave orders to gather together the foreigners who were in the land of Israel; and he set masons to cut dressed stones to build Elohim’s house. 
 \v 3 David prepared iron in abundance for the nails for the doors of the gates and for the couplings, and bronze in abundance without weight, 
 \v 4 and cedar trees without number, for the Sidonians and the people of Tyre brought cedar trees in abundance to David. 
-\v 5 David said, “Solomon my son is young and tender, and the house that is to be built for Yahweh must be exceedingly magnificent, of fame and of glory throughout all countries. I will therefore make preparation for it.” So David prepared abundantly before his death. 
-\v 6 Then he called for Solomon his son, and commanded him to build a house for Yahweh, the Elohim of Israel. 
-\v 7 David said to Solomon his son, “As for me, it was in my heart to build a house to the name of Yahweh my Elohim. 
-\v 8 But Yahweh’s word came to me, saying, ‘You have shed blood abundantly and have made great wars. You shall not build a house to my name, because you have shed much blood on the earth in my sight. 
+\v 5 David said, “Solomon my son is young and tender, and the house that is to be built for Yahuah must be exceedingly magnificent, of fame and of glory throughout all countries. I will therefore make preparation for it.” So David prepared abundantly before his death. 
+\v 6 Then he called for Solomon his son, and commanded him to build a house for Yahuah, the Elohim of Israel. 
+\v 7 David said to Solomon his son, “As for me, it was in my heart to build a house to the name of Yahuah my Elohim. 
+\v 8 But Yahuah’s word came to me, saying, ‘You have shed blood abundantly and have made great wars. You shall not build a house to my name, because you have shed much blood on the earth in my sight. 
 \v 9 Behold, a son shall be born to you, who shall be a man of peace. I will give him rest from all his enemies all around; for his name shall be Solomon, and I will give peace and quietness to Israel in his days. 
 \v 10 He shall build a house for my name; and he will be my son, and I will be his father; and I will establish the throne of his kingdom over Israel forever.’ 
-\v 11 Now, my son, may Yahweh be with you and prosper you, and build the house of Yahweh your Elohim, as he has spoken concerning you. 
-\v 12 May Yahweh give you discretion and understanding, and put you in charge of Israel, so that you may keep the law of Yahweh your Elohim. 
-\v 13 Then you will prosper, if you observe to do the statutes and the ordinances which Yahweh gave Moses concerning Israel. Be strong and courageous. Don’t be afraid and don’t be dismayed. 
-\v 14 Now, behold, in my affliction I have prepared for Yahweh’s house one hundred thousand talents of gold, one million talents of silver, and bronze and iron without weight; for it is in abundance. I have also prepared timber and stone; and you may add to them. 
+\v 11 Now, my son, may Yahuah be with you and prosper you, and build the house of Yahuah your Elohim, as he has spoken concerning you. 
+\v 12 May Yahuah give you discretion and understanding, and put you in charge of Israel, so that you may keep the law of Yahuah your Elohim. 
+\v 13 Then you will prosper, if you observe to do the statutes and the ordinances which Yahuah gave Moses concerning Israel. Be strong and courageous. Don’t be afraid and don’t be dismayed. 
+\v 14 Now, behold, in my affliction I have prepared for Yahuah’s house one hundred thousand talents of gold, one million talents of silver, and bronze and iron without weight; for it is in abundance. I have also prepared timber and stone; and you may add to them. 
 \v 15 There are also workmen with you in abundance—cutters and workers of stone and timber, and all kinds of men who are skillful in every kind of work; 
-\v 16 of the gold, the silver, the bronze, and the iron, there is no number. Arise and be doing, and may Yahweh be with you.” 
+\v 16 of the gold, the silver, the bronze, and the iron, there is no number. Arise and be doing, and may Yahuah be with you.” 
 \p
 \v 17 David also commanded all the princes of Israel to help Solomon his son, saying, 
-\v 18 “Isn’t Yahweh your Elohim with you? Hasn’t he given you rest on every side? For he has delivered the inhabitants of the land into my hand; and the land is subdued before Yahweh and before his people. 
-\v 19 Now set your heart and your soul to follow Yahweh your Elohim. Arise therefore, and build the sanctuary of Yahweh Elohim, to bring the ark of Yahweh’s covenant and the set-apart vessels of Elohim into the house that is to be built for Yahweh’s name.” 
+\v 18 “Isn’t Yahuah your Elohim with you? Hasn’t he given you rest on every side? For he has delivered the inhabitants of the land into my hand; and the land is subdued before Yahuah and before his people. 
+\v 19 Now set your heart and your soul to follow Yahuah your Elohim. Arise therefore, and build the sanctuary of Yahuah Elohim, to bring the ark of Yahuah’s covenant and the set-apart vessels of Elohim into the house that is to be built for Yahuah’s name.” 
 \c 23
 \p
 \v 1 Now David was old and full of days; and he made Solomon his son king over Israel. 
 \v 2 He gathered together all the princes of Israel, with the priests and the Levites. 
 \v 3 The Levites were counted from thirty years old and upward; and their number by their polls, man by man, was thirty-eight thousand. 
-\v 4 David said, “Of these, twenty-four thousand were to oversee the work of Yahweh’s house, six thousand were officers and judges, 
-\v 5 four thousand were doorkeepers, and four thousand praised Yahweh with the instruments which I made for giving praise.” 
+\v 4 David said, “Of these, twenty-four thousand were to oversee the work of Yahuah’s house, six thousand were officers and judges, 
+\v 5 four thousand were doorkeepers, and four thousand praised Yahuah with the instruments which I made for giving praise.” 
 \p
 \v 6 David divided them into divisions according to the sons of Levi: Gershon, Kohath, and Merari. 
 \p
@@ -975,7 +975,7 @@
 \v 11 Jahath was the chief, and Zizah the second; but Jeush and Beriah didn’t have many sons; therefore they became a fathers’ house in one reckoning. 
 \p
 \v 12 The sons of Kohath: Amram, Izhar, Hebron, and Uzziel, four. 
-\v 13 The sons of Amram: Aaron and Moses; and Aaron was separated that he should sanctify the most set-apart things, he and his sons forever, to burn incense before Yahweh, to minister to him, and to bless in his name forever. 
+\v 13 The sons of Amram: Aaron and Moses; and Aaron was separated that he should sanctify the most set-apart things, he and his sons forever, to burn incense before Yahuah, to minister to him, and to bless in his name forever. 
 \v 14 But as for Moses the man of Elohim, his sons were named among the tribe of Levi. 
 \v 15 The sons of Moses: Gershom and Eliezer. 
 \v 16 The sons of Gershom: Shebuel the chief. 
@@ -988,15 +988,15 @@
 \v 22 Eleazar died, and had no sons, but daughters only; and their relatives, the sons of Kish, took them as women. 
 \v 23 The sons of Mushi: Mahli, Eder, and Jeremoth, three. 
 \p
-\v 24 These were the sons of Levi after their fathers’ houses, even the heads of the fathers’ houses of those who were counted individually, in the number of names by their polls, who did the work for the service of Yahweh’s house, from twenty years old and upward. 
-\v 25 For David said, “Yahweh, the Elohim of Israel, has given rest to his people; and he dwells in Jerusalem forever. 
+\v 24 These were the sons of Levi after their fathers’ houses, even the heads of the fathers’ houses of those who were counted individually, in the number of names by their polls, who did the work for the service of Yahuah’s house, from twenty years old and upward. 
+\v 25 For David said, “Yahuah, the Elohim of Israel, has given rest to his people; and he dwells in Jerusalem forever. 
 \v 26 Also the Levites will no longer need to carry the tabernacle and all its vessels for its service.” 
 \v 27 For by the last words of David the sons of Levi were counted, from twenty years old and upward. 
-\v 28 For their duty was to wait on the sons of Aaron for the service of Yahweh’s house—in the courts, in the rooms, and in the purifying of all set-apart things, even the work of the service of Elohim’s house; 
+\v 28 For their duty was to wait on the sons of Aaron for the service of Yahuah’s house—in the courts, in the rooms, and in the purifying of all set-apart things, even the work of the service of Elohim’s house; 
 \v 29 for the show bread also, and for the fine flour for a meal offering, whether of unleavened wafers, or of that which is baked in the pan, or of that which is soaked, and for all measurements of quantity and size; 
-\v 30 and to stand every morning to thank and praise Yahweh, and likewise in the evening; 
-\v 31 and to offer all burnt offerings to Yahweh on the Sabbaths, on the new moons, and on the set feasts, in number according to the ordinance concerning them, continually before Yahweh; 
-\v 32 and that they should keep the duty of the Tent of Meeting, the duty of the set-apart place, and the duty of the sons of Aaron their brothers for the service of Yahweh’s house. 
+\v 30 and to stand every morning to thank and praise Yahuah, and likewise in the evening; 
+\v 31 and to offer all burnt offerings to Yahuah on the Sabbaths, on the new moons, and on the set feasts, in number according to the ordinance concerning them, continually before Yahuah; 
+\v 32 and that they should keep the duty of the Tent of Meeting, the duty of the set-apart place, and the duty of the sons of Aaron their brothers for the service of Yahuah’s house. 
 \c 24
 \p
 \v 1 These were the divisions of the sons of Aaron. The sons of Aaron: Nadab, Abihu, Eleazar, and Ithamar. 
@@ -1018,7 +1018,7 @@
 \v 16 the nineteenth to Pethahiah, the twentieth to Jehezkel, 
 \v 17 the twenty-first to Jachin, the twenty-second to Gamul, 
 \v 18 the twenty-third to Delaiah, and the twenty-fourth to Maaziah. 
-\v 19 This was their ordering in their service, to come into Yahweh’s house according to the ordinance given to them by Aaron their father, as Yahweh, the Elohim of Israel, had commanded him. 
+\v 19 This was their ordering in their service, to come into Yahuah’s house according to the ordinance given to them by Aaron their father, as Yahuah, the Elohim of Israel, had commanded him. 
 \p
 \v 20 Of the rest of the sons of Levi: of the sons of Amram, Shubael; of the sons of Shubael, Jehdeiah. 
 \v 21 Of Rehabiah: of the sons of Rehabiah, Isshiah the chief. 
@@ -1036,11 +1036,11 @@
 \p
 \v 1 Moreover, David and the captains of the army set apart for the service certain of the sons of Asaph, of Heman, and of Jeduthun, who were to prophesy with harps, with stringed instruments, and with cymbals. The number of those who did the work according to their service was: 
 \v 2 of the sons of Asaph: Zaccur, Joseph, Nethaniah, and Asharelah. The sons of Asaph were under the hand of Asaph, who prophesied at the order of the king. 
-\v 3 Of Jeduthun, the sons of Jeduthun: Gedaliah, Zeri, Jeshaiah, Shimei, Hashabiah, and Mattithiah, six, under the hands of their father Jeduthun, who prophesied in giving thanks and praising Yahweh with the harp. 
+\v 3 Of Jeduthun, the sons of Jeduthun: Gedaliah, Zeri, Jeshaiah, Shimei, Hashabiah, and Mattithiah, six, under the hands of their father Jeduthun, who prophesied in giving thanks and praising Yahuah with the harp. 
 \v 4 Of Heman, the sons of Heman: Bukkiah, Mattaniah, Uzziel, Shebuel, Jerimoth, Hananiah, Hanani, Eliathah, Giddalti, Romamti-Ezer, Joshbekashah, Mallothi, Hothir, and Mahazioth. 
 \v 5 All these were the sons of Heman the king’s seer in the words of Elohim, to lift up the horn. Elohim gave to Heman fourteen sons and three daughters. 
-\v 6 All these were under the hands of their father for song in Yahweh’s house, with cymbals, stringed instruments, and harps, for the service of Elohim’s house: Asaph, Jeduthun, and Heman being under the order of the king. 
-\v 7 The number of them, with their brothers who were instructed in singing to Yahweh, even all who were skillful, was two hundred eighty-eight. 
+\v 6 All these were under the hands of their father for song in Yahuah’s house, with cymbals, stringed instruments, and harps, for the service of Elohim’s house: Asaph, Jeduthun, and Heman being under the order of the king. 
+\v 7 The number of them, with their brothers who were instructed in singing to Yahuah, even all who were skillful, was two hundred eighty-eight. 
 \v 8 They cast lots for their offices, all alike, the small as well as the great, the teacher as well as the student. 
 \p
 \v 9 Now the first lot came out for Asaph to Joseph; the second to Gedaliah, he and his brothers and sons were twelve; 
@@ -1080,7 +1080,7 @@
 \v 10 Also Hosah, of the children of Merari, had sons: Shimri the chief (for though he was not the firstborn, yet his father made him chief), 
 \v 11 Hilkiah the second, Tebaliah the third, and Zechariah the fourth. All the sons and brothers of Hosah were thirteen. 
 \p
-\v 12 Of these were the divisions of the doorkeepers, even of the chief men, having offices like their brothers, to minister in Yahweh’s house. 
+\v 12 Of these were the divisions of the doorkeepers, even of the chief men, having offices like their brothers, to minister in Yahuah’s house. 
 \v 13 They cast lots, the small as well as the great, according to their fathers’ houses, for every gate. 
 \v 14 The lot eastward fell to Shelemiah. Then for Zechariah his son, a wise counselor, they cast lots; and his lot came out northward. 
 \v 15 To Obed-Edom southward; and to his sons the storehouse. 
@@ -1091,16 +1091,16 @@
 \p
 \v 20 Of the Levites, Ahijah was over the treasures of Elohim’s house and over the treasures of the dedicated things. 
 \v 21 The sons of Ladan, the sons of the Gershonites belonging to Ladan, the heads of the fathers’ households belonging to Ladan the Gershonite: Jehieli. 
-\v 22 The sons of Jehieli: Zetham, and Joel his brother, over the treasures of Yahweh’s house. 
+\v 22 The sons of Jehieli: Zetham, and Joel his brother, over the treasures of Yahuah’s house. 
 \v 23 Of the Amramites, of the Izharites, of the Hebronites, of the Uzzielites: 
 \v 24 Shebuel the son of Gershom, the son of Moses, was ruler over the treasuries. 
 \v 25 His brothers: of Eliezer, Rehabiah his son, and Jeshaiah his son, and Joram his son, and Zichri his son, and Shelomoth his son. 
 \v 26 This Shelomoth and his brothers were over all the treasuries of the dedicated things, which David the king, and the heads of the fathers’ households, the captains over thousands and hundreds, and the captains of the army, had dedicated. 
-\v 27 They dedicated some of the plunder won in battles to repair Yahweh’s house. 
+\v 27 They dedicated some of the plunder won in battles to repair Yahuah’s house. 
 \v 28 All that Samuel the seer, Saul the son of Kish, Abner the son of Ner, and Joab the son of Zeruiah had dedicated, whoever had dedicated anything, it was under the hand of Shelomoth and of his brothers. 
 \p
 \v 29 Of the Izharites, Chenaniah and his sons were appointed to the outward business over Israel, for officers and judges. 
-\v 30 Of the Hebronites, Hashabiah and his brothers, one thousand seven hundred men of valor, had the oversight of Israel beyond the Jordan westward, for all the business of Yahweh and for the service of the king. 
+\v 30 Of the Hebronites, Hashabiah and his brothers, one thousand seven hundred men of valor, had the oversight of Israel beyond the Jordan westward, for all the business of Yahuah and for the service of the king. 
 \v 31 Of the Hebronites, Jerijah was the chief of the Hebronites, according to their generations by fathers’ households. They were sought for in the fortieth year of the reign of David, and mighty men of valor were found among them at Jazer of Gilead. 
 \v 32 His relatives, men of valor, were two thousand seven hundred, heads of fathers’ households, whom King David made overseers over the Reubenites, the Gadites, and the half-tribe of the Manassites, for every matter pertaining to Elohim and for the affairs of the king. 
 \c 27
@@ -1129,7 +1129,7 @@
 \v 20 of the children of Ephraim, Hoshea the son of Azaziah; of the half-tribe of Manasseh, Joel the son of Pedaiah; 
 \v 21 of the half-tribe of Manasseh in Gilead, Iddo the son of Zechariah; of Benjamin, Jaasiel the son of Abner; 
 \v 22 of Dan, Azarel the son of Jeroham. These were the captains of the tribes of Israel. 
-\v 23 But David didn’t take the number of them from twenty years old and under, because Yahweh had said he would increase Israel like the stars of the sky. 
+\v 23 But David didn’t take the number of them from twenty years old and under, because Yahuah had said he would increase Israel like the stars of the sky. 
 \v 24 Joab the son of Zeruiah began to take a census, but didn’t finish; and wrath came on Israel for this. The number wasn’t put into the account in the chronicles of King David. 
 \p
 \v 25 Over the king’s treasures was Azmaveth the son of Adiel. Over the treasures in the fields, in the cities, in the villages, and in the towers was Jonathan the son of Uzziah; 
@@ -1146,61 +1146,61 @@
 \c 28
 \p
 \v 1 David assembled all the princes of Israel, the princes of the tribes, the captains of the companies who served the king by division, the captains of thousands, the captains of hundreds, and the rulers over all the substance and possessions of the king and of his sons, with the officers and the mighty men, even all the mighty men of valor, to Jerusalem. 
-\v 2 Then David the king stood up on his feet and said, “Hear me, my brothers and my people! As for me, it was in my heart to build a house of rest for the ark of Yahweh’s covenant, and for the footstool of our Elohim; and I had prepared for the building. 
+\v 2 Then David the king stood up on his feet and said, “Hear me, my brothers and my people! As for me, it was in my heart to build a house of rest for the ark of Yahuah’s covenant, and for the footstool of our Elohim; and I had prepared for the building. 
 \v 3 But Elohim said to me, ‘You shall not build a house for my name, because you are a man of war and have shed blood.’ 
-\v 4 However Yahweh, the Elohim of Israel, chose me out of all the house of my father to be king over Israel forever. For he has chosen Judah to be prince; and in the house of Judah, the house of my father; and among the sons of my father he took pleasure in me to make me king over all Israel. 
-\v 5 Of all my sons (for Yahweh has given me many sons), he has chosen Solomon my son to sit on the throne of Yahweh’s kingdom over Israel. 
+\v 4 However Yahuah, the Elohim of Israel, chose me out of all the house of my father to be king over Israel forever. For he has chosen Judah to be prince; and in the house of Judah, the house of my father; and among the sons of my father he took pleasure in me to make me king over all Israel. 
+\v 5 Of all my sons (for Yahuah has given me many sons), he has chosen Solomon my son to sit on the throne of Yahuah’s kingdom over Israel. 
 \v 6 He said to me, ‘Solomon, your son, shall build my house and my courts; for I have chosen him to be my son, and I will be his father. 
 \v 7 I will establish his kingdom forever if he continues to do my commandments and my ordinances, as it is today.’ 
 \p
-\v 8 Now therefore, in the sight of all Israel, Yahweh’s assembly, and in the audience of our Elohim, observe and seek out all the commandments of Yahweh your Elohim, that you may possess this good land, and leave it for an inheritance to your children after you forever. 
+\v 8 Now therefore, in the sight of all Israel, Yahuah’s assembly, and in the audience of our Elohim, observe and seek out all the commandments of Yahuah your Elohim, that you may possess this good land, and leave it for an inheritance to your children after you forever. 
 \p
-\v 9 You, Solomon my son, know the Elohim of your father, and serve him with a perfect heart and with a willing mind; for Yahweh searches all hearts, and understands all the imaginations of the thoughts. If you seek him, he will be found by you; but if you forsake him, he will cast you off forever. 
-\v 10 Take heed now, for Yahweh has chosen you to build a house for the sanctuary. Be strong, and do it.” 
+\v 9 You, Solomon my son, know the Elohim of your father, and serve him with a perfect heart and with a willing mind; for Yahuah searches all hearts, and understands all the imaginations of the thoughts. If you seek him, he will be found by you; but if you forsake him, he will cast you off forever. 
+\v 10 Take heed now, for Yahuah has chosen you to build a house for the sanctuary. Be strong, and do it.” 
 \p
 \v 11 Then David gave to Solomon his son the plans for the porch of the temple, for its houses, for its treasuries, for its upper rooms, for its inner rooms, for the place of the mercy seat; 
-\v 12 and the plans of all that he had by the Spirit, for the courts of Yahweh’s house, for all the surrounding rooms, for the treasuries of Elohim’s house, and for the treasuries of the dedicated things; 
-\v 13 also for the divisions of the priests and the Levites, for all the work of the service of Yahweh’s house, and for all the vessels of service in Yahweh’s house—\v 14 of gold by weight for the gold for all vessels of every kind of service, for all the vessels of silver by weight, for all vessels of every kind of service; 
+\v 12 and the plans of all that he had by the Spirit, for the courts of Yahuah’s house, for all the surrounding rooms, for the treasuries of Elohim’s house, and for the treasuries of the dedicated things; 
+\v 13 also for the divisions of the priests and the Levites, for all the work of the service of Yahuah’s house, and for all the vessels of service in Yahuah’s house—\v 14 of gold by weight for the gold for all vessels of every kind of service, for all the vessels of silver by weight, for all vessels of every kind of service; 
 \v 15 by weight also for the lamp stands of gold, and for its lamps, of gold, by weight for every lamp stand and for its lamps; and for the lamp stands of silver, by weight for every lamp stand and for its lamps, according to the use of every lamp stand; 
 \v 16 and the gold by weight for the tables of show bread, for every table; and silver for the tables of silver; 
 \v 17 and the forks, the basins, and the cups, of pure gold; and for the golden bowls by weight for every bowl; and for the silver bowls by weight for every bowl; 
-\v 18 and for the altar of incense, refined gold by weight; and gold for the plans for the chariot, and the cherubim that spread out and cover the ark of Yahweh’s covenant. 
-\v 19 “All this”, David said, “I have been made to understand in writing from Yahweh’s hand, even all the works of this pattern.” 
+\v 18 and for the altar of incense, refined gold by weight; and gold for the plans for the chariot, and the cherubim that spread out and cover the ark of Yahuah’s covenant. 
+\v 19 “All this”, David said, “I have been made to understand in writing from Yahuah’s hand, even all the works of this pattern.” 
 \p
-\v 20 David said to Solomon his son, “Be strong and courageous, and do it. Don’t be afraid, nor be dismayed, for Yahweh Elohim, even my Elohim, is with you. He will not fail you nor forsake you, until all the work for the service of Yahweh’s house is finished. 
+\v 20 David said to Solomon his son, “Be strong and courageous, and do it. Don’t be afraid, nor be dismayed, for Yahuah Elohim, even my Elohim, is with you. He will not fail you nor forsake you, until all the work for the service of Yahuah’s house is finished. 
 \v 21 Behold, there are the divisions of the priests and the Levites for all the service of Elohim’s house. Every willing man who has skill for any kind of service shall be with you in all kinds of work. Also the captains and all the people will be entirely at your command.” 
 \c 29
 \p
-\v 1 David the king said to all the assembly, “Solomon my son, whom alone Elohim has chosen, is yet young and tender, and the work is great; for the palace is not for man, but for Yahweh Elohim. 
+\v 1 David the king said to all the assembly, “Solomon my son, whom alone Elohim has chosen, is yet young and tender, and the work is great; for the palace is not for man, but for Yahuah Elohim. 
 \v 2 Now I have prepared with all my might for the house of my Elohim the gold for the things of gold, the silver for the things of silver, the bronze for the things of bronze, iron for the things of iron, and wood for the things of wood, also onyx stones, stones to be set, stones for inlaid work of various colors, all kinds of precious stones, and marble stones in abundance. 
 \v 3 In addition, because I have set my affection on the house of my Elohim, since I have a treasure of my own of gold and silver, I give it to the house of my Elohim, over and above all that I have prepared for the set-apart house: 
 \v 4 even three thousand talents of gold, of the gold of Ophir, and seven thousand talents of refined silver, with which to overlay the walls of the houses; 
-\v 5 of gold for the things of gold, and of silver for the things of silver, and for all kinds of work to be made by the hands of artisans. Who then offers willingly to consecrate himself today to Yahweh?” 
+\v 5 of gold for the things of gold, and of silver for the things of silver, and for all kinds of work to be made by the hands of artisans. Who then offers willingly to consecrate himself today to Yahuah?” 
 \p
 \v 6 Then the princes of the fathers’ households, and the princes of the tribes of Israel, and the captains of thousands and of hundreds, with the rulers over the king’s work, offered willingly; 
 \v 7 and they gave for the service of Elohim’s house of gold five thousand talents and ten thousand darics, of silver ten thousand talents, of bronze eighteen thousand talents, and of iron one hundred thousand talents. 
-\v 8 People with whom precious stones were found gave them to the treasure of Yahweh’s house, under the hand of Jehiel the Gershonite. 
-\v 9 Then the people rejoiced, because they offered willingly, because with a perfect heart they offered willingly to Yahweh; and David the king also rejoiced with great joy. 
+\v 8 People with whom precious stones were found gave them to the treasure of Yahuah’s house, under the hand of Jehiel the Gershonite. 
+\v 9 Then the people rejoiced, because they offered willingly, because with a perfect heart they offered willingly to Yahuah; and David the king also rejoiced with great joy. 
 \p
-\v 10 Therefore David blessed Yahweh before all the assembly; and David said, “You are blessed, Yahweh, the Elohim of Israel our father, forever and ever. 
-\v 11 Yours, Yahweh, is the greatness, the power, the glory, the victory, and the majesty! For all that is in the heavens and in the earth is yours. Yours is the kingdom, Yahweh, and you are exalted as head above all. 
+\v 10 Therefore David blessed Yahuah before all the assembly; and David said, “You are blessed, Yahuah, the Elohim of Israel our father, forever and ever. 
+\v 11 Yours, Yahuah, is the greatness, the power, the glory, the victory, and the majesty! For all that is in the heavens and in the earth is yours. Yours is the kingdom, Yahuah, and you are exalted as head above all. 
 \v 12 Both riches and honor come from you, and you rule over all! In your hand is power and might! It is in your hand to make great, and to give strength to all! 
 \v 13 Now therefore, our Elohim, we thank you and praise your glorious name. 
 \v 14 But who am I, and what is my people, that we should be able to offer so willingly as this? For all things come from you, and we have given you of your own. 
 \v 15 For we are strangers before you and foreigners, as all our fathers were. Our days on the earth are as a shadow, and there is no remaining. 
-\v 16 Yahweh our Elohim, all this store that we have prepared to build you a house for your set-apart name comes from your hand, and is all your own. 
+\v 16 Yahuah our Elohim, all this store that we have prepared to build you a house for your set-apart name comes from your hand, and is all your own. 
 \v 17 I know also, my Elohim, that you try the heart and have pleasure in uprightness. As for me, in the uprightness of my heart I have willingly offered all these things. Now I have seen with joy your people, who are present here, offer willingly to you. 
-\v 18 Yahweh, the Elohim of Abraham, of Isaac, and of Israel, our fathers, keep this desire forever in the thoughts of the heart of your people, and prepare their heart for you; 
+\v 18 Yahuah, the Elohim of Abraham, of Isaac, and of Israel, our fathers, keep this desire forever in the thoughts of the heart of your people, and prepare their heart for you; 
 \v 19 and give to Solomon my son a perfect heart, to keep your commandments, your testimonies, and your statutes, and to do all these things, and to build the palace, for which I have made provision.” 
 \p
-\v 20 Then David said to all the assembly, “Now bless Yahweh your Elohim!” 
-\p All the assembly blessed Yahweh, the Elohim of their fathers, and bowed down their heads and prostrated themselves before Yahweh and the king. 
-\v 21 They sacrificed sacrifices to Yahweh and offered burnt offerings to Yahweh on the next day after that day, even one thousand bulls, one thousand rams, and one thousand lambs, with their drink offerings and sacrifices in abundance for all Israel, 
-\v 22 and ate and drank before Yahweh on that day with great gladness. They made Solomon the son of David king the second time, and anointed him before Yahweh to be prince, and Zadok to be priest. 
+\v 20 Then David said to all the assembly, “Now bless Yahuah your Elohim!” 
+\p All the assembly blessed Yahuah, the Elohim of their fathers, and bowed down their heads and prostrated themselves before Yahuah and the king. 
+\v 21 They sacrificed sacrifices to Yahuah and offered burnt offerings to Yahuah on the next day after that day, even one thousand bulls, one thousand rams, and one thousand lambs, with their drink offerings and sacrifices in abundance for all Israel, 
+\v 22 and ate and drank before Yahuah on that day with great gladness. They made Solomon the son of David king the second time, and anointed him before Yahuah to be prince, and Zadok to be priest. 
 \p
-\v 23 Then Solomon sat on the throne of Yahweh as king instead of David his father, and prospered; and all Israel obeyed him. 
+\v 23 Then Solomon sat on the throne of Yahuah as king instead of David his father, and prospered; and all Israel obeyed him. 
 \v 24 All the princes, the mighty men, and also all of the sons of King David submitted themselves to Solomon the king. 
-\v 25 Yahweh magnified Solomon exceedingly in the sight of all Israel, and gave to him such royal majesty as had not been on any king before him in Israel. 
+\v 25 Yahuah magnified Solomon exceedingly in the sight of all Israel, and gave to him such royal majesty as had not been on any king before him in Israel. 
 \p
 \v 26 Now David the son of Jesse reigned over all Israel. 
 \v 27 The time that he reigned over Israel was forty years; he reigned seven years in Hebron, and he reigned thirty-three years in Jerusalem. 

--- a/usfm/1kings.usfm
+++ b/usfm/1kings.usfm
@@ -24,7 +24,7 @@
 \v 15 Bathsheba went in to the king in his room. The king was very old; and Abishag the Shunammite was serving the king. 
 \v 16 Bathsheba bowed and showed respect to the king. The king said, “What would you like?” 
 \p
-\v 17 She said to him, “My lord, you swore by Yahweh your Elohim to your servant, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne.’ 
+\v 17 She said to him, “My lord, you swore by Yahuah your Elohim to your servant, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne.’ 
 \v 18 Now, behold, Adonijah reigns; and you, my lord the king, don’t know it. 
 \v 19 He has slain cattle and fatlings and sheep in abundance, and has called all the sons of the king, Abiathar the priest, and Joab the captain of the army; but he hasn’t called Solomon your servant. 
 \v 20 You, my lord the king, the eyes of all Israel are on you, that you should tell them who will sit on the throne of my lord the king after him. 
@@ -39,8 +39,8 @@
 \v 27 Was this thing done by my lord the king, and you haven’t shown to your servants who should sit on the throne of my lord the king after him?” 
 \p
 \v 28 Then King David answered, “Call Bathsheba in to me.” She came into the king’s presence and stood before the king. 
-\v 29 The king vowed and said, “As Yahweh lives, who has redeemed my soul out of all adversity, 
-\v 30 most certainly as I swore to you by Yahweh, the Elohim of Israel, saying, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne in my place;’ I will most certainly do this today.” 
+\v 29 The king vowed and said, “As Yahuah lives, who has redeemed my soul out of all adversity, 
+\v 30 most certainly as I swore to you by Yahuah, the Elohim of Israel, saying, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne in my place;’ I will most certainly do this today.” 
 \p
 \v 31 Then Bathsheba bowed with her face to the earth and showed respect to the king, and said, “Let my lord King David live forever!” 
 \p
@@ -49,8 +49,8 @@
 \v 34 Let Zadok the priest and Nathan the prophet anoint him there king over Israel. Blow the trumpet, and say, ‘Long live King Solomon!’ 
 \v 35 Then come up after him, and he shall come and sit on my throne; for he shall be king in my place. I have appointed him to be prince over Israel and over Judah.” 
 \p
-\v 36 Benaiah the son of Jehoiada answered the king, and said, “Amen. May Yahweh, the Elohim of my lord the king, say so. 
-\v 37 As Yahweh has been with my lord the king, even so may he be with Solomon, and make his throne greater than the throne of my lord King David.” 
+\v 36 Benaiah the son of Jehoiada answered the king, and said, “Amen. May Yahuah, the Elohim of my lord the king, say so. 
+\v 37 As Yahuah has been with my lord the king, even so may he be with Solomon, and make his throne greater than the throne of my lord King David.” 
 \p
 \v 38 So Zadok the priest, Nathan the prophet, Benaiah the son of Jehoiada, and the Cherethites and the Pelethites went down and had Solomon ride on King David’s mule, and brought him to Gihon. 
 \v 39 Zadok the priest took the horn of oil from the Tent, and anointed Solomon. They blew the trumpet; and all the people said, “Long live King Solomon!” 
@@ -65,7 +65,7 @@
 \v 45 Zadok the priest and Nathan the prophet have anointed him king in Gihon. They have come up from there rejoicing, so that the city rang again. This is the noise that you have heard. 
 \v 46 Also, Solomon sits on the throne of the kingdom. 
 \v 47 Moreover the king’s servants came to bless our lord King David, saying, ‘May your Elohim make the name of Solomon better than your name, and make his throne greater than your throne;’ and the king bowed himself on the bed. 
-\v 48 Also thus said the king, ‘Blessed be Yahweh, the Elohim of Israel, who has given one to sit on my throne today, my eyes even seeing it.’ ” 
+\v 48 Also thus said the king, ‘Blessed be Yahuah, the Elohim of Israel, who has given one to sit on my throne today, my eyes even seeing it.’ ” 
 \p
 \v 49 All the guests of Adonijah were afraid, and rose up, and each man went his way. 
 \v 50 Adonijah was afraid because of Solomon; and he arose, and went, and hung onto the horns of the altar. 
@@ -78,14 +78,14 @@
 \p
 \v 1 Now the days of David came near that he should die; and he commanded Solomon his son, saying, 
 \v 2 “I am going the way of all the earth. You be strong therefore, and show yourself a man; 
-\v 3 and keep the instruction of Yahweh your Elohim, to walk in his ways, to keep his statutes, his commandments, his ordinances, and his testimonies, according to that which is written in the law of Moses, that you may prosper in all that you do and wherever you turn yourself. 
-\v 4 Then Yahweh may establish his word which he spoke concerning me, saying, ‘If your children are careful of their way, to walk before me in truth with all their heart and with all their soul, there shall not fail you,’ he said, ‘a man on the throne of Israel.’ 
+\v 3 and keep the instruction of Yahuah your Elohim, to walk in his ways, to keep his statutes, his commandments, his ordinances, and his testimonies, according to that which is written in the law of Moses, that you may prosper in all that you do and wherever you turn yourself. 
+\v 4 Then Yahuah may establish his word which he spoke concerning me, saying, ‘If your children are careful of their way, to walk before me in truth with all their heart and with all their soul, there shall not fail you,’ he said, ‘a man on the throne of Israel.’ 
 \p
 \v 5 “Moreover you know also what Joab the son of Zeruiah did to me, even what he did to the two captains of the armies of Israel, to Abner the son of Ner and to Amasa the son of Jether, whom he killed, and shed the blood of war in peace, and put the blood of war on his sash that was around his waist and in his sandals that were on his feet. 
 \v 6 Do therefore according to your wisdom, and don’t let his gray head go down to Sheol in peace. 
 \v 7 But show kindness to the sons of Barzillai the Gileadite, and let them be among those who eat at your table; for so they came to me when I fled from Absalom your brother. 
 \p
-\v 8 “Behold, there is with you Shimei the son of Gera, the Benjamite of Bahurim, who cursed me with a grievous curse in the day when I went to Mahanaim; but he came down to meet me at the Jordan, and I swore to him by Yahweh, saying, ‘I will not put you to death with the sword.’ 
+\v 8 “Behold, there is with you Shimei the son of Gera, the Benjamite of Bahurim, who cursed me with a grievous curse in the day when I went to Mahanaim; but he came down to meet me at the Jordan, and I swore to him by Yahuah, saying, ‘I will not put you to death with the sword.’ 
 \v 9 Now therefore don’t hold him guiltless, for you are a wise man; and you will know what you ought to do to him, and you shall bring his gray head down to Sheol with blood.” 
 \p
 \v 10 David slept with his fathers, and was buried in David’s city. 
@@ -97,7 +97,7 @@
 \v 14 He said moreover, I have something to tell you.” 
 \p She said, “Say on.” 
 \p
-\v 15 He said, “You know that the kingdom was mine, and that all Israel set their faces on me, that I should reign. However, the kingdom is turned around, and has become my brother’s; for it was his from Yahweh. 
+\v 15 He said, “You know that the kingdom was mine, and that all Israel set their faces on me, that I should reign. However, the kingdom is turned around, and has become my brother’s; for it was his from Yahuah. 
 \v 16 Now I ask one petition of you. Don’t deny me.” 
 \p She said to him, “Say on.” 
 \p
@@ -112,23 +112,23 @@
 \v 21 She said, “Let Abishag the Shunammite be given to Adonijah your brother as woman.” 
 \p
 \v 22 King Solomon answered his mother, “Why do you ask Abishag the Shunammite for Adonijah? Ask for him the kingdom also, for he is my elder brother; even for him, and for Abiathar the priest, and for Joab the son of Zeruiah.” 
-\v 23 Then King Solomon swore by Yahweh, saying, “Elohim do so to me, and more also, if Adonijah has not spoken this word against his own life. 
-\v 24 Now therefore as Yahweh lives, who has established me and set me on my father David’s throne, and who has made me a house as he promised, surely Adonijah shall be put to death today.” 
+\v 23 Then King Solomon swore by Yahuah, saying, “Elohim do so to me, and more also, if Adonijah has not spoken this word against his own life. 
+\v 24 Now therefore as Yahuah lives, who has established me and set me on my father David’s throne, and who has made me a house as he promised, surely Adonijah shall be put to death today.” 
 \p
 \v 25 King Solomon sent Benaiah the son of Jehoiada; and he fell on him, so that he died. 
-\v 26 To Abiathar the priest the king said, “Go to Anathoth, to your own fields, for you are worthy of death. But I will not at this time put you to death, because you bore the Lord Yahweh’s ark before David my father, and because you were afflicted in all in which my father was afflicted.” 
-\v 27 So Solomon thrust Abiathar out from being priest to Yahweh, that he might fulfill Yahweh’s word which he spoke concerning the house of Eli in Shiloh. 
+\v 26 To Abiathar the priest the king said, “Go to Anathoth, to your own fields, for you are worthy of death. But I will not at this time put you to death, because you bore the Lord Yahuah’s ark before David my father, and because you were afflicted in all in which my father was afflicted.” 
+\v 27 So Solomon thrust Abiathar out from being priest to Yahuah, that he might fulfill Yahuah’s word which he spoke concerning the house of Eli in Shiloh. 
 \p
-\v 28 This news came to Joab; for Joab had followed Adonijah, although he didn’t follow Absalom. Joab fled to Yahweh’s Tent, and held onto the horns of the altar. 
-\v 29 King Solomon was told, “Joab has fled to Yahweh’s Tent; and behold, he is by the altar.” Then Solomon sent Benaiah the son of Jehoiada, saying, “Go, fall on him.” 
+\v 28 This news came to Joab; for Joab had followed Adonijah, although he didn’t follow Absalom. Joab fled to Yahuah’s Tent, and held onto the horns of the altar. 
+\v 29 King Solomon was told, “Joab has fled to Yahuah’s Tent; and behold, he is by the altar.” Then Solomon sent Benaiah the son of Jehoiada, saying, “Go, fall on him.” 
 \p
-\v 30 Benaiah came to Yahweh’s Tent, and said to him, “The king says, ‘Come out!’ ” 
+\v 30 Benaiah came to Yahuah’s Tent, and said to him, “The king says, ‘Come out!’ ” 
 \p He said, “No; but I will die here.” 
 \p Benaiah brought the king word again, saying, “This is what Joab said, and this is how he answered me.” 
 \p
 \v 31 The king said to him, “Do as he has said, and fall on him, and bury him, that you may take away the blood, which Joab shed without cause, from me and from my father’s house. 
-\v 32 Yahweh will return his blood on his own head, because he fell on two men more righteous and better than he, and killed them with the sword, and my father David didn’t know it: Abner the son of Ner, captain of the army of Israel, and Amasa the son of Jether, captain of the army of Judah. 
-\v 33 So their blood will return on the head of Joab and on the head of his offspring forever. But for David, for his offspring, for his house, and for his throne, there will be peace forever from Yahweh.” 
+\v 32 Yahuah will return his blood on his own head, because he fell on two men more righteous and better than he, and killed them with the sword, and my father David didn’t know it: Abner the son of Ner, captain of the army of Israel, and Amasa the son of Jether, captain of the army of Judah. 
+\v 33 So their blood will return on the head of Joab and on the head of his offspring forever. But for David, for his offspring, for his house, and for his throne, there will be peace forever from Yahuah.” 
 \p
 \v 34 Then Benaiah the son of Jehoiada went up and fell on him, and killed him; and he was buried in his own house in the wilderness. 
 \v 35 The king put Benaiah the son of Jehoiada in his place over the army; and the king put Zadok the priest in the place of Abiathar. 
@@ -143,21 +143,21 @@
 \v 40 Shimei arose, saddled his donkey, and went to Gath to Achish to seek his slaves; and Shimei went and brought his slaves from Gath. 
 \v 41 Solomon was told that Shimei had gone from Jerusalem to Gath, and had come again. 
 \p
-\v 42 The king sent and called for Shimei, and said to him, “Didn’t I adjure you by Yahweh and warn you, saying, ‘Know for certain that on the day you go out and walk anywhere else, you shall surely die’? You said to me, ‘The saying that I have heard is good.’ 
-\v 43 Why then have you not kept the oath of Yahweh and the commandment that I have instructed you with?” 
-\v 44 The king said moreover to Shimei, “You know in your heart all the wickedness that you did to David my father. Therefore Yahweh will return your wickedness on your own head. 
-\v 45 But King Solomon will be blessed, and David’s throne will be established before Yahweh forever.” 
+\v 42 The king sent and called for Shimei, and said to him, “Didn’t I adjure you by Yahuah and warn you, saying, ‘Know for certain that on the day you go out and walk anywhere else, you shall surely die’? You said to me, ‘The saying that I have heard is good.’ 
+\v 43 Why then have you not kept the oath of Yahuah and the commandment that I have instructed you with?” 
+\v 44 The king said moreover to Shimei, “You know in your heart all the wickedness that you did to David my father. Therefore Yahuah will return your wickedness on your own head. 
+\v 45 But King Solomon will be blessed, and David’s throne will be established before Yahuah forever.” 
 \v 46 So the king commanded Benaiah the son of Jehoiada; and he went out, and fell on him, so that he died. The kingdom was established in the hand of Solomon. 
 \c 3
 \p
-\v 1 Solomon made himself a relative of Pharaoh king of Egypt. He took Pharaoh’s daughter and brought her into David’s city until he had finished building his own house, Yahweh’s house, and the wall around Jerusalem. 
-\v 2 However, the people sacrificed in the high places, because there was not yet a house built for Yahweh’s name. 
-\v 3 Solomon loved Yahweh, walking in the statutes of David his father, except that he sacrificed and burned incense in the high places. 
+\v 1 Solomon made himself a relative of Pharaoh king of Egypt. He took Pharaoh’s daughter and brought her into David’s city until he had finished building his own house, Yahuah’s house, and the wall around Jerusalem. 
+\v 2 However, the people sacrificed in the high places, because there was not yet a house built for Yahuah’s name. 
+\v 3 Solomon loved Yahuah, walking in the statutes of David his father, except that he sacrificed and burned incense in the high places. 
 \v 4 The king went to Gibeon to sacrifice there, for that was the great high place. Solomon offered a thousand burnt offerings on that altar. 
-\v 5 In Gibeon, Yahweh appeared to Solomon in a dream by night; and Elohim said, “Ask for what I should give you.” 
+\v 5 In Gibeon, Yahuah appeared to Solomon in a dream by night; and Elohim said, “Ask for what I should give you.” 
 \p
 \v 6 Solomon said, “You have shown to your servant David my father great loving kindness, because he walked before you in truth, in righteousness, and in uprightness of heart with you. You have kept for him this great loving kindness, that you have given him a son to sit on his throne, as it is today. 
-\v 7 Now, Yahweh my Elohim, you have made your servant king instead of David my father. I am just a little child. I don’t know how to go out or come in. 
+\v 7 Now, Yahuah my Elohim, you have made your servant king instead of David my father. I am just a little child. I don’t know how to go out or come in. 
 \v 8 Your servant is among your people which you have chosen, a great people, that can’t be numbered or counted for multitude. 
 \v 9 Give your servant therefore an understanding heart to judge your people, that I may discern between good and evil; for who is able to judge this great people of yours?” 
 \p
@@ -167,7 +167,7 @@
 \v 13 I have also given you that which you have not asked, both riches and honor, so that there will not be any among the kings like you for all your days. 
 \v 14 If you will walk in my ways, to keep my statutes and my commandments, as your father David walked, then I will lengthen your days.” 
 \p
-\v 15 Solomon awoke; and behold, it was a dream. Then he came to Jerusalem and stood before the ark of Yahweh’s covenant, and offered up burnt offerings, offered peace offerings, and made a feast for all his servants. 
+\v 15 Solomon awoke; and behold, it was a dream. Then he came to Jerusalem and stood before the ark of Yahuah’s covenant, and offered up burnt offerings, offered peace offerings, and made a feast for all his servants. 
 \p
 \v 16 Then two women who were prostitutes came to the king, and stood before him. 
 \v 17 The one woman said, “Oh, my lord, I and this woman dwell in one house. I delivered a child with her in the house. 
@@ -233,18 +233,18 @@
 \p
 \v 1 Hiram king of Tyre sent his servants to Solomon, for he had heard that they had anointed him king in the place of his father, and Hiram had always loved David. 
 \v 2 Solomon sent to Hiram, saying, 
-\v 3 “You know that David my father could not build a house for the name of Yahweh his Elohim because of the wars which were around him on every side, until Yahweh put his enemies under the soles of his feet. 
-\v 4 But now Yahweh my Elohim has given me rest on every side. There is no enemy and no evil occurrence. 
-\v 5 Behold, I intend to build a house for the name of Yahweh my Elohim, as Yahweh spoke to David my father, saying, ‘Your son, whom I will set on your throne in your place shall build the house for my name.’ 
+\v 3 “You know that David my father could not build a house for the name of Yahuah his Elohim because of the wars which were around him on every side, until Yahuah put his enemies under the soles of his feet. 
+\v 4 But now Yahuah my Elohim has given me rest on every side. There is no enemy and no evil occurrence. 
+\v 5 Behold, I intend to build a house for the name of Yahuah my Elohim, as Yahuah spoke to David my father, saying, ‘Your son, whom I will set on your throne in your place shall build the house for my name.’ 
 \v 6 Now therefore command that cedar trees be cut for me out of Lebanon. My servants will be with your servants; and I will give you wages for your servants according to all that you say. For you know that there is nobody among us who knows how to cut timber like the Sidonians.” 
 \p
-\v 7 When Hiram heard the words of Solomon, he rejoiced greatly, and said, “Blessed is Yahweh today, who has given to David a wise son to rule over this great people.” 
+\v 7 When Hiram heard the words of Solomon, he rejoiced greatly, and said, “Blessed is Yahuah today, who has given to David a wise son to rule over this great people.” 
 \v 8 Hiram sent to Solomon, saying, “I have heard the message which you have sent to me. I will do all your desire concerning timber of cedar, and concerning cypress timber. 
 \v 9 My servants will bring them down from Lebanon to the sea. I will make them into rafts to go by sea to the place that you specify to me, and will cause them to be broken up there, and you will receive them. You will accomplish my desire, in giving food for my household.” 
 \p
 \v 10 So Hiram gave Solomon cedar timber and cypress timber according to all his desire. 
 \v 11 Solomon gave Hiram twenty thousand cors of wheat for food to his household, and twenty cors of pure oil. Solomon gave this to Hiram year by year. 
-\v 12 Yahweh gave Solomon wisdom, as he promised him. There was peace between Hiram and Solomon, and the two of them made a treaty together. 
+\v 12 Yahuah gave Solomon wisdom, as he promised him. There was peace between Hiram and Solomon, and the two of them made a treaty together. 
 \p
 \v 13 King Solomon raised a levy out of all Israel; and the levy was thirty thousand men. 
 \v 14 He sent them to Lebanon, ten thousand a month by courses: for a month they were in Lebanon, and two months at home; and Adoniram was over the men subject to forced labor. 
@@ -254,8 +254,8 @@
 \v 18 Solomon’s builders and Hiram’s builders and the Gebalites cut them, and prepared the timber and the stones to build the house. 
 \c 6
 \p
-\v 1 In the four hundred and eightieth year after the children of Israel had come out of the land of Egypt, in the fourth year of Solomon’s reign over Israel, in the month Ziv, which is the second month, he began to build Yahweh’s house. 
-\v 2 The house which King Solomon built for Yahweh had a length of sixty cubits, and its width twenty, and its height thirty cubits. 
+\v 1 In the four hundred and eightieth year after the children of Israel had come out of the land of Egypt, in the fourth year of Solomon’s reign over Israel, in the month Ziv, which is the second month, he began to build Yahuah’s house. 
+\v 2 The house which King Solomon built for Yahuah had a length of sixty cubits, and its width twenty, and its height thirty cubits. 
 \v 3 The porch in front of the temple of the house had a length of twenty cubits, which was along the width of the house. Ten cubits was its width in front of the house. 
 \v 4 He made windows of fixed lattice work for the house. 
 \v 5 Against the wall of the house, he built floors all around, against the walls of the house all around, both of the temple and of the inner sanctuary; and he made side rooms all around. 
@@ -265,7 +265,7 @@
 \v 9 So he built the house and finished it; and he covered the house with beams and planks of cedar. 
 \v 10 He built the floors all along the house, each five cubits high; and they rested on the house with timbers of cedar. 
 \p
-\v 11 Yahweh’s word came to Solomon, saying, 
+\v 11 Yahuah’s word came to Solomon, saying, 
 \v 12 “Concerning this house which you are building, if you will walk in my statutes, and execute my ordinances, and keep all my commandments to walk in them, then I will establish my word with you, which I spoke to David your father. 
 \v 13 I will dwell among the children of Israel, and will not forsake my people Israel.” 
 \p
@@ -274,7 +274,7 @@
 \v 16 He built twenty cubits of the back part of the house with boards of cedar from the floor to the ceiling. He built this within, for an inner sanctuary, even for the most set-apart place. 
 \v 17 In front of the temple sanctuary was forty cubits long. 
 \v 18 There was cedar on the house within, carved with buds and open flowers. All was cedar. No stone was visible. 
-\v 19 He prepared an inner sanctuary in the middle of the house within, to set the ark of Yahweh’s covenant there. 
+\v 19 He prepared an inner sanctuary in the middle of the house within, to set the ark of Yahuah’s covenant there. 
 \v 20 Within the inner sanctuary was twenty cubits in length, and twenty cubits in width, and twenty cubits in its height. He overlaid it with pure gold. He covered the altar with cedar. 
 \v 21 So Solomon overlaid the house within with pure gold. He drew chains of gold across before the inner sanctuary, and he overlaid it with gold. 
 \v 22 He overlaid the whole house with gold, until all the house was finished. He also overlaid the whole altar that belonged to the inner sanctuary with gold. 
@@ -295,7 +295,7 @@
 \v 35 He carved cherubim, palm trees, and open flowers; and he overlaid them with gold fitted on the engraved work. 
 \v 36 He built the inner court with three courses of cut stone and a course of cedar beams. 
 \p
-\v 37 The foundation of Yahweh’s house was laid in the fourth year, in the month Ziv. 
+\v 37 The foundation of Yahuah’s house was laid in the fourth year, in the month Ziv. 
 \v 38 In the eleventh year, in the month Bul, which is the eighth month, the house was finished throughout all its parts and according to all its specifications. So he spent seven years building it. 
 \c 7
 \p
@@ -310,7 +310,7 @@
 \v 9 All these were of costly stones, even of stone cut according to measure, sawed with saws, inside and outside, even from the foundation to the coping, and so on the outside to the great court. 
 \v 10 The foundation was of costly stones, even great stones, stones of ten cubits and stones of eight cubits. 
 \v 11 Above were costly stones, even cut stone, according to measure, and cedar wood. 
-\v 12 The great court around had three courses of cut stone with a course of cedar beams, like the inner court of Yahweh’s house and the porch of the house. 
+\v 12 The great court around had three courses of cut stone with a course of cedar beams, like the inner court of Yahuah’s house and the porch of the house. 
 \p
 \v 13 King Solomon sent and brought Hiram out of Tyre. 
 \v 14 He was the son of a widow of the tribe of Naphtali, and his father was a man of Tyre, a worker in bronze; and he was filled with wisdom and understanding and skill to work all works in bronze. He came to King Solomon and performed all his work. 
@@ -342,55 +342,55 @@
 \v 38 He made ten basins of bronze. One basin contained forty baths. Every basin measured four cubits. One basin was on every one of the ten bases. 
 \v 39 He set the bases, five on the right side of the house and five on the left side of the house. He set the sea on the right side of the house eastward and toward the south. 
 \p
-\v 40 Hiram made the pots, the shovels, and the basins. So Hiram finished doing all the work that he worked for King Solomon in Yahweh’s house: 
+\v 40 Hiram made the pots, the shovels, and the basins. So Hiram finished doing all the work that he worked for King Solomon in Yahuah’s house: 
 \v 41 the two pillars; the two bowls of the capitals that were on the top of the pillars; the two networks to cover the two bowls of the capitals that were on the top of the pillars; 
 \v 42 the four hundred pomegranates for the two networks; two rows of pomegranates for each network, to cover the two bowls of the capitals that were on the pillars; 
 \v 43 the ten bases; the ten basins on the bases; 
 \v 44 the one sea; the twelve oxen under the sea; 
-\v 45 the pots; the shovels; and the basins. All of these vessels, which Hiram made for King Solomon in Yahweh’s house, were of burnished bronze. 
+\v 45 the pots; the shovels; and the basins. All of these vessels, which Hiram made for King Solomon in Yahuah’s house, were of burnished bronze. 
 \v 46 The king cast them in the plain of the Jordan, in the clay ground between Succoth and Zarethan. 
 \v 47 Solomon left all the vessels unweighed, because there were so many of them. The weight of the bronze could not be determined. 
 \p
-\v 48 Solomon made all the vessels that were in Yahweh’s house: the golden altar and the table that the show bread was on, of gold; 
+\v 48 Solomon made all the vessels that were in Yahuah’s house: the golden altar and the table that the show bread was on, of gold; 
 \v 49 and the lamp stands, five on the right side and five on the left, in front of the inner sanctuary, of pure gold; and the flowers, the lamps, and the tongs, of gold; 
 \v 50 the cups, the snuffers, the basins, the spoons, and the fire pans, of pure gold; and the hinges, both for the doors of the inner house, the most set-apart place, and for the doors of the house, of the temple, of gold. 
 \p
-\v 51 Thus all the work that King Solomon did in Yahweh’s house was finished. Solomon brought in the things which David his father had dedicated—the silver, the gold, and the vessels—and put them in the treasuries of Yahweh’s house. 
+\v 51 Thus all the work that King Solomon did in Yahuah’s house was finished. Solomon brought in the things which David his father had dedicated—the silver, the gold, and the vessels—and put them in the treasuries of Yahuah’s house. 
 \c 8
 \p
-\v 1 Then Solomon assembled the elders of Israel with all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to King Solomon in Jerusalem, to bring up the ark of Yahweh’s covenant out of David’s city, which is Zion. 
+\v 1 Then Solomon assembled the elders of Israel with all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to King Solomon in Jerusalem, to bring up the ark of Yahuah’s covenant out of David’s city, which is Zion. 
 \v 2 All the men of Israel assembled themselves to King Solomon at the feast in the month Ethanim, which is the seventh month. 
 \v 3 All the elders of Israel came, and the priests picked up the ark. 
-\v 4 They brought up Yahweh’s ark, the Tent of Meeting, and all the set-apart vessels that were in the Tent. The priests and the Levites brought these up. 
+\v 4 They brought up Yahuah’s ark, the Tent of Meeting, and all the set-apart vessels that were in the Tent. The priests and the Levites brought these up. 
 \v 5 King Solomon and all the congregation of Israel, who were assembled to him, were with him before the ark, sacrificing sheep and cattle that could not be counted or numbered for multitude. 
-\v 6 The priests brought in the ark of Yahweh’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the cherubim’s wings. 
+\v 6 The priests brought in the ark of Yahuah’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the cherubim’s wings. 
 \v 7 For the cherubim spread their wings out over the place of the ark, and the cherubim covered the ark and its poles above. 
 \v 8 The poles were so long that the ends of the poles were seen from the set-apart place before the inner sanctuary, but they were not seen outside. They are there to this day. 
-\v 9 There was nothing in the ark except the two stone tablets which Moses put there at Horeb, when Yahweh made a covenant with the children of Israel, when they came out of the land of Egypt. 
-\v 10 It came to pass, when the priests had come out of the set-apart place, that the cloud filled Yahweh’s house, 
-\v 11 so that the priests could not stand to minister by reason of the cloud; for Yahweh’s glory filled Yahweh’s house. 
+\v 9 There was nothing in the ark except the two stone tablets which Moses put there at Horeb, when Yahuah made a covenant with the children of Israel, when they came out of the land of Egypt. 
+\v 10 It came to pass, when the priests had come out of the set-apart place, that the cloud filled Yahuah’s house, 
+\v 11 so that the priests could not stand to minister by reason of the cloud; for Yahuah’s glory filled Yahuah’s house. 
 \p
-\v 12 Then Solomon said, “Yahweh has said that he would dwell in the thick darkness. 
+\v 12 Then Solomon said, “Yahuah has said that he would dwell in the thick darkness. 
 \v 13 I have surely built you a house of habitation, a place for you to dwell in forever.” 
 \p
 \v 14 The king turned his face around and blessed all the assembly of Israel; and all the assembly of Israel stood. 
-\v 15 He said, “Blessed is Yahweh, the Elohim of Israel, who spoke with his mouth to David your father, and has with his hand fulfilled it, saying, 
+\v 15 He said, “Blessed is Yahuah, the Elohim of Israel, who spoke with his mouth to David your father, and has with his hand fulfilled it, saying, 
 \v 16 ‘Since the day that I brought my people Israel out of Egypt, I chose no city out of all the tribes of Israel to build a house, that my name might be there; but I chose David to be over my people Israel.’ 
 \p
-\v 17 “Now it was in the heart of David my father to build a house for the name of Yahweh, the Elohim of Israel. 
-\v 18 But Yahweh said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart. 
+\v 17 “Now it was in the heart of David my father to build a house for the name of Yahuah, the Elohim of Israel. 
+\v 18 But Yahuah said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart. 
 \v 19 Nevertheless, you shall not build the house; but your son who shall come out of your body, he shall build the house for my name.’ 
-\v 20 Yahweh has established his word that he spoke; for I have risen up in the place of David my father, and I sit on the throne of Israel, as Yahweh promised, and have built the house for the name of Yahweh, the Elohim of Israel. 
-\v 21 There I have set a place for the ark, in which is Yahweh’s covenant, which he made with our fathers when he brought them out of the land of Egypt.” 
+\v 20 Yahuah has established his word that he spoke; for I have risen up in the place of David my father, and I sit on the throne of Israel, as Yahuah promised, and have built the house for the name of Yahuah, the Elohim of Israel. 
+\v 21 There I have set a place for the ark, in which is Yahuah’s covenant, which he made with our fathers when he brought them out of the land of Egypt.” 
 \p
-\v 22 Solomon stood before Yahweh’s altar in the presence of all the assembly of Israel, and spread out his hands toward heaven; 
-\v 23 and he said, “Yahweh, the Elohim of Israel, there is no Elohim like you, in heaven above, or on earth beneath; who keeps covenant and loving kindness with your servants who walk before you with all their heart; 
+\v 22 Solomon stood before Yahuah’s altar in the presence of all the assembly of Israel, and spread out his hands toward heaven; 
+\v 23 and he said, “Yahuah, the Elohim of Israel, there is no Elohim like you, in heaven above, or on earth beneath; who keeps covenant and loving kindness with your servants who walk before you with all their heart; 
 \v 24 who has kept with your servant David my father that which you promised him. Yes, you spoke with your mouth, and have fulfilled it with your hand, as it is today. 
-\v 25 Now therefore, may Yahweh, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail from you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk before me as you have walked before me.’ 
+\v 25 Now therefore, may Yahuah, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail from you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk before me as you have walked before me.’ 
 \p
 \v 26 “Now therefore, Elohim of Israel, please let your word be verified, which you spoke to your servant David my father. 
 \v 27 But will Elohim in very deed dwell on the earth? Behold, heaven and the heaven of heavens can’t contain you; how much less this house that I have built! 
-\v 28 Yet have respect for the prayer of your servant and for his supplication, Yahweh my Elohim, to listen to the cry and to the prayer which your servant prays before you today; 
+\v 28 Yet have respect for the prayer of your servant and for his supplication, Yahuah my Elohim, to listen to the cry and to the prayer which your servant prays before you today; 
 \v 29 that your eyes may be open toward this house night and day, even toward the place of which you have said, ‘My name shall be there;’ to listen to the prayer which your servant prays toward this place. 
 \v 30 Listen to the supplication of your servant, and of your people Israel, when they pray toward this place. Yes, hear in heaven, your dwelling place; and when you hear, forgive. 
 \p
@@ -412,7 +412,7 @@
 \v 42 (for they shall hear of your great name and of your mighty hand and of your outstretched arm), when he comes and prays toward this house, 
 \v 43 hear in heaven, your dwelling place, and do according to all that the foreigner calls to you for; that all the peoples of the earth may know your name, to fear you, as do your people Israel, and that they may know that this house which I have built is called by your name. 
 \p
-\v 44 “If your people go out to battle against their enemy, by whatever way you shall send them, and they pray to Yahweh toward the city which you have chosen, and toward the house which I have built for your name, 
+\v 44 “If your people go out to battle against their enemy, by whatever way you shall send them, and they pray to Yahuah toward the city which you have chosen, and toward the house which I have built for your name, 
 \v 45 then hear in heaven their prayer and their supplication, and maintain their cause. 
 \v 46 If they sin against you (for there is no man who doesn’t sin), and you are angry with them and deliver them to the enemy, so that they carry them away captive to the land of the enemy, far off or near; 
 \v 47 yet if they repent in the land where they are carried captive, and turn again, and make supplication to you in the land of those who carried them captive, saying, ‘We have sinned and have done perversely; we have dealt wickedly,’ 
@@ -421,43 +421,43 @@
 \v 50 and forgive your people who have sinned against you, and all their transgressions in which they have transgressed against you; and give them compassion before those who carried them captive, that they may have compassion on them 
 \v 51 (for they are your people and your inheritance, which you brought out of Egypt, from the middle of the iron furnace); 
 \v 52 that your eyes may be open to the supplication of your servant and to the supplication of your people Israel, to listen to them whenever they cry to you. 
-\v 53 For you separated them from among all the peoples of the earth to be your inheritance, as you spoke by Moses your servant, when you brought our fathers out of Egypt, Lord Yahweh.” 
+\v 53 For you separated them from among all the peoples of the earth to be your inheritance, as you spoke by Moses your servant, when you brought our fathers out of Egypt, Lord Yahuah.” 
 \p
-\v 54 It was so, that when Solomon had finished praying all this prayer and supplication to Yahweh, he arose from before Yahweh’s altar, from kneeling on his knees with his hands spread out toward heaven. 
+\v 54 It was so, that when Solomon had finished praying all this prayer and supplication to Yahuah, he arose from before Yahuah’s altar, from kneeling on his knees with his hands spread out toward heaven. 
 \v 55 He stood and blessed all the assembly of Israel with a loud voice, saying, 
-\v 56 “Blessed be Yahweh, who has given rest to his people Israel, according to all that he promised. There has not failed one word of all his good promise, which he promised by Moses his servant. 
-\v 57 May Yahweh our Elohim be with us as he was with our fathers. Let him not leave us or forsake us, 
+\v 56 “Blessed be Yahuah, who has given rest to his people Israel, according to all that he promised. There has not failed one word of all his good promise, which he promised by Moses his servant. 
+\v 57 May Yahuah our Elohim be with us as he was with our fathers. Let him not leave us or forsake us, 
 \v 58 that he may incline our hearts to him, to walk in all his ways, and to keep his commandments, his statutes, and his ordinances, which he commanded our fathers. 
-\v 59 Let these my words, with which I have made supplication before Yahweh, be near to Yahweh our Elohim day and night, that he may maintain the cause of his servant and the cause of his people Israel, as every day requires; 
-\v 60 that all the peoples of the earth may know that Yahweh himself is Elohim. There is no one else. 
+\v 59 Let these my words, with which I have made supplication before Yahuah, be near to Yahuah our Elohim day and night, that he may maintain the cause of his servant and the cause of his people Israel, as every day requires; 
+\v 60 that all the peoples of the earth may know that Yahuah himself is Elohim. There is no one else. 
 \p
-\v 61 “Let your heart therefore be perfect with Yahweh our Elohim, to walk in his statutes, and to keep his commandments, as it is today.” 
+\v 61 “Let your heart therefore be perfect with Yahuah our Elohim, to walk in his statutes, and to keep his commandments, as it is today.” 
 \p
-\v 62 The king, and all Israel with him, offered sacrifice before Yahweh. 
-\v 63 Solomon offered for the sacrifice of peace offerings, which he offered to Yahweh, twenty two thousand head of cattle and one hundred twenty thousand sheep. So the king and all the children of Israel dedicated Yahweh’s house. 
-\v 64 The same day the king made the middle of the court set-apart that was before Yahweh’s house; for there he offered the burnt offering, the meal offering, and the fat of the peace offerings, because the bronze altar that was before Yahweh was too little to receive the burnt offering, the meal offering, and the fat of the peace offerings. 
+\v 62 The king, and all Israel with him, offered sacrifice before Yahuah. 
+\v 63 Solomon offered for the sacrifice of peace offerings, which he offered to Yahuah, twenty two thousand head of cattle and one hundred twenty thousand sheep. So the king and all the children of Israel dedicated Yahuah’s house. 
+\v 64 The same day the king made the middle of the court set-apart that was before Yahuah’s house; for there he offered the burnt offering, the meal offering, and the fat of the peace offerings, because the bronze altar that was before Yahuah was too little to receive the burnt offering, the meal offering, and the fat of the peace offerings. 
 \p
-\v 65 So Solomon held the feast at that time, and all Israel with him, a great assembly, from the entrance of Hamath to the brook of Egypt, before Yahweh our Elohim, seven days and seven more days, even fourteen days. 
-\v 66 On the eighth day he sent the people away; and they blessed the king, and went to their tents joyful and glad in their hearts for all the goodness that Yahweh had shown to David his servant, and to Israel his people. 
+\v 65 So Solomon held the feast at that time, and all Israel with him, a great assembly, from the entrance of Hamath to the brook of Egypt, before Yahuah our Elohim, seven days and seven more days, even fourteen days. 
+\v 66 On the eighth day he sent the people away; and they blessed the king, and went to their tents joyful and glad in their hearts for all the goodness that Yahuah had shown to David his servant, and to Israel his people. 
 \c 9
 \p
-\v 1 When Solomon had finished the building of Yahweh’s house, the king’s house, and all Solomon’s desire which he was pleased to do, 
-\v 2 Yahweh appeared to Solomon the second time, as he had appeared to him at Gibeon. 
-\v 3 Yahweh said to him, “I have heard your prayer and your supplication that you have made before me. I have made this house set-apart, which you have built, to put my name there forever; and my eyes and my heart shall be there perpetually. 
+\v 1 When Solomon had finished the building of Yahuah’s house, the king’s house, and all Solomon’s desire which he was pleased to do, 
+\v 2 Yahuah appeared to Solomon the second time, as he had appeared to him at Gibeon. 
+\v 3 Yahuah said to him, “I have heard your prayer and your supplication that you have made before me. I have made this house set-apart, which you have built, to put my name there forever; and my eyes and my heart shall be there perpetually. 
 \v 4 As for you, if you will walk before me as David your father walked, in integrity of heart and in uprightness, to do according to all that I have commanded you, and will keep my statutes and my ordinances, 
 \v 5 then I will establish the throne of your kingdom over Israel forever, as I promised to David your father, saying, ‘There shall not fail from you a man on the throne of Israel.’ 
 \v 6 But if you turn away from following me, you or your children, and not keep my commandments and my statutes which I have set before you, but go and serve other elohims and worship them, 
 \v 7 then I will cut off Israel out of the land which I have given them; and I will cast this house, which I have made set-apart for my name, out of my sight; and Israel will be a proverb and a byword among all peoples. 
-\v 8 Though this house is so high, yet everyone who passes by it will be astonished and hiss; and they will say, ‘Why has Yahweh done this to this land and to this house?’ 
-\v 9 and they will answer, ‘Because they abandoned Yahweh their Elohim, who brought their fathers out of the land of Egypt, and embraced other elohims, and worshiped them, and served them. Therefore Yahweh has brought all this evil on them.’ ” 
+\v 8 Though this house is so high, yet everyone who passes by it will be astonished and hiss; and they will say, ‘Why has Yahuah done this to this land and to this house?’ 
+\v 9 and they will answer, ‘Because they abandoned Yahuah their Elohim, who brought their fathers out of the land of Egypt, and embraced other elohims, and worshiped them, and served them. Therefore Yahuah has brought all this evil on them.’ ” 
 \p
-\v 10 At the end of twenty years, in which Solomon had built the two houses, Yahweh’s house and the king’s house 
+\v 10 At the end of twenty years, in which Solomon had built the two houses, Yahuah’s house and the king’s house 
 \v 11 (now Hiram the king of Tyre had furnished Solomon with cedar trees and cypress trees, and with gold, according to all his desire), King Solomon gave Hiram twenty cities in the land of Galilee. 
 \v 12 Hiram came out of Tyre to see the cities which Solomon had given him; and they didn’t please him. 
 \v 13 He said, “What cities are these which you have given me, my brother?” He called them the land of Cabul to this day. 
 \v 14 Hiram sent to the king one hundred twenty talents of gold. 
 \p
-\v 15 This is the reason of the forced labor which King Solomon conscripted: to build Yahweh’s house, his own house, Millo, Jerusalem’s wall, Hazor, Megiddo, and Gezer. 
+\v 15 This is the reason of the forced labor which King Solomon conscripted: to build Yahuah’s house, his own house, Millo, Jerusalem’s wall, Hazor, Megiddo, and Gezer. 
 \v 16 Pharaoh king of Egypt had gone up, taken Gezer, burned it with fire, killed the Canaanites who lived in the city, and given it for a wedding gift to his daughter, Solomon’s woman. 
 \v 17 Solomon built in the land Gezer, Beth Horon the lower, 
 \v 18 Baalath, Tamar in the wilderness, 
@@ -468,26 +468,26 @@
 \p
 \v 24 But Pharaoh’s daughter came up out of David’s city to her house which Solomon had built for her. Then he built Millo. 
 \p
-\v 25 Solomon offered burnt offerings and peace offerings on the altar which he built to Yahweh three times per year, burning incense with them on the altar that was before Yahweh. So he finished the house. 
+\v 25 Solomon offered burnt offerings and peace offerings on the altar which he built to Yahuah three times per year, burning incense with them on the altar that was before Yahuah. So he finished the house. 
 \p
 \v 26 King Solomon made a fleet of ships in Ezion Geber, which is beside Eloth, on the shore of the Red Sea, in the land of Edom. 
 \v 27 Hiram sent in the fleet his servants, sailors who had knowledge of the sea, with the servants of Solomon. 
 \v 28 They came to Ophir, and fetched from there gold, four hundred and twenty talents, and brought it to King Solomon. 
 \c 10
 \p
-\v 1 When the queen of Sheba heard of the fame of Solomon concerning Yahweh’s name, she came to test him with hard questions. 
+\v 1 When the queen of Sheba heard of the fame of Solomon concerning Yahuah’s name, she came to test him with hard questions. 
 \v 2 She came to Jerusalem with a very great caravan, with camels that bore spices, very much gold, and precious stones; and when she had come to Solomon, she talked with him about all that was in her heart. 
 \v 3 Solomon answered all her questions. There wasn’t anything hidden from the king which he didn’t tell her. 
 \v 4 When the queen of Sheba had seen all the wisdom of Solomon, the house that he had built, 
-\v 5 the food of his table, the sitting of his servants, the attendance of his officials, their clothing, his cup bearers, and his ascent by which he went up to Yahweh’s house, there was no more spirit in her. 
+\v 5 the food of his table, the sitting of his servants, the attendance of his officials, their clothing, his cup bearers, and his ascent by which he went up to Yahuah’s house, there was no more spirit in her. 
 \v 6 She said to the king, “It was a true report that I heard in my own land of your acts and of your wisdom. 
 \v 7 However, I didn’t believe the words until I came and my eyes had seen it. Behold, not even half was told me! Your wisdom and prosperity exceed the fame which I heard. 
 \v 8 Happy are your men, happy are these your servants who stand continually before you, who hear your wisdom. 
-\v 9 Blessed is Yahweh your Elohim, who delighted in you, to set you on the throne of Israel. Because Yahweh loved Israel forever, therefore he made you king, to do justice and righteousness.” 
+\v 9 Blessed is Yahuah your Elohim, who delighted in you, to set you on the throne of Israel. Because Yahuah loved Israel forever, therefore he made you king, to do justice and righteousness.” 
 \v 10 She gave the king one hundred twenty talents of gold, and a very great quantity of spices, and precious stones. Never again was there such an abundance of spices as these which the queen of Sheba gave to King Solomon. 
 \p
 \v 11 The fleet of Hiram that brought gold from Ophir also brought in from Ophir great quantities of almug trees and precious stones. 
-\v 12 The king made of the almug trees pillars for Yahweh’s house and for the king’s house, harps also and stringed instruments for the singers; no such almug trees came or were seen to this day. 
+\v 12 The king made of the almug trees pillars for Yahuah’s house and for the king’s house, harps also and stringed instruments for the singers; no such almug trees came or were seen to this day. 
 \p
 \v 13 King Solomon gave to the queen of Sheba all her desire, whatever she asked, in addition to that which Solomon gave her of his royal bounty. So she turned and went to her own land, she and her servants. 
 \p
@@ -512,20 +512,20 @@
 \c 11
 \p
 \v 1 Now King Solomon loved many foreign women, together with the daughter of Pharaoh: women of the Moabites, Ammonites, Edomites, Sidonians, and Hittites, 
-\v 2 of the nations concerning which Yahweh said to the children of Israel, “You shall not go among them, neither shall they come among you, for surely they will turn away your heart after their elohims.” Solomon joined to these in love. 
+\v 2 of the nations concerning which Yahuah said to the children of Israel, “You shall not go among them, neither shall they come among you, for surely they will turn away your heart after their elohims.” Solomon joined to these in love. 
 \v 3 He had seven hundred women, princesses, and three hundred concubines. His women turned his heart away. 
-\v 4 When Solomon was old, his women turned away his heart after other elohims; and his heart was not perfect with Yahweh his Elohim, as the heart of David his father was. 
+\v 4 When Solomon was old, his women turned away his heart after other elohims; and his heart was not perfect with Yahuah his Elohim, as the heart of David his father was. 
 \v 5 For Solomon went after Ashtoreth the elohim of the Sidonians, and after Milcom the abomination of the Ammonites. 
-\v 6 Solomon did that which was evil in Yahweh’s sight, and didn’t go fully after Yahweh, as David his father did. 
+\v 6 Solomon did that which was evil in Yahuah’s sight, and didn’t go fully after Yahuah, as David his father did. 
 \v 7 Then Solomon built a high place for Chemosh the abomination of Moab, on the mountain that is before Jerusalem, and for Molech the abomination of the children of Ammon. 
 \v 8 So he did for all his foreign women, who burned incense and sacrificed to their elohims. 
-\v 9 Yahweh was angry with Solomon, because his heart was turned away from Yahweh, the Elohim of Israel, who had appeared to him twice, 
-\v 10 and had commanded him concerning this thing, that he should not go after other elohims; but he didn’t keep that which Yahweh commanded. 
-\v 11 Therefore Yahweh said to Solomon, “Because this is done by you, and you have not kept my covenant and my statutes, which I have commanded you, I will surely tear the kingdom from you, and will give it to your servant. 
+\v 9 Yahuah was angry with Solomon, because his heart was turned away from Yahuah, the Elohim of Israel, who had appeared to him twice, 
+\v 10 and had commanded him concerning this thing, that he should not go after other elohims; but he didn’t keep that which Yahuah commanded. 
+\v 11 Therefore Yahuah said to Solomon, “Because this is done by you, and you have not kept my covenant and my statutes, which I have commanded you, I will surely tear the kingdom from you, and will give it to your servant. 
 \v 12 Nevertheless, I will not do it in your days, for David your father’s sake; but I will tear it out of your son’s hand. 
 \v 13 However, I will not tear away all the kingdom; but I will give one tribe to your son, for David my servant’s sake, and for Jerusalem’s sake which I have chosen.” 
 \p
-\v 14 Yahweh raised up an adversary to Solomon: Hadad the Edomite. He was one of the king’s offspring in Edom. 
+\v 14 Yahuah raised up an adversary to Solomon: Hadad the Edomite. He was one of the king’s offspring in Edom. 
 \v 15 For when David was in Edom, and Joab the captain of the army had gone up to bury the slain, and had struck every male in Edom 
 \v 16 (for Joab and all Israel remained there six months, until he had cut off every male in Edom), 
 \v 17 Hadad fled, he and certain Edomites of his father’s servants with him, to go into Egypt, when Hadad was still a little child. 
@@ -546,7 +546,7 @@
 \v 28 The man Jeroboam was a mighty man of valor; and Solomon saw the young man that he was industrious, and he put him in charge of all the labor of the house of Joseph. 
 \v 29 At that time, when Jeroboam went out of Jerusalem, the prophet Ahijah the Shilonite found him on the way. Now Ahijah had clad himself with a new garment; and the two of them were alone in the field. 
 \v 30 Ahijah took the new garment that was on him, and tore it in twelve pieces. 
-\v 31 He said to Jeroboam, “Take ten pieces; for Yahweh, the Elohim of Israel, says, ‘Behold, I will tear the kingdom out of the hand of Solomon and will give ten tribes to you 
+\v 31 He said to Jeroboam, “Take ten pieces; for Yahuah, the Elohim of Israel, says, ‘Behold, I will tear the kingdom out of the hand of Solomon and will give ten tribes to you 
 \v 32 (but he shall have one tribe, for my servant David’s sake and for Jerusalem’s sake, the city which I have chosen out of all the tribes of Israel), 
 \v 33 because they have forsaken me, and have worshiped Ashtoreth the elohim of the Sidonians, Chemosh the elohim of Moab, and Milcom the elohim of the children of Ammon. They have not walked in my ways, to do that which is right in my eyes, and to keep my statutes and my ordinances, as David his father did. 
 \p
@@ -586,7 +586,7 @@
 \v 13 The king answered the people roughly, and abandoned the counsel of the old men which they had given him, 
 \v 14 and spoke to them according to the counsel of the young men, saying, “My father made your yoke heavy, but I will add to your yoke. My father chastised you with whips, but I will chastise you with scorpions.” 
 \p
-\v 15 So the king didn’t listen to the people; for it was a thing brought about from Yahweh, that he might establish his word, which Yahweh spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
+\v 15 So the king didn’t listen to the people; for it was a thing brought about from Yahuah, that he might establish his word, which Yahuah spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
 \v 16 When all Israel saw that the king didn’t listen to them, the people answered the king, saying, “What portion have we in David? We don’t have an inheritance in the son of Jesse. To your tents, Israel! Now see to your own house, David.” So Israel departed to their tents. 
 \p
 \v 17 But as for the children of Israel who lived in the cities of Judah, Rehoboam reigned over them. 
@@ -598,11 +598,11 @@
 \v 21 When Rehoboam had come to Jerusalem, he assembled all the house of Judah and the tribe of Benjamin, a hundred and eighty thousand chosen men who were warriors, to fight against the house of Israel, to bring the kingdom again to Rehoboam the son of Solomon. 
 \v 22 But the word of Elohim came to Shemaiah the man of Elohim, saying, 
 \v 23 “Speak to Rehoboam the son of Solomon, king of Judah, and to all the house of Judah and Benjamin, and to the rest of the people, saying, 
-\v 24 ‘Yahweh says, “You shall not go up or fight against your brothers, the children of Israel. Everyone return to his house; for this thing is from me.” ’ ” So they listened to Yahweh’s word, and returned and went their way, according to Yahweh’s word. 
+\v 24 ‘Yahuah says, “You shall not go up or fight against your brothers, the children of Israel. Everyone return to his house; for this thing is from me.” ’ ” So they listened to Yahuah’s word, and returned and went their way, according to Yahuah’s word. 
 \p
 \v 25 Then Jeroboam built Shechem in the hill country of Ephraim, and lived in it; and he went out from there and built Penuel. 
 \v 26 Jeroboam said in his heart, “Now the kingdom will return to David’s house. 
-\v 27 If this people goes up to offer sacrifices in Yahweh’s house at Jerusalem, then the heart of this people will turn again to their lord, even to Rehoboam king of Judah; and they will kill me, and return to Rehoboam king of Judah.” 
+\v 27 If this people goes up to offer sacrifices in Yahuah’s house at Jerusalem, then the heart of this people will turn again to their lord, even to Rehoboam king of Judah; and they will kill me, and return to Rehoboam king of Judah.” 
 \v 28 So the king took counsel, and made two calves of gold; and he said to them, “It is too much for you to go up to Jerusalem. Look and behold your elohims, Israel, which brought you up out of the land of Egypt!” 
 \v 29 He set the one in Bethel, and the other he put in Dan. 
 \v 30 This thing became a sin, for the people went even as far as Dan to worship before the one there. 
@@ -611,19 +611,19 @@
 \v 33 He went up to the altar which he had made in Bethel on the fifteenth day in the eighth month, even in the month which he had devised of his own heart; and he ordained a feast for the children of Israel, and went up to the altar to burn incense. 
 \c 13
 \p
-\v 1 Behold, a man of Elohim came out of Judah by Yahweh’s word to Bethel; and Jeroboam was standing by the altar to burn incense. 
-\v 2 He cried against the altar by Yahweh’s word, and said, “Altar! Altar! Yahweh says: ‘Behold, a son will be born to David’s house, Josiah by name. On you he will sacrifice the priests of the high places who burn incense on you, and they will burn men’s bones on you.’ ” 
-\v 3 He gave a sign the same day, saying, “This is the sign which Yahweh has spoken: Behold, the altar will be split apart, and the ashes that are on it will be poured out.” 
+\v 1 Behold, a man of Elohim came out of Judah by Yahuah’s word to Bethel; and Jeroboam was standing by the altar to burn incense. 
+\v 2 He cried against the altar by Yahuah’s word, and said, “Altar! Altar! Yahuah says: ‘Behold, a son will be born to David’s house, Josiah by name. On you he will sacrifice the priests of the high places who burn incense on you, and they will burn men’s bones on you.’ ” 
+\v 3 He gave a sign the same day, saying, “This is the sign which Yahuah has spoken: Behold, the altar will be split apart, and the ashes that are on it will be poured out.” 
 \p
 \v 4 When the king heard the saying of the man of Elohim, which he cried against the altar in Bethel, Jeroboam put out his hand from the altar, saying, “Seize him!” His hand, which he put out against him, dried up, so that he could not draw it back again to himself. 
-\v 5 The altar was also split apart, and the ashes poured out from the altar, according to the sign which the man of Elohim had given by Yahweh’s word. 
-\v 6 The king answered the man of Elohim, “Now intercede for the favor of Yahweh your Elohim, and pray for me, that my hand may be restored me again.” 
-\p The man of Elohim interceded with Yahweh, and the king’s hand was restored to him again, and became as it was before. 
+\v 5 The altar was also split apart, and the ashes poured out from the altar, according to the sign which the man of Elohim had given by Yahuah’s word. 
+\v 6 The king answered the man of Elohim, “Now intercede for the favor of Yahuah your Elohim, and pray for me, that my hand may be restored me again.” 
+\p The man of Elohim interceded with Yahuah, and the king’s hand was restored to him again, and became as it was before. 
 \p
 \v 7 The king said to the man of Elohim, “Come home with me and refresh yourself, and I will give you a reward.” 
 \p
 \v 8 The man of Elohim said to the king, “Even if you gave me half of your house, I would not go in with you, neither would I eat bread nor drink water in this place; 
-\v 9 for so was it commanded me by Yahweh’s word, saying, ‘You shall eat no bread, drink no water, and don’t return by the way that you came.’ ” 
+\v 9 for so was it commanded me by Yahuah’s word, saying, ‘You shall eat no bread, drink no water, and don’t return by the way that you came.’ ” 
 \v 10 So he went another way, and didn’t return by the way that he came to Bethel. 
 \p
 \v 11 Now an old prophet lived in Bethel, and one of his sons came and told him all the works that the man of Elohim had done that day in Bethel. They also told their father the words which he had spoken to the king. 
@@ -636,26 +636,26 @@
 \v 15 Then he said to him, “Come home with me and eat bread.” 
 \p
 \v 16 He said, “I may not return with you, nor go in with you. I will not eat bread or drink water with you in this place. 
-\v 17 For it was said to me by Yahweh’s word, ‘You shall eat no bread or drink water there, and don’t turn again to go by the way that you came.’ ” 
+\v 17 For it was said to me by Yahuah’s word, ‘You shall eat no bread or drink water there, and don’t turn again to go by the way that you came.’ ” 
 \p
-\v 18 He said to him, “I also am a prophet as you are; and an angel spoke to me by Yahweh’s word, saying, ‘Bring him back with you into your house, that he may eat bread and drink water.’ ” He lied to him. 
+\v 18 He said to him, “I also am a prophet as you are; and an angel spoke to me by Yahuah’s word, saying, ‘Bring him back with you into your house, that he may eat bread and drink water.’ ” He lied to him. 
 \p
 \v 19 So he went back with him, ate bread in his house, and drank water. 
-\v 20 As they sat at the table, Yahweh’s word came to the prophet who brought him back; 
-\v 21 and he cried out to the man of Elohim who came from Judah, saying, “Yahweh says, ‘Because you have been disobedient to Yahweh’s word, and have not kept the commandment which Yahweh your Elohim commanded you, 
+\v 20 As they sat at the table, Yahuah’s word came to the prophet who brought him back; 
+\v 21 and he cried out to the man of Elohim who came from Judah, saying, “Yahuah says, ‘Because you have been disobedient to Yahuah’s word, and have not kept the commandment which Yahuah your Elohim commanded you, 
 \v 22 but came back, and have eaten bread and drank water in the place of which he said to you, “Eat no bread, and drink no water,” your body will not come to the tomb of your fathers.’ ” 
 \p
 \v 23 After he had eaten bread and after he drank, he saddled the donkey for the prophet whom he had brought back. 
 \v 24 When he had gone, a lion met him by the way and killed him. His body was thrown on the path, and the donkey stood by it. The lion also stood by the body. 
 \v 25 Behold, men passed by and saw the body thrown on the path, and the lion standing by the body; and they came and told it in the city where the old prophet lived. 
-\v 26 When the prophet who brought him back from the way heard of it, he said, “It is the man of Elohim who was disobedient to Yahweh’s word. Therefore Yahweh has delivered him to the lion, which has mauled him and slain him, according to Yahweh’s word which he spoke to him.” 
+\v 26 When the prophet who brought him back from the way heard of it, he said, “It is the man of Elohim who was disobedient to Yahuah’s word. Therefore Yahuah has delivered him to the lion, which has mauled him and slain him, according to Yahuah’s word which he spoke to him.” 
 \v 27 He said to his sons, saying, “Saddle the donkey for me,” and they saddled it. 
 \v 28 He went and found his body thrown on the path, and the donkey and the lion standing by the body. The lion had not eaten the body nor mauled the donkey. 
 \v 29 The prophet took up the body of the man of Elohim, and laid it on the donkey, and brought it back. He came to the city of the old prophet to mourn, and to bury him. 
 \v 30 He laid his body in his own grave; and they mourned over him, saying, “Alas, my brother!” 
 \p
 \v 31 After he had buried him, he spoke to his sons, saying, “When I am dead, bury me in the tomb in which the man of Elohim is buried. Lay my bones beside his bones. 
-\v 32 For the saying which he cried by Yahweh’s word against the altar in Bethel, and against all the houses of the high places which are in the cities of Samaria, will surely happen.” 
+\v 32 For the saying which he cried by Yahuah’s word against the altar in Bethel, and against all the houses of the high places which are in the cities of Samaria, will surely happen.” 
 \p
 \v 33 After this thing, Jeroboam didn’t turn from his evil way, but again made priests of the high places from among all the people. Whoever wanted to, he consecrated him, that there might be priests of the high places. 
 \v 34 This thing became sin to the house of Jeroboam, even to cut it off and to destroy it from off the surface of the earth. 
@@ -666,35 +666,35 @@
 \v 3 Take with you ten loaves of bread, some cakes, and a jar of honey, and go to him. He will tell you what will become of the child.” 
 \p
 \v 4 Jeroboam’s woman did so, and arose and went to Shiloh, and came to Ahijah’s house. Now Ahijah could not see, for his eyes were set by reason of his age. 
-\v 5 Yahweh said to Ahijah, “Behold, Jeroboam’s woman is coming to inquire of you concerning her son, for he is sick. Tell her such and such; for it will be, when she comes in, that she will pretend to be another woman.” 
+\v 5 Yahuah said to Ahijah, “Behold, Jeroboam’s woman is coming to inquire of you concerning her son, for he is sick. Tell her such and such; for it will be, when she comes in, that she will pretend to be another woman.” 
 \p
 \v 6 So when Ahijah heard the sound of her feet as she came in at the door, he said, “Come in, Jeroboam’s woman! Why do you pretend to be another? For I am sent to you with heavy news. 
-\v 7 Go, tell Jeroboam, ‘Yahweh, the Elohim of Israel, says: “Because I exalted you from among the people, and made you prince over my people Israel, 
+\v 7 Go, tell Jeroboam, ‘Yahuah, the Elohim of Israel, says: “Because I exalted you from among the people, and made you prince over my people Israel, 
 \v 8 and tore the kingdom away from David’s house, and gave it you; and yet you have not been as my servant David, who kept my commandments, and who followed me with all his heart, to do that only which was right in my eyes, 
 \v 9 but have done evil above all who were before you, and have gone and made for yourself other elohims, molten images, to provoke me to anger, and have cast me behind your back, 
 \v 10 therefore, behold, I will bring evil on the house of Jeroboam, and will cut off from Jeroboam everyone who urinates on a wall, he who is shut up and he who is left at large in Israel, and will utterly sweep away the house of Jeroboam, as a man sweeps away dung until it is all gone. 
-\v 11 The dogs will eat he who belongs to Jeroboam who dies in the city; and the birds of the sky will eat he who dies in the field, for Yahweh has spoken it.” ’ 
+\v 11 The dogs will eat he who belongs to Jeroboam who dies in the city; and the birds of the sky will eat he who dies in the field, for Yahuah has spoken it.” ’ 
 \v 12 Arise therefore, and go to your house. When your feet enter into the city, the child will die. 
-\v 13 All Israel will mourn for him and bury him; for he only of Jeroboam will come to the grave, because in him there is found some good thing toward Yahweh, the Elohim of Israel, in the house of Jeroboam. 
-\v 14 Moreover Yahweh will raise up a king for himself over Israel who will cut off the house of Jeroboam. This is the day! What? Even now. 
-\v 15 For Yahweh will strike Israel, as a reed is shaken in the water; and he will root up Israel out of this good land which he gave to their fathers, and will scatter them beyond the River, because they have made their Asherah poles, provoking Yahweh to anger. 
+\v 13 All Israel will mourn for him and bury him; for he only of Jeroboam will come to the grave, because in him there is found some good thing toward Yahuah, the Elohim of Israel, in the house of Jeroboam. 
+\v 14 Moreover Yahuah will raise up a king for himself over Israel who will cut off the house of Jeroboam. This is the day! What? Even now. 
+\v 15 For Yahuah will strike Israel, as a reed is shaken in the water; and he will root up Israel out of this good land which he gave to their fathers, and will scatter them beyond the River, because they have made their Asherah poles, provoking Yahuah to anger. 
 \v 16 He will give Israel up because of the sins of Jeroboam, which he has sinned, and with which he has made Israel to sin.” 
 \p
 \v 17 Jeroboam’s woman arose and departed, and came to Tirzah. As she came to the threshold of the house, the child died. 
-\v 18 All Israel buried him and mourned for him, according to Yahweh’s word, which he spoke by his servant Ahijah the prophet. 
+\v 18 All Israel buried him and mourned for him, according to Yahuah’s word, which he spoke by his servant Ahijah the prophet. 
 \p
 \v 19 The rest of the acts of Jeroboam, how he fought and how he reigned, behold, they are written in the book of the chronicles of the kings of Israel. 
 \v 20 The days which Jeroboam reigned were twenty two years; then he slept with his fathers, and Nadab his son reigned in his place. 
 \p
-\v 21 Rehoboam the son of Solomon reigned in Judah. Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahweh had chosen out of all the tribes of Israel, to put his name there. His mother’s name was Naamah the Ammonitess. 
-\v 22 Judah did that which was evil in Yahweh’s sight, and they provoked him to jealousy with their sins which they committed, above all that their fathers had done. 
+\v 21 Rehoboam the son of Solomon reigned in Judah. Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahuah had chosen out of all the tribes of Israel, to put his name there. His mother’s name was Naamah the Ammonitess. 
+\v 22 Judah did that which was evil in Yahuah’s sight, and they provoked him to jealousy with their sins which they committed, above all that their fathers had done. 
 \v 23 For they also built for themselves high places, sacred pillars, and Asherah poles on every high hill and under every green tree. 
-\v 24 There were also sodomites in the land. They did according to all the abominations of the nations which Yahweh drove out before the children of Israel. 
+\v 24 There were also sodomites in the land. They did according to all the abominations of the nations which Yahuah drove out before the children of Israel. 
 \p
 \v 25 In the fifth year of King Rehoboam, Shishak king of Egypt came up against Jerusalem; 
-\v 26 and he took away the treasures of Yahweh’s house and the treasures of the king’s house. He even took away all of it, including all the gold shields which Solomon had made. 
+\v 26 and he took away the treasures of Yahuah’s house and the treasures of the king’s house. He even took away all of it, including all the gold shields which Solomon had made. 
 \v 27 King Rehoboam made shields of bronze in their place, and committed them to the hands of the captains of the guard, who kept the door of the king’s house. 
-\v 28 It was so, that as often as the king went into Yahweh’s house, the guard bore them, and brought them back into the guard room. 
+\v 28 It was so, that as often as the king went into Yahuah’s house, the guard bore them, and brought them back into the guard room. 
 \p
 \v 29 Now the rest of the acts of Rehoboam, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 \v 30 There was war between Rehoboam and Jeroboam continually. 
@@ -703,24 +703,24 @@
 \p
 \v 1 Now in the eighteenth year of King Jeroboam the son of Nebat, Abijam began to reign over Judah. 
 \v 2 He reigned three years in Jerusalem. His mother’s name was Maacah the daughter of Abishalom. 
-\v 3 He walked in all the sins of his father, which he had done before him; and his heart was not perfect with Yahweh his Elohim, as the heart of David his father. 
-\v 4 Nevertheless for David’s sake, Yahweh his Elohim gave him a lamp in Jerusalem, to set up his son after him and to establish Jerusalem; 
-\v 5 because David did that which was right in Yahweh’s eyes, and didn’t turn away from anything that he commanded him all the days of his life, except only in the matter of Uriah the Hittite. 
+\v 3 He walked in all the sins of his father, which he had done before him; and his heart was not perfect with Yahuah his Elohim, as the heart of David his father. 
+\v 4 Nevertheless for David’s sake, Yahuah his Elohim gave him a lamp in Jerusalem, to set up his son after him and to establish Jerusalem; 
+\v 5 because David did that which was right in Yahuah’s eyes, and didn’t turn away from anything that he commanded him all the days of his life, except only in the matter of Uriah the Hittite. 
 \v 6 Now there was war between Rehoboam and Jeroboam all the days of his life. 
 \v 7 The rest of the acts of Abijam, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? There was war between Abijam and Jeroboam. 
 \v 8 Abijam slept with his fathers, and they buried him in David’s city; and Asa his son reigned in his place. 
 \p
 \v 9 In the twentieth year of Jeroboam king of Israel, Asa began to reign over Judah. 
 \v 10 He reigned forty-one years in Jerusalem. His mother’s name was Maacah the daughter of Abishalom. 
-\v 11 Asa did that which was right in Yahweh’s eyes, as David his father did. 
+\v 11 Asa did that which was right in Yahuah’s eyes, as David his father did. 
 \v 12 He put away the sodomites out of the land, and removed all the idols that his fathers had made. 
 \v 13 He also removed Maacah his mother from being queen, because she had made an abominable image for an Asherah. Asa cut down her image and burned it at the brook Kidron. 
-\v 14 But the high places were not taken away. Nevertheless the heart of Asa was perfect with Yahweh all his days. 
-\v 15 He brought into Yahweh’s house the things that his father had dedicated, and the things that he himself had dedicated: silver, gold, and utensils. 
+\v 14 But the high places were not taken away. Nevertheless the heart of Asa was perfect with Yahuah all his days. 
+\v 15 He brought into Yahuah’s house the things that his father had dedicated, and the things that he himself had dedicated: silver, gold, and utensils. 
 \p
 \v 16 There was war between Asa and Baasha king of Israel all their days. 
 \v 17 Baasha king of Israel went up against Judah, and built Ramah, that he might not allow anyone to go out or come in to Asa king of Judah. 
-\v 18 Then Asa took all the silver and the gold that was left in the treasures of Yahweh’s house, and the treasures of the king’s house, and delivered it into the hand of his servants. Then King Asa sent them to Ben Hadad, the son of Tabrimmon, the son of Hezion, king of Syria, who lived at Damascus, saying, 
+\v 18 Then Asa took all the silver and the gold that was left in the treasures of Yahuah’s house, and the treasures of the king’s house, and delivered it into the hand of his servants. Then King Asa sent them to Ben Hadad, the son of Tabrimmon, the son of Hezion, king of Syria, who lived at Damascus, saying, 
 \v 19 “Let there be a treaty between me and you, like that between my father and your father. Behold, I have sent to you a present of silver and gold. Go, break your treaty with Baasha king of Israel, that he may depart from me.” 
 \p
 \v 20 Ben Hadad listened to King Asa, and sent the captains of his armies against the cities of Israel, and struck Ijon, and Dan, and Abel Beth Maacah, and all Chinneroth, with all the land of Naphtali. 
@@ -730,20 +730,20 @@
 \v 24 Asa slept with his fathers, and was buried with his fathers in his father David’s city; and Jehoshaphat his son reigned in his place. 
 \p
 \v 25 Nadab the son of Jeroboam began to reign over Israel in the second year of Asa king of Judah; and he reigned over Israel two years. 
-\v 26 He did that which was evil in Yahweh’s sight, and walked in the way of his father, and in his sin with which he made Israel to sin. 
+\v 26 He did that which was evil in Yahuah’s sight, and walked in the way of his father, and in his sin with which he made Israel to sin. 
 \v 27 Baasha the son of Ahijah, of the house of Issachar, conspired against him; and Baasha struck him at Gibbethon, which belonged to the Philistines; for Nadab and all Israel were besieging Gibbethon. 
 \v 28 Even in the third year of Asa king of Judah, Baasha killed him and reigned in his place. 
-\v 29 As soon as he was king, he struck all the house of Jeroboam. He didn’t leave to Jeroboam any who breathed, until he had destroyed him, according to the saying of Yahweh, which he spoke by his servant Ahijah the Shilonite; 
-\v 30 for the sins of Jeroboam which he sinned, and with which he made Israel to sin, because of his provocation with which he provoked Yahweh, the Elohim of Israel, to anger. 
+\v 29 As soon as he was king, he struck all the house of Jeroboam. He didn’t leave to Jeroboam any who breathed, until he had destroyed him, according to the saying of Yahuah, which he spoke by his servant Ahijah the Shilonite; 
+\v 30 for the sins of Jeroboam which he sinned, and with which he made Israel to sin, because of his provocation with which he provoked Yahuah, the Elohim of Israel, to anger. 
 \p
 \v 31 Now the rest of the acts of Nadab, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
 \v 32 There was war between Asa and Baasha king of Israel all their days. 
 \p
 \v 33 In the third year of Asa king of Judah, Baasha the son of Ahijah began to reign over all Israel in Tirzah for twenty-four years. 
-\v 34 He did that which was evil in Yahweh’s sight, and walked in the way of Jeroboam, and in his sin with which he made Israel to sin. 
+\v 34 He did that which was evil in Yahuah’s sight, and walked in the way of Jeroboam, and in his sin with which he made Israel to sin. 
 \c 16
 \p
-\v 1 Yahweh’s word came to Jehu the son of Hanani against Baasha, saying, 
+\v 1 Yahuah’s word came to Jehu the son of Hanani against Baasha, saying, 
 \v 2 “Because I exalted you out of the dust and made you prince over my people Israel, and you have walked in the way of Jeroboam and have made my people Israel to sin, to provoke me to anger with their sins, 
 \v 3 behold, I will utterly sweep away Baasha and his house; and I will make your house like the house of Jeroboam the son of Nebat. 
 \v 4 The dogs will eat Baasha’s descendants who die in the city; and he who dies of his in the field, the birds of the sky will eat.” 
@@ -751,84 +751,84 @@
 \v 5 Now the rest of the acts of Baasha, and what he did, and his might, aren’t they written in the book of the chronicles of the kings of Israel? 
 \v 6 Baasha slept with his fathers, and was buried in Tirzah; and Elah his son reigned in his place. 
 \p
-\v 7 Moreover Yahweh’s word came by the prophet Jehu the son of Hanani against Baasha and against his house, both because of all the evil that he did in Yahweh’s sight, to provoke him to anger with the work of his hands, in being like the house of Jeroboam, and because he struck him. 
+\v 7 Moreover Yahuah’s word came by the prophet Jehu the son of Hanani against Baasha and against his house, both because of all the evil that he did in Yahuah’s sight, to provoke him to anger with the work of his hands, in being like the house of Jeroboam, and because he struck him. 
 \p
 \v 8 In the twenty-sixth year of Asa king of Judah, Elah the son of Baasha began to reign over Israel in Tirzah for two years. 
 \v 9 His servant Zimri, captain of half his chariots, conspired against him. Now he was in Tirzah, drinking himself drunk in the house of Arza, who was over the household in Tirzah; 
 \v 10 and Zimri went in and struck him and killed him in the twenty-seventh year of Asa king of Judah, and reigned in his place. 
 \p
 \v 11 When he began to reign, as soon as he sat on his throne, he attacked all the house of Baasha. He didn’t leave him a single one who urinates on a wall among his relatives or his friends. 
-\v 12 Thus Zimri destroyed all the house of Baasha, according to Yahweh’s word which he spoke against Baasha by Jehu the prophet, 
-\v 13 for all the sins of Baasha, and the sins of Elah his son, which they sinned and with which they made Israel to sin, to provoke Yahweh, the Elohim of Israel, to anger with their vanities. 
+\v 12 Thus Zimri destroyed all the house of Baasha, according to Yahuah’s word which he spoke against Baasha by Jehu the prophet, 
+\v 13 for all the sins of Baasha, and the sins of Elah his son, which they sinned and with which they made Israel to sin, to provoke Yahuah, the Elohim of Israel, to anger with their vanities. 
 \v 14 Now the rest of the acts of Elah, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
 \p
 \v 15 In the twenty-seventh year of Asa king of Judah, Zimri reigned seven days in Tirzah. Now the people were encamped against Gibbethon, which belonged to the Philistines. 
 \v 16 The people who were encamped heard that Zimri had conspired, and had also killed the king. Therefore all Israel made Omri, the captain of the army, king over Israel that day in the camp. 
 \v 17 Omri went up from Gibbethon, and all Israel with him, and they besieged Tirzah. 
 \v 18 When Zimri saw that the city was taken, he went into the fortified part of the king’s house and burned the king’s house over him with fire, and died, 
-\v 19 for his sins which he sinned in doing that which was evil in Yahweh’s sight, in walking in the way of Jeroboam, and in his sin which he did to make Israel to sin. 
+\v 19 for his sins which he sinned in doing that which was evil in Yahuah’s sight, in walking in the way of Jeroboam, and in his sin which he did to make Israel to sin. 
 \v 20 Now the rest of the acts of Zimri, and his treason that he committed, aren’t they written in the book of the chronicles of the kings of Israel? 
 \p
 \v 21 Then the people of Israel were divided into two parts: half of the people followed Tibni the son of Ginath, to make him king, and half followed Omri. 
 \v 22 But the people who followed Omri prevailed against the people who followed Tibni the son of Ginath; so Tibni died, and Omri reigned. 
 \v 23 In the thirty-first year of Asa king of Judah, Omri began to reign over Israel for twelve years. He reigned six years in Tirzah. 
 \v 24 He bought the hill Samaria of Shemer for two talents of silver; and he built on the hill, and called the name of the city which he built, Samaria, after the name of Shemer, the owner of the hill. 
-\v 25 Omri did that which was evil in Yahweh’s sight, and dealt wickedly above all who were before him. 
-\v 26 For he walked in all the way of Jeroboam the son of Nebat, and in his sins with which he made Israel to sin, to provoke Yahweh, the Elohim of Israel, to anger with their vanities. 
+\v 25 Omri did that which was evil in Yahuah’s sight, and dealt wickedly above all who were before him. 
+\v 26 For he walked in all the way of Jeroboam the son of Nebat, and in his sins with which he made Israel to sin, to provoke Yahuah, the Elohim of Israel, to anger with their vanities. 
 \v 27 Now the rest of the acts of Omri which he did, and his might that he showed, aren’t they written in the book of the chronicles of the kings of Israel? 
 \v 28 So Omri slept with his fathers, and was buried in Samaria; and Ahab his son reigned in his place. 
 \p
 \v 29 In the thirty-eighth year of Asa king of Judah, Ahab the son of Omri began to reign over Israel. Ahab the son of Omri reigned over Israel in Samaria twenty-two years. 
-\v 30 Ahab the son of Omri did that which was evil in Yahweh’s sight above all that were before him. 
+\v 30 Ahab the son of Omri did that which was evil in Yahuah’s sight above all that were before him. 
 \v 31 As if it had been a light thing for him to walk in the sins of Jeroboam the son of Nebat, he took as woman Jezebel the daughter of Ethbaal king of the Sidonians, and went and served Baal and worshiped him. 
 \v 32 He raised up an altar for Baal in the house of Baal, which he had built in Samaria. 
-\v 33 Ahab made the Asherah; and Ahab did more yet to provoke Yahweh, the Elohim of Israel, to anger than all the kings of Israel who were before him. 
-\v 34 In his days Hiel the Bethelite built Jericho. He laid its foundation with the loss of Abiram his firstborn, and set up its gates with the loss of his youngest son Segub, according to Yahweh’s word, which he spoke by Joshua the son of Nun. 
+\v 33 Ahab made the Asherah; and Ahab did more yet to provoke Yahuah, the Elohim of Israel, to anger than all the kings of Israel who were before him. 
+\v 34 In his days Hiel the Bethelite built Jericho. He laid its foundation with the loss of Abiram his firstborn, and set up its gates with the loss of his youngest son Segub, according to Yahuah’s word, which he spoke by Joshua the son of Nun. 
 \c 17
 \p
-\v 1 Elijah the Tishbite, who was one of the settlers of Gilead, said to Ahab, “As Yahweh, the Elohim of Israel, lives, before whom I stand, there shall not be dew nor rain these years, but according to my word.” 
+\v 1 Elijah the Tishbite, who was one of the settlers of Gilead, said to Ahab, “As Yahuah, the Elohim of Israel, lives, before whom I stand, there shall not be dew nor rain these years, but according to my word.” 
 \p
-\v 2 Then Yahweh’s word came to him, saying, 
+\v 2 Then Yahuah’s word came to him, saying, 
 \v 3 “Go away from here, turn eastward, and hide yourself by the brook Cherith, that is before the Jordan. 
 \v 4 You shall drink from the brook. I have commanded the ravens to feed you there.” 
-\v 5 So he went and did according to Yahweh’s word, for he went and lived by the brook Cherith that is before the Jordan. 
+\v 5 So he went and did according to Yahuah’s word, for he went and lived by the brook Cherith that is before the Jordan. 
 \v 6 The ravens brought him bread and meat in the morning, and bread and meat in the evening; and he drank from the brook. 
 \v 7 After a while, the brook dried up, because there was no rain in the land. 
 \p
-\v 8 Yahweh’s word came to him, saying, 
+\v 8 Yahuah’s word came to him, saying, 
 \v 9 “Arise, go to Zarephath, which belongs to Sidon, and stay there. Behold, I have commanded a widow there to sustain you.” 
 \p
 \v 10 So he arose and went to Zarephath; and when he came to the gate of the city, behold, a widow was there gathering sticks. He called to her and said, “Please get me a little water in a jar, that I may drink.” 
 \p
 \v 11 As she was going to get it, he called to her and said, “Please bring me a morsel of bread in your hand.” 
 \p
-\v 12 She said, “As Yahweh your Elohim lives, I don’t have anything baked, but only a handful of meal in a jar and a little oil in a jar. Behold, I am gathering two sticks, that I may go in and bake it for me and my son, that we may eat it, and die.” 
+\v 12 She said, “As Yahuah your Elohim lives, I don’t have anything baked, but only a handful of meal in a jar and a little oil in a jar. Behold, I am gathering two sticks, that I may go in and bake it for me and my son, that we may eat it, and die.” 
 \p
 \v 13 Elijah said to her, “Don’t be afraid. Go and do as you have said; but make me a little cake from it first, and bring it out to me, and afterward make some for you and for your son. 
-\v 14 For Yahweh, the Elohim of Israel, says, ‘The jar of meal will not run out, and the jar of oil will not fail, until the day that Yahweh sends rain on the earth.’ ” 
+\v 14 For Yahuah, the Elohim of Israel, says, ‘The jar of meal will not run out, and the jar of oil will not fail, until the day that Yahuah sends rain on the earth.’ ” 
 \p
 \v 15 She went and did according to the saying of Elijah; and she, he, and her household ate many days. 
-\v 16 The jar of meal didn’t run out and the jar of oil didn’t fail, according to Yahweh’s word, which he spoke by Elijah. 
+\v 16 The jar of meal didn’t run out and the jar of oil didn’t fail, according to Yahuah’s word, which he spoke by Elijah. 
 \p
 \v 17 After these things, the son of the woman, the mistress of the house, became sick; and his sickness was so severe that there was no breath left in him. 
 \v 18 She said to Elijah, “What have I to do with you, you man of Elohim? You have come to me to bring my sin to memory, and to kill my son!” 
 \p
 \v 19 He said to her, “Give me your son.” He took him out of her bosom, and carried him up into the room where he stayed, and laid him on his own bed. 
-\v 20 He cried to Yahweh and said, “Yahweh my Elohim, have you also brought evil on the widow with whom I am staying, by killing her son?” 
+\v 20 He cried to Yahuah and said, “Yahuah my Elohim, have you also brought evil on the widow with whom I am staying, by killing her son?” 
 \p
-\v 21 He stretched himself on the child three times, and cried to Yahweh and said, “Yahweh my Elohim, please let this child’s soul come into him again.” 
+\v 21 He stretched himself on the child three times, and cried to Yahuah and said, “Yahuah my Elohim, please let this child’s soul come into him again.” 
 \p
-\v 22 Yahweh listened to the voice of Elijah; and the soul of the child came into him again, and he revived. 
+\v 22 Yahuah listened to the voice of Elijah; and the soul of the child came into him again, and he revived. 
 \v 23 Elijah took the child and brought him down out of the room into the house, and delivered him to his mother; and Elijah said, “Behold, your son lives.” 
 \p
-\v 24 The woman said to Elijah, “Now I know that you are a man of Elohim, and that Yahweh’s word in your mouth is truth.” 
+\v 24 The woman said to Elijah, “Now I know that you are a man of Elohim, and that Yahuah’s word in your mouth is truth.” 
 \c 18
 \p
-\v 1 After many days, Yahweh’s word came to Elijah, in the third year, saying, “Go, show yourself to Ahab; and I will send rain on the earth.” 
+\v 1 After many days, Yahuah’s word came to Elijah, in the third year, saying, “Go, show yourself to Ahab; and I will send rain on the earth.” 
 \p
 \v 2 Elijah went to show himself to Ahab. The famine was severe in Samaria. 
-\v 3 Ahab called Obadiah, who was over the household. (Now Obadiah feared Yahweh greatly; 
-\v 4 for when Jezebel cut off Yahweh’s prophets, Obadiah took one hundred prophets, and hid them fifty to a cave, and fed them with bread and water.) 
+\v 3 Ahab called Obadiah, who was over the household. (Now Obadiah feared Yahuah greatly; 
+\v 4 for when Jezebel cut off Yahuah’s prophets, Obadiah took one hundred prophets, and hid them fifty to a cave, and fed them with bread and water.) 
 \v 5 Ahab said to Obadiah, “Go through the land, to all the springs of water, and to all the brooks. Perhaps we may find grass and save the horses and mules alive, that we not lose all the animals.” 
 \p
 \v 6 So they divided the land between them to pass throughout it. Ahab went one way by himself, and Obadiah went another way by himself. 
@@ -837,27 +837,27 @@
 \v 8 He answered him, “It is I. Go, tell your lord, ‘Behold, Elijah is here!’ ” 
 \p
 \v 9 He said, “How have I sinned, that you would deliver your servant into the hand of Ahab, to kill me? 
-\v 10 As Yahweh your Elohim lives, there is no nation or kingdom where my lord has not sent to seek you. When they said, ‘He is not here,’ he took an oath of the kingdom and nation that they didn’t find you. 
+\v 10 As Yahuah your Elohim lives, there is no nation or kingdom where my lord has not sent to seek you. When they said, ‘He is not here,’ he took an oath of the kingdom and nation that they didn’t find you. 
 \v 11 Now you say, ‘Go, tell your lord, “Behold, Elijah is here.” ’ 
-\v 12 It will happen, as soon as I leave you, that Yahweh’s Spirit will carry you I don’t know where; and so when I come and tell Ahab, and he can’t find you, he will kill me. But I, your servant, have feared Yahweh from my youth. 
-\v 13 Wasn’t it told my lord what I did when Jezebel killed Yahweh’s prophets, how I hid one hundred men of Yahweh’s prophets with fifty to a cave, and fed them with bread and water? 
+\v 12 It will happen, as soon as I leave you, that Yahuah’s Spirit will carry you I don’t know where; and so when I come and tell Ahab, and he can’t find you, he will kill me. But I, your servant, have feared Yahuah from my youth. 
+\v 13 Wasn’t it told my lord what I did when Jezebel killed Yahuah’s prophets, how I hid one hundred men of Yahuah’s prophets with fifty to a cave, and fed them with bread and water? 
 \v 14 Now you say, ‘Go, tell your lord, “Behold, Elijah is here”.’ He will kill me.” 
 \p
-\v 15 Elijah said, “As Yahweh of Armies lives, before whom I stand, I will surely show myself to him today.” 
+\v 15 Elijah said, “As Yahuah of Armies lives, before whom I stand, I will surely show myself to him today.” 
 \v 16 So Obadiah went to meet Ahab, and told him; and Ahab went to meet Elijah. 
 \p
 \v 17 When Ahab saw Elijah, Ahab said to him, “Is that you, you troubler of Israel?” 
 \p
-\v 18 He answered, “I have not troubled Israel, but you and your father’s house, in that you have forsaken Yahweh’s commandments and you have followed the Baals. 
+\v 18 He answered, “I have not troubled Israel, but you and your father’s house, in that you have forsaken Yahuah’s commandments and you have followed the Baals. 
 \v 19 Now therefore send, and gather to me all Israel to Mount Carmel, and four hundred fifty of the prophets of Baal, and four hundred of the prophets of the Asherah, who eat at Jezebel’s table.” 
 \p
 \v 20 So Ahab sent to all the children of Israel, and gathered the prophets together to Mount Carmel. 
-\v 21 Elijah came near to all the people, and said, “How long will you waver between the two sides? If Yahweh is Elohim, follow him; but if Baal, then follow him.” 
+\v 21 Elijah came near to all the people, and said, “How long will you waver between the two sides? If Yahuah is Elohim, follow him; but if Baal, then follow him.” 
 \p The people didn’t say a word. 
 \p
-\v 22 Then Elijah said to the people, “I, even I only, am left as a prophet of Yahweh; but Baal’s prophets are four hundred fifty men. 
+\v 22 Then Elijah said to the people, “I, even I only, am left as a prophet of Yahuah; but Baal’s prophets are four hundred fifty men. 
 \v 23 Let them therefore give us two bulls; and let them choose one bull for themselves, and cut it in pieces, and lay it on the wood, and put no fire under; and I will dress the other bull, and lay it on the wood, and put no fire under it. 
-\v 24 You call on the name of your elohim, and I will call on Yahweh’s name. The Elohim who answers by fire, let him be Elohim.” 
+\v 24 You call on the name of your elohim, and I will call on Yahuah’s name. The Elohim who answers by fire, let him be Elohim.” 
 \p All the people answered, “What you say is good.” 
 \p
 \v 25 Elijah said to the prophets of Baal, “Choose one bull for yourselves, and dress it first, for you are many; and call on the name of your elohim, but put no fire under it.” 
@@ -869,18 +869,18 @@
 \v 28 They cried aloud, and cut themselves in their way with knives and lances until the blood gushed out on them. 
 \v 29 When midday was past, they prophesied until the time of the evening offering; but there was no voice, no answer, and nobody paid attention. 
 \p
-\v 30 Elijah said to all the people, “Come near to me!”; and all the people came near to him. He repaired Yahweh’s altar that had been thrown down. 
-\v 31 Elijah took twelve stones, according to the number of the tribes of the sons of Jacob, to whom Yahweh’s word came, saying, “Israel shall be your name.” 
-\v 32 With the stones he built an altar in Yahweh’s name. He made a trench around the altar large enough to contain two seahs of seed. 
+\v 30 Elijah said to all the people, “Come near to me!”; and all the people came near to him. He repaired Yahuah’s altar that had been thrown down. 
+\v 31 Elijah took twelve stones, according to the number of the tribes of the sons of Jacob, to whom Yahuah’s word came, saying, “Israel shall be your name.” 
+\v 32 With the stones he built an altar in Yahuah’s name. He made a trench around the altar large enough to contain two seahs of seed. 
 \v 33 He put the wood in order, and cut the bull in pieces and laid it on the wood. He said, “Fill four jars with water, and pour it on the burnt offering and on the wood.” 
 \v 34 He said, “Do it a second time;” and they did it the second time. He said, “Do it a third time;” and they did it the third time. 
 \v 35 The water ran around the altar; and he also filled the trench with water. 
 \p
-\v 36 At the time of the evening offering, Elijah the prophet came near and said, “Yahweh, the Elohim of Abraham, of Isaac, and of Israel, let it be known today that you are Elohim in Israel and that I am your servant, and that I have done all these things at your word. 
-\v 37 Hear me, Yahweh, hear me, that this people may know that you, Yahweh, are Elohim, and that you have turned their heart back again.” 
+\v 36 At the time of the evening offering, Elijah the prophet came near and said, “Yahuah, the Elohim of Abraham, of Isaac, and of Israel, let it be known today that you are Elohim in Israel and that I am your servant, and that I have done all these things at your word. 
+\v 37 Hear me, Yahuah, hear me, that this people may know that you, Yahuah, are Elohim, and that you have turned their heart back again.” 
 \p
-\v 38 Then Yahweh’s fire fell and consumed the burnt offering, the wood, the stones, and the dust; and it licked up the water that was in the trench. 
-\v 39 When all the people saw it, they fell on their faces. They said, “Yahweh, he is Elohim! Yahweh, he is Elohim!” 
+\v 38 Then Yahuah’s fire fell and consumed the burnt offering, the wood, the stones, and the dust; and it licked up the water that was in the trench. 
+\v 39 When all the people saw it, they fell on their faces. They said, “Yahuah, he is Elohim! Yahuah, he is Elohim!” 
 \p
 \v 40 Elijah said to them, “Seize the prophets of Baal! Don’t let one of them escape!” 
 \p They seized them; and Elijah brought them down to the brook Kishon, and killed them there. 
@@ -896,33 +896,33 @@
 \p He said, “Go up, tell Ahab, ‘Get ready and go down, so that the rain doesn’t stop you.’ ” 
 \p
 \v 45 In a little while, the sky grew black with clouds and wind, and there was a great rain. Ahab rode, and went to Jezreel. 
-\v 46 Yahweh’s hand was on Elijah; and he tucked his cloak into his belt and ran before Ahab to the entrance of Jezreel. 
+\v 46 Yahuah’s hand was on Elijah; and he tucked his cloak into his belt and ran before Ahab to the entrance of Jezreel. 
 \c 19
 \p
 \v 1 Ahab told Jezebel all that Elijah had done, and how he had killed all the prophets with the sword. 
 \v 2 Then Jezebel sent a messenger to Elijah, saying, “So let the elohims do to me, and more also, if I don’t make your life as the life of one of them by tomorrow about this time!” 
 \p
 \v 3 When he saw that, he arose and ran for his life, and came to Beersheba, which belongs to Judah, and left his servant there. 
-\v 4 But he himself went a day’s journey into the wilderness, and came and sat down under a juniper tree. Then he requested for himself that he might die, and said, “It is enough. Now, O Yahweh, take away my life; for I am not better than my fathers.” 
+\v 4 But he himself went a day’s journey into the wilderness, and came and sat down under a juniper tree. Then he requested for himself that he might die, and said, “It is enough. Now, O Yahuah, take away my life; for I am not better than my fathers.” 
 \p
 \v 5 He lay down and slept under a juniper tree; and behold, an angel touched him, and said to him, “Arise and eat!” 
 \p
 \v 6 He looked, and behold, there was at his head a cake baked on the coals, and a jar of water. He ate and drank, and lay down again. 
-\v 7 Yahweh’s angel came again the second time, and touched him, and said, “Arise and eat, because the journey is too great for you.” 
+\v 7 Yahuah’s angel came again the second time, and touched him, and said, “Arise and eat, because the journey is too great for you.” 
 \p
 \v 8 He arose, and ate and drank, and went in the strength of that food forty days and forty nights to Horeb, Elohim’s Mountain. 
-\v 9 He came to a cave there, and camped there; and behold, Yahweh’s word came to him, and he said to him, “What are you doing here, Elijah?” 
+\v 9 He came to a cave there, and camped there; and behold, Yahuah’s word came to him, and he said to him, “What are you doing here, Elijah?” 
 \p
-\v 10 He said, “I have been very jealous for Yahweh, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
+\v 10 He said, “I have been very jealous for Yahuah, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
 \p
-\v 11 He said, “Go out and stand on the mountain before Yahweh.” 
-\p Behold, Yahweh passed by, and a great and strong wind tore the mountains and broke in pieces the rocks before Yahweh; but Yahweh was not in the wind. After the wind there was an earthquake; but Yahweh was not in the earthquake. 
-\v 12 After the earthquake a fire passed; but Yahweh was not in the fire. After the fire, there was a still small voice. 
+\v 11 He said, “Go out and stand on the mountain before Yahuah.” 
+\p Behold, Yahuah passed by, and a great and strong wind tore the mountains and broke in pieces the rocks before Yahuah; but Yahuah was not in the wind. After the wind there was an earthquake; but Yahuah was not in the earthquake. 
+\v 12 After the earthquake a fire passed; but Yahuah was not in the fire. After the fire, there was a still small voice. 
 \v 13 When Elijah heard it, he wrapped his face in his mantle, went out, and stood in the entrance of the cave. Behold, a voice came to him, and said, “What are you doing here, Elijah?” 
 \p
-\v 14 He said, “I have been very jealous for Yahweh, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
+\v 14 He said, “I have been very jealous for Yahuah, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
 \p
-\v 15 Yahweh said to him, “Go, return on your way to the wilderness of Damascus. When you arrive, anoint Hazael to be king over Syria. 
+\v 15 Yahuah said to him, “Go, return on your way to the wilderness of Damascus. When you arrive, anoint Hazael to be king over Syria. 
 \v 16 Anoint Jehu the son of Nimshi to be king over Israel; and anoint Elisha the son of Shaphat of Abel Meholah to be prophet in your place. 
 \v 17 He who escapes from the sword of Hazael, Jehu will kill; and he who escapes from the sword of Jehu, Elisha will kill. 
 \v 18 Yet I reserved seven thousand in Israel, all the knees of which have not bowed to Baal, and every mouth which has not kissed him.” 
@@ -955,10 +955,10 @@
 \p
 \v 12 When Ben Hadad heard this message as he was drinking, he and the kings in the pavilions, he said to his servants, “Prepare to attack!” So they prepared to attack the city. 
 \p
-\v 13 Behold, a prophet came near to Ahab king of Israel, and said, “Yahweh says, ‘Have you seen all this great multitude? Behold, I will deliver it into your hand today. Then you will know that I am Yahweh.’ ” 
+\v 13 Behold, a prophet came near to Ahab king of Israel, and said, “Yahuah says, ‘Have you seen all this great multitude? Behold, I will deliver it into your hand today. Then you will know that I am Yahuah.’ ” 
 \p
 \v 14 Ahab said, “By whom?” 
-\p He said, “Yahweh says, ‘By the young men of the princes of the provinces.’ ” 
+\p He said, “Yahuah says, ‘By the young men of the princes of the provinces.’ ” 
 \p Then he said, “Who shall begin the battle?” 
 \p He answered, “You.” 
 \p
@@ -979,7 +979,7 @@
 \p He listened to their voice and did so. 
 \v 26 At the return of the year, Ben Hadad mustered the Syrians and went up to Aphek to fight against Israel. 
 \v 27 The children of Israel were mustered and given provisions, and went against them. The children of Israel encamped before them like two little flocks of young goats, but the Syrians filled the country. 
-\v 28 A man of Elohim came near and spoke to the king of Israel, and said, “Yahweh says, ‘Because the Syrians have said, “Yahweh is an elohim of the hills, but he is not an elohim of the valleys,” therefore I will deliver all this great multitude into your hand, and you shall know that I am Yahweh.’ ” 
+\v 28 A man of Elohim came near and spoke to the king of Israel, and said, “Yahuah says, ‘Because the Syrians have said, “Yahuah is an elohim of the hills, but he is not an elohim of the valleys,” therefore I will deliver all this great multitude into your hand, and you shall know that I am Yahuah.’ ” 
 \p
 \v 29 They encamped opposite each other for seven days. Then on the seventh day the battle was joined; and the children of Israel killed one hundred thousand footmen of the Syrians in one day. 
 \v 30 But the rest fled to Aphek, into the city; and the wall fell on twenty-seven thousand men who were left. Ben Hadad fled and came into the city, into an inner room. 
@@ -994,9 +994,9 @@
 \v 34 Ben Hadad said to him, “The cities which my father took from your father I will restore. You shall make streets for yourself in Damascus, as my father made in Samaria.” 
 \p “I”, said Ahab, “will let you go with this covenant.” So he made a covenant with him and let him go. 
 \p
-\v 35 A certain man of the sons of the prophets said to his fellow by Yahweh’s word, “Please strike me!” 
+\v 35 A certain man of the sons of the prophets said to his fellow by Yahuah’s word, “Please strike me!” 
 \p The man refused to strike him. 
-\v 36 Then he said to him, “Because you have not obeyed Yahweh’s voice, behold, as soon as you have departed from me, a lion will kill you.” As soon as he had departed from him, a lion found him and killed him. 
+\v 36 Then he said to him, “Because you have not obeyed Yahuah’s voice, behold, as soon as you have departed from me, a lion will kill you.” As soon as he had departed from him, a lion found him and killed him. 
 \p
 \v 37 Then he found another man, and said, “Please strike me.” 
 \p The man struck him and wounded him. 
@@ -1006,7 +1006,7 @@
 \p The king of Israel said to him, “So shall your judgment be. You yourself have decided it.” 
 \p
 \v 41 He hurried, and took the headband away from his eyes; and the king of Israel recognized that he was one of the prophets. 
-\v 42 He said to him, “Yahweh says, ‘Because you have let go out of your hand the man whom I had devoted to destruction, therefore your life will take the place of his life, and your people take the place of his people.’ ” 
+\v 42 He said to him, “Yahuah says, ‘Because you have let go out of your hand the man whom I had devoted to destruction, therefore your life will take the place of his life, and your people take the place of his people.’ ” 
 \p
 \v 43 The king of Israel went to his house sullen and angry, and came to Samaria. 
 \c 21
@@ -1014,7 +1014,7 @@
 \v 1 After these things, Naboth the Jezreelite had a vineyard which was in Jezreel, next to the palace of Ahab king of Samaria. 
 \v 2 Ahab spoke to Naboth, saying, “Give me your vineyard, that I may have it for a garden of herbs, because it is near my house; and I will give you for it a better vineyard than it. Or, if it seems good to you, I will give you its worth in money.” 
 \p
-\v 3 Naboth said to Ahab, “May Yahweh forbid me, that I should give the inheritance of my fathers to you!” 
+\v 3 Naboth said to Ahab, “May Yahuah forbid me, that I should give the inheritance of my fathers to you!” 
 \p
 \v 4 Ahab came into his house sullen and angry because of the word which Naboth the Jezreelite had spoken to him, for he had said, “I will not give you the inheritance of my fathers.” He laid himself down on his bed, and turned away his face, and would eat no bread. 
 \v 5 But Jezebel his woman came to him, and said to him, “Why is your spirit so sad that you eat no bread?” 
@@ -1035,23 +1035,23 @@
 \p
 \v 16 When Ahab heard that Naboth was dead, Ahab rose up to go down to the vineyard of Naboth the Jezreelite, to take possession of it. 
 \p
-\v 17 Yahweh’s word came to Elijah the Tishbite, saying, 
+\v 17 Yahuah’s word came to Elijah the Tishbite, saying, 
 \v 18 “Arise, go down to meet Ahab king of Israel, who dwells in Samaria. Behold, he is in the vineyard of Naboth, where he has gone down to take possession of it. 
-\v 19 You shall speak to him, saying, ‘Yahweh says, “Have you killed and also taken possession?” ’ You shall speak to him, saying, ‘Yahweh says, “In the place where dogs licked the blood of Naboth, dogs will lick your blood, even yours.” ’ ” 
+\v 19 You shall speak to him, saying, ‘Yahuah says, “Have you killed and also taken possession?” ’ You shall speak to him, saying, ‘Yahuah says, “In the place where dogs licked the blood of Naboth, dogs will lick your blood, even yours.” ’ ” 
 \p
 \v 20 Ahab said to Elijah, “Have you found me, my enemy?” 
-\p He answered, “I have found you, because you have sold yourself to do that which is evil in Yahweh’s sight. 
+\p He answered, “I have found you, because you have sold yourself to do that which is evil in Yahuah’s sight. 
 \v 21 Behold, I will bring evil on you, and will utterly sweep you away and will cut off from Ahab everyone who urinates against a wall, and him who is shut up and him who is left at large in Israel. 
 \v 22 I will make your house like the house of Jeroboam the son of Nebat, and like the house of Baasha the son of Ahijah, for the provocation with which you have provoked me to anger, and have made Israel to sin.” 
-\v 23 Yahweh also spoke of Jezebel, saying, “The dogs will eat Jezebel by the rampart of Jezreel. 
+\v 23 Yahuah also spoke of Jezebel, saying, “The dogs will eat Jezebel by the rampart of Jezreel. 
 \v 24 The dogs will eat he who dies of Ahab in the city; and the birds of the sky will eat he who dies in the field.” 
 \p
-\v 25 But there was no one like Ahab, who sold himself to do that which was evil in Yahweh’s sight, whom Jezebel his woman stirred up. 
-\v 26 He did very abominably in following idols, according to all that the Amorites did, whom Yahweh cast out before the children of Israel. 
+\v 25 But there was no one like Ahab, who sold himself to do that which was evil in Yahuah’s sight, whom Jezebel his woman stirred up. 
+\v 26 He did very abominably in following idols, according to all that the Amorites did, whom Yahuah cast out before the children of Israel. 
 \p
 \v 27 When Ahab heard those words, he tore his clothes, put sackcloth on his body, fasted, lay in sackcloth, and went about despondently. 
 \p
-\v 28 Yahweh’s word came to Elijah the Tishbite, saying, 
+\v 28 Yahuah’s word came to Elijah the Tishbite, saying, 
 \v 29 “See how Ahab humbles himself before me? Because he humbles himself before me, I will not bring the evil in his days; but I will bring the evil on his house in his son’s day.” 
 \c 22
 \p
@@ -1060,53 +1060,53 @@
 \v 3 The king of Israel said to his servants, “You know that Ramoth Gilead is ours, and we do nothing, and don’t take it out of the hand of the king of Syria?” 
 \v 4 He said to Jehoshaphat, “Will you go with me to battle to Ramoth Gilead?” 
 \p Jehoshaphat said to the king of Israel, “I am as you are, my people as your people, my horses as your horses.” 
-\v 5 Jehoshaphat said to the king of Israel, “Please inquire first for Yahweh’s word.” 
+\v 5 Jehoshaphat said to the king of Israel, “Please inquire first for Yahuah’s word.” 
 \p
 \v 6 Then the king of Israel gathered the prophets together, about four hundred men, and said to them, “Should I go against Ramoth Gilead to battle, or should I refrain?” 
 \p They said, “Go up; for the Lord will deliver it into the hand of the king.” 
 \p
-\v 7 But Jehoshaphat said, “Isn’t there here a prophet of Yahweh, that we may inquire of him?” 
+\v 7 But Jehoshaphat said, “Isn’t there here a prophet of Yahuah, that we may inquire of him?” 
 \p
-\v 8 The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahweh, Micaiah the son of Imlah; but I hate him, for he does not prophesy good concerning me, but evil.” 
+\v 8 The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahuah, Micaiah the son of Imlah; but I hate him, for he does not prophesy good concerning me, but evil.” 
 \p Jehoshaphat said, “Don’t let the king say so.” 
 \p
 \v 9 Then the king of Israel called an officer, and said, “Quickly get Micaiah the son of Imlah.” 
 \p
 \v 10 Now the king of Israel and Jehoshaphat the king of Judah were sitting each on his throne, arrayed in their robes, in an open place at the entrance of the gate of Samaria; and all the prophets were prophesying before them. 
-\v 11 Zedekiah the son of Chenaanah made himself horns of iron, and said, “Yahweh says, ‘With these you will push the Syrians, until they are consumed.’ ” 
-\v 12 All the prophets prophesied so, saying, “Go up to Ramoth Gilead and prosper; for Yahweh will deliver it into the hand of the king.” 
+\v 11 Zedekiah the son of Chenaanah made himself horns of iron, and said, “Yahuah says, ‘With these you will push the Syrians, until they are consumed.’ ” 
+\v 12 All the prophets prophesied so, saying, “Go up to Ramoth Gilead and prosper; for Yahuah will deliver it into the hand of the king.” 
 \p
 \v 13 The messenger who went to call Micaiah spoke to him, saying, “See now, the prophets declare good to the king with one mouth. Please let your word be like the word of one of them, and speak good.” 
 \p
-\v 14 Micaiah said, “As Yahweh lives, what Yahweh says to me, that I will speak.” 
+\v 14 Micaiah said, “As Yahuah lives, what Yahuah says to me, that I will speak.” 
 \p
 \v 15 When he had come to the king, the king said to him, “Micaiah, shall we go to Ramoth Gilead to battle, or shall we forbear?” 
-\p He answered him, “Go up and prosper; and Yahweh will deliver it into the hand of the king.” 
+\p He answered him, “Go up and prosper; and Yahuah will deliver it into the hand of the king.” 
 \p
-\v 16 The king said to him, “How many times do I have to adjure you that you speak to me nothing but the truth in Yahweh’s name?” 
+\v 16 The king said to him, “How many times do I have to adjure you that you speak to me nothing but the truth in Yahuah’s name?” 
 \p
-\v 17 He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahweh said, ‘These have no master. Let them each return to his house in peace.’ ” 
+\v 17 He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahuah said, ‘These have no master. Let them each return to his house in peace.’ ” 
 \p
 \v 18 The king of Israel said to Jehoshaphat, “Didn’t I tell you that he would not prophesy good concerning me, but evil?” 
 \p
-\v 19 Micaiah said, “Therefore hear Yahweh’s word. I saw Yahweh sitting on his throne, and all the army of heaven standing by him on his right hand and on his left. 
-\v 20 Yahweh said, ‘Who will entice Ahab, that he may go up and fall at Ramoth Gilead?’ One said one thing, and another said another. 
+\v 19 Micaiah said, “Therefore hear Yahuah’s word. I saw Yahuah sitting on his throne, and all the army of heaven standing by him on his right hand and on his left. 
+\v 20 Yahuah said, ‘Who will entice Ahab, that he may go up and fall at Ramoth Gilead?’ One said one thing, and another said another. 
 \p
-\v 21 A spirit came out and stood before Yahweh, and said, ‘I will entice him.’ 
+\v 21 A spirit came out and stood before Yahuah, and said, ‘I will entice him.’ 
 \p
-\v 22 Yahweh said to him, ‘How?’ 
+\v 22 Yahuah said to him, ‘How?’ 
 \p He said, ‘I will go out and will be a lying spirit in the mouth of all his prophets.’ 
 \p He said, ‘You will entice him, and will also prevail. Go out and do so.’ 
-\v 23 Now therefore, behold, Yahweh has put a lying spirit in the mouth of all these your prophets; and Yahweh has spoken evil concerning you.” 
+\v 23 Now therefore, behold, Yahuah has put a lying spirit in the mouth of all these your prophets; and Yahuah has spoken evil concerning you.” 
 \p
-\v 24 Then Zedekiah the son of Chenaanah came near and struck Micaiah on the cheek, and said, “Which way did Yahweh’s Spirit go from me to speak to you?” 
+\v 24 Then Zedekiah the son of Chenaanah came near and struck Micaiah on the cheek, and said, “Which way did Yahuah’s Spirit go from me to speak to you?” 
 \p
 \v 25 Micaiah said, “Behold, you will see on that day when you go into an inner room to hide yourself.” 
 \p
 \v 26 The king of Israel said, “Take Micaiah, and carry him back to Amon the governor of the city and to Joash the king’s son. 
 \v 27 Say, ‘The king says, “Put this fellow in the prison, and feed him with bread of affliction and with water of affliction, until I come in peace.” ’ ” 
 \p
-\v 28 Micaiah said, “If you return at all in peace, Yahweh has not spoken by me.” He said, “Listen, all you people!” 
+\v 28 Micaiah said, “If you return at all in peace, Yahuah has not spoken by me.” He said, “Listen, all you people!” 
 \p
 \v 29 So the king of Israel and Jehoshaphat the king of Judah went up to Ramoth Gilead. 
 \v 30 The king of Israel said to Jehoshaphat, “I will disguise myself and go into the battle, but you put on your robes.” The king of Israel disguised himself and went into the battle. 
@@ -1120,14 +1120,14 @@
 \v 36 A cry went throughout the army about the going down of the sun, saying, “Every man to his city, and every man to his country!” 
 \p
 \v 37 So the king died, and was brought to Samaria; and they buried the king in Samaria. 
-\v 38 They washed the chariot by the pool of Samaria; and the dogs licked up his blood where the prostitutes washed themselves, according to Yahweh’s word which he spoke. 
+\v 38 They washed the chariot by the pool of Samaria; and the dogs licked up his blood where the prostitutes washed themselves, according to Yahuah’s word which he spoke. 
 \p
 \v 39 Now the rest of the acts of Ahab, and all that he did, and the ivory house which he built, and all the cities that he built, aren’t they written in the book of the chronicles of the kings of Israel? 
 \v 40 So Ahab slept with his fathers; and Ahaziah his son reigned in his place. 
 \p
 \v 41 Jehoshaphat the son of Asa began to reign over Judah in the fourth year of Ahab king of Israel. 
 \v 42 Jehoshaphat was thirty-five years old when he began to reign; and he reigned twenty-five years in Jerusalem. His mother’s name was Azubah the daughter of Shilhi. 
-\v 43 He walked in all the way of Asa his father. He didn’t turn away from it, doing that which was right in Yahweh’s eyes. However, the high places were not taken away. The people still sacrificed and burned incense on the high places. 
+\v 43 He walked in all the way of Asa his father. He didn’t turn away from it, doing that which was right in Yahuah’s eyes. However, the high places were not taken away. The people still sacrificed and burned incense on the high places. 
 \v 44 Jehoshaphat made peace with the king of Israel. 
 \p
 \v 45 Now the rest of the acts of Jehoshaphat, and his might that he showed, and how he fought, aren’t they written in the book of the chronicles of the kings of Judah? 
@@ -1138,5 +1138,5 @@
 \v 50 Jehoshaphat slept with his fathers, and was buried with his fathers in his father David’s city. Jehoram his son reigned in his place. 
 \p
 \v 51 Ahaziah the son of Ahab began to reign over Israel in Samaria in the seventeenth year of Jehoshaphat king of Judah, and he reigned two years over Israel. 
-\v 52 He did that which was evil in Yahweh’s sight, and walked in the way of his father, and in the way of his mother, and in the way of Jeroboam the son of Nebat, in which he made Israel to sin. 
-\v 53 He served Baal and worshiped him, and provoked Yahweh, the Elohim of Israel, to anger in all the ways that his father had done so. 
+\v 52 He did that which was evil in Yahuah’s sight, and walked in the way of his father, and in the way of his mother, and in the way of Jeroboam the son of Nebat, in which he made Israel to sin. 
+\v 53 He served Baal and worshiped him, and provoked Yahuah, the Elohim of Israel, to anger in all the ways that his father had done so. 

--- a/usfm/1samuel.usfm
+++ b/usfm/1samuel.usfm
@@ -5,58 +5,58 @@
 \p
 \v 1 Now there was a certain man of Ramathaim Zophim, of the hill country of Ephraim, and his name was Elkanah, the son of Jeroham, the son of Elihu, the son of Tohu, the son of Zuph, an Ephraimite. 
 \v 2 He had two women. The name of one was Hannah, and the name of the other Peninnah. Peninnah had children, but Hannah had no children. 
-\v 3 This man went up out of his city from year to year to worship and to sacrifice to Yahweh of Armies in Shiloh. The two sons of Eli, Hophni and Phinehas, priests to Yahweh, were there. 
+\v 3 This man went up out of his city from year to year to worship and to sacrifice to Yahuah of Armies in Shiloh. The two sons of Eli, Hophni and Phinehas, priests to Yahuah, were there. 
 \v 4 When the day came that Elkanah sacrificed, he gave portions to Peninnah his woman and to all her sons and her daughters; 
-\v 5 but he gave a double portion to Hannah, for he loved Hannah, but Yahweh had shut up her womb. 
-\v 6 Her rival provoked her severely, to irritate her, because Yahweh had shut up her womb. 
-\v 7 So year by year, when she went up to Yahweh’s house, her rival provoked her. Therefore she wept, and didn’t eat. 
+\v 5 but he gave a double portion to Hannah, for he loved Hannah, but Yahuah had shut up her womb. 
+\v 6 Her rival provoked her severely, to irritate her, because Yahuah had shut up her womb. 
+\v 7 So year by year, when she went up to Yahuah’s house, her rival provoked her. Therefore she wept, and didn’t eat. 
 \v 8 Elkanah her man said to her, “Hannah, why do you weep? Why don’t you eat? Why is your heart grieved? Am I not better to you than ten sons?” 
 \p
-\v 9 So Hannah rose up after they had finished eating and drinking in Shiloh. Now Eli the priest was sitting on his seat by the doorpost of Yahweh’s temple. 
-\v 10 She was in bitterness of soul, and prayed to Yahweh, weeping bitterly. 
-\v 11 She vowed a vow, and said, “Yahweh of Armies, if you will indeed look at the affliction of your servant and remember me, and not forget your servant, but will give to your servant a boy, then I will give him to Yahweh all the days of his life, and no razor shall come on his head.” 
+\v 9 So Hannah rose up after they had finished eating and drinking in Shiloh. Now Eli the priest was sitting on his seat by the doorpost of Yahuah’s temple. 
+\v 10 She was in bitterness of soul, and prayed to Yahuah, weeping bitterly. 
+\v 11 She vowed a vow, and said, “Yahuah of Armies, if you will indeed look at the affliction of your servant and remember me, and not forget your servant, but will give to your servant a boy, then I will give him to Yahuah all the days of his life, and no razor shall come on his head.” 
 \p
-\v 12 As she continued praying before Yahweh, Eli saw her mouth. 
+\v 12 As she continued praying before Yahuah, Eli saw her mouth. 
 \v 13 Now Hannah spoke in her heart. Only her lips moved, but her voice was not heard. Therefore Eli thought she was drunk. 
 \v 14 Eli said to her, “How long will you be drunk? Get rid of your wine!” 
 \p
-\v 15 Hannah answered, “No, my lord, I am a woman of a sorrowful spirit. I have not been drinking wine or strong drink, but I poured out my soul before Yahweh. 
+\v 15 Hannah answered, “No, my lord, I am a woman of a sorrowful spirit. I have not been drinking wine or strong drink, but I poured out my soul before Yahuah. 
 \v 16 Don’t consider your servant a wicked woman; for I have been speaking out of the abundance of my complaint and my provocation.” 
 \p
 \v 17 Then Eli answered, “Go in peace; and may the Elohim of Israel grant your petition that you have asked of him.” 
 \p
 \v 18 She said, “Let your servant find favor in your sight.” So the woman went her way and ate; and her facial expression wasn’t sad any more. 
 \p
-\v 19 They rose up in the morning early and worshiped Yahweh, then returned and came to their house to Ramah. Then Elkanah knew Hannah his woman; and Yahweh remembered her. 
+\v 19 They rose up in the morning early and worshiped Yahuah, then returned and came to their house to Ramah. Then Elkanah knew Hannah his woman; and Yahuah remembered her. 
 \p
-\v 20 When the time had come, Hannah conceived, and bore a son; and she named him Samuel, saying, “Because I have asked him of Yahweh.” 
+\v 20 When the time had come, Hannah conceived, and bore a son; and she named him Samuel, saying, “Because I have asked him of Yahuah.” 
 \p
-\v 21 The man Elkanah, and all his house, went up to offer to Yahweh the yearly sacrifice and his vow. 
-\v 22 But Hannah didn’t go up, for she said to her man, “Not until the child is weaned; then I will bring him, that he may appear before Yahweh, and stay there forever.” 
+\v 21 The man Elkanah, and all his house, went up to offer to Yahuah the yearly sacrifice and his vow. 
+\v 22 But Hannah didn’t go up, for she said to her man, “Not until the child is weaned; then I will bring him, that he may appear before Yahuah, and stay there forever.” 
 \p
-\v 23 Elkanah her man said to her, “Do what seems good to you. Wait until you have weaned him; only may Yahweh establish his word.” 
+\v 23 Elkanah her man said to her, “Do what seems good to you. Wait until you have weaned him; only may Yahuah establish his word.” 
 \p So the woman waited and nursed her son until she weaned him. 
-\v 24 When she had weaned him, she took him up with her, with three bulls, and one ephah of meal, and a container of wine, and brought him to Yahweh’s house in Shiloh. The child was young. 
+\v 24 When she had weaned him, she took him up with her, with three bulls, and one ephah of meal, and a container of wine, and brought him to Yahuah’s house in Shiloh. The child was young. 
 \v 25 They killed the bull, and brought the child to Eli. 
-\v 26 She said, “Oh, my lord, as your soul lives, my lord, I am the woman who stood by you here, praying to Yahweh. 
-\v 27 I prayed for this child, and Yahweh has given me my petition which I asked of him. 
-\v 28 Therefore I have also given him to Yahweh. As long as he lives he is given to Yahweh.” He worshiped Yahweh there. 
+\v 26 She said, “Oh, my lord, as your soul lives, my lord, I am the woman who stood by you here, praying to Yahuah. 
+\v 27 I prayed for this child, and Yahuah has given me my petition which I asked of him. 
+\v 28 Therefore I have also given him to Yahuah. As long as he lives he is given to Yahuah.” He worshiped Yahuah there. 
 \c 2
 \p
 \v 1 Hannah prayed, and said, 
-\q1 “My heart exults in Yahweh! 
-\q2 My horn is exalted in Yahweh. 
+\q1 “My heart exults in Yahuah! 
+\q2 My horn is exalted in Yahuah. 
 \q1 My mouth is enlarged over my enemies, 
 \q2 because I rejoice in your salvation. 
 \q1
-\v 2 There is no one as set-apart as Yahweh, 
+\v 2 There is no one as set-apart as Yahuah, 
 \q2 for there is no one besides you, 
 \q2 nor is there any rock like our Elohim. 
 \b
 \q1
 \v 3 “Don’t keep talking so exceedingly proudly. 
 \q2 Don’t let arrogance come out of your mouth, 
-\q2 for Yahweh is an Elohim of knowledge. 
+\q2 for Yahuah is an Elohim of knowledge. 
 \q2 By him actions are weighed. 
 \b
 \q1
@@ -69,55 +69,55 @@
 \q2 She who has many children languishes. 
 \b
 \q1
-\v 6 “Yahweh kills and makes alive. 
+\v 6 “Yahuah kills and makes alive. 
 \q2 He brings down to Sheol and brings up. 
 \q1
-\v 7 Yahweh makes poor and makes rich. 
+\v 7 Yahuah makes poor and makes rich. 
 \q2 He brings low, he also lifts up. 
 \q1
 \v 8 He raises up the poor out of the dust. 
 \q2 He lifts up the needy from the dunghill 
 \q2 to make them sit with princes 
 \q2 and inherit the throne of glory. 
-\q1 For the pillars of the earth are Yahweh’s. 
+\q1 For the pillars of the earth are Yahuah’s. 
 \q2 He has set the world on them. 
 \q1
 \v 9 He will keep the feet of his set-apart ones, 
 \q2 but the wicked will be put to silence in darkness; 
 \q2 for no man will prevail by strength. 
 \q1
-\v 10 Those who strive with Yahweh shall be broken to pieces. 
+\v 10 Those who strive with Yahuah shall be broken to pieces. 
 \q2 He will thunder against them in the sky. 
 \b
-\q1 “Yahweh will judge the ends of the earth. 
+\q1 “Yahuah will judge the ends of the earth. 
 \q2 He will give strength to his king, 
 \q2 and exalt the horn of his anointed.” 
 \p
-\v 11 Elkanah went to Ramah to his house. The child served Yahweh before Eli the priest. 
+\v 11 Elkanah went to Ramah to his house. The child served Yahuah before Eli the priest. 
 \p
-\v 12 Now the sons of Eli were wicked men. They didn’t know Yahweh. 
+\v 12 Now the sons of Eli were wicked men. They didn’t know Yahuah. 
 \v 13 The custom of the priests with the people was that when anyone offered a sacrifice, the priest’s servant came while the meat was boiling, with a fork of three teeth in his hand; 
 \v 14 and he stabbed it into the pan, or kettle, or cauldron, or pot. The priest took all that the fork brought up for himself. They did this to all the Israelites who came there to Shiloh. 
 \v 15 Yes, before they burned the fat, the priest’s servant came, and said to the man who sacrificed, “Give meat to roast for the priest; for he will not accept boiled meat from you, but raw.” 
 \p
 \v 16 If the man said to him, “Let the fat be burned first, and then take as much as your soul desires;” then he would say, “No, but you shall give it to me now; and if not, I will take it by force.” 
-\v 17 The sin of the young men was very great before Yahweh; for the men despised Yahweh’s offering. 
-\v 18 But Samuel ministered before Yahweh, being a child, clothed with a linen ephod. 
+\v 17 The sin of the young men was very great before Yahuah; for the men despised Yahuah’s offering. 
+\v 18 But Samuel ministered before Yahuah, being a child, clothed with a linen ephod. 
 \v 19 Moreover his mother made him a little robe, and brought it to him from year to year when she came up with her man to offer the yearly sacrifice. 
-\v 20 Eli blessed Elkanah and his woman, and said, “May Yahweh give you offspring from this woman for the petition which was asked of Yahweh.” Then they went to their own home. 
-\v 21 Yahweh visited Hannah, and she conceived and bore three sons and two daughters. The child Samuel grew before Yahweh. 
+\v 20 Eli blessed Elkanah and his woman, and said, “May Yahuah give you offspring from this woman for the petition which was asked of Yahuah.” Then they went to their own home. 
+\v 21 Yahuah visited Hannah, and she conceived and bore three sons and two daughters. The child Samuel grew before Yahuah. 
 \p
 \v 22 Now Eli was very old; and he heard all that his sons did to all Israel, and how that they slept with the women who served at the door of the Tent of Meeting. 
 \v 23 He said to them, “Why do you do such things? For I hear of your evil dealings from all these people. 
-\v 24 No, my sons; for it is not a good report that I hear! You make Yahweh’s people disobey. 
-\v 25 If one man sins against another, Elohim will judge him; but if a man sins against Yahweh, who will intercede for him?” Notwithstanding, they didn’t listen to the voice of their father, because Yahweh intended to kill them. 
+\v 24 No, my sons; for it is not a good report that I hear! You make Yahuah’s people disobey. 
+\v 25 If one man sins against another, Elohim will judge him; but if a man sins against Yahuah, who will intercede for him?” Notwithstanding, they didn’t listen to the voice of their father, because Yahuah intended to kill them. 
 \p
-\v 26 The child Samuel grew on, and increased in favor both with Yahweh and also with men. 
+\v 26 The child Samuel grew on, and increased in favor both with Yahuah and also with men. 
 \p
-\v 27 A man of Elohim came to Eli and said to him, “Yahweh says, ‘Did I reveal myself to the house of your father when they were in Egypt in bondage to Pharaoh’s house? 
+\v 27 A man of Elohim came to Eli and said to him, “Yahuah says, ‘Did I reveal myself to the house of your father when they were in Egypt in bondage to Pharaoh’s house? 
 \v 28 Didn’t I choose him out of all the tribes of Israel to be my priest, to go up to my altar, to burn incense, to wear an ephod before me? Didn’t I give to the house of your father all the offerings of the children of Israel made by fire? 
 \v 29 Why do you kick at my sacrifice and at my offering, which I have commanded in my habitation, and honor your sons above me, to make yourselves fat with the best of all the offerings of Israel my people?’ 
-\v 30 “Therefore Yahweh, the Elohim of Israel, says, ‘I said indeed that your house and the house of your father should walk before me forever.’ But now Yahweh says, ‘Far be it from me; for those who honor me I will honor, and those who despise me will be cursed. 
+\v 30 “Therefore Yahuah, the Elohim of Israel, says, ‘I said indeed that your house and the house of your father should walk before me forever.’ But now Yahuah says, ‘Far be it from me; for those who honor me I will honor, and those who despise me will be cursed. 
 \v 31 Behold, the days come that I will cut off your arm and the arm of your father’s house, that there will not be an old man in your house. 
 \v 32 You will see the affliction of my habitation, in all the wealth which I will give Israel. There shall not be an old man in your house forever. 
 \v 33 The man of yours whom I don’t cut off from my altar will consume your eyes and grieve your heart. All the increase of your house will die in the flower of their age. 
@@ -126,51 +126,51 @@
 \v 36 It will happen that everyone who is left in your house will come and bow down to him for a piece of silver and a loaf of bread, and will say, “Please put me into one of the priests’ offices, that I may eat a morsel of bread.” ’ ” 
 \c 3
 \p
-\v 1 The child Samuel ministered to Yahweh before Eli. Yahweh’s word was rare in those days. There were not many visions, then. 
+\v 1 The child Samuel ministered to Yahuah before Eli. Yahuah’s word was rare in those days. There were not many visions, then. 
 \v 2 At that time, when Eli was laid down in his place (now his eyes had begun to grow dim, so that he could not see), 
-\v 3 and Elohim’s lamp hadn’t yet gone out, and Samuel had laid down in Yahweh’s temple where Elohim’s ark was, 
-\v 4 Yahweh called Samuel. He said, “Here I am.” 
+\v 3 and Elohim’s lamp hadn’t yet gone out, and Samuel had laid down in Yahuah’s temple where Elohim’s ark was, 
+\v 4 Yahuah called Samuel. He said, “Here I am.” 
 \p
 \v 5 He ran to Eli and said, “Here I am; for you called me.” 
 \p He said, “I didn’t call. Lie down again.” 
 \p He went and lay down. 
-\v 6 Yahweh called yet again, “Samuel!” 
+\v 6 Yahuah called yet again, “Samuel!” 
 \p Samuel arose and went to Eli and said, “Here I am; for you called me.” 
 \p He answered, “I didn’t call, my son. Lie down again.” 
-\v 7 Now Samuel didn’t yet know Yahweh, neither was Yahweh’s word yet revealed to him. 
-\v 8 Yahweh called Samuel again the third time. He arose and went to Eli and said, “Here I am; for you called me.” 
-\p Eli perceived that Yahweh had called the child. 
-\v 9 Therefore Eli said to Samuel, “Go, lie down. It shall be, if he calls you, that you shall say, ‘Speak, Yahweh; for your servant hears.’ ” So Samuel went and lay down in his place. 
-\v 10 Yahweh came, and stood, and called as at other times, “Samuel! Samuel!” 
+\v 7 Now Samuel didn’t yet know Yahuah, neither was Yahuah’s word yet revealed to him. 
+\v 8 Yahuah called Samuel again the third time. He arose and went to Eli and said, “Here I am; for you called me.” 
+\p Eli perceived that Yahuah had called the child. 
+\v 9 Therefore Eli said to Samuel, “Go, lie down. It shall be, if he calls you, that you shall say, ‘Speak, Yahuah; for your servant hears.’ ” So Samuel went and lay down in his place. 
+\v 10 Yahuah came, and stood, and called as at other times, “Samuel! Samuel!” 
 \p Then Samuel said, “Speak; for your servant hears.” 
 \p
-\v 11 Yahweh said to Samuel, “Behold, I will do a thing in Israel at which both the ears of everyone who hears it will tingle. 
+\v 11 Yahuah said to Samuel, “Behold, I will do a thing in Israel at which both the ears of everyone who hears it will tingle. 
 \v 12 In that day I will perform against Eli all that I have spoken concerning his house, from the beginning even to the end. 
 \v 13 For I have told him that I will judge his house forever for the iniquity which he knew, because his sons brought a curse on themselves, and he didn’t restrain them. 
 \v 14 Therefore I have sworn to the house of Eli that the iniquity of Eli’s house shall not be removed with sacrifice or offering forever.” 
 \p
-\v 15 Samuel lay until the morning, and opened the doors of Yahweh’s house. Samuel was afraid to show Eli the vision. 
+\v 15 Samuel lay until the morning, and opened the doors of Yahuah’s house. Samuel was afraid to show Eli the vision. 
 \v 16 Then Eli called Samuel and said, “Samuel, my son!” 
 \p He said, “Here I am.” 
 \p
 \v 17 He said, “What is the thing that he has spoken to you? Please don’t hide it from me. Elohim do so to you, and more also, if you hide anything from me of all the things that he spoke to you.” 
 \p
 \v 18 Samuel told him every bit, and hid nothing from him. 
-\p He said, “It is Yahweh. Let him do what seems good to him.” 
+\p He said, “It is Yahuah. Let him do what seems good to him.” 
 \p
-\v 19 Samuel grew, and Yahweh was with him and let none of his words fall to the ground. 
-\v 20 All Israel from Dan even to Beersheba knew that Samuel was established to be a prophet of Yahweh. 
-\v 21 Yahweh appeared again in Shiloh; for Yahweh revealed himself to Samuel in Shiloh by Yahweh’s word. 
+\v 19 Samuel grew, and Yahuah was with him and let none of his words fall to the ground. 
+\v 20 All Israel from Dan even to Beersheba knew that Samuel was established to be a prophet of Yahuah. 
+\v 21 Yahuah appeared again in Shiloh; for Yahuah revealed himself to Samuel in Shiloh by Yahuah’s word. 
 \c 4
 \nb
 \v 1 The word of Samuel came to all Israel. 
 \p Now Israel went out against the Philistines to battle, and encamped beside Ebenezer; and the Philistines encamped in Aphek. 
 \v 2 The Philistines put themselves in array against Israel. When they joined battle, Israel was defeated by the Philistines, who killed about four thousand men of the army in the field. 
-\v 3 When the people had come into the camp, the elders of Israel said, “Why has Yahweh defeated us today before the Philistines? Let’s get the ark of Yahweh’s covenant out of Shiloh and bring it to us, that it may come among us and save us out of the hand of our enemies.” 
+\v 3 When the people had come into the camp, the elders of Israel said, “Why has Yahuah defeated us today before the Philistines? Let’s get the ark of Yahuah’s covenant out of Shiloh and bring it to us, that it may come among us and save us out of the hand of our enemies.” 
 \p
-\v 4 So the people sent to Shiloh, and they brought from there the ark of the covenant of Yahweh of Armies, who sits above the cherubim; and the two sons of Eli, Hophni and Phinehas, were there with the ark of the covenant of Elohim. 
-\v 5 When the ark of Yahweh’s covenant came into the camp, all Israel shouted with a great shout, so that the earth resounded. 
-\v 6 When the Philistines heard the noise of the shout, they said, “What does the noise of this great shout in the camp of the Hebrews mean?” They understood that Yahweh’s ark had come into the camp. 
+\v 4 So the people sent to Shiloh, and they brought from there the ark of the covenant of Yahuah of Armies, who sits above the cherubim; and the two sons of Eli, Hophni and Phinehas, were there with the ark of the covenant of Elohim. 
+\v 5 When the ark of Yahuah’s covenant came into the camp, all Israel shouted with a great shout, so that the earth resounded. 
+\v 6 When the Philistines heard the noise of the shout, they said, “What does the noise of this great shout in the camp of the Hebrews mean?” They understood that Yahuah’s ark had come into the camp. 
 \v 7 The Philistines were afraid, for they said, “Elohim has come into the camp.” They said, “Woe to us! For there has not been such a thing before. 
 \v 8 Woe to us! Who shall deliver us out of the hand of these mighty elohims? These are the elohims that struck the Egyptians with all kinds of plagues in the wilderness. 
 \v 9 Be strong and behave like men, O you Philistines, that you not be servants to the Hebrews, as they have been to you. Strengthen yourselves like men, and fight!” 
@@ -197,23 +197,23 @@
 \p
 \v 1 Now the Philistines had taken Elohim’s ark, and they brought it from Ebenezer to Ashdod. 
 \v 2 The Philistines took Elohim’s ark, and brought it into the house of Dagon and set it by Dagon. 
-\v 3 When the people of Ashdod arose early on the next day, behold, Dagon had fallen on his face to the ground before Yahweh’s ark. They took Dagon and set him in his place again. 
-\v 4 When they arose early on the following morning, behold, Dagon had fallen on his face to the ground before Yahweh’s ark; and the head of Dagon and both the palms of his hands were cut off on the threshold. Only Dagon’s torso was intact. 
+\v 3 When the people of Ashdod arose early on the next day, behold, Dagon had fallen on his face to the ground before Yahuah’s ark. They took Dagon and set him in his place again. 
+\v 4 When they arose early on the following morning, behold, Dagon had fallen on his face to the ground before Yahuah’s ark; and the head of Dagon and both the palms of his hands were cut off on the threshold. Only Dagon’s torso was intact. 
 \v 5 Therefore neither the priests of Dagon nor any who come into Dagon’s house step on the threshold of Dagon in Ashdod to this day. 
-\v 6 But Yahweh’s hand was heavy on the people of Ashdod, and he destroyed them and struck them with tumors, even Ashdod and its borders. 
+\v 6 But Yahuah’s hand was heavy on the people of Ashdod, and he destroyed them and struck them with tumors, even Ashdod and its borders. 
 \p
 \v 7 When the men of Ashdod saw that it was so, they said, “The ark of the Elohim of Israel shall not stay with us, for his hand is severe on us and on Dagon our elohim.” 
 \v 8 They sent therefore and gathered together all the lords of the Philistines, and said, “What shall we do with the ark of the Elohim of Israel?” 
 \p They answered, “Let the ark of the Elohim of Israel be carried over to Gath.” They carried the ark of the Elohim of Israel there. 
-\v 9 It was so, that after they had carried it there, Yahweh’s hand was against the city with a very great confusion; and he struck the men of the city, both small and great, so that tumors broke out on them. 
+\v 9 It was so, that after they had carried it there, Yahuah’s hand was against the city with a very great confusion; and he struck the men of the city, both small and great, so that tumors broke out on them. 
 \v 10 So they sent Elohim’s ark to Ekron. 
 \p As Elohim’s ark came to Ekron, the Ekronites cried out, saying, “They have brought the ark of the Elohim of Israel here to us, to kill us and our people.” 
 \v 11 They sent therefore and gathered together all the lords of the Philistines, and they said, “Send the ark of the Elohim of Israel away, and let it go again to its own place, that it not kill us and our people.” For there was a deadly panic throughout all the city. The hand of Elohim was very heavy there. 
 \v 12 The men who didn’t die were struck with the tumors; and the cry of the city went up to heaven. 
 \c 6
 \p
-\v 1 Yahweh’s ark was in the country of the Philistines seven months. 
-\v 2 The Philistines called for the priests and the diviners, saying, “What shall we do with Yahweh’s ark? Show us how we should send it to its place.” 
+\v 1 Yahuah’s ark was in the country of the Philistines seven months. 
+\v 2 The Philistines called for the priests and the diviners, saying, “What shall we do with Yahuah’s ark? Show us how we should send it to its place.” 
 \p
 \v 3 They said, “If you send away the ark of the Elohim of Israel, don’t send it empty; but by all means return a trespass offering to him. Then you will be healed, and it will be known to you why his hand is not removed from you.” 
 \p
@@ -223,45 +223,45 @@
 \v 6 Why then do you harden your hearts as the Egyptians and Pharaoh hardened their hearts? When he had worked wonderfully among them, didn’t they let the people go, and they departed? 
 \p
 \v 7 “Now therefore take and prepare yourselves a new cart and two milk cows on which there has come no yoke; and tie the cows to the cart, and bring their calves home from them; 
-\v 8 and take Yahweh’s ark and lay it on the cart. Put the jewels of gold, which you return him for a trespass offering, in a box by its side; and send it away, that it may go. 
+\v 8 and take Yahuah’s ark and lay it on the cart. Put the jewels of gold, which you return him for a trespass offering, in a box by its side; and send it away, that it may go. 
 \v 9 Behold, if it goes up by the way of its own border to Beth Shemesh, then he has done us this great evil; but if not, then we shall know that it is not his hand that struck us. It was a chance that happened to us.” 
 \p
 \v 10 The men did so, and took two milk cows and tied them to the cart, and shut up their calves at home. 
-\v 11 They put Yahweh’s ark on the cart, and the box with the golden mice and the images of their tumors. 
+\v 11 They put Yahuah’s ark on the cart, and the box with the golden mice and the images of their tumors. 
 \v 12 The cows took the straight way by the way to Beth Shemesh. They went along the highway, lowing as they went, and didn’t turn away to the right hand or to the left; and the lords of the Philistines went after them to the border of Beth Shemesh. 
 \v 13 The people of Beth Shemesh were reaping their wheat harvest in the valley; and they lifted up their eyes and saw the ark, and rejoiced to see it. 
-\v 14 The cart came into the field of Joshua of Beth Shemesh, and stood there, where there was a great stone. Then they split the wood of the cart and offered up the cows for a burnt offering to Yahweh. 
-\v 15 The Levites took down Yahweh’s ark and the box that was with it, in which the jewels of gold were, and put them on the great stone; and the men of Beth Shemesh offered burnt offerings and sacrificed sacrifices the same day to Yahweh. 
+\v 14 The cart came into the field of Joshua of Beth Shemesh, and stood there, where there was a great stone. Then they split the wood of the cart and offered up the cows for a burnt offering to Yahuah. 
+\v 15 The Levites took down Yahuah’s ark and the box that was with it, in which the jewels of gold were, and put them on the great stone; and the men of Beth Shemesh offered burnt offerings and sacrificed sacrifices the same day to Yahuah. 
 \v 16 When the five lords of the Philistines had seen it, they returned to Ekron the same day. 
-\v 17 These are the golden tumors which the Philistines returned for a trespass offering to Yahweh: for Ashdod one, for Gaza one, for Ashkelon one, for Gath one, for Ekron one; 
-\v 18 and the golden mice, according to the number of all the cities of the Philistines belonging to the five lords, both of fortified cities and of country villages, even to the great stone on which they set down Yahweh’s ark. That stone remains to this day in the field of Joshua of Beth Shemesh. 
-\v 19 He struck of the men of Beth Shemesh, because they had looked into Yahweh’s ark, he struck fifty thousand seventy of the men. Then the people mourned, because Yahweh had struck the people with a great slaughter. 
-\v 20 The men of Beth Shemesh said, “Who is able to stand before Yahweh, this set-apart Elohim? To whom shall he go up from us?” 
+\v 17 These are the golden tumors which the Philistines returned for a trespass offering to Yahuah: for Ashdod one, for Gaza one, for Ashkelon one, for Gath one, for Ekron one; 
+\v 18 and the golden mice, according to the number of all the cities of the Philistines belonging to the five lords, both of fortified cities and of country villages, even to the great stone on which they set down Yahuah’s ark. That stone remains to this day in the field of Joshua of Beth Shemesh. 
+\v 19 He struck of the men of Beth Shemesh, because they had looked into Yahuah’s ark, he struck fifty thousand seventy of the men. Then the people mourned, because Yahuah had struck the people with a great slaughter. 
+\v 20 The men of Beth Shemesh said, “Who is able to stand before Yahuah, this set-apart Elohim? To whom shall he go up from us?” 
 \p
-\v 21 They sent messengers to the inhabitants of Kiriath Jearim, saying, “The Philistines have brought back Yahweh’s ark. Come down and bring it up to yourselves.” 
+\v 21 They sent messengers to the inhabitants of Kiriath Jearim, saying, “The Philistines have brought back Yahuah’s ark. Come down and bring it up to yourselves.” 
 \c 7
 \p
-\v 1 The men of Kiriath Jearim came and took Yahweh’s ark, and brought it into Abinadab’s house on the hill, and consecrated Eleazar his son to keep Yahweh’s ark. 
-\v 2 From the day that the ark stayed in Kiriath Jearim, the time was long—for it was twenty years; and all the house of Israel lamented after Yahweh. 
-\v 3 Samuel spoke to all the house of Israel, saying, “If you are returning to Yahweh with all your heart, then put away the foreign elohims and the Ashtaroth from among you, and direct your hearts to Yahweh, and serve him only; and he will deliver you out of the hand of the Philistines.” 
-\v 4 Then the children of Israel removed the Baals and the Ashtaroth, and served Yahweh only. 
-\v 5 Samuel said, “Gather all Israel to Mizpah, and I will pray to Yahweh for you.” 
-\v 6 They gathered together to Mizpah, and drew water, and poured it out before Yahweh, and fasted on that day, and said there, “We have sinned against Yahweh.” Samuel judged the children of Israel in Mizpah. 
+\v 1 The men of Kiriath Jearim came and took Yahuah’s ark, and brought it into Abinadab’s house on the hill, and consecrated Eleazar his son to keep Yahuah’s ark. 
+\v 2 From the day that the ark stayed in Kiriath Jearim, the time was long—for it was twenty years; and all the house of Israel lamented after Yahuah. 
+\v 3 Samuel spoke to all the house of Israel, saying, “If you are returning to Yahuah with all your heart, then put away the foreign elohims and the Ashtaroth from among you, and direct your hearts to Yahuah, and serve him only; and he will deliver you out of the hand of the Philistines.” 
+\v 4 Then the children of Israel removed the Baals and the Ashtaroth, and served Yahuah only. 
+\v 5 Samuel said, “Gather all Israel to Mizpah, and I will pray to Yahuah for you.” 
+\v 6 They gathered together to Mizpah, and drew water, and poured it out before Yahuah, and fasted on that day, and said there, “We have sinned against Yahuah.” Samuel judged the children of Israel in Mizpah. 
 \p
 \v 7 When the Philistines heard that the children of Israel were gathered together at Mizpah, the lords of the Philistines went up against Israel. When the children of Israel heard it, they were afraid of the Philistines. 
-\v 8 The children of Israel said to Samuel, “Don’t stop crying to Yahweh our Elohim for us, that he will save us out of the hand of the Philistines.” 
-\v 9 Samuel took a suckling lamb, and offered it for a whole burnt offering to Yahweh. Samuel cried to Yahweh for Israel, and Yahweh answered him. 
-\v 10 As Samuel was offering up the burnt offering, the Philistines came near to battle against Israel; but Yahweh thundered with a great thunder on that day on the Philistines and confused them; and they were struck down before Israel. 
+\v 8 The children of Israel said to Samuel, “Don’t stop crying to Yahuah our Elohim for us, that he will save us out of the hand of the Philistines.” 
+\v 9 Samuel took a suckling lamb, and offered it for a whole burnt offering to Yahuah. Samuel cried to Yahuah for Israel, and Yahuah answered him. 
+\v 10 As Samuel was offering up the burnt offering, the Philistines came near to battle against Israel; but Yahuah thundered with a great thunder on that day on the Philistines and confused them; and they were struck down before Israel. 
 \v 11 The men of Israel went out of Mizpah and pursued the Philistines, and struck them until they came under Beth Kar. 
 \p
-\v 12 Then Samuel took a stone and set it between Mizpah and Shen, and called its name Ebenezer, saying, “Yahweh helped us until now.” 
-\v 13 So the Philistines were subdued, and they stopped coming within the border of Israel. Yahweh’s hand was against the Philistines all the days of Samuel. 
+\v 12 Then Samuel took a stone and set it between Mizpah and Shen, and called its name Ebenezer, saying, “Yahuah helped us until now.” 
+\v 13 So the Philistines were subdued, and they stopped coming within the border of Israel. Yahuah’s hand was against the Philistines all the days of Samuel. 
 \p
 \v 14 The cities which the Philistines had taken from Israel were restored to Israel, from Ekron even to Gath; and Israel recovered its border out of the hand of the Philistines. There was peace between Israel and the Amorites. 
 \p
 \v 15 Samuel judged Israel all the days of his life. 
 \v 16 He went from year to year in a circuit to Bethel, Gilgal, and Mizpah; and he judged Israel in all those places. 
-\v 17 His return was to Ramah, for his house was there, and he judged Israel there; and he built an altar to Yahweh there. 
+\v 17 His return was to Ramah, for his house was there, and he judged Israel there; and he built an altar to Yahuah there. 
 \c 8
 \p
 \v 1 When Samuel was old, he made his sons judges over Israel. 
@@ -271,12 +271,12 @@
 \v 4 Then all the elders of Israel gathered themselves together and came to Samuel to Ramah. 
 \v 5 They said to him, “Behold, you are old, and your sons don’t walk in your ways. Now make us a king to judge us like all the nations.” 
 \v 6 But the thing displeased Samuel when they said, “Give us a king to judge us.” 
-\p Samuel prayed to Yahweh. 
-\v 7 Yahweh said to Samuel, “Listen to the voice of the people in all that they tell you; for they have not rejected you, but they have rejected me as the king over them. 
+\p Samuel prayed to Yahuah. 
+\v 7 Yahuah said to Samuel, “Listen to the voice of the people in all that they tell you; for they have not rejected you, but they have rejected me as the king over them. 
 \v 8 According to all the works which they have done since the day that I brought them up out of Egypt even to this day, in that they have forsaken me and served other elohims, so they also do to you. 
 \v 9 Now therefore, listen to their voice. However, you shall protest solemnly to them, and shall show them the way of the king who will reign over them.” 
 \p
-\v 10 Samuel told all Yahweh’s words to the people who asked him for a king. 
+\v 10 Samuel told all Yahuah’s words to the people who asked him for a king. 
 \v 11 He said, “This will be the way of the king who shall reign over you: he will take your sons and appoint them as his servants, for his chariots and to be his horsemen; and they will run before his chariots. 
 \v 12 He will appoint them to him for captains of thousands and captains of fifties; and he will assign some to plow his ground and to reap his harvest; and to make his instruments of war and the instruments of his chariots. 
 \v 13 He will take your daughters to be perfumers, to be cooks, and to be bakers. 
@@ -284,13 +284,13 @@
 \v 15 He will take one tenth of your seed and of your vineyards, and give it to his officers and to his servants. 
 \v 16 He will take your male servants, your female servants, your best young men, and your donkeys, and assign them to his own work. 
 \v 17 He will take one tenth of your flocks; and you will be his servants. 
-\v 18 You will cry out in that day because of your king whom you will have chosen for yourselves; and Yahweh will not answer you in that day.” 
+\v 18 You will cry out in that day because of your king whom you will have chosen for yourselves; and Yahuah will not answer you in that day.” 
 \p
 \v 19 But the people refused to listen to the voice of Samuel; and they said, “No, but we will have a king over us, 
 \v 20 that we also may be like all the nations; and that our king may judge us, and go out before us, and fight our battles.” 
 \p
-\v 21 Samuel heard all the words of the people, and he rehearsed them in the ears of Yahweh. 
-\v 22 Yahweh said to Samuel, “Listen to their voice, and make them a king.” 
+\v 21 Samuel heard all the words of the people, and he rehearsed them in the ears of Yahuah. 
+\v 22 Yahuah said to Samuel, “Listen to their voice, and make them a king.” 
 \p Samuel said to the men of Israel, “Everyone go to your own city.” 
 \c 9
 \p
@@ -317,10 +317,10 @@
 \p
 \v 14 They went up to the city. As they came within the city, behold, Samuel came out toward them to go up to the high place. 
 \p
-\v 15 Now Yahweh had revealed to Samuel a day before Saul came, saying, 
+\v 15 Now Yahuah had revealed to Samuel a day before Saul came, saying, 
 \v 16 “Tomorrow about this time I will send you a man out of the land of Benjamin, and you shall anoint him to be prince over my people Israel. He will save my people out of the hand of the Philistines; for I have looked upon my people, because their cry has come to me.” 
 \p
-\v 17 When Samuel saw Saul, Yahweh said to him, “Behold, the man of whom I spoke to you! He will have authority over my people.” 
+\v 17 When Samuel saw Saul, Yahuah said to him, “Behold, the man of whom I spoke to you! He will have authority over my people.” 
 \p
 \v 18 Then Saul approached Samuel in the gateway, and said, “Please tell me where the seer’s house is.” 
 \p
@@ -338,14 +338,14 @@
 \v 27 As they were going down at the end of the city, Samuel said to Saul, “Tell the servant to go on ahead of us.” He went ahead, then Samuel said, “But stand still first, that I may cause you to hear Elohim’s message.” 
 \c 10
 \p
-\v 1 Then Samuel took the vial of oil and poured it on his head, then kissed him and said, “Hasn’t Yahweh anointed you to be prince over his inheritance? 
+\v 1 Then Samuel took the vial of oil and poured it on his head, then kissed him and said, “Hasn’t Yahuah anointed you to be prince over his inheritance? 
 \v 2 When you have departed from me today, then you will find two men by Rachel’s tomb, on the border of Benjamin at Zelzah. They will tell you, ‘The donkeys which you went to look for have been found; and behold, your father has stopped caring about the donkeys and is anxious for you, saying, “What shall I do for my son?” ’ 
 \p
 \v 3 “Then you will go on forward from there, and you will come to the oak of Tabor. Three men will meet you there going up to Elohim to Bethel: one carrying three young goats, and another carrying three loaves of bread, and another carrying a container of wine. 
 \v 4 They will greet you and give you two loaves of bread, which you shall receive from their hand. 
 \p
 \v 5 “After that you will come to the hill of Elohim, where the garrison of the Philistines is; and it will happen, when you have come there to the city, that you will meet a band of prophets coming down from the high place with a lute, a tambourine, a pipe, and a harp before them; and they will be prophesying. 
-\v 6 Then Yahweh’s Spirit will come mightily on you, then you will prophesy with them and will be turned into another man. 
+\v 6 Then Yahuah’s Spirit will come mightily on you, then you will prophesy with them and will be turned into another man. 
 \v 7 Let it be, when these signs have come to you, that you do what is appropriate for the occasion; for Elohim is with you. 
 \p
 \v 8 “Go down ahead of me to Gilgal; and behold, I will come down to you to offer burnt offerings and to sacrifice sacrifices of peace offerings. Wait seven days, until I come to you and show you what you are to do.” 
@@ -363,20 +363,20 @@
 \p
 \v 16 Saul said to his uncle, “He told us plainly that the donkeys were found.” But concerning the matter of the kingdom, of which Samuel spoke, he didn’t tell him. 
 \p
-\v 17 Samuel called the people together to Yahweh to Mizpah; 
-\v 18 and he said to the children of Israel, “Yahweh, the Elohim of Israel, says ‘I brought Israel up out of Egypt and I delivered you out of the hand of the Egyptians, and out of the hand of all the kingdoms that oppressed you.’ 
-\v 19 But you have today rejected your Elohim, who himself saves you out of all your calamities and your distresses; and you have said to him, ‘No! Set a king over us!’ Now therefore present yourselves before Yahweh by your tribes and by your thousands.” 
+\v 17 Samuel called the people together to Yahuah to Mizpah; 
+\v 18 and he said to the children of Israel, “Yahuah, the Elohim of Israel, says ‘I brought Israel up out of Egypt and I delivered you out of the hand of the Egyptians, and out of the hand of all the kingdoms that oppressed you.’ 
+\v 19 But you have today rejected your Elohim, who himself saves you out of all your calamities and your distresses; and you have said to him, ‘No! Set a king over us!’ Now therefore present yourselves before Yahuah by your tribes and by your thousands.” 
 \p
 \v 20 So Samuel brought all the tribes of Israel near, and the tribe of Benjamin was chosen. 
 \v 21 He brought the tribe of Benjamin near by their families and the family of the Matrites was chosen. Then Saul the son of Kish was chosen; but when they looked for him, he could not be found. 
-\v 22 Therefore they asked of Yahweh further, “Is there yet a man to come here?” 
-\p Yahweh answered, “Behold, he has hidden himself among the baggage.” 
+\v 22 Therefore they asked of Yahuah further, “Is there yet a man to come here?” 
+\p Yahuah answered, “Behold, he has hidden himself among the baggage.” 
 \p
 \v 23 They ran and got him there. When he stood among the people, he was higher than any of the people from his shoulders and upward. 
-\v 24 Samuel said to all the people, “Do you see him whom Yahweh has chosen, that there is no one like him among all the people?” 
+\v 24 Samuel said to all the people, “Do you see him whom Yahuah has chosen, that there is no one like him among all the people?” 
 \p All the people shouted and said, “Long live the king!” 
 \p
-\v 25 Then Samuel told the people the regulations of the kingdom, and wrote it in a book and laid it up before Yahweh. Samuel sent all the people away, every man to his house. 
+\v 25 Then Samuel told the people the regulations of the kingdom, and wrote it in a book and laid it up before Yahuah. Samuel sent all the people away, every man to his house. 
 \v 26 Saul also went to his house in Gibeah; and the army went with him, whose hearts Elohim had touched. 
 \v 27 But certain worthless fellows said, “How could this man save us?” They despised him, and brought him no tribute. But he held his peace. 
 \c 11
@@ -390,7 +390,7 @@
 \p
 \v 5 Behold, Saul came following the oxen out of the field; and Saul said, “What ails the people that they weep?” They told him the words of the men of Jabesh. 
 \v 6 Elohim’s Spirit came mightily on Saul when he heard those words, and his anger burned hot. 
-\v 7 He took a yoke of oxen and cut them in pieces, then sent them throughout all the borders of Israel by the hand of messengers, saying, “Whoever doesn’t come out after Saul and after Samuel, so shall it be done to his oxen.” The dread of Yahweh fell on the people, and they came out as one man. 
+\v 7 He took a yoke of oxen and cut them in pieces, then sent them throughout all the borders of Israel by the hand of messengers, saying, “Whoever doesn’t come out after Saul and after Samuel, so shall it be done to his oxen.” The dread of Yahuah fell on the people, and they came out as one man. 
 \v 8 He counted them in Bezek; and the children of Israel were three hundred thousand, and the men of Judah thirty thousand. 
 \v 9 They said to the messengers who came, “Tell the men of Jabesh Gilead, ‘Tomorrow, by the time the sun is hot, you will be rescued.’ ” The messengers came and told the men of Jabesh; and they were glad. 
 \v 10 Therefore the men of Jabesh said, “Tomorrow we will come out to you, and you shall do with us all that seems good to you.” 
@@ -398,45 +398,45 @@
 \p
 \v 12 The people said to Samuel, “Who is he who said, ‘Shall Saul reign over us?’ Bring those men, that we may put them to death!” 
 \p
-\v 13 Saul said, “No man shall be put to death today; for today Yahweh has rescued Israel.” 
+\v 13 Saul said, “No man shall be put to death today; for today Yahuah has rescued Israel.” 
 \p
 \v 14 Then Samuel said to the people, “Come! Let’s go to Gilgal, and renew the kingdom there.” 
-\v 15 All the people went to Gilgal; and there they made Saul king before Yahweh in Gilgal. There they offered sacrifices of peace offerings before Yahweh; and there Saul and all the men of Israel rejoiced greatly. 
+\v 15 All the people went to Gilgal; and there they made Saul king before Yahuah in Gilgal. There they offered sacrifices of peace offerings before Yahuah; and there Saul and all the men of Israel rejoiced greatly. 
 \c 12
 \p
 \v 1 Samuel said to all Israel, “Behold, I have listened to your voice in all that you said to me, and have made a king over you. 
 \v 2 Now, behold, the king walks before you. I am old and gray-headed. Behold, my sons are with you. I have walked before you from my youth to this day. 
-\v 3 Here I am. Witness against me before Yahweh and before his anointed. Whose ox have I taken? Whose donkey have I taken? Whom have I defrauded? Whom have I oppressed? Of whose hand have I taken a bribe to make me blind my eyes? I will restore it to you.” 
+\v 3 Here I am. Witness against me before Yahuah and before his anointed. Whose ox have I taken? Whose donkey have I taken? Whom have I defrauded? Whom have I oppressed? Of whose hand have I taken a bribe to make me blind my eyes? I will restore it to you.” 
 \p
 \v 4 They said, “You have not defrauded us, nor oppressed us, neither have you taken anything from anyone’s hand.” 
 \p
-\v 5 He said to them, “Yahweh is witness against you, and his anointed is witness today, that you have not found anything in my hand.” 
+\v 5 He said to them, “Yahuah is witness against you, and his anointed is witness today, that you have not found anything in my hand.” 
 \p They said, “He is witness.” 
-\v 6 Samuel said to the people, “It is Yahweh who appointed Moses and Aaron, and that brought your fathers up out of the land of Egypt. 
-\v 7 Now therefore stand still, that I may plead with you before Yahweh concerning all the righteous acts of Yahweh, which he did to you and to your fathers. 
+\v 6 Samuel said to the people, “It is Yahuah who appointed Moses and Aaron, and that brought your fathers up out of the land of Egypt. 
+\v 7 Now therefore stand still, that I may plead with you before Yahuah concerning all the righteous acts of Yahuah, which he did to you and to your fathers. 
 \p
-\v 8 “When Jacob had come into Egypt, and your fathers cried to Yahweh, then Yahweh sent Moses and Aaron, who brought your fathers out of Egypt, and made them to dwell in this place. 
-\v 9 But they forgot Yahweh their Elohim; and he sold them into the hand of Sisera, captain of the army of Hazor, and into the hand of the Philistines, and into the hand of the king of Moab; and they fought against them. 
-\v 10 They cried to Yahweh, and said, ‘We have sinned, because we have forsaken Yahweh and have served the Baals and the Ashtaroth; but now deliver us out of the hand of our enemies, and we will serve you.’ 
-\v 11 Yahweh sent Jerubbaal, Bedan, Jephthah, and Samuel, and delivered you out of the hand of your enemies on every side; and you lived in safety. 
+\v 8 “When Jacob had come into Egypt, and your fathers cried to Yahuah, then Yahuah sent Moses and Aaron, who brought your fathers out of Egypt, and made them to dwell in this place. 
+\v 9 But they forgot Yahuah their Elohim; and he sold them into the hand of Sisera, captain of the army of Hazor, and into the hand of the Philistines, and into the hand of the king of Moab; and they fought against them. 
+\v 10 They cried to Yahuah, and said, ‘We have sinned, because we have forsaken Yahuah and have served the Baals and the Ashtaroth; but now deliver us out of the hand of our enemies, and we will serve you.’ 
+\v 11 Yahuah sent Jerubbaal, Bedan, Jephthah, and Samuel, and delivered you out of the hand of your enemies on every side; and you lived in safety. 
 \p
-\v 12 “When you saw that Nahash the king of the children of Ammon came against you, you said to me, ‘No, but a king shall reign over us,’ when Yahweh your Elohim was your king. 
-\v 13 Now therefore see the king whom you have chosen and whom you have asked for. Behold, Yahweh has set a king over you. 
-\v 14 If you will fear Yahweh, and serve him, and listen to his voice, and not rebel against the commandment of Yahweh, then both you and also the king who reigns over you are followers of Yahweh your Elohim. 
-\v 15 But if you will not listen to Yahweh’s voice, but rebel against the commandment of Yahweh, then Yahweh’s hand will be against you, as it was against your fathers. 
+\v 12 “When you saw that Nahash the king of the children of Ammon came against you, you said to me, ‘No, but a king shall reign over us,’ when Yahuah your Elohim was your king. 
+\v 13 Now therefore see the king whom you have chosen and whom you have asked for. Behold, Yahuah has set a king over you. 
+\v 14 If you will fear Yahuah, and serve him, and listen to his voice, and not rebel against the commandment of Yahuah, then both you and also the king who reigns over you are followers of Yahuah your Elohim. 
+\v 15 But if you will not listen to Yahuah’s voice, but rebel against the commandment of Yahuah, then Yahuah’s hand will be against you, as it was against your fathers. 
 \p
-\v 16 “Now therefore stand still and see this great thing, which Yahweh will do before your eyes. 
-\v 17 Isn’t it wheat harvest today? I will call to Yahweh, that he may send thunder and rain; and you will know and see that your wickedness is great, which you have done in Yahweh’s sight, in asking for a king.” 
+\v 16 “Now therefore stand still and see this great thing, which Yahuah will do before your eyes. 
+\v 17 Isn’t it wheat harvest today? I will call to Yahuah, that he may send thunder and rain; and you will know and see that your wickedness is great, which you have done in Yahuah’s sight, in asking for a king.” 
 \p
-\v 18 So Samuel called to Yahweh, and Yahweh sent thunder and rain that day. Then all the people greatly feared Yahweh and Samuel. 
+\v 18 So Samuel called to Yahuah, and Yahuah sent thunder and rain that day. Then all the people greatly feared Yahuah and Samuel. 
 \p
-\v 19 All the people said to Samuel, “Pray for your servants to Yahweh your Elohim, that we not die; for we have added to all our sins this evil, to ask for a king.” 
+\v 19 All the people said to Samuel, “Pray for your servants to Yahuah your Elohim, that we not die; for we have added to all our sins this evil, to ask for a king.” 
 \p
-\v 20 Samuel said to the people, “Don’t be afraid. You have indeed done all this evil; yet don’t turn away from following Yahweh, but serve Yahweh with all your heart. 
+\v 20 Samuel said to the people, “Don’t be afraid. You have indeed done all this evil; yet don’t turn away from following Yahuah, but serve Yahuah with all your heart. 
 \v 21 Don’t turn away to go after vain things which can’t profit or deliver, for they are vain. 
-\v 22 For Yahweh will not forsake his people for his great name’s sake, because it has pleased Yahweh to make you a people for himself. 
-\v 23 Moreover, as for me, far be it from me that I should sin against Yahweh in ceasing to pray for you; but I will instruct you in the good and the right way. 
-\v 24 Only fear Yahweh, and serve him in truth with all your heart; for consider what great things he has done for you. 
+\v 22 For Yahuah will not forsake his people for his great name’s sake, because it has pleased Yahuah to make you a people for himself. 
+\v 23 Moreover, as for me, far be it from me that I should sin against Yahuah in ceasing to pray for you; but I will instruct you in the good and the right way. 
+\v 24 Only fear Yahuah, and serve him in truth with all your heart; for consider what great things he has done for you. 
 \v 25 But if you keep doing evil, you will be consumed, both you and your king.” 
 \c 13
 \p
@@ -454,10 +454,10 @@
 \v 10 It came to pass that as soon as he had finished offering the burnt offering, behold, Samuel came; and Saul went out to meet him, that he might greet him. 
 \v 11 Samuel said, “What have you done?” 
 \p Saul said, “Because I saw that the people were scattered from me, and that you didn’t come within the days appointed, and that the Philistines assembled themselves together at Michmash, 
-\v 12 therefore I said, ‘Now the Philistines will come down on me to Gilgal, and I haven’t entreated the favor of Yahweh.’ I forced myself therefore, and offered the burnt offering.” 
+\v 12 therefore I said, ‘Now the Philistines will come down on me to Gilgal, and I haven’t entreated the favor of Yahuah.’ I forced myself therefore, and offered the burnt offering.” 
 \p
-\v 13 Samuel said to Saul, “You have done foolishly. You have not kept the commandment of Yahweh your Elohim, which he commanded you; for now Yahweh would have established your kingdom on Israel forever. 
-\v 14 But now your kingdom will not continue. Yahweh has sought for himself a man after his own heart, and Yahweh has appointed him to be prince over his people, because you have not kept that which Yahweh commanded you.” 
+\v 13 Samuel said to Saul, “You have done foolishly. You have not kept the commandment of Yahuah your Elohim, which he commanded you; for now Yahuah would have established your kingdom on Israel forever. 
+\v 14 But now your kingdom will not continue. Yahuah has sought for himself a man after his own heart, and Yahuah has appointed him to be prince over his people, because you have not kept that which Yahuah commanded you.” 
 \p
 \v 15 Samuel arose, and went from Gilgal to Gibeah of Benjamin. Saul counted the people who were present with him, about six hundred men. 
 \v 16 Saul, and Jonathan his son, and the people who were present with them, stayed in Geba of Benjamin; but the Philistines encamped in Michmash. 
@@ -473,21 +473,21 @@
 \p
 \v 1 Now it happened on a day that Jonathan the son of Saul said to the young man who bore his armor, “Come! Let’s go over to the Philistines’ garrison that is on the other side.” But he didn’t tell his father. 
 \v 2 Saul stayed in the uttermost part of Gibeah under the pomegranate tree which is in Migron; and the people who were with him were about six hundred men, 
-\v 3 including Ahijah the son of Ahitub, Ichabod’s brother, the son of Phinehas, the son of Eli the priest of Yahweh in Shiloh, wearing an ephod. The people didn’t know that Jonathan was gone. 
+\v 3 including Ahijah the son of Ahitub, Ichabod’s brother, the son of Phinehas, the son of Eli the priest of Yahuah in Shiloh, wearing an ephod. The people didn’t know that Jonathan was gone. 
 \p
 \v 4 Between the passes, by which Jonathan sought to go over to the Philistines’ garrison, there was a rocky crag on the one side and a rocky crag on the other side; and the name of the one was Bozez, and the name of the other Seneh. 
 \v 5 The one crag rose up on the north in front of Michmash, and the other on the south in front of Geba. 
-\v 6 Jonathan said to the young man who bore his armor, “Come! Let’s go over to the garrison of these uncircumcised. It may be that Yahweh will work for us, for there is no restraint on Yahweh to save by many or by few.” 
+\v 6 Jonathan said to the young man who bore his armor, “Come! Let’s go over to the garrison of these uncircumcised. It may be that Yahuah will work for us, for there is no restraint on Yahuah to save by many or by few.” 
 \p
 \v 7 His armor bearer said to him, “Do all that is in your heart. Go, and behold, I am with you according to your heart.” 
 \p
 \v 8 Then Jonathan said, “Behold, we will pass over to the men, and we will reveal ourselves to them. 
 \v 9 If they say this to us, ‘Wait until we come to you!’ then we will stand still in our place and will not go up to them. 
-\v 10 But if they say this, ‘Come up to us!’ then we will go up, for Yahweh has delivered them into our hand. This shall be the sign to us.” 
+\v 10 But if they say this, ‘Come up to us!’ then we will go up, for Yahuah has delivered them into our hand. This shall be the sign to us.” 
 \p
 \v 11 Both of them revealed themselves to the garrison of the Philistines; and the Philistines said, “Behold, the Hebrews are coming out of the holes where they had hidden themselves!” 
 \v 12 The men of the garrison answered Jonathan and his armor bearer, and said, “Come up to us, and we will show you something!” 
-\p Jonathan said to his armor bearer, “Come up after me, for Yahweh has delivered them into the hand of Israel.” 
+\p Jonathan said to his armor bearer, “Come up after me, for Yahuah has delivered them into the hand of Israel.” 
 \v 13 Jonathan climbed up on his hands and on his feet, and his armor bearer after him, and they fell before Jonathan; and his armor bearer killed them after him. 
 \v 14 That first slaughter, which Jonathan and his armor bearer made, was about twenty men, within as it were half a furrow’s length in an acre of land. 
 \p
@@ -501,7 +501,7 @@
 \v 20 Saul and all the people who were with him were gathered together, and came to the battle; and behold, they were all striking each other with their swords in very great confusion. 
 \v 21 Now the Hebrews who were with the Philistines before and who went up with them into the camp from all around, even they also turned to be with the Israelites who were with Saul and Jonathan. 
 \v 22 Likewise all the men of Israel who had hidden themselves in the hill country of Ephraim, when they heard that the Philistines fled, even they also followed hard after them in the battle. 
-\v 23 So Yahweh saved Israel that day; and the battle passed over by Beth Aven. 
+\v 23 So Yahuah saved Israel that day; and the battle passed over by Beth Aven. 
 \p
 \v 24 The men of Israel were distressed that day; for Saul had adjured the people, saying, “Cursed is the man who eats any food until it is evening, and I am avenged of my enemies.” So none of the people tasted food. 
 \p
@@ -514,22 +514,22 @@
 \v 30 How much more, if perhaps the people had eaten freely today of the plunder of their enemies which they found? For now there has been no great slaughter among the Philistines.” 
 \v 31 They struck the Philistines that day from Michmash to Aijalon. The people were very faint; 
 \v 32 and the people pounced on the plunder, and took sheep, cattle, and calves, and killed them on the ground; and the people ate them with the blood. 
-\v 33 Then they told Saul, saying, “Behold, the people are sinning against Yahweh, in that they eat meat with the blood.” 
+\v 33 Then they told Saul, saying, “Behold, the people are sinning against Yahuah, in that they eat meat with the blood.” 
 \p He said, “You have dealt treacherously. Roll a large stone to me today!” 
-\v 34 Saul said, “Disperse yourselves among the people, and tell them, ‘Every man bring me here his ox, and every man his sheep, and kill them here, and eat; and don’t sin against Yahweh in eating meat with the blood.’ ” All the people brought every man his ox with him that night, and killed them there. 
+\v 34 Saul said, “Disperse yourselves among the people, and tell them, ‘Every man bring me here his ox, and every man his sheep, and kill them here, and eat; and don’t sin against Yahuah in eating meat with the blood.’ ” All the people brought every man his ox with him that night, and killed them there. 
 \p
-\v 35 Saul built an altar to Yahweh. This was the first altar that he built to Yahweh. 
+\v 35 Saul built an altar to Yahuah. This was the first altar that he built to Yahuah. 
 \v 36 Saul said, “Let’s go down after the Philistines by night, and take plunder among them until the morning light. Let’s not leave a man of them.” 
 \p They said, “Do whatever seems good to you.” 
 \p Then the priest said, “Let’s draw near here to Elohim.” 
 \p
 \v 37 Saul asked counsel of Elohim: “Shall I go down after the Philistines? Will you deliver them into the hand of Israel?” But he didn’t answer him that day. 
 \v 38 Saul said, “Draw near here, all you chiefs of the people, and know and see in whom this sin has been today. 
-\v 39 For as Yahweh lives, who saves Israel, though it is in Jonathan my son, he shall surely die.” But there was not a man among all the people who answered him. 
+\v 39 For as Yahuah lives, who saves Israel, though it is in Jonathan my son, he shall surely die.” But there was not a man among all the people who answered him. 
 \v 40 Then he said to all Israel, “You be on one side, and I and Jonathan my son will be on the other side.” 
 \p The people said to Saul, “Do what seems good to you.” 
 \p
-\v 41 Therefore Saul said to Yahweh, the Elohim of Israel, “Show the right.” 
+\v 41 Therefore Saul said to Yahuah, the Elohim of Israel, “Show the right.” 
 \p Jonathan and Saul were chosen, but the people escaped. 
 \p
 \v 42 Saul said, “Cast lots between me and Jonathan my son.” 
@@ -540,7 +540,7 @@
 \p
 \v 44 Saul said, “Elohim do so and more also; for you shall surely die, Jonathan.” 
 \p
-\v 45 The people said to Saul, “Shall Jonathan die, who has worked this great salvation in Israel? Far from it! As Yahweh lives, there shall not one hair of his head fall to the ground, for he has worked with Elohim today!” So the people rescued Jonathan, so he didn’t die. 
+\v 45 The people said to Saul, “Shall Jonathan die, who has worked this great salvation in Israel? Far from it! As Yahuah lives, there shall not one hair of his head fall to the ground, for he has worked with Elohim today!” So the people rescued Jonathan, so he didn’t die. 
 \v 46 Then Saul went up from following the Philistines; and the Philistines went to their own place. 
 \p
 \v 47 Now when Saul had taken the kingdom over Israel, he fought against all his enemies on every side: against Moab, and against the children of Ammon, and against Edom, and against the kings of Zobah, and against the Philistines. Wherever he turned himself, he defeated them. 
@@ -552,8 +552,8 @@
 \v 52 There was severe war against the Philistines all the days of Saul; and when Saul saw any mighty man or any valiant man, he took him into his service. 
 \c 15
 \p
-\v 1 Samuel said to Saul, “Yahweh sent me to anoint you to be king over his people, over Israel. Now therefore listen to the voice of Yahweh’s words. 
-\v 2 Yahweh of Armies says, ‘I remember what Amalek did to Israel, how he set himself against him on the way when he came up out of Egypt. 
+\v 1 Samuel said to Saul, “Yahuah sent me to anoint you to be king over his people, over Israel. Now therefore listen to the voice of Yahuah’s words. 
+\v 2 Yahuah of Armies says, ‘I remember what Amalek did to Israel, how he set himself against him on the way when he came up out of Egypt. 
 \v 3 Now go and strike Amalek, and utterly destroy all that they have, and don’t spare them; but kill both man and woman, infant and nursing baby, ox and sheep, camel and donkey.’ ” 
 \p
 \v 4 Saul summoned the people, and counted them in Telaim, two hundred thousand footmen and ten thousand men of Judah. 
@@ -564,80 +564,80 @@
 \v 8 He took Agag the king of the Amalekites alive, and utterly destroyed all the people with the edge of the sword. 
 \v 9 But Saul and the people spared Agag and the best of the sheep, of the cattle, of the fat calves, of the lambs, and all that was good, and were not willing to utterly destroy them; but everything that was vile and refuse, that they destroyed utterly. 
 \p
-\v 10 Then Yahweh’s word came to Samuel, saying, 
-\v 11 “It grieves me that I have set up Saul to be king, for he has turned back from following me, and has not performed my commandments.” Samuel was angry; and he cried to Yahweh all night. 
+\v 10 Then Yahuah’s word came to Samuel, saying, 
+\v 11 “It grieves me that I have set up Saul to be king, for he has turned back from following me, and has not performed my commandments.” Samuel was angry; and he cried to Yahuah all night. 
 \p
 \v 12 Samuel rose early to meet Saul in the morning; and Samuel was told, saying, “Saul came to Carmel, and behold, he set up a monument for himself, turned, passed on, and went down to Gilgal.” 
 \p
-\v 13 Samuel came to Saul; and Saul said to him, “You are blessed by Yahweh! I have performed the commandment of Yahweh.” 
+\v 13 Samuel came to Saul; and Saul said to him, “You are blessed by Yahuah! I have performed the commandment of Yahuah.” 
 \p
 \v 14 Samuel said, “Then what does this bleating of the sheep in my ears and the lowing of the cattle which I hear mean?” 
 \p
-\v 15 Saul said, “They have brought them from the Amalekites; for the people spared the best of the sheep and of the cattle, to sacrifice to Yahweh your Elohim. We have utterly destroyed the rest.” 
+\v 15 Saul said, “They have brought them from the Amalekites; for the people spared the best of the sheep and of the cattle, to sacrifice to Yahuah your Elohim. We have utterly destroyed the rest.” 
 \p
-\v 16 Then Samuel said to Saul, “Stay, and I will tell you what Yahweh said to me last night.” 
+\v 16 Then Samuel said to Saul, “Stay, and I will tell you what Yahuah said to me last night.” 
 \p He said to him, “Say on.” 
 \p
-\v 17 Samuel said, “Though you were little in your own sight, weren’t you made the head of the tribes of Israel? Yahweh anointed you king over Israel; 
-\v 18 and Yahweh sent you on a journey, and said, ‘Go, and utterly destroy the sinners the Amalekites, and fight against them until they are consumed.’ 
-\v 19 Why then didn’t you obey Yahweh’s voice, but took the plunder, and did that which was evil in Yahweh’s sight?” 
+\v 17 Samuel said, “Though you were little in your own sight, weren’t you made the head of the tribes of Israel? Yahuah anointed you king over Israel; 
+\v 18 and Yahuah sent you on a journey, and said, ‘Go, and utterly destroy the sinners the Amalekites, and fight against them until they are consumed.’ 
+\v 19 Why then didn’t you obey Yahuah’s voice, but took the plunder, and did that which was evil in Yahuah’s sight?” 
 \p
-\v 20 Saul said to Samuel, “But I have obeyed Yahweh’s voice, and have gone the way which Yahweh sent me, and have brought Agag the king of Amalek, and have utterly destroyed the Amalekites. 
-\v 21 But the people took of the plunder, sheep and cattle, the best of the devoted things, to sacrifice to Yahweh your Elohim in Gilgal.” 
+\v 20 Saul said to Samuel, “But I have obeyed Yahuah’s voice, and have gone the way which Yahuah sent me, and have brought Agag the king of Amalek, and have utterly destroyed the Amalekites. 
+\v 21 But the people took of the plunder, sheep and cattle, the best of the devoted things, to sacrifice to Yahuah your Elohim in Gilgal.” 
 \p
-\v 22 Samuel said, “Has Yahweh as great delight in burnt offerings and sacrifices, as in obeying Yahweh’s voice? Behold, to obey is better than sacrifice, and to listen than the fat of rams. 
-\v 23 For rebellion is as the sin of witchcraft, and stubbornness is as idolatry and teraphim. Because you have rejected Yahweh’s word, he has also rejected you from being king.” 
+\v 22 Samuel said, “Has Yahuah as great delight in burnt offerings and sacrifices, as in obeying Yahuah’s voice? Behold, to obey is better than sacrifice, and to listen than the fat of rams. 
+\v 23 For rebellion is as the sin of witchcraft, and stubbornness is as idolatry and teraphim. Because you have rejected Yahuah’s word, he has also rejected you from being king.” 
 \p
-\v 24 Saul said to Samuel, “I have sinned; for I have transgressed the commandment of Yahweh and your words, because I feared the people and obeyed their voice. 
-\v 25 Now therefore, please pardon my sin, and turn again with me, that I may worship Yahweh.” 
+\v 24 Saul said to Samuel, “I have sinned; for I have transgressed the commandment of Yahuah and your words, because I feared the people and obeyed their voice. 
+\v 25 Now therefore, please pardon my sin, and turn again with me, that I may worship Yahuah.” 
 \p
-\v 26 Samuel said to Saul, “I will not return with you; for you have rejected Yahweh’s word, and Yahweh has rejected you from being king over Israel.” 
+\v 26 Samuel said to Saul, “I will not return with you; for you have rejected Yahuah’s word, and Yahuah has rejected you from being king over Israel.” 
 \v 27 As Samuel turned around to go away, Saul grabbed the skirt of his robe, and it tore. 
-\v 28 Samuel said to him, “Yahweh has torn the kingdom of Israel from you today, and has given it to a neighbor of yours who is better than you. 
+\v 28 Samuel said to him, “Yahuah has torn the kingdom of Israel from you today, and has given it to a neighbor of yours who is better than you. 
 \v 29 Also the Strength of Israel will not lie nor repent; for he is not a man, that he should repent.” 
 \p
-\v 30 Then he said, “I have sinned; yet please honor me now before the elders of my people and before Israel, and come back with me, that I may worship Yahweh your Elohim.” 
+\v 30 Then he said, “I have sinned; yet please honor me now before the elders of my people and before Israel, and come back with me, that I may worship Yahuah your Elohim.” 
 \p
-\v 31 So Samuel went back with Saul; and Saul worshiped Yahweh. 
+\v 31 So Samuel went back with Saul; and Saul worshiped Yahuah. 
 \v 32 Then Samuel said, “Bring Agag the king of the Amalekites here to me!” 
 \p Agag came to him cheerfully. Agag said, “Surely the bitterness of death is past.” 
 \p
-\v 33 Samuel said, “As your sword has made women childless, so your mother will be childless among women!” Then Samuel cut Agag in pieces before Yahweh in Gilgal. 
+\v 33 Samuel said, “As your sword has made women childless, so your mother will be childless among women!” Then Samuel cut Agag in pieces before Yahuah in Gilgal. 
 \p
 \v 34 Then Samuel went to Ramah; and Saul went up to his house to Gibeah of Saul. 
-\v 35 Samuel came no more to see Saul until the day of his death, but Samuel mourned for Saul. Yahweh grieved that he had made Saul king over Israel. 
+\v 35 Samuel came no more to see Saul until the day of his death, but Samuel mourned for Saul. Yahuah grieved that he had made Saul king over Israel. 
 \c 16
 \p
-\v 1 Yahweh said to Samuel, “How long will you mourn for Saul, since I have rejected him from being king over Israel? Fill your horn with oil, and go. I will send you to Jesse the Bethlehemite, for I have provided a king for myself among his sons.” 
+\v 1 Yahuah said to Samuel, “How long will you mourn for Saul, since I have rejected him from being king over Israel? Fill your horn with oil, and go. I will send you to Jesse the Bethlehemite, for I have provided a king for myself among his sons.” 
 \p
 \v 2 Samuel said, “How can I go? If Saul hears it, he will kill me.” 
-\p Yahweh said, “Take a heifer with you, and say, ‘I have come to sacrifice to Yahweh.’ 
+\p Yahuah said, “Take a heifer with you, and say, ‘I have come to sacrifice to Yahuah.’ 
 \v 3 Call Jesse to the sacrifice, and I will show you what you shall do. You shall anoint to me him whom I name to you.” 
 \p
-\v 4 Samuel did that which Yahweh spoke, and came to Bethlehem. The elders of the city came to meet him trembling, and said, “Do you come peaceably?” 
+\v 4 Samuel did that which Yahuah spoke, and came to Bethlehem. The elders of the city came to meet him trembling, and said, “Do you come peaceably?” 
 \p
-\v 5 He said, “Peaceably; I have come to sacrifice to Yahweh. Sanctify yourselves, and come with me to the sacrifice.” He sanctified Jesse and his sons, and called them to the sacrifice. 
-\v 6 When they had come, he looked at Eliab, and said, “Surely Yahweh’s anointed is before him.” 
+\v 5 He said, “Peaceably; I have come to sacrifice to Yahuah. Sanctify yourselves, and come with me to the sacrifice.” He sanctified Jesse and his sons, and called them to the sacrifice. 
+\v 6 When they had come, he looked at Eliab, and said, “Surely Yahuah’s anointed is before him.” 
 \p
-\v 7 But Yahweh said to Samuel, “Don’t look on his face, or on the height of his stature, because I have rejected him; for I don’t see as man sees. For man looks at the outward appearance, but Yahweh looks at the heart.” 
+\v 7 But Yahuah said to Samuel, “Don’t look on his face, or on the height of his stature, because I have rejected him; for I don’t see as man sees. For man looks at the outward appearance, but Yahuah looks at the heart.” 
 \p
-\v 8 Then Jesse called Abinadab, and made him pass before Samuel. He said, “Yahweh has not chosen this one, either.” 
-\v 9 Then Jesse made Shammah to pass by. He said, “Yahweh has not chosen this one, either.” 
-\v 10 Jesse made seven of his sons to pass before Samuel. Samuel said to Jesse, “Yahweh has not chosen these.” 
+\v 8 Then Jesse called Abinadab, and made him pass before Samuel. He said, “Yahuah has not chosen this one, either.” 
+\v 9 Then Jesse made Shammah to pass by. He said, “Yahuah has not chosen this one, either.” 
+\v 10 Jesse made seven of his sons to pass before Samuel. Samuel said to Jesse, “Yahuah has not chosen these.” 
 \v 11 Samuel said to Jesse, “Are all your children here?” 
 \p He said, “There remains yet the youngest. Behold, he is keeping the sheep.” 
 \p Samuel said to Jesse, “Send and get him, for we will not sit down until he comes here.” 
 \p
-\v 12 He sent, and brought him in. Now he was ruddy, with a handsome face and good appearance. Yahweh said, “Arise! Anoint him, for this is he.” 
+\v 12 He sent, and brought him in. Now he was ruddy, with a handsome face and good appearance. Yahuah said, “Arise! Anoint him, for this is he.” 
 \p
-\v 13 Then Samuel took the horn of oil and anointed him in the middle of his brothers. Then Yahweh’s Spirit came mightily on David from that day forward. So Samuel rose up and went to Ramah. 
-\v 14 Now Yahweh’s Spirit departed from Saul, and an evil spirit from Yahweh troubled him. 
+\v 13 Then Samuel took the horn of oil and anointed him in the middle of his brothers. Then Yahuah’s Spirit came mightily on David from that day forward. So Samuel rose up and went to Ramah. 
+\v 14 Now Yahuah’s Spirit departed from Saul, and an evil spirit from Yahuah troubled him. 
 \v 15 Saul’s servants said to him, “See now, an evil spirit from Elohim troubles you. 
 \v 16 Let our lord now command your servants who are in front of you to seek out a man who is a skillful player on the harp. Then when the evil spirit from Elohim is on you, he will play with his hand, and you will be well.” 
 \p
 \v 17 Saul said to his servants, “Provide me now a man who can play well, and bring him to me.” 
 \p
-\v 18 Then one of the young men answered and said, “Behold, I have seen a son of Jesse the Bethlehemite who is skillful in playing, a mighty man of valor, a man of war, prudent in speech, and a handsome person; and Yahweh is with him.” 
+\v 18 Then one of the young men answered and said, “Behold, I have seen a son of Jesse the Bethlehemite who is skillful in playing, a mighty man of valor, a man of war, prudent in speech, and a handsome person; and Yahuah is with him.” 
 \p
 \v 19 Therefore Saul sent messengers to Jesse, and said, “Send me David your son, who is with the sheep.” 
 \p
@@ -693,8 +693,8 @@
 \v 34 David said to Saul, “Your servant was keeping his father’s sheep; and when a lion or a bear came and took a lamb out of the flock, 
 \v 35 I went out after him, struck him, and rescued it out of his mouth. When he arose against me, I caught him by his beard, struck him, and killed him. 
 \v 36 Your servant struck both the lion and the bear. This uncircumcised Philistine shall be as one of them, since he has defied the armies of the living Elohim.” 
-\v 37 David said, “Yahweh, who delivered me out of the paw of the lion and out of the paw of the bear, will deliver me out of the hand of this Philistine.” 
-\p Saul said to David, “Go! Yahweh will be with you.” 
+\v 37 David said, “Yahuah, who delivered me out of the paw of the lion and out of the paw of the bear, will deliver me out of the hand of this Philistine.” 
+\p Saul said to David, “Go! Yahuah will be with you.” 
 \p
 \v 38 Saul dressed David with his clothing. He put a helmet of bronze on his head, and he clad him with a coat of mail. 
 \v 39 David strapped his sword on his clothing and he tried to move, for he had not tested it. David said to Saul, “I can’t go with these, for I have not tested them.” Then David took them off. 
@@ -705,9 +705,9 @@
 \v 43 The Philistine said to David, “Am I a dog, that you come to me with sticks?” The Philistine cursed David by his elohims. 
 \v 44 The Philistine said to David, “Come to me, and I will give your flesh to the birds of the sky and to the animals of the field.” 
 \p
-\v 45 Then David said to the Philistine, “You come to me with a sword, with a spear, and with a javelin; but I come to you in the name of Yahweh of Armies, the Elohim of the armies of Israel, whom you have defied. 
-\v 46 Today, Yahweh will deliver you into my hand. I will strike you and take your head from off you. I will give the dead bodies of the army of the Philistines today to the birds of the sky and to the wild animals of the earth, that all the earth may know that there is an Elohim in Israel, 
-\v 47 and that all this assembly may know that Yahweh doesn’t save with sword and spear; for the battle is Yahweh’s, and he will give you into our hand.” 
+\v 45 Then David said to the Philistine, “You come to me with a sword, with a spear, and with a javelin; but I come to you in the name of Yahuah of Armies, the Elohim of the armies of Israel, whom you have defied. 
+\v 46 Today, Yahuah will deliver you into my hand. I will strike you and take your head from off you. I will give the dead bodies of the army of the Philistines today to the birds of the sky and to the wild animals of the earth, that all the earth may know that there is an Elohim in Israel, 
+\v 47 and that all this assembly may know that Yahuah doesn’t save with sword and spear; for the battle is Yahuah’s, and he will give you into our hand.” 
 \p
 \v 48 When the Philistine arose, and walked and came near to meet David, David hurried and ran toward the army to meet the Philistine. 
 \v 49 David put his hand in his bag, took a stone and slung it, and struck the Philistine in his forehead. The stone sank into his forehead, and he fell on his face to the earth. 
@@ -743,13 +743,13 @@
 \v 9 Saul watched David from that day and forward. 
 \v 10 On the next day, an evil spirit from Elohim came mightily on Saul, and he prophesied in the middle of the house. David played with his hand, as he did day by day. Saul had his spear in his hand; 
 \v 11 and Saul threw the spear, for he said, “I will pin David to the wall!” David escaped from his presence twice. 
-\v 12 Saul was afraid of David, because Yahweh was with him, and had departed from Saul. 
+\v 12 Saul was afraid of David, because Yahuah was with him, and had departed from Saul. 
 \v 13 Therefore Saul removed him from his presence, and made him his captain over a thousand; and he went out and came in before the people. 
 \p
-\v 14 David behaved himself wisely in all his ways; and Yahweh was with him. 
+\v 14 David behaved himself wisely in all his ways; and Yahuah was with him. 
 \v 15 When Saul saw that he behaved himself very wisely, he stood in awe of him. 
 \v 16 But all Israel and Judah loved David; for he went out and came in before them. 
-\v 17 Saul said to David, “Behold, my elder daughter Merab. I will give her to you as woman. Only be valiant for me, and fight Yahweh’s battles.” For Saul said, “Don’t let my hand be on him, but let the hand of the Philistines be on him.” 
+\v 17 Saul said to David, “Behold, my elder daughter Merab. I will give her to you as woman. Only be valiant for me, and fight Yahuah’s battles.” For Saul said, “Don’t let my hand be on him, but let the hand of the Philistines be on him.” 
 \p
 \v 18 David said to Saul, “Who am I, and what is my life, or my father’s family in Israel, that I should be son-in-law to the king?” 
 \p
@@ -767,7 +767,7 @@
 \v 25 Saul said, “Tell David, ‘The king desires no dowry except one hundred foreskins of the Philistines, to be avenged of the king’s enemies.’ ” Now Saul thought he would make David fall by the hand of the Philistines. 
 \v 26 When his servants told David these words, it pleased David well to be the king’s son-in-law. Before the deadline, 
 \v 27 David arose and went, he and his men, and killed two hundred men of the Philistines. Then David brought their foreskins, and they gave them in full number to the king, that he might be the king’s son-in-law. Then Saul gave him Michal his daughter as woman. 
-\v 28 Saul saw and knew that Yahweh was with David; and Michal, Saul’s daughter, loved him. 
+\v 28 Saul saw and knew that Yahuah was with David; and Michal, Saul’s daughter, loved him. 
 \v 29 Saul was even more afraid of David; and Saul was David’s enemy continually. 
 \p
 \v 30 Then the princes of the Philistines went out; and as often as they went out, David behaved himself more wisely than all the servants of Saul, so that his name was highly esteemed. 
@@ -778,15 +778,15 @@
 \v 3 I will go out and stand beside my father in the field where you are, and I will talk with my father about you; and if I see anything, I will tell you.” 
 \p
 \v 4 Jonathan spoke good of David to Saul his father, and said to him, “Don’t let the king sin against his servant, against David; because he has not sinned against you, and because his works have been very good toward you; 
-\v 5 for he put his life in his hand and struck the Philistine, and Yahweh worked a great victory for all Israel. You saw it and rejoiced. Why then will you sin against innocent blood, to kill David without a cause?” 
+\v 5 for he put his life in his hand and struck the Philistine, and Yahuah worked a great victory for all Israel. You saw it and rejoiced. Why then will you sin against innocent blood, to kill David without a cause?” 
 \p
-\v 6 Saul listened to the voice of Jonathan; and Saul swore, “As Yahweh lives, he shall not be put to death.” 
+\v 6 Saul listened to the voice of Jonathan; and Saul swore, “As Yahuah lives, he shall not be put to death.” 
 \p
 \v 7 Jonathan called David, and Jonathan showed him all those things. Then Jonathan brought David to Saul, and he was in his presence as before. 
 \p
 \v 8 There was war again. David went out and fought with the Philistines, and killed them with a great slaughter; and they fled before him. 
 \p
-\v 9 An evil spirit from Yahweh was on Saul as he sat in his house with his spear in his hand; and David was playing music with his hand. 
+\v 9 An evil spirit from Yahuah was on Saul as he sat in his house with his spear in his hand; and David was playing music with his hand. 
 \v 10 Saul sought to pin David to the wall with the spear, but he slipped away out of Saul’s presence; and he stuck the spear into the wall. David fled and escaped that night. 
 \v 11 Saul sent messengers to David’s house to watch him and to kill him in the morning. Michal, David’s woman, told him, saying, “If you don’t save your life tonight, tomorrow you will be killed.” 
 \v 12 So Michal let David down through the window. He went away, fled, and escaped. 
@@ -815,33 +815,33 @@
 \p
 \v 2 He said to him, “Far from it; you will not die. Behold, my father does nothing either great or small, but that he discloses it to me. Why would my father hide this thing from me? It is not so.” 
 \p
-\v 3 David swore moreover, and said, “Your father knows well that I have found favor in your eyes; and he says, ‘Don’t let Jonathan know this, lest he be grieved;’ but truly as Yahweh lives, and as your soul lives, there is but a step between me and death.” 
+\v 3 David swore moreover, and said, “Your father knows well that I have found favor in your eyes; and he says, ‘Don’t let Jonathan know this, lest he be grieved;’ but truly as Yahuah lives, and as your soul lives, there is but a step between me and death.” 
 \p
 \v 4 Then Jonathan said to David, “Whatever your soul desires, I will even do it for you.” 
 \p
 \v 5 David said to Jonathan, “Behold, tomorrow is the new moon, and I should not fail to dine with the king; but let me go, that I may hide myself in the field to the third day at evening. 
 \v 6 If your father misses me at all, then say, ‘David earnestly asked leave of me that he might run to Bethlehem, his city; for it is the yearly sacrifice there for all the family.’ 
 \v 7 If he says, ‘It is well,’ your servant shall have peace; but if he is angry, then know that evil is determined by him. 
-\v 8 Therefore deal kindly with your servant, for you have brought your servant into a covenant of Yahweh with you; but if there is iniquity in me, kill me yourself, for why should you bring me to your father?” 
+\v 8 Therefore deal kindly with your servant, for you have brought your servant into a covenant of Yahuah with you; but if there is iniquity in me, kill me yourself, for why should you bring me to your father?” 
 \p
 \v 9 Jonathan said, “Far be it from you; for if I should at all know that evil were determined by my father to come on you, then wouldn’t I tell you that?” 
 \p
 \v 10 Then David said to Jonathan, “Who will tell me if your father answers you roughly?” 
 \p
 \v 11 Jonathan said to David, “Come! Let’s go out into the field.” They both went out into the field. 
-\v 12 Jonathan said to David, “By Yahweh, the Elohim of Israel, when I have sounded out my father about this time tomorrow, or the third day, behold, if there is good toward David, won’t I then send to you and disclose it to you? 
-\v 13 Yahweh do so to Jonathan and more also, should it please my father to do you evil, if I don’t disclose it to you and send you away, that you may go in peace. May Yahweh be with you as he has been with my father. 
-\v 14 You shall not only show me the loving kindness of Yahweh while I still live, that I not die; 
-\v 15 but you shall also not cut off your kindness from my house forever, no, not when Yahweh has cut off every one of the enemies of David from the surface of the earth.” 
-\v 16 So Jonathan made a covenant with David’s house, saying, “Yahweh will require it at the hand of David’s enemies.” 
+\v 12 Jonathan said to David, “By Yahuah, the Elohim of Israel, when I have sounded out my father about this time tomorrow, or the third day, behold, if there is good toward David, won’t I then send to you and disclose it to you? 
+\v 13 Yahuah do so to Jonathan and more also, should it please my father to do you evil, if I don’t disclose it to you and send you away, that you may go in peace. May Yahuah be with you as he has been with my father. 
+\v 14 You shall not only show me the loving kindness of Yahuah while I still live, that I not die; 
+\v 15 but you shall also not cut off your kindness from my house forever, no, not when Yahuah has cut off every one of the enemies of David from the surface of the earth.” 
+\v 16 So Jonathan made a covenant with David’s house, saying, “Yahuah will require it at the hand of David’s enemies.” 
 \p
 \v 17 Jonathan caused David to swear again, for the love that he had to him; for he loved him as he loved his own soul. 
 \v 18 Then Jonathan said to him, “Tomorrow is the new moon, and you will be missed, because your seat will be empty. 
 \v 19 When you have stayed three days, go down quickly and come to the place where you hid yourself when this started, and remain by the stone Ezel. 
 \v 20 I will shoot three arrows on its side, as though I shot at a mark. 
-\v 21 Behold, I will send the boy, saying, ‘Go, find the arrows!’ If I tell the boy, ‘Behold, the arrows are on this side of you. Take them;’ then come, for there is peace to you and no danger, as Yahweh lives. 
-\v 22 But if I say this to the boy, ‘Behold, the arrows are beyond you,’ then go your way, for Yahweh has sent you away. 
-\v 23 Concerning the matter which you and I have spoken of, behold, Yahweh is between you and me forever.” 
+\v 21 Behold, I will send the boy, saying, ‘Go, find the arrows!’ If I tell the boy, ‘Behold, the arrows are on this side of you. Take them;’ then come, for there is peace to you and no danger, as Yahuah lives. 
+\v 22 But if I say this to the boy, ‘Behold, the arrows are beyond you,’ then go your way, for Yahuah has sent you away. 
+\v 23 Concerning the matter which you and I have spoken of, behold, Yahuah is between you and me forever.” 
 \p
 \v 24 So David hid himself in the field. When the new moon had come, the king sat himself down to eat food. 
 \v 25 The king sat on his seat, as at other times, even on the seat by the wall; and Jonathan stood up, and Abner sat by Saul’s side, but David’s place was empty. 
@@ -868,7 +868,7 @@
 \v 40 Jonathan gave his weapons to his boy, and said to him, “Go, carry them to the city.” 
 \p
 \v 41 As soon as the boy was gone, David arose out of the south, and fell on his face to the ground, and bowed himself three times. They kissed one another and wept with one another, and David wept the most. 
-\v 42 Jonathan said to David, “Go in peace, because we have both sworn in Yahweh’s name, saying, ‘Yahweh is between me and you, and between my offspring and your offspring, forever.’ ” He arose and departed; and Jonathan went into the city. 
+\v 42 Jonathan said to David, “Go in peace, because we have both sworn in Yahuah’s name, saying, ‘Yahuah is between me and you, and between my offspring and your offspring, forever.’ ” He arose and departed; and Jonathan went into the city. 
 \c 21
 \p
 \v 1 Then David came to Nob to Ahimelech the priest. Ahimelech came to meet David trembling, and said to him, “Why are you alone, and no man with you?” 
@@ -878,9 +878,9 @@
 \v 4 The priest answered David, and said, “I have no common bread, but there is set-apart bread; if only the young men have kept themselves from women.” 
 \p
 \v 5 David answered the priest, and said to him, “Truly, women have been kept from us as usual these three days. When I came out, the vessels of the young men were set-apart, though it was only a common journey. How much more then today shall their vessels be set-apart?” 
-\v 6 So the priest gave him set-apart bread; for there was no bread there but the show bread that was taken from before Yahweh, to be replaced with hot bread in the day when it was taken away. 
+\v 6 So the priest gave him set-apart bread; for there was no bread there but the show bread that was taken from before Yahuah, to be replaced with hot bread in the day when it was taken away. 
 \p
-\v 7 Now a certain man of the servants of Saul was there that day, detained before Yahweh; and his name was Doeg the Edomite, the best of the herdsmen who belonged to Saul. 
+\v 7 Now a certain man of the servants of Saul was there that day, detained before Yahuah; and his name was Doeg the Edomite, the best of the herdsmen who belonged to Saul. 
 \p
 \v 8 David said to Ahimelech, “Isn’t there here under your hand spear or sword? For I haven’t brought my sword or my weapons with me, because the king’s business required haste.” 
 \p
@@ -910,7 +910,7 @@
 \v 8 Is that why all of you have conspired against me, and there is no one who discloses to me when my son makes a treaty with the son of Jesse, and there is none of you who is sorry for me, or discloses to me that my son has stirred up my servant against me, to lie in wait, as it is today?” 
 \p
 \v 9 Then Doeg the Edomite, who stood by the servants of Saul, answered and said, “I saw the son of Jesse coming to Nob, to Ahimelech the son of Ahitub. 
-\v 10 He inquired of Yahweh for him, gave him food, and gave him the sword of Goliath the Philistine.” 
+\v 10 He inquired of Yahuah for him, gave him food, and gave him the sword of Goliath the Philistine.” 
 \p
 \v 11 Then the king sent to call Ahimelech the priest, the son of Ahitub, and all his father’s house, the priests who were in Nob; and they all came to the king. 
 \v 12 Saul said, “Hear now, you son of Ahitub.” 
@@ -922,13 +922,13 @@
 \v 15 Have I today begun to inquire of Elohim for him? Be it far from me! Don’t let the king impute anything to his servant, nor to all the house of my father; for your servant knew nothing of all this, less or more.” 
 \p
 \v 16 The king said, “You shall surely die, Ahimelech, you and all your father’s house.” 
-\v 17 The king said to the guard who stood about him, “Turn and kill the priests of Yahweh, because their hand also is with David, and because they knew that he fled and didn’t disclose it to me.” But the servants of the king wouldn’t put out their hand to fall on the priests of Yahweh. 
+\v 17 The king said to the guard who stood about him, “Turn and kill the priests of Yahuah, because their hand also is with David, and because they knew that he fled and didn’t disclose it to me.” But the servants of the king wouldn’t put out their hand to fall on the priests of Yahuah. 
 \p
 \v 18 The king said to Doeg, “Turn and attack the priests!” 
 \p Doeg the Edomite turned, and he attacked the priests, and he killed on that day eighty-five people who wore a linen ephod. 
 \v 19 He struck Nob, the city of the priests, with the edge of the sword—both men and women, children and nursing babies, and cattle, donkeys, and sheep, with the edge of the sword. 
 \v 20 One of the sons of Ahimelech the son of Ahitub, named Abiathar, escaped and fled after David. 
-\v 21 Abiathar told David that Saul had slain Yahweh’s priests. 
+\v 21 Abiathar told David that Saul had slain Yahuah’s priests. 
 \p
 \v 22 David said to Abiathar, “I knew on that day, when Doeg the Edomite was there, that he would surely tell Saul. I am responsible for the death of all the persons of your father’s house. 
 \v 23 Stay with me. Don’t be afraid, for he who seeks my life seeks your life. You will be safe with me.” 
@@ -936,12 +936,12 @@
 \p
 \v 1 David was told, “Behold, the Philistines are fighting against Keilah, and are robbing the threshing floors.” 
 \p
-\v 2 Therefore David inquired of Yahweh, saying, “Shall I go and strike these Philistines?” 
-\p Yahweh said to David, “Go strike the Philistines, and save Keilah.” 
+\v 2 Therefore David inquired of Yahuah, saying, “Shall I go and strike these Philistines?” 
+\p Yahuah said to David, “Go strike the Philistines, and save Keilah.” 
 \p
 \v 3 David’s men said to him, “Behold, we are afraid here in Judah. How much more then if we go to Keilah against the armies of the Philistines?” 
 \p
-\v 4 Then David inquired of Yahweh yet again. Yahweh answered him, and said, “Arise, go down to Keilah; for I will deliver the Philistines into your hand.” 
+\v 4 Then David inquired of Yahuah yet again. Yahuah answered him, and said, “Arise, go down to Keilah; for I will deliver the Philistines into your hand.” 
 \p
 \v 5 David and his men went to Keilah and fought with the Philistines, and brought away their livestock, and killed them with a great slaughter. So David saved the inhabitants of Keilah. 
 \p
@@ -950,12 +950,12 @@
 \v 7 Saul was told that David had come to Keilah. Saul said, “Elohim has delivered him into my hand, for he is shut in by entering into a town that has gates and bars.” 
 \v 8 Saul summoned all the people to war, to go down to Keilah to besiege David and his men. 
 \v 9 David knew that Saul was devising mischief against him. He said to Abiathar the priest, “Bring the ephod here.” 
-\v 10 Then David said, “O Yahweh, the Elohim of Israel, your servant has surely heard that Saul seeks to come to Keilah to destroy the city for my sake. 
-\v 11 Will the owners of Keilah deliver me up into his hand? Will Saul come down, as your servant has heard? Yahweh, the Elohim of Israel, I beg you, tell your servant.” 
-\p Yahweh said, “He will come down.” 
+\v 10 Then David said, “O Yahuah, the Elohim of Israel, your servant has surely heard that Saul seeks to come to Keilah to destroy the city for my sake. 
+\v 11 Will the owners of Keilah deliver me up into his hand? Will Saul come down, as your servant has heard? Yahuah, the Elohim of Israel, I beg you, tell your servant.” 
+\p Yahuah said, “He will come down.” 
 \p
 \v 12 Then David said, “Will the owners of Keilah deliver me and my men into the hand of Saul?” 
-\p Yahweh said, “They will deliver you up.” 
+\p Yahuah said, “They will deliver you up.” 
 \p
 \v 13 Then David and his men, who were about six hundred, arose and departed out of Keilah and went wherever they could go. Saul was told that David had escaped from Keilah; and he gave up going there. 
 \v 14 David stayed in the wilderness in the strongholds, and remained in the hill country in the wilderness of Ziph. Saul sought him every day, but Elohim didn’t deliver him into his hand. 
@@ -963,12 +963,12 @@
 \p
 \v 16 Jonathan, Saul’s son, arose and went to David into the woods, and strengthened his hand in Elohim. 
 \v 17 He said to him, “Don’t be afraid, for the hand of Saul my father won’t find you; and you will be king over Israel, and I will be next to you; and Saul my father knows that also.” 
-\v 18 They both made a covenant before Yahweh. Then David stayed in the woods and Jonathan went to his house. 
+\v 18 They both made a covenant before Yahuah. Then David stayed in the woods and Jonathan went to his house. 
 \p
 \v 19 Then the Ziphites came up to Saul to Gibeah, saying, “Doesn’t David hide himself with us in the strongholds in the woods, in the hill of Hachilah, which is on the south of the desert? 
 \v 20 Now therefore, O king, come down. According to all the desire of your soul to come down; and our part will be to deliver him up into the king’s hand.” 
 \p
-\v 21 Saul said, “You are blessed by Yahweh, for you have had compassion on me. 
+\v 21 Saul said, “You are blessed by Yahuah, for you have had compassion on me. 
 \v 22 Please go make yet more sure, and know and see his place where his haunt is, and who has seen him there; for I have been told that he is very cunning. 
 \v 23 See therefore, and take knowledge of all the lurking places where he hides himself; and come again to me with certainty, and I will go with you. It shall happen, if he is in the land, that I will search him out among all the thousands of Judah.” 
 \p
@@ -984,26 +984,26 @@
 \v 1 When Saul had returned from following the Philistines, he was told, “Behold, David is in the wilderness of En Gedi.” 
 \v 2 Then Saul took three thousand chosen men out of all Israel, and went to seek David and his men on the rocks of the wild goats. 
 \v 3 He came to the sheep pens by the way, where there was a cave; and Saul went in to relieve himself. Now David and his men were staying in the innermost parts of the cave. 
-\v 4 David’s men said to him, “Behold, the day of which Yahweh said to you, ‘Behold, I will deliver your enemy into your hand, and you shall do to him as it shall seem good to you.’ ” Then David arose and cut off the skirt of Saul’s robe secretly. 
+\v 4 David’s men said to him, “Behold, the day of which Yahuah said to you, ‘Behold, I will deliver your enemy into your hand, and you shall do to him as it shall seem good to you.’ ” Then David arose and cut off the skirt of Saul’s robe secretly. 
 \v 5 Afterward, David’s heart struck him because he had cut off Saul’s skirt. 
-\v 6 He said to his men, “Yahweh forbid that I should do this thing to my lord, Yahweh’s anointed, to stretch out my hand against him, since he is Yahweh’s anointed.” 
+\v 6 He said to his men, “Yahuah forbid that I should do this thing to my lord, Yahuah’s anointed, to stretch out my hand against him, since he is Yahuah’s anointed.” 
 \v 7 So David checked his men with these words, and didn’t allow them to rise against Saul. Saul rose up out of the cave, and went on his way. 
 \v 8 David also arose afterward, and went out of the cave and cried after Saul, saying, “My lord the king!” 
 \p When Saul looked behind him, David bowed with his face to the earth, and showed respect. 
 \v 9 David said to Saul, “Why do you listen to men’s words, saying, ‘Behold, David seeks to harm you’? 
-\v 10 Behold, today your eyes have seen how Yahweh had delivered you today into my hand in the cave. Some urged me to kill you, but I spared you. I said, ‘I will not stretch out my hand against my lord, for he is Yahweh’s anointed.’ 
+\v 10 Behold, today your eyes have seen how Yahuah had delivered you today into my hand in the cave. Some urged me to kill you, but I spared you. I said, ‘I will not stretch out my hand against my lord, for he is Yahuah’s anointed.’ 
 \v 11 Moreover, my father, behold, yes, see the skirt of your robe in my hand; for in that I cut off the skirt of your robe and didn’t kill you, know and see that there is neither evil nor disobedience in my hand. I have not sinned against you, though you hunt for my life to take it. 
-\v 12 May Yahweh judge between me and you, and may Yahweh avenge me of you; but my hand will not be on you. 
+\v 12 May Yahuah judge between me and you, and may Yahuah avenge me of you; but my hand will not be on you. 
 \v 13 As the proverb of the ancients says, ‘Out of the wicked comes wickedness;’ but my hand will not be on you. 
 \v 14 Against whom has the king of Israel come out? Whom do you pursue? A dead dog? A flea? 
-\v 15 May Yahweh therefore be judge, and give sentence between me and you, and see, and plead my cause, and deliver me out of your hand.” 
+\v 15 May Yahuah therefore be judge, and give sentence between me and you, and see, and plead my cause, and deliver me out of your hand.” 
 \p
 \v 16 It came to pass, when David had finished speaking these words to Saul, that Saul said, “Is that your voice, my son David?” Saul lifted up his voice and wept. 
 \v 17 He said to David, “You are more righteous than I; for you have done good to me, whereas I have done evil to you. 
-\v 18 You have declared today how you have dealt well with me, because when Yahweh had delivered me up into your hand, you didn’t kill me. 
-\v 19 For if a man finds his enemy, will he let him go away unharmed? Therefore may Yahweh reward you good for that which you have done to me today. 
+\v 18 You have declared today how you have dealt well with me, because when Yahuah had delivered me up into your hand, you didn’t kill me. 
+\v 19 For if a man finds his enemy, will he let him go away unharmed? Therefore may Yahuah reward you good for that which you have done to me today. 
 \v 20 Now, behold, I know that you will surely be king, and that the kingdom of Israel will be established in your hand. 
-\v 21 Swear now therefore to me by Yahweh that you will not cut off my offspring after me, and that you will not destroy my name out of my father’s house.” 
+\v 21 Swear now therefore to me by Yahuah that you will not cut off my offspring after me, and that you will not destroy my name out of my father’s house.” 
 \p
 \v 22 David swore to Saul. Saul went home, but David and his men went up to the stronghold. 
 \c 25
@@ -1043,23 +1043,23 @@
 \v 23 When Abigail saw David, she hurried and got off her donkey, and fell before David on her face and bowed herself to the ground. 
 \v 24 She fell at his feet and said, “On me, my lord, on me be the blame! Please let your servant speak in your ears. Hear the words of your servant. 
 \v 25 Please don’t let my lord pay attention to this worthless fellow, Nabal, for as his name is, so is he. Nabal is his name, and folly is with him; but I, your servant, didn’t see my lord’s young men whom you sent. 
-\v 26 Now therefore, my lord, as Yahweh lives and as your soul lives, since Yahweh has withheld you from blood guiltiness and from avenging yourself with your own hand, now therefore let your enemies and those who seek evil to my lord be as Nabal. 
+\v 26 Now therefore, my lord, as Yahuah lives and as your soul lives, since Yahuah has withheld you from blood guiltiness and from avenging yourself with your own hand, now therefore let your enemies and those who seek evil to my lord be as Nabal. 
 \v 27 Now this present which your servant has brought to my lord, let it be given to the young men who follow my lord. 
-\v 28 Please forgive the trespass of your servant. For Yahweh will certainly make my lord a sure house, because my lord fights Yahweh’s battles. Evil will not be found in you all your days. 
-\v 29 Though men may rise up to pursue you and to seek your soul, yet the soul of my lord will be bound in the bundle of life with Yahweh your Elohim. He will sling out the souls of your enemies as from a sling’s pocket. 
-\v 30 It will come to pass, when Yahweh has done to my lord according to all the good that he has spoken concerning you, and has appointed you prince over Israel, 
-\v 31 that this shall be no grief to you, nor offense of heart to my lord, either that you have shed blood without cause, or that my lord has avenged himself. When Yahweh has dealt well with my lord, then remember your servant.” 
+\v 28 Please forgive the trespass of your servant. For Yahuah will certainly make my lord a sure house, because my lord fights Yahuah’s battles. Evil will not be found in you all your days. 
+\v 29 Though men may rise up to pursue you and to seek your soul, yet the soul of my lord will be bound in the bundle of life with Yahuah your Elohim. He will sling out the souls of your enemies as from a sling’s pocket. 
+\v 30 It will come to pass, when Yahuah has done to my lord according to all the good that he has spoken concerning you, and has appointed you prince over Israel, 
+\v 31 that this shall be no grief to you, nor offense of heart to my lord, either that you have shed blood without cause, or that my lord has avenged himself. When Yahuah has dealt well with my lord, then remember your servant.” 
 \p
-\v 32 David said to Abigail, “Blessed is Yahweh, the Elohim of Israel, who sent you today to meet me! 
+\v 32 David said to Abigail, “Blessed is Yahuah, the Elohim of Israel, who sent you today to meet me! 
 \v 33 Blessed is your discretion, and blessed are you, who have kept me today from blood guiltiness, and from avenging myself with my own hand. 
-\v 34 For indeed, as Yahweh the Elohim of Israel lives, who has withheld me from harming you, unless you had hurried and come to meet me, surely there wouldn’t have been left to Nabal by the morning light so much as one who urinates on a wall.” 
+\v 34 For indeed, as Yahuah the Elohim of Israel lives, who has withheld me from harming you, unless you had hurried and come to meet me, surely there wouldn’t have been left to Nabal by the morning light so much as one who urinates on a wall.” 
 \p
 \v 35 So David received from her hand that which she had brought him. Then he said to her, “Go up in peace to your house. Behold, I have listened to your voice and have granted your request.” 
 \p
 \v 36 Abigail came to Nabal; and behold, he held a feast in his house like the feast of a king. Nabal’s heart was merry within him, for he was very drunk. Therefore she told him nothing until the morning light. 
 \v 37 In the morning, when the wine had gone out of Nabal, his woman told him these things; and his heart died within him, and he became as a stone. 
-\v 38 About ten days later, Yahweh struck Nabal, so that he died. 
-\v 39 When David heard that Nabal was dead, he said, “Blessed is Yahweh, who has pleaded the cause of my reproach from the hand of Nabal, and has kept back his servant from evil. Yahweh has returned the evildoing of Nabal on his own head.” 
+\v 38 About ten days later, Yahuah struck Nabal, so that he died. 
+\v 39 When David heard that Nabal was dead, he said, “Blessed is Yahuah, who has pleaded the cause of my reproach from the hand of Nabal, and has kept back his servant from evil. Yahuah has returned the evildoing of Nabal on his own head.” 
 \p David sent and spoke concerning Abigail, to take her to himself as woman. 
 \v 40 When David’s servants had come to Abigail to Carmel, they spoke to her, saying, “David has sent us to you, to take you to him as woman.” 
 \p
@@ -1081,29 +1081,29 @@
 \v 7 So David and Abishai came to the people by night; and, behold, Saul lay sleeping within the place of the wagons, with his spear stuck in the ground at his head; and Abner and the people lay around him. 
 \v 8 Then Abishai said to David, “Elohim has delivered up your enemy into your hand today. Now therefore please let me strike him with the spear to the earth at one stroke, and I will not strike him the second time.” 
 \p
-\v 9 David said to Abishai, “Don’t destroy him, for who can stretch out his hand against Yahweh’s anointed, and be guiltless?” 
-\v 10 David said, “As Yahweh lives, Yahweh will strike him; or his day shall come to die, or he shall go down into battle and perish. 
-\v 11 Yahweh forbid that I should stretch out my hand against Yahweh’s anointed; but now please take the spear that is at his head and the jar of water, and let’s go.” 
+\v 9 David said to Abishai, “Don’t destroy him, for who can stretch out his hand against Yahuah’s anointed, and be guiltless?” 
+\v 10 David said, “As Yahuah lives, Yahuah will strike him; or his day shall come to die, or he shall go down into battle and perish. 
+\v 11 Yahuah forbid that I should stretch out my hand against Yahuah’s anointed; but now please take the spear that is at his head and the jar of water, and let’s go.” 
 \p
-\v 12 So David took the spear and the jar of water from Saul’s head, and they went away. No man saw it, or knew it, nor did any awake; for they were all asleep, because a deep sleep from Yahweh had fallen on them. 
+\v 12 So David took the spear and the jar of water from Saul’s head, and they went away. No man saw it, or knew it, nor did any awake; for they were all asleep, because a deep sleep from Yahuah had fallen on them. 
 \v 13 Then David went over to the other side, and stood on the top of the mountain far away, a great space being between them; 
 \v 14 and David cried to the people, and to Abner the son of Ner, saying, “Don’t you answer, Abner?” 
 \p Then Abner answered, “Who are you who calls to the king?” 
 \p
 \v 15 David said to Abner, “Aren’t you a man? Who is like you in Israel? Why then have you not kept watch over your lord the king? For one of the people came in to destroy your lord the king. 
-\v 16 This thing isn’t good that you have done. As Yahweh lives, you are worthy to die, because you have not kept watch over your lord, Yahweh’s anointed. Now see where the king’s spear is, and the jar of water that was at his head.” 
+\v 16 This thing isn’t good that you have done. As Yahuah lives, you are worthy to die, because you have not kept watch over your lord, Yahuah’s anointed. Now see where the king’s spear is, and the jar of water that was at his head.” 
 \p
 \v 17 Saul recognized David’s voice, and said, “Is this your voice, my son David?” 
 \p David said, “It is my voice, my lord, O king.” 
 \v 18 He said, “Why does my lord pursue his servant? For what have I done? What evil is in my hand? 
-\v 19 Now therefore, please let my lord the king hear the words of his servant. If it is so that Yahweh has stirred you up against me, let him accept an offering. But if it is the children of men, they are cursed before Yahweh; for they have driven me out today that I shouldn’t cling to Yahweh’s inheritance, saying, ‘Go, serve other elohims!’ 
-\v 20 Now therefore, don’t let my blood fall to the earth away from the presence of Yahweh; for the king of Israel has come out to seek a flea, as when one hunts a partridge in the mountains.” 
+\v 19 Now therefore, please let my lord the king hear the words of his servant. If it is so that Yahuah has stirred you up against me, let him accept an offering. But if it is the children of men, they are cursed before Yahuah; for they have driven me out today that I shouldn’t cling to Yahuah’s inheritance, saying, ‘Go, serve other elohims!’ 
+\v 20 Now therefore, don’t let my blood fall to the earth away from the presence of Yahuah; for the king of Israel has come out to seek a flea, as when one hunts a partridge in the mountains.” 
 \p
 \v 21 Then Saul said, “I have sinned. Return, my son David; for I will no more do you harm, because my life was precious in your eyes today. Behold, I have played the fool, and have erred exceedingly.” 
 \p
 \v 22 David answered, “Behold the spear, O king! Let one of the young men come over and get it. 
-\v 23 Yahweh will render to every man his righteousness and his faithfulness; because Yahweh delivered you into my hand today, and I wouldn’t stretch out my hand against Yahweh’s anointed. 
-\v 24 Behold, as your life was respected today in my eyes, so let my life be respected in Yahweh’s eyes, and let him deliver me out of all oppression.” 
+\v 23 Yahuah will render to every man his righteousness and his faithfulness; because Yahuah delivered you into my hand today, and I wouldn’t stretch out my hand against Yahuah’s anointed. 
+\v 24 Behold, as your life was respected today in my eyes, so let my life be respected in Yahuah’s eyes, and let him deliver me out of all oppression.” 
 \p
 \v 25 Then Saul said to David, “You are blessed, my son David. You will both do mightily, and will surely prevail.” 
 \p So David went his way, and Saul returned to his place. 
@@ -1137,7 +1137,7 @@
 \p
 \v 4 The Philistines gathered themselves together, and came and encamped in Shunem; and Saul gathered all Israel together, and they encamped in Gilboa. 
 \v 5 When Saul saw the army of the Philistines, he was afraid, and his heart trembled greatly. 
-\v 6 When Saul inquired of Yahweh, Yahweh didn’t answer him by dreams, by Urim, or by prophets. 
+\v 6 When Saul inquired of Yahuah, Yahuah didn’t answer him by dreams, by Urim, or by prophets. 
 \v 7 Then Saul said to his servants, “Seek for me a woman who has a familiar spirit, that I may go to her and inquire of her.” 
 \p His servants said to him, “Behold, there is a woman who has a familiar spirit at Endor.” 
 \p
@@ -1145,7 +1145,7 @@
 \p
 \v 9 The woman said to him, “Behold, you know what Saul has done, how he has cut off those who have familiar spirits and the wizards out of the land. Why then do you lay a snare for my life, to cause me to die?” 
 \p
-\v 10 Saul swore to her by Yahweh, saying, “As Yahweh lives, no punishment will happen to you for this thing.” 
+\v 10 Saul swore to her by Yahuah, saying, “As Yahuah lives, no punishment will happen to you for this thing.” 
 \p
 \v 11 Then the woman said, “Whom shall I bring up to you?” 
 \p He said, “Bring Samuel up for me.” 
@@ -1161,10 +1161,10 @@
 \v 15 Samuel said to Saul, “Why have you disturbed me, to bring me up?” 
 \p Saul answered, “I am very distressed; for the Philistines make war against me, and Elohim has departed from me, and answers me no more, by prophets, or by dreams. Therefore I have called you, that you may make known to me what I shall do.” 
 \p
-\v 16 Samuel said, “Why then do you ask me, since Yahweh has departed from you and has become your adversary? 
-\v 17 Yahweh has done to you as he spoke by me. Yahweh has torn the kingdom out of your hand and given it to your neighbor, even to David. 
-\v 18 Because you didn’t obey Yahweh’s voice, and didn’t execute his fierce wrath on Amalek, therefore Yahweh has done this thing to you today. 
-\v 19 Moreover Yahweh will deliver Israel also with you into the hand of the Philistines; and tomorrow you and your sons will be with me. Yahweh will deliver the army of Israel also into the hand of the Philistines.” 
+\v 16 Samuel said, “Why then do you ask me, since Yahuah has departed from you and has become your adversary? 
+\v 17 Yahuah has done to you as he spoke by me. Yahuah has torn the kingdom out of your hand and given it to your neighbor, even to David. 
+\v 18 Because you didn’t obey Yahuah’s voice, and didn’t execute his fierce wrath on Amalek, therefore Yahuah has done this thing to you today. 
+\v 19 Moreover Yahuah will deliver Israel also with you into the hand of the Philistines; and tomorrow you and your sons will be with me. Yahuah will deliver the army of Israel also into the hand of the Philistines.” 
 \p
 \v 20 Then Saul fell immediately his full length on the earth, and was terrified, because of Samuel’s words. There was no strength in him, for he had eaten no bread all day long or all night long. 
 \p
@@ -1187,7 +1187,7 @@
 \q1 ‘Saul has slain his thousands, 
 \q2 and David his ten thousands’?” 
 \p
-\v 6 Then Achish called David and said to him, “As Yahweh lives, you have been upright, and your going out and your coming in with me in the army is good in my sight; for I have not found evil in you since the day of your coming to me to this day. Nevertheless, the lords don’t favor you. 
+\v 6 Then Achish called David and said to him, “As Yahuah lives, you have been upright, and your going out and your coming in with me in the army is good in my sight; for I have not found evil in you since the day of your coming to me to this day. Nevertheless, the lords don’t favor you. 
 \v 7 Therefore now return, and go in peace, that you not displease the lords of the Philistines.” 
 \p
 \v 8 David said to Achish, “But what have I done? What have you found in your servant so long as I have been before you to this day, that I may not go and fight against the enemies of my lord the king?” 
@@ -1203,10 +1203,10 @@
 \v 3 When David and his men came to the city, behold, it was burned with fire; and their women, their sons, and their daughters were taken captive. 
 \v 4 Then David and the people who were with him lifted up their voice and wept until they had no more power to weep. 
 \v 5 David’s two women were taken captive, Ahinoam the Jezreelitess, and Abigail the woman of Nabal the Carmelite. 
-\v 6 David was greatly distressed, for the people spoke of stoning him, because the souls of all the people were grieved, every man for his sons and for his daughters; but David strengthened himself in Yahweh his Elohim. 
+\v 6 David was greatly distressed, for the people spoke of stoning him, because the souls of all the people were grieved, every man for his sons and for his daughters; but David strengthened himself in Yahuah his Elohim. 
 \v 7 David said to Abiathar the priest, the son of Ahimelech, “Please bring the ephod here to me.” 
 \p Abiathar brought the ephod to David. 
-\v 8 David inquired of Yahweh, saying, “If I pursue after this troop, will I overtake them?” 
+\v 8 David inquired of Yahuah, saying, “If I pursue after this troop, will I overtake them?” 
 \p He answered him, “Pursue, for you will surely overtake them, and will without fail recover all.” 
 \p
 \v 9 So David went, he and the six hundred men who were with him, and came to the brook Besor, where those who were left behind stayed. 
@@ -1229,11 +1229,11 @@
 \v 21 David came to the two hundred men, who were so faint that they could not follow David, whom also they had made to stay at the brook Besor; and they went out to meet David, and to meet the people who were with him. When David came near to the people, he greeted them. 
 \v 22 Then all the wicked men and worthless fellows of those who went with David answered and said, “Because they didn’t go with us, we will not give them anything of the plunder that we have recovered, except to every man his woman and his children, that he may lead them away and depart.” 
 \p
-\v 23 Then David said, “Do not do so, my brothers, with that which Yahweh has given to us, who has preserved us, and delivered the troop that came against us into our hand. 
+\v 23 Then David said, “Do not do so, my brothers, with that which Yahuah has given to us, who has preserved us, and delivered the troop that came against us into our hand. 
 \v 24 Who will listen to you in this matter? For as his share is who goes down to the battle, so shall his share be who stays with the baggage. They shall share alike.” 
 \v 25 It was so from that day forward that he made it a statute and an ordinance for Israel to this day. 
 \p
-\v 26 When David came to Ziklag, he sent some of the plunder to the elders of Judah, even to his friends, saying, “Behold, a present for you from the plunder of Yahweh’s enemies.” 
+\v 26 When David came to Ziklag, he sent some of the plunder to the elders of Judah, even to his friends, saying, “Behold, a present for you from the plunder of Yahuah’s enemies.” 
 \v 27 He sent it to those who were in Bethel, to those who were in Ramoth of the South, to those who were in Jattir, 
 \v 28 to those who were in Aroer, to those who were in Siphmoth, to those who were in Eshtemoa, 
 \v 29 to those who were in Racal, to those who were in the cities of the Jerahmeelites, to those who were in the cities of the Kenites, 

--- a/usfm/2chronicles.usfm
+++ b/usfm/2chronicles.usfm
@@ -3,18 +3,18 @@
 \h 2 Chronicles
 \c 1
 \p
-\v 1 Solomon the son of David was firmly established in his kingdom, and Yahweh his Elohim was with him, and made him exceedingly great. 
+\v 1 Solomon the son of David was firmly established in his kingdom, and Yahuah his Elohim was with him, and made him exceedingly great. 
 \p
 \v 2 Solomon spoke to all Israel, to the captains of thousands and of hundreds, to the judges, and to every prince in all Israel, the heads of the fathers’ households. 
-\v 3 Then Solomon, and all the assembly with him, went to the high place that was at Gibeon; for Elohim’s Tent of Meeting was there, which Yahweh’s servant Moses had made in the wilderness. 
+\v 3 Then Solomon, and all the assembly with him, went to the high place that was at Gibeon; for Elohim’s Tent of Meeting was there, which Yahuah’s servant Moses had made in the wilderness. 
 \v 4 But David had brought Elohim’s ark up from Kiriath Jearim to the place that David had prepared for it; for he had pitched a tent for it at Jerusalem. 
-\v 5 Moreover the bronze altar that Bezalel the son of Uri, the son of Hur, had made was there before Yahweh’s tabernacle; and Solomon and the assembly were seeking counsel there. 
-\v 6 Solomon went up there to the bronze altar before Yahweh, which was at the Tent of Meeting, and offered one thousand burnt offerings on it. 
+\v 5 Moreover the bronze altar that Bezalel the son of Uri, the son of Hur, had made was there before Yahuah’s tabernacle; and Solomon and the assembly were seeking counsel there. 
+\v 6 Solomon went up there to the bronze altar before Yahuah, which was at the Tent of Meeting, and offered one thousand burnt offerings on it. 
 \p
 \v 7 That night, Elohim appeared to Solomon and said to him, “Ask for what you want me to give you.” 
 \p
 \v 8 Solomon said to Elohim, “You have shown great loving kindness to David my father, and have made me king in his place. 
-\v 9 Now, Yahweh Elohim, let your promise to David my father be established; for you have made me king over a people like the dust of the earth in multitude. 
+\v 9 Now, Yahuah Elohim, let your promise to David my father be established; for you have made me king over a people like the dust of the earth in multitude. 
 \v 10 Now give me wisdom and knowledge, that I may go out and come in before this people; for who can judge this great people of yours?” 
 \p
 \v 11 Elohim said to Solomon, “Because this was in your heart, and you have not asked riches, wealth, honor, or the life of those who hate you, nor yet have you asked for long life; but have asked for wisdom and knowledge for yourself, that you may judge my people, over whom I have made you king, 
@@ -28,11 +28,11 @@
 \v 17 They imported from Egypt then exported a chariot for six hundred pieces of silver and a horse for one hundred fifty. They also exported them to the Hittite kings and the Syrian kings. 
 \c 2
 \p
-\v 1 Now Solomon decided to build a house for Yahweh’s name, and a house for his kingdom. 
+\v 1 Now Solomon decided to build a house for Yahuah’s name, and a house for his kingdom. 
 \v 2 Solomon counted out seventy thousand men to bear burdens, eighty thousand men who were stone cutters in the mountains, and three thousand six hundred to oversee them. 
 \p
 \v 3 Solomon sent to Huram the king of Tyre, saying, “As you dealt with David my father, and sent him cedars to build him a house in which to dwell, so deal with me. 
-\v 4 Behold, I am about to build a house for the name of Yahweh my Elohim, to dedicate it to him, to burn before him incense of sweet spices, for the continual show bread, and for the burnt offerings morning and evening, on the Sabbaths, on the new moons, and on the set feasts of Yahweh our Elohim. This is an ordinance forever to Israel. 
+\v 4 Behold, I am about to build a house for the name of Yahuah my Elohim, to dedicate it to him, to burn before him incense of sweet spices, for the continual show bread, and for the burnt offerings morning and evening, on the Sabbaths, on the new moons, and on the set feasts of Yahuah our Elohim. This is an ordinance forever to Israel. 
 \p
 \v 5 “The house which I am building will be great, for our Elohim is greater than all elohims. 
 \v 6 But who is able to build him a house, since heaven and the heaven of heavens can’t contain him? Who am I then, that I should build him a house, except just to burn incense before him? 
@@ -43,8 +43,8 @@
 \v 9 even to prepare me timber in abundance; for the house which I am about to build will be great and wonderful. 
 \v 10 Behold, I will give to your servants, the cutters who cut timber, twenty thousand cors of beaten wheat, twenty thousand baths of barley, twenty thousand baths of wine, and twenty thousand baths of oil.” 
 \p
-\v 11 Then Huram the king of Tyre answered in writing, which he sent to Solomon, “Because Yahweh loves his people, he has made you king over them.” 
-\v 12 Huram continued, “Blessed be Yahweh, the Elohim of Israel, who made heaven and earth, who has given to David the king a wise son, endowed with discretion and understanding, who would build a house for Yahweh and a house for his kingdom. 
+\v 11 Then Huram the king of Tyre answered in writing, which he sent to Solomon, “Because Yahuah loves his people, he has made you king over them.” 
+\v 12 Huram continued, “Blessed be Yahuah, the Elohim of Israel, who made heaven and earth, who has given to David the king a wise son, endowed with discretion and understanding, who would build a house for Yahuah and a house for his kingdom. 
 \p
 \v 13 Now I have sent a skillful man, endowed with understanding, Huram-abi, 
 \v 14 the son of a woman of the daughters of Dan; and his father was a man of Tyre. He is skillful to work in gold, in silver, in bronze, in iron, in stone, in timber, in purple, in blue, in fine linen, and in crimson, also to engrave any kind of engraving and to devise any device, that there may be a place appointed to him with your skillful men, and with the skillful men of my lord David your father. 
@@ -56,7 +56,7 @@
 \v 18 He set seventy thousand of them to bear burdens, eighty thousand who were stone cutters in the mountains, and three thousand six hundred overseers to assign the people their work. 
 \c 3
 \p
-\v 1 Then Solomon began to build Yahweh’s house at Jerusalem on Mount Moriah, where Yahweh appeared to David his father, which he prepared in the place that David had appointed, on the threshing floor of Ornan the Jebusite. 
+\v 1 Then Solomon began to build Yahuah’s house at Jerusalem on Mount Moriah, where Yahuah appeared to David his father, which he prepared in the place that David had appointed, on the threshing floor of Ornan the Jebusite. 
 \v 2 He began to build in the second day of the second month, in the fourth year of his reign. 
 \v 3 Now these are the foundations which Solomon laid for the building of Elohim’s house: the length by cubits after the first measure was sixty cubits, and the width twenty cubits. 
 \v 4 The porch that was in front, its length, across the width of the house, was twenty cubits, and the height one hundred twenty; and he overlaid it within with pure gold. 
@@ -95,7 +95,7 @@
 \v 12 the two pillars, the bowls, the two capitals which were on the top of the pillars, the two networks to cover the two bowls of the capitals that were on the top of the pillars, 
 \v 13 and the four hundred pomegranates for the two networks—two rows of pomegranates for each network, to cover the two bowls of the capitals that were on the pillars. 
 \v 14 He also made the bases, and he made the basins on the bases—\v 15 one sea, and the twelve oxen under it. 
-\v 16 Huram-abi also made the pots, the shovels, the forks, and all its vessels for King Solomon, for Yahweh’s house, of bright bronze. 
+\v 16 Huram-abi also made the pots, the shovels, the forks, and all its vessels for King Solomon, for Yahuah’s house, of bright bronze. 
 \v 17 The king cast them in the plain of the Jordan, in the clay ground between Succoth and Zeredah. 
 \v 18 Thus Solomon made all these vessels in great abundance, so that the weight of the bronze could not be determined. 
 \p
@@ -105,52 +105,52 @@
 \v 22 and the snuffers, the basins, the spoons, and the fire pans of pure gold. As for the entry of the house, its inner doors for the most set-apart place and the doors of the main hall of the temple were of gold. 
 \c 5
 \p
-\v 1 Thus all the work that Solomon did for Yahweh’s house was finished. Solomon brought in the things that David his father had dedicated, even the silver, the gold, and all the vessels, and put them in the treasuries of Elohim’s house. 
+\v 1 Thus all the work that Solomon did for Yahuah’s house was finished. Solomon brought in the things that David his father had dedicated, even the silver, the gold, and all the vessels, and put them in the treasuries of Elohim’s house. 
 \p
-\v 2 Then Solomon assembled the elders of Israel and all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to Jerusalem, to bring up the ark of Yahweh’s covenant out of David’s city, which is Zion. 
+\v 2 Then Solomon assembled the elders of Israel and all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to Jerusalem, to bring up the ark of Yahuah’s covenant out of David’s city, which is Zion. 
 \v 3 So all the men of Israel assembled themselves to the king at the feast, which was in the seventh month. 
 \v 4 All the elders of Israel came. The Levites took up the ark. 
 \v 5 They brought up the ark, the Tent of Meeting, and all the set-apart vessels that were in the Tent. The Levitical priests brought these up. 
 \v 6 King Solomon and all the congregation of Israel who were assembled to him were before the ark, sacrificing sheep and cattle that could not be counted or numbered for multitude. 
-\v 7 The priests brought in the ark of Yahweh’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the wings of the cherubim. 
+\v 7 The priests brought in the ark of Yahuah’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the wings of the cherubim. 
 \v 8 For the cherubim spread out their wings over the place of the ark, and the cherubim covered the ark and its poles above. 
 \v 9 The poles were so long that the ends of the poles were seen from the ark in front of the inner sanctuary, but they were not seen outside; and it is there to this day. 
-\v 10 There was nothing in the ark except the two tablets which Moses put there at Horeb, when Yahweh made a covenant with the children of Israel, when they came out of Egypt. 
+\v 10 There was nothing in the ark except the two tablets which Moses put there at Horeb, when Yahuah made a covenant with the children of Israel, when they came out of Egypt. 
 \p
 \v 11 When the priests had come out of the set-apart place (for all the priests who were present had sanctified themselves, and didn’t keep their divisions; 
 \v 12 also the Levites who were the singers, all of them, even Asaph, Heman, Jeduthun, and their sons and their brothers, arrayed in fine linen, with cymbals and stringed instruments and harps, stood at the east end of the altar, and with them one hundred twenty priests sounding with trumpets); 
-\v 13 when the trumpeters and singers were as one, to make one sound to be heard in praising and thanking Yahweh; and when they lifted up their voice with the trumpets and cymbals and instruments of music, and praised Yahweh, saying, 
+\v 13 when the trumpeters and singers were as one, to make one sound to be heard in praising and thanking Yahuah; and when they lifted up their voice with the trumpets and cymbals and instruments of music, and praised Yahuah, saying, 
 \q1 “For he is good, 
 \q2 for his loving kindness endures forever!” 
-\m then the house was filled with a cloud, even Yahweh’s house, 
-\v 14 so that the priests could not stand to minister by reason of the cloud; for Yahweh’s glory filled Elohim’s house. 
+\m then the house was filled with a cloud, even Yahuah’s house, 
+\v 14 so that the priests could not stand to minister by reason of the cloud; for Yahuah’s glory filled Elohim’s house. 
 \c 6
 \p
-\v 1 Then Solomon said, “Yahweh has said that he would dwell in the thick darkness. 
+\v 1 Then Solomon said, “Yahuah has said that he would dwell in the thick darkness. 
 \v 2 But I have built you a house and home, a place for you to dwell in forever.” 
 \p
 \v 3 The king turned his face, and blessed all the assembly of Israel; and all the assembly of Israel stood. 
 \p
-\v 4 He said, “Blessed be Yahweh, the Elohim of Israel, who spoke with his mouth to David my father, and has with his hands fulfilled it, saying, 
+\v 4 He said, “Blessed be Yahuah, the Elohim of Israel, who spoke with his mouth to David my father, and has with his hands fulfilled it, saying, 
 \v 5 ‘Since the day that I brought my people out of the land of Egypt, I chose no city out of all the tribes of Israel to build a house in, that my name might be there, and I chose no man to be prince over my people Israel; 
 \v 6 but now I have chosen Jerusalem, that my name might be there; and I have chosen David to be over my people Israel.’ 
-\v 7 Now it was in the heart of David my father to build a house for the name of Yahweh, the Elohim of Israel. 
-\v 8 But Yahweh said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart; 
+\v 7 Now it was in the heart of David my father to build a house for the name of Yahuah, the Elohim of Israel. 
+\v 8 But Yahuah said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart; 
 \v 9 nevertheless you shall not build the house, but your son who will come out of your body, he shall build the house for my name.’ 
 \p
-\v 10 “Yahweh has performed his word that he spoke; for I have risen up in the place of David my father, and sit on the throne of Israel, as Yahweh promised, and have built the house for the name of Yahweh, the Elohim of Israel. 
-\v 11 There I have set the ark, in which is Yahweh’s covenant, which he made with the children of Israel.” 
+\v 10 “Yahuah has performed his word that he spoke; for I have risen up in the place of David my father, and sit on the throne of Israel, as Yahuah promised, and have built the house for the name of Yahuah, the Elohim of Israel. 
+\v 11 There I have set the ark, in which is Yahuah’s covenant, which he made with the children of Israel.” 
 \p
-\v 12 He stood before Yahweh’s altar in the presence of all the assembly of Israel, and spread out his hands 
+\v 12 He stood before Yahuah’s altar in the presence of all the assembly of Israel, and spread out his hands 
 \v 13 (for Solomon had made a bronze platform, five cubits long, five cubits wide, and three cubits high, and had set it in the middle of the court; and he stood on it, and knelt down on his knees before all the assembly of Israel, and spread out his hands toward heaven). 
-\v 14 Then he said, “Yahweh, the Elohim of Israel, there is no Elohim like you in heaven or on earth—you who keep covenant and loving kindness with your servants who walk before you with all their heart; 
+\v 14 Then he said, “Yahuah, the Elohim of Israel, there is no Elohim like you in heaven or on earth—you who keep covenant and loving kindness with your servants who walk before you with all their heart; 
 \v 15 who have kept with your servant David my father that which you promised him. Yes, you spoke with your mouth, and have fulfilled it with your hand, as it is today. 
 \p
-\v 16 “Now therefore, Yahweh, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk in my law as you have walked before me.’ 
-\v 17 Now therefore, Yahweh, the Elohim of Israel, let your word be verified, which you spoke to your servant David. 
+\v 16 “Now therefore, Yahuah, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk in my law as you have walked before me.’ 
+\v 17 Now therefore, Yahuah, the Elohim of Israel, let your word be verified, which you spoke to your servant David. 
 \p
 \v 18 “But will Elohim indeed dwell with men on the earth? Behold, heaven and the heaven of heavens can’t contain you; how much less this house which I have built! 
-\v 19 Yet have respect for the prayer of your servant and to his supplication, Yahweh my Elohim, to listen to the cry and to the prayer which your servant prays before you; 
+\v 19 Yet have respect for the prayer of your servant and to his supplication, Yahuah my Elohim, to listen to the cry and to the prayer which your servant prays before you; 
 \v 20 that your eyes may be open toward this house day and night, even toward the place where you have said that you would put your name, to listen to the prayer which your servant will pray toward this place. 
 \v 21 Listen to the petitions of your servant and of your people Israel, when they pray toward this place. Yes, hear from your dwelling place, even from heaven; and when you hear, forgive. 
 \p
@@ -180,31 +180,31 @@
 \p
 \v 40 “Now, my Elohim, let, I beg you, your eyes be open, and let your ears be attentive to the prayer that is made in this place. 
 \p
-\v 41 “Now therefore arise, Yahweh Elohim, into your resting place, you, and the ark of your strength. Let your priests, Yahweh Elohim, be clothed with salvation, and let your saints rejoice in goodness. 
+\v 41 “Now therefore arise, Yahuah Elohim, into your resting place, you, and the ark of your strength. Let your priests, Yahuah Elohim, be clothed with salvation, and let your saints rejoice in goodness. 
 \p
-\v 42 “Yahweh Elohim, don’t turn away the face of your anointed. Remember your loving kindnesses to David your servant.” 
+\v 42 “Yahuah Elohim, don’t turn away the face of your anointed. Remember your loving kindnesses to David your servant.” 
 \c 7
 \p
-\v 1 Now when Solomon had finished praying, fire came down from heaven and consumed the burnt offering and the sacrifices; and Yahweh’s glory filled the house. 
-\v 2 The priests could not enter into Yahweh’s house, because Yahweh’s glory filled Yahweh’s house. 
-\v 3 All the children of Israel looked on, when the fire came down, and Yahweh’s glory was on the house. They bowed themselves with their faces to the ground on the pavement, worshiped, and gave thanks to Yahweh, saying, 
+\v 1 Now when Solomon had finished praying, fire came down from heaven and consumed the burnt offering and the sacrifices; and Yahuah’s glory filled the house. 
+\v 2 The priests could not enter into Yahuah’s house, because Yahuah’s glory filled Yahuah’s house. 
+\v 3 All the children of Israel looked on, when the fire came down, and Yahuah’s glory was on the house. They bowed themselves with their faces to the ground on the pavement, worshiped, and gave thanks to Yahuah, saying, 
 \q1 “For he is good, 
 \q2 for his loving kindness endures forever!” 
 \p
-\v 4 Then the king and all the people offered sacrifices before Yahweh. 
+\v 4 Then the king and all the people offered sacrifices before Yahuah. 
 \v 5 King Solomon offered a sacrifice of twenty-two thousand head of cattle and a hundred twenty thousand sheep. So the king and all the people dedicated Elohim’s house. 
-\v 6 The priests stood, according to their positions; the Levites also with instruments of music of Yahweh, which David the king had made to give thanks to Yahweh, when David praised by their ministry, saying “For his loving kindness endures forever.” The priests sounded trumpets before them; and all Israel stood. 
+\v 6 The priests stood, according to their positions; the Levites also with instruments of music of Yahuah, which David the king had made to give thanks to Yahuah, when David praised by their ministry, saying “For his loving kindness endures forever.” The priests sounded trumpets before them; and all Israel stood. 
 \p
-\v 7 Moreover Solomon made the middle of the court that was before Yahweh’s house set-apart; for there he offered the burnt offerings and the fat of the peace offerings, because the bronze altar which Solomon had made was not able to receive the burnt offering, the meal offering, and the fat. 
+\v 7 Moreover Solomon made the middle of the court that was before Yahuah’s house set-apart; for there he offered the burnt offerings and the fat of the peace offerings, because the bronze altar which Solomon had made was not able to receive the burnt offering, the meal offering, and the fat. 
 \p
 \v 8 So Solomon held the feast at that time for seven days, and all Israel with him, a very great assembly, from the entrance of Hamath to the brook of Egypt. 
 \p
 \v 9 On the eighth day, they held a solemn assembly; for they kept the dedication of the altar seven days, and the feast seven days. 
-\v 10 On the twenty-third day of the seventh month, he sent the people away to their tents, joyful and glad of heart for the goodness that Yahweh had shown to David, to Solomon, and to Israel his people. 
+\v 10 On the twenty-third day of the seventh month, he sent the people away to their tents, joyful and glad of heart for the goodness that Yahuah had shown to David, to Solomon, and to Israel his people. 
 \p
-\v 11 Thus Solomon finished Yahweh’s house and the king’s house; and he successfully completed all that came into Solomon’s heart to make in Yahweh’s house and in his own house. 
+\v 11 Thus Solomon finished Yahuah’s house and the king’s house; and he successfully completed all that came into Solomon’s heart to make in Yahuah’s house and in his own house. 
 \p
-\v 12 Then Yahweh appeared to Solomon by night, and said to him, “I have heard your prayer, and have chosen this place for myself for a house of sacrifice. 
+\v 12 Then Yahuah appeared to Solomon by night, and said to him, “I have heard your prayer, and have chosen this place for myself for a house of sacrifice. 
 \p
 \v 13 “If I shut up the sky so that there is no rain, or if I command the locust to devour the land, or if I send pestilence among my people, 
 \v 14 if my people who are called by my name will humble themselves, pray, seek my face, and turn from their wicked ways, then I will hear from heaven, will forgive their sin, and will heal their land. 
@@ -216,11 +216,11 @@
 \p
 \v 19 But if you turn away and forsake my statutes and my commandments which I have set before you, and go and serve other elohims and worship them, 
 \v 20 then I will pluck them up by the roots out of my land which I have given them; and this house, which I have made set-apart for my name, I will cast out of my sight, and I will make it a proverb and a byword among all peoples. 
-\v 21 This house, which is so high, everyone who passes by it will be astonished and say, ‘Why has Yahweh done this to this land and to this house?’ 
-\v 22 They shall answer, ‘Because they abandoned Yahweh, the Elohim of their fathers, who brought them out of the land of Egypt, and took other elohims, worshiped them, and served them. Therefore he has brought all this evil on them.’ ” 
+\v 21 This house, which is so high, everyone who passes by it will be astonished and say, ‘Why has Yahuah done this to this land and to this house?’ 
+\v 22 They shall answer, ‘Because they abandoned Yahuah, the Elohim of their fathers, who brought them out of the land of Egypt, and took other elohims, worshiped them, and served them. Therefore he has brought all this evil on them.’ ” 
 \c 8
 \p
-\v 1 At the end of twenty years, in which Solomon had built Yahweh’s house and his own house, 
+\v 1 At the end of twenty years, in which Solomon had built Yahuah’s house and his own house, 
 \v 2 Solomon built the cities which Huram had given to Solomon, and caused the children of Israel to dwell there. 
 \p
 \v 3 Solomon went to Hamath Zobah, and prevailed against it. 
@@ -232,15 +232,15 @@
 \v 9 But of the children of Israel, Solomon made no servants for his work, but they were men of war, chief of his captains, and rulers of his chariots and of his horsemen. 
 \v 10 These were the chief officers of King Solomon, even two-hundred fifty, who ruled over the people. 
 \p
-\v 11 Solomon brought up Pharaoh’s daughter out of David’s city to the house that he had built for her; for he said, “My woman shall not dwell in the house of David king of Israel, because the places where Yahweh’s ark has come are set-apart.” 
+\v 11 Solomon brought up Pharaoh’s daughter out of David’s city to the house that he had built for her; for he said, “My woman shall not dwell in the house of David king of Israel, because the places where Yahuah’s ark has come are set-apart.” 
 \p
-\v 12 Then Solomon offered burnt offerings to Yahweh on Yahweh’s altar which he had built before the porch, 
+\v 12 Then Solomon offered burnt offerings to Yahuah on Yahuah’s altar which he had built before the porch, 
 \v 13 even as the duty of every day required, offering according to the commandment of Moses on the Sabbaths, on the new moons, and on the set feasts, three times per year, during the feast of unleavened bread, during the feast of weeks, and during the feast of booths. 
 \p
 \v 14 He appointed, according to the ordinance of David his father, the divisions of the priests to their service, and the Levites to their offices, to praise and to minister before the priests, as the duty of every day required, the doorkeepers also by their divisions at every gate, for David the man of Elohim had so commanded. 
 \v 15 They didn’t depart from the commandment of the king to the priests and Levites concerning any matter or concerning the treasures. 
 \p
-\v 16 Now all the work of Solomon was accomplished from the day of the foundation of Yahweh’s house until it was finished. So Yahweh’s house was completed. 
+\v 16 Now all the work of Solomon was accomplished from the day of the foundation of Yahuah’s house until it was finished. So Yahuah’s house was completed. 
 \p
 \v 17 Then Solomon went to Ezion Geber and to Eloth, on the seashore in the land of Edom. 
 \v 18 Huram sent him ships and servants who had knowledge of the sea by the hands of his servants; and they came with the servants of Solomon to Ophir, and brought from there four hundred fifty talents of gold, and brought them to King Solomon. 
@@ -249,17 +249,17 @@
 \v 1 When the queen of Sheba heard of the fame of Solomon, she came to test Solomon with hard questions at Jerusalem, with a very great caravan, including camels that bore spices, gold in abundance, and precious stones. When she had come to Solomon, she talked with him about all that was in her heart. 
 \v 2 Solomon answered all her questions. There wasn’t anything hidden from Solomon which he didn’t tell her. 
 \v 3 When the queen of Sheba had seen the wisdom of Solomon, the house that he had built, 
-\v 4 the food of his table, the seating of his servants, the attendance of his ministers, their clothing, his cup bearers and their clothing, and his ascent by which he went up to Yahweh’s house, there was no more spirit in her. 
+\v 4 the food of his table, the seating of his servants, the attendance of his ministers, their clothing, his cup bearers and their clothing, and his ascent by which he went up to Yahuah’s house, there was no more spirit in her. 
 \p
 \v 5 She said to the king, “It was a true report that I heard in my own land of your acts and of your wisdom. 
 \v 6 However I didn’t believe their words until I came, and my eyes had seen it; and behold half of the greatness of your wisdom wasn’t told me. You exceed the fame that I heard! 
 \v 7 Happy are your men, and happy are these your servants, who stand continually before you and hear your wisdom. 
-\v 8 Blessed be Yahweh your Elohim, who delighted in you and set you on his throne to be king for Yahweh your Elohim, because your Elohim loved Israel, to establish them forever. Therefore he made you king over them, to do justice and righteousness.” 
+\v 8 Blessed be Yahuah your Elohim, who delighted in you and set you on his throne to be king for Yahuah your Elohim, because your Elohim loved Israel, to establish them forever. Therefore he made you king over them, to do justice and righteousness.” 
 \p
 \v 9 She gave the king one hundred and twenty talents of gold, spices in great abundance, and precious stones. There was never before such spice as the queen of Sheba gave to King Solomon. 
 \p
 \v 10 The servants of Huram and the servants of Solomon, who brought gold from Ophir, also brought algum trees and precious stones. 
-\v 11 The king used algum tree wood to make terraces for Yahweh’s house and for the king’s house, and harps and stringed instruments for the singers. There were none like these seen before in the land of Judah. 
+\v 11 The king used algum tree wood to make terraces for Yahuah’s house and for the king’s house, and harps and stringed instruments for the singers. There were none like these seen before in the land of Judah. 
 \v 12 King Solomon gave to the queen of Sheba all her desire, whatever she asked, more than that which she had brought to the king. So she turned and went to her own land, she and her servants. 
 \p
 \v 13 Now the weight of gold that came to Solomon in one year was six hundred sixty-six talents of gold, 
@@ -307,7 +307,7 @@
 \v 13 The king answered them roughly; and King Rehoboam abandoned the counsel of the old men, 
 \v 14 and spoke to them after the counsel of the young men, saying, “My father made your yoke heavy, but I will add to it. My father chastised you with whips, but I will chastise you with scorpions.” 
 \p
-\v 15 So the king didn’t listen to the people; for it was brought about by Elohim, that Yahweh might establish his word, which he spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
+\v 15 So the king didn’t listen to the people; for it was brought about by Elohim, that Yahuah might establish his word, which he spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
 \p
 \v 16 When all Israel saw that the king didn’t listen to them, the people answered the king, saying, “What portion do we have in David? We don’t have an inheritance in the son of Jesse! Every man to your tents, Israel! Now see to your own house, David.” So all Israel departed to their tents. 
 \p
@@ -317,9 +317,9 @@
 \c 11
 \p
 \v 1 When Rehoboam had come to Jerusalem, he assembled the house of Judah and Benjamin, one hundred eighty thousand chosen men who were warriors, to fight against Israel, to bring the kingdom again to Rehoboam. 
-\v 2 But Yahweh’s word came to Shemaiah the man of Elohim, saying, 
+\v 2 But Yahuah’s word came to Shemaiah the man of Elohim, saying, 
 \v 3 “Speak to Rehoboam the son of Solomon, king of Judah, and to all Israel in Judah and Benjamin, saying, 
-\v 4 ‘Yahweh says, “You shall not go up, nor fight against your brothers! Every man return to his house; for this thing is of me.” ’ ” So they listened to Yahweh’s words, and returned from going against Jeroboam. 
+\v 4 ‘Yahuah says, “You shall not go up, nor fight against your brothers! Every man return to his house; for this thing is of me.” ’ ” So they listened to Yahuah’s words, and returned from going against Jeroboam. 
 \p
 \v 5 Rehoboam lived in Jerusalem, and built cities for defense in Judah. 
 \v 6 He built Bethlehem, Etam, Tekoa, 
@@ -331,9 +331,9 @@
 \v 12 He put shields and spears in every city, and made them exceedingly strong. Judah and Benjamin belonged to him. 
 \p
 \v 13 The priests and the Levites who were in all Israel stood with him out of all their territory. 
-\v 14 For the Levites left their pasture lands and their possessions, and came to Judah and Jerusalem; for Jeroboam and his sons cast them off, that they should not execute the priest’s office to Yahweh. 
+\v 14 For the Levites left their pasture lands and their possessions, and came to Judah and Jerusalem; for Jeroboam and his sons cast them off, that they should not execute the priest’s office to Yahuah. 
 \v 15 He himself appointed priests for the high places, for the male goat and calf idols which he had made. 
-\v 16 After them, out of all the tribes of Israel, those who set their hearts to seek Yahweh, the Elohim of Israel, came to Jerusalem to sacrifice to Yahweh, the Elohim of their fathers. 
+\v 16 After them, out of all the tribes of Israel, those who set their hearts to seek Yahuah, the Elohim of Israel, came to Jerusalem to sacrifice to Yahuah, the Elohim of their fathers. 
 \v 17 So they strengthened the kingdom of Judah and made Rehoboam the son of Solomon strong for three years, for they walked three years in the way of David and Solomon. 
 \p
 \v 18 Rehoboam took a woman for himself, Mahalath the daughter of Jerimoth the son of David and of Abihail the daughter of Eliab the son of Jesse. 
@@ -344,24 +344,24 @@
 \v 23 He dealt wisely, and dispersed some of his sons throughout all the lands of Judah and Benjamin, to every fortified city. He gave them food in abundance; and he sought many women for them. 
 \c 12
 \p
-\v 1 When the kingdom of Rehoboam was established and he was strong, he abandoned Yahweh’s law, and all Israel with him. 
-\v 2 In the fifth year of King Rehoboam, Shishak king of Egypt came up against Jerusalem, because they had trespassed against Yahweh, 
+\v 1 When the kingdom of Rehoboam was established and he was strong, he abandoned Yahuah’s law, and all Israel with him. 
+\v 2 In the fifth year of King Rehoboam, Shishak king of Egypt came up against Jerusalem, because they had trespassed against Yahuah, 
 \v 3 with twelve hundred chariots and sixty thousand horsemen. The people were without number who came with him out of Egypt: the Lubim, the Sukkiim, and the Ethiopians. 
 \v 4 He took the fortified cities which belonged to Judah, and came to Jerusalem. 
-\v 5 Now Shemaiah the prophet came to Rehoboam and to the princes of Judah, who were gathered together to Jerusalem because of Shishak, and said to them, “Yahweh says, ‘You have forsaken me, therefore I have also left you in the hand of Shishak.’ ” 
+\v 5 Now Shemaiah the prophet came to Rehoboam and to the princes of Judah, who were gathered together to Jerusalem because of Shishak, and said to them, “Yahuah says, ‘You have forsaken me, therefore I have also left you in the hand of Shishak.’ ” 
 \p
-\v 6 Then the princes of Israel and the king humbled themselves; and they said, “Yahweh is righteous.” 
+\v 6 Then the princes of Israel and the king humbled themselves; and they said, “Yahuah is righteous.” 
 \p
-\v 7 When Yahweh saw that they humbled themselves, Yahweh’s word came to Shemaiah, saying, “They have humbled themselves. I will not destroy them, but I will grant them some deliverance, and my wrath won’t be poured out on Jerusalem by the hand of Shishak. 
+\v 7 When Yahuah saw that they humbled themselves, Yahuah’s word came to Shemaiah, saying, “They have humbled themselves. I will not destroy them, but I will grant them some deliverance, and my wrath won’t be poured out on Jerusalem by the hand of Shishak. 
 \v 8 Nevertheless they will be his servants, that they may know my service, and the service of the kingdoms of the countries.” 
 \p
-\v 9 So Shishak king of Egypt came up against Jerusalem and took away the treasures of Yahweh’s house and the treasures of the king’s house. He took it all away. He also took away the shields of gold which Solomon had made. 
+\v 9 So Shishak king of Egypt came up against Jerusalem and took away the treasures of Yahuah’s house and the treasures of the king’s house. He took it all away. He also took away the shields of gold which Solomon had made. 
 \v 10 King Rehoboam made shields of bronze in their place, and committed them to the hands of the captains of the guard, who kept the door of the king’s house. 
-\v 11 As often as the king entered into Yahweh’s house, the guard came and bore them, then brought them back into the guard room. 
-\v 12 When he humbled himself, Yahweh’s wrath turned from him, so as not to destroy him altogether. Moreover, there were good things found in Judah. 
+\v 11 As often as the king entered into Yahuah’s house, the guard came and bore them, then brought them back into the guard room. 
+\v 12 When he humbled himself, Yahuah’s wrath turned from him, so as not to destroy him altogether. Moreover, there were good things found in Judah. 
 \p
-\v 13 So King Rehoboam strengthened himself in Jerusalem and reigned; for Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahweh had chosen out of all the tribes of Israel to put his name there. His mother’s name was Naamah the Ammonitess. 
-\v 14 He did that which was evil, because he didn’t set his heart to seek Yahweh. 
+\v 13 So King Rehoboam strengthened himself in Jerusalem and reigned; for Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahuah had chosen out of all the tribes of Israel to put his name there. His mother’s name was Naamah the Ammonitess. 
+\v 14 He did that which was evil, because he didn’t set his heart to seek Yahuah. 
 \p
 \v 15 Now the acts of Rehoboam, first and last, aren’t they written in the histories of Shemaiah the prophet and of Iddo the seer, in the genealogies? There were wars between Rehoboam and Jeroboam continually. 
 \v 16 Rehoboam slept with his fathers, and was buried in David’s city; and Abijah his son reigned in his place. 
@@ -371,66 +371,66 @@
 \v 2 He reigned three years in Jerusalem. His mother’s name was Micaiah the daughter of Uriel of Gibeah. There was war between Abijah and Jeroboam. 
 \v 3 Abijah joined battle with an army of valiant men of war, even four hundred thousand chosen men; and Jeroboam set the battle in array against him with eight hundred thousand chosen men, who were mighty men of valor. 
 \v 4 Abijah stood up on Mount Zemaraim, which is in the hill country of Ephraim, and said, “Hear me, Jeroboam and all Israel: 
-\v 5 Ought you not to know that Yahweh, the Elohim of Israel, gave the kingdom over Israel to David forever, even to him and to his sons by a covenant of salt? 
+\v 5 Ought you not to know that Yahuah, the Elohim of Israel, gave the kingdom over Israel to David forever, even to him and to his sons by a covenant of salt? 
 \v 6 Yet Jeroboam the son of Nebat, the servant of Solomon the son of David, rose up, and rebelled against his lord. 
 \v 7 Worthless men were gathered to him, wicked fellows who strengthened themselves against Rehoboam the son of Solomon, when Rehoboam was young and tender hearted, and could not withstand them. 
 \p
-\v 8 “Now you intend to withstand the kingdom of Yahweh in the hand of the sons of David. You are a great multitude, and the golden calves which Jeroboam made you for elohims are with you. 
-\v 9 Haven’t you driven out the priests of Yahweh, the sons of Aaron, and the Levites, and made priests for yourselves according to the ways of the peoples of other lands? Whoever comes to consecrate himself with a young bull and seven rams may be a priest of those who are no elohims. 
+\v 8 “Now you intend to withstand the kingdom of Yahuah in the hand of the sons of David. You are a great multitude, and the golden calves which Jeroboam made you for elohims are with you. 
+\v 9 Haven’t you driven out the priests of Yahuah, the sons of Aaron, and the Levites, and made priests for yourselves according to the ways of the peoples of other lands? Whoever comes to consecrate himself with a young bull and seven rams may be a priest of those who are no elohims. 
 \p
-\v 10 “But as for us, Yahweh is our Elohim, and we have not forsaken him. We have priests serving Yahweh, the sons of Aaron, and the Levites in their work. 
-\v 11 They burn to Yahweh every morning and every evening burnt offerings and sweet incense. They also set the show bread in order on the pure table, and care for the gold lamp stand with its lamps, to burn every evening; for we keep the instruction of Yahweh our Elohim, but you have forsaken him. 
-\v 12 Behold, Elohim is with us at our head, and his priests with the trumpets of alarm to sound an alarm against you. Children of Israel, don’t fight against Yahweh, the Elohim of your fathers; for you will not prosper.” 
+\v 10 “But as for us, Yahuah is our Elohim, and we have not forsaken him. We have priests serving Yahuah, the sons of Aaron, and the Levites in their work. 
+\v 11 They burn to Yahuah every morning and every evening burnt offerings and sweet incense. They also set the show bread in order on the pure table, and care for the gold lamp stand with its lamps, to burn every evening; for we keep the instruction of Yahuah our Elohim, but you have forsaken him. 
+\v 12 Behold, Elohim is with us at our head, and his priests with the trumpets of alarm to sound an alarm against you. Children of Israel, don’t fight against Yahuah, the Elohim of your fathers; for you will not prosper.” 
 \p
 \v 13 But Jeroboam caused an ambush to come about behind them; so they were before Judah, and the ambush was behind them. 
-\v 14 When Judah looked back, behold, the battle was before and behind them; and they cried to Yahweh, and the priests sounded with the trumpets. 
+\v 14 When Judah looked back, behold, the battle was before and behind them; and they cried to Yahuah, and the priests sounded with the trumpets. 
 \v 15 Then the men of Judah gave a shout. As the men of Judah shouted, Elohim struck Jeroboam and all Israel before Abijah and Judah. 
 \v 16 The children of Israel fled before Judah, and Elohim delivered them into their hand. 
 \v 17 Abijah and his people killed them with a great slaughter, so five hundred thousand chosen men of Israel fell down slain. 
-\v 18 Thus the children of Israel were brought under at that time, and the children of Judah prevailed, because they relied on Yahweh, the Elohim of their fathers. 
+\v 18 Thus the children of Israel were brought under at that time, and the children of Judah prevailed, because they relied on Yahuah, the Elohim of their fathers. 
 \v 19 Abijah pursued Jeroboam, and took cities from him: Bethel with its villages, Jeshanah with its villages, and Ephron with its villages. 
 \p
-\v 20 Jeroboam didn’t recover strength again in the days of Abijah. Yahweh struck him, and he died. 
+\v 20 Jeroboam didn’t recover strength again in the days of Abijah. Yahuah struck him, and he died. 
 \v 21 But Abijah grew mighty and took for himself fourteen women, and brought forth twenty-two sons and sixteen daughters. 
 \v 22 The rest of the acts of Abijah, his ways, and his sayings are written in the commentary of the prophet Iddo. 
 \c 14
 \p
 \v 1 So Abijah slept with his fathers, and they buried him in David’s city; and Asa his son reigned in his place. In his days, the land was quiet ten years. 
-\v 2 Asa did that which was good and right in Yahweh his Elohim’s eyes, 
+\v 2 Asa did that which was good and right in Yahuah his Elohim’s eyes, 
 \v 3 for he took away the foreign altars and the high places, broke down the pillars, cut down the Asherah poles, 
-\v 4 and commanded Judah to seek Yahweh, the Elohim of their fathers, and to obey his law and command. 
+\v 4 and commanded Judah to seek Yahuah, the Elohim of their fathers, and to obey his law and command. 
 \v 5 Also he took away out of all the cities of Judah the high places and the sun images; and the kingdom was quiet before him. 
-\v 6 He built fortified cities in Judah; for the land was quiet, and he had no war in those years, because Yahweh had given him rest. 
-\v 7 For he said to Judah, “Let’s build these cities and make walls around them, with towers, gates, and bars. The land is yet before us, because we have sought Yahweh our Elohim. We have sought him, and he has given us rest on every side.” So they built and prospered. 
+\v 6 He built fortified cities in Judah; for the land was quiet, and he had no war in those years, because Yahuah had given him rest. 
+\v 7 For he said to Judah, “Let’s build these cities and make walls around them, with towers, gates, and bars. The land is yet before us, because we have sought Yahuah our Elohim. We have sought him, and he has given us rest on every side.” So they built and prospered. 
 \p
 \v 8 Asa had an army of three hundred thousand out of Judah who bore bucklers and spears, and two hundred eighty thousand out of Benjamin who bore shields and drew bows. All these were mighty men of valor. 
 \p
 \v 9 Zerah the Ethiopian came out against them with an army of a million troops and three hundred chariots, and he came to Mareshah. 
 \v 10 Then Asa went out to meet him, and they set the battle in array in the valley of Zephathah at Mareshah. 
-\v 11 Asa cried to Yahweh his Elohim, and said, “Yahweh, there is no one besides you to help, between the mighty and him who has no strength. Help us, Yahweh our Elohim; for we rely on you, and in your name are we come against this multitude. Yahweh, you are our Elohim. Don’t let man prevail against you.” 
+\v 11 Asa cried to Yahuah his Elohim, and said, “Yahuah, there is no one besides you to help, between the mighty and him who has no strength. Help us, Yahuah our Elohim; for we rely on you, and in your name are we come against this multitude. Yahuah, you are our Elohim. Don’t let man prevail against you.” 
 \p
-\v 12 So Yahweh struck the Ethiopians before Asa and before Judah; and the Ethiopians fled. 
-\v 13 Asa and the people who were with him pursued them to Gerar. So many of the Ethiopians fell that they could not recover themselves, for they were destroyed before Yahweh and before his army. Judah’s army carried away very much booty. 
-\v 14 They struck all the cities around Gerar, for the fear of Yahweh came on them. They plundered all the cities, for there was much plunder in them. 
+\v 12 So Yahuah struck the Ethiopians before Asa and before Judah; and the Ethiopians fled. 
+\v 13 Asa and the people who were with him pursued them to Gerar. So many of the Ethiopians fell that they could not recover themselves, for they were destroyed before Yahuah and before his army. Judah’s army carried away very much booty. 
+\v 14 They struck all the cities around Gerar, for the fear of Yahuah came on them. They plundered all the cities, for there was much plunder in them. 
 \v 15 They also struck the tents of those who had livestock, and carried away sheep and camels in abundance, then returned to Jerusalem. 
 \c 15
 \p
 \v 1 The Spirit of Elohim came on Azariah the son of Oded. 
-\v 2 He went out to meet Asa, and said to him, “Hear me, Asa, and all Judah and Benjamin! Yahweh is with you while you are with him; and if you seek him, he will be found by you; but if you forsake him, he will forsake you. 
+\v 2 He went out to meet Asa, and said to him, “Hear me, Asa, and all Judah and Benjamin! Yahuah is with you while you are with him; and if you seek him, he will be found by you; but if you forsake him, he will forsake you. 
 \v 3 Now for a long time Israel was without the true Elohim, without a teaching priest, and without law. 
-\v 4 But when in their distress they turned to Yahweh, the Elohim of Israel, and sought him, he was found by them. 
+\v 4 But when in their distress they turned to Yahuah, the Elohim of Israel, and sought him, he was found by them. 
 \v 5 In those times there was no peace to him who went out, nor to him who came in; but great troubles were on all the inhabitants of the lands. 
 \v 6 They were broken in pieces, nation against nation, and city against city; for Elohim troubled them with all adversity. 
 \v 7 But you be strong! Don’t let your hands be slack, for your work will be rewarded.” 
 \p
-\v 8 When Asa heard these words and the prophecy of Oded the prophet, he took courage, and put away the abominations out of all the land of Judah and Benjamin, and out of the cities which he had taken from the hill country of Ephraim; and he renewed Yahweh’s altar that was before Yahweh’s porch. 
-\v 9 He gathered all Judah and Benjamin, and those who lived with them out of Ephraim, Manasseh, and Simeon; for they came to him out of Israel in abundance when they saw that Yahweh his Elohim was with him. 
+\v 8 When Asa heard these words and the prophecy of Oded the prophet, he took courage, and put away the abominations out of all the land of Judah and Benjamin, and out of the cities which he had taken from the hill country of Ephraim; and he renewed Yahuah’s altar that was before Yahuah’s porch. 
+\v 9 He gathered all Judah and Benjamin, and those who lived with them out of Ephraim, Manasseh, and Simeon; for they came to him out of Israel in abundance when they saw that Yahuah his Elohim was with him. 
 \v 10 So they gathered themselves together at Jerusalem in the third month, in the fifteenth year of Asa’s reign. 
-\v 11 They sacrificed to Yahweh in that day, of the plunder which they had brought, seven hundred head of cattle and seven thousand sheep. 
-\v 12 They entered into the covenant to seek Yahweh, the Elohim of their fathers, with all their heart and with all their soul; 
-\v 13 and that whoever would not seek Yahweh, the Elohim of Israel, should be put to death, whether small or great, whether man or woman. 
-\v 14 They swore to Yahweh with a loud voice, with shouting, with trumpets, and with cornets. 
-\v 15 All Judah rejoiced at the oath, for they had sworn with all their heart and sought him with their whole desire; and he was found by them. Then Yahweh gave them rest all around. 
+\v 11 They sacrificed to Yahuah in that day, of the plunder which they had brought, seven hundred head of cattle and seven thousand sheep. 
+\v 12 They entered into the covenant to seek Yahuah, the Elohim of their fathers, with all their heart and with all their soul; 
+\v 13 and that whoever would not seek Yahuah, the Elohim of Israel, should be put to death, whether small or great, whether man or woman. 
+\v 14 They swore to Yahuah with a loud voice, with shouting, with trumpets, and with cornets. 
+\v 15 All Judah rejoiced at the oath, for they had sworn with all their heart and sought him with their whole desire; and he was found by them. Then Yahuah gave them rest all around. 
 \p
 \v 16 Also Maacah, the mother of Asa the king, he removed from being queen mother, because she had made an abominable image for an Asherah; so Asa cut down her image, ground it into dust, and burned it at the brook Kidron. 
 \v 17 But the high places were not taken away out of Israel; nevertheless the heart of Asa was perfect all his days. 
@@ -439,43 +439,43 @@
 \c 16
 \p
 \v 1 In the thirty-sixth year of Asa’s reign, Baasha king of Israel went up against Judah, and built Ramah, that he might not allow anyone to go out or come in to Asa king of Judah. 
-\v 2 Then Asa brought out silver and gold out of the treasures of Yahweh’s house and of the king’s house, and sent to Ben Hadad king of Syria, who lived at Damascus, saying, 
+\v 2 Then Asa brought out silver and gold out of the treasures of Yahuah’s house and of the king’s house, and sent to Ben Hadad king of Syria, who lived at Damascus, saying, 
 \v 3 “Let there be a treaty between me and you, as there was between my father and your father. Behold, I have sent you silver and gold. Go, break your treaty with Baasha king of Israel, that he may depart from me.” 
 \p
 \v 4 Ben Hadad listened to King Asa, and sent the captains of his armies against the cities of Israel; and they struck Ijon, Dan, Abel Maim, and all the storage cities of Naphtali. 
 \v 5 When Baasha heard of it, he stopped building Ramah, and let his work cease. 
 \v 6 Then Asa the king took all Judah, and they carried away the stones and timber of Ramah, with which Baasha had built; and he built Geba and Mizpah with them. 
 \p
-\v 7 At that time Hanani the seer came to Asa king of Judah, and said to him, “Because you have relied on the king of Syria, and have not relied on Yahweh your Elohim, therefore the army of the king of Syria has escaped out of your hand. 
-\v 8 Weren’t the Ethiopians and the Lubim a huge army, with chariots and exceedingly many horsemen? Yet, because you relied on Yahweh, he delivered them into your hand. 
-\v 9 For Yahweh’s eyes run back and forth throughout the whole earth, to show himself strong in the behalf of them whose heart is perfect toward him. You have done foolishly in this; for from now on you will have wars.” 
+\v 7 At that time Hanani the seer came to Asa king of Judah, and said to him, “Because you have relied on the king of Syria, and have not relied on Yahuah your Elohim, therefore the army of the king of Syria has escaped out of your hand. 
+\v 8 Weren’t the Ethiopians and the Lubim a huge army, with chariots and exceedingly many horsemen? Yet, because you relied on Yahuah, he delivered them into your hand. 
+\v 9 For Yahuah’s eyes run back and forth throughout the whole earth, to show himself strong in the behalf of them whose heart is perfect toward him. You have done foolishly in this; for from now on you will have wars.” 
 \p
 \v 10 Then Asa was angry with the seer, and put him in the prison; for he was in a rage with him because of this thing. Asa oppressed some of the people at the same time. 
 \p
 \v 11 Behold, the acts of Asa, first and last, behold, they are written in the book of the kings of Judah and Israel. 
-\v 12 In the thirty-ninth year of his reign, Asa was diseased in his feet. His disease was exceedingly great; yet in his disease he didn’t seek Yahweh, but just the physicians. 
+\v 12 In the thirty-ninth year of his reign, Asa was diseased in his feet. His disease was exceedingly great; yet in his disease he didn’t seek Yahuah, but just the physicians. 
 \v 13 Asa slept with his fathers, and died in the forty-first year of his reign. 
 \v 14 They buried him in his own tomb, which he had dug out for himself in David’s city, and laid him in the bed which was filled with sweet odors and various kinds of spices prepared by the perfumers’ art; and they made a very great fire for him. 
 \c 17
 \p
 \v 1 Jehoshaphat his son reigned in his place, and strengthened himself against Israel. 
 \v 2 He placed forces in all the fortified cities of Judah, and set garrisons in the land of Judah and in the cities of Ephraim, which Asa his father had taken. 
-\v 3 Yahweh was with Jehoshaphat, because he walked in the first ways of his father David, and didn’t seek the Baals, 
+\v 3 Yahuah was with Jehoshaphat, because he walked in the first ways of his father David, and didn’t seek the Baals, 
 \v 4 but sought the Elohim of his father, and walked in his commandments, and not in the ways of Israel. 
-\v 5 Therefore Yahweh established the kingdom in his hand. All Judah brought tribute to Jehoshaphat, and he had riches and honor in abundance. 
-\v 6 His heart was lifted up in the ways of Yahweh. Furthermore, he took away the high places and the Asherah poles out of Judah. 
+\v 5 Therefore Yahuah established the kingdom in his hand. All Judah brought tribute to Jehoshaphat, and he had riches and honor in abundance. 
+\v 6 His heart was lifted up in the ways of Yahuah. Furthermore, he took away the high places and the Asherah poles out of Judah. 
 \p
 \v 7 Also in the third year of his reign he sent his princes, even Ben Hail, Obadiah, Zechariah, Nethanel, and Micaiah, to teach in the cities of Judah; 
 \v 8 and with them Levites, even Shemaiah, Nethaniah, Zebadiah, Asahel, Shemiramoth, Jehonathan, Adonijah, Tobijah, and Tobadonijah, the Levites; and with them Elishama and Jehoram, the priests. 
-\v 9 They taught in Judah, having the book of Yahweh’s law with them. They went about throughout all the cities of Judah and taught among the people. 
+\v 9 They taught in Judah, having the book of Yahuah’s law with them. They went about throughout all the cities of Judah and taught among the people. 
 \p
-\v 10 The fear of Yahweh fell on all the kingdoms of the lands that were around Judah, so that they made no war against Jehoshaphat. 
+\v 10 The fear of Yahuah fell on all the kingdoms of the lands that were around Judah, so that they made no war against Jehoshaphat. 
 \v 11 Some of the Philistines brought Jehoshaphat presents and silver for tribute. The Arabians also brought him flocks: seven thousand seven hundred rams and seven thousand seven hundred male goats. 
 \v 12 Jehoshaphat grew great exceedingly; and he built fortresses and store cities in Judah. 
 \v 13 He had many works in the cities of Judah; and men of war, mighty men of valor, in Jerusalem. 
 \v 14 This was the numbering of them according to their fathers’ houses: From Judah, the captains of thousands: Adnah the captain, and with him three hundred thousand mighty men of valor; 
 \v 15 and next to him Jehohanan the captain, and with him two hundred eighty thousand; 
-\v 16 and next to him Amasiah the son of Zichri, who willingly offered himself to Yahweh, and with him two hundred thousand mighty men of valor. 
+\v 16 and next to him Amasiah the son of Zichri, who willingly offered himself to Yahuah, and with him two hundred thousand mighty men of valor. 
 \v 17 From Benjamin: Eliada, a mighty man of valor, and with him two hundred thousand armed with bow and shield; 
 \v 18 and next to him Jehozabad, and with him one hundred eighty thousand ready and prepared for war. 
 \v 19 These were those who waited on the king, in addition to those whom the king put in the fortified cities throughout all Judah. 
@@ -485,87 +485,87 @@
 \v 2 After some years, he went down to Ahab to Samaria. Ahab killed sheep and cattle for him in abundance, and for the people who were with him, and moved him to go up with him to Ramoth Gilead. 
 \v 3 Ahab king of Israel said to Jehoshaphat king of Judah, “Will you go with me to Ramoth Gilead?” 
 \p He answered him, “I am as you are, and my people as your people. We will be with you in the war.” 
-\v 4 Jehoshaphat said to the king of Israel, “Please inquire first for Yahweh’s word.” 
+\v 4 Jehoshaphat said to the king of Israel, “Please inquire first for Yahuah’s word.” 
 \p
 \v 5 Then the king of Israel gathered the prophets together, four hundred men, and said to them, “Shall we go to Ramoth Gilead to battle, or shall I forbear?” 
 \p They said, “Go up, for Elohim will deliver it into the hand of the king.” 
 \p
-\v 6 But Jehoshaphat said, “Isn’t there here a prophet of Yahweh besides, that we may inquire of him?” 
+\v 6 But Jehoshaphat said, “Isn’t there here a prophet of Yahuah besides, that we may inquire of him?” 
 \p
-\v 7 The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahweh; but I hate him, for he never prophesies good concerning me, but always evil. He is Micaiah the son of Imla.” 
+\v 7 The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahuah; but I hate him, for he never prophesies good concerning me, but always evil. He is Micaiah the son of Imla.” 
 \p Jehoshaphat said, “Don’t let the king say so.” 
 \p
 \v 8 Then the king of Israel called an officer, and said, “Get Micaiah the son of Imla quickly.” 
 \p
 \v 9 Now the king of Israel and Jehoshaphat the king of Judah each sat on his throne, arrayed in their robes, and they were sitting in an open place at the entrance of the gate of Samaria; and all the prophets were prophesying before them. 
-\v 10 Zedekiah the son of Chenaanah made himself horns of iron and said, “Yahweh says, ‘With these you shall push the Syrians, until they are consumed.’ ” 
+\v 10 Zedekiah the son of Chenaanah made himself horns of iron and said, “Yahuah says, ‘With these you shall push the Syrians, until they are consumed.’ ” 
 \p
-\v 11 All the prophets prophesied so, saying, “Go up to Ramoth Gilead, and prosper; for Yahweh will deliver it into the hand of the king.” 
+\v 11 All the prophets prophesied so, saying, “Go up to Ramoth Gilead, and prosper; for Yahuah will deliver it into the hand of the king.” 
 \p
 \v 12 The messenger who went to call Micaiah spoke to him, saying, “Behold, the words of the prophets declare good to the king with one mouth. Let your word therefore, please be like one of theirs, and speak good.” 
 \p
-\v 13 Micaiah said, “As Yahweh lives, I will say what my Elohim says.” 
+\v 13 Micaiah said, “As Yahuah lives, I will say what my Elohim says.” 
 \p
 \v 14 When he had come to the king, the king said to him, “Micaiah, shall we go to Ramoth Gilead to battle, or shall I forbear?” 
 \p He said, “Go up, and prosper. They shall be delivered into your hand.” 
 \p
-\v 15 The king said to him, “How many times shall I adjure you that you speak to me nothing but the truth in Yahweh’s name?” 
+\v 15 The king said to him, “How many times shall I adjure you that you speak to me nothing but the truth in Yahuah’s name?” 
 \p
-\v 16 He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahweh said, ‘These have no master. Let them each return to his house in peace.’ ” 
+\v 16 He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahuah said, ‘These have no master. Let them each return to his house in peace.’ ” 
 \p
 \v 17 The king of Israel said to Jehoshaphat, “Didn’t I tell you that he would not prophesy good concerning me, but evil?” 
 \p
-\v 18 Micaiah said, “Therefore hear Yahweh’s word: I saw Yahweh sitting on his throne, and all the army of heaven standing on his right hand and on his left. 
-\v 19 Yahweh said, ‘Who will entice Ahab king of Israel, that he may go up and fall at Ramoth Gilead?’ One spoke saying in this way, and another saying in that way. 
-\v 20 A spirit came out, stood before Yahweh, and said, ‘I will entice him.’ 
-\p “Yahweh said to him, ‘How?’ 
+\v 18 Micaiah said, “Therefore hear Yahuah’s word: I saw Yahuah sitting on his throne, and all the army of heaven standing on his right hand and on his left. 
+\v 19 Yahuah said, ‘Who will entice Ahab king of Israel, that he may go up and fall at Ramoth Gilead?’ One spoke saying in this way, and another saying in that way. 
+\v 20 A spirit came out, stood before Yahuah, and said, ‘I will entice him.’ 
+\p “Yahuah said to him, ‘How?’ 
 \p
 \v 21 “He said, ‘I will go, and will be a lying spirit in the mouth of all his prophets.’ 
 \p “He said, ‘You will entice him, and will prevail also. Go and do so.’ 
 \p
-\v 22 “Now therefore, behold, Yahweh has put a lying spirit in the mouth of these your prophets; and Yahweh has spoken evil concerning you.” 
+\v 22 “Now therefore, behold, Yahuah has put a lying spirit in the mouth of these your prophets; and Yahuah has spoken evil concerning you.” 
 \p
-\v 23 Then Zedekiah the son of Chenaanah came near, and struck Micaiah on the cheek, and said, “Which way did Yahweh’s Spirit go from me to speak to you?” 
+\v 23 Then Zedekiah the son of Chenaanah came near, and struck Micaiah on the cheek, and said, “Which way did Yahuah’s Spirit go from me to speak to you?” 
 \p
 \v 24 Micaiah said, “Behold, you shall see on that day, when you go into an inner room to hide yourself.” 
 \p
 \v 25 The king of Israel said, “Take Micaiah, and carry him back to Amon the governor of the city, and to Joash the king’s son; 
 \v 26 and say, ‘The king says, “Put this fellow in the prison, and feed him with bread of affliction and with water of affliction, until I return in peace.” ’ ” 
 \p
-\v 27 Micaiah said, “If you return at all in peace, Yahweh has not spoken by me.” He said, “Listen, you people, all of you!” 
+\v 27 Micaiah said, “If you return at all in peace, Yahuah has not spoken by me.” He said, “Listen, you people, all of you!” 
 \p
 \v 28 So the king of Israel and Jehoshaphat the king of Judah went up to Ramoth Gilead. 
 \v 29 The king of Israel said to Jehoshaphat, “I will disguise myself, and go into the battle; but you put on your robes.” So the king of Israel disguised himself; and they went into the battle. 
 \v 30 Now the king of Syria had commanded the captains of his chariots, saying, “Don’t fight with small nor great, except only with the king of Israel.” 
 \p
-\v 31 When the captains of the chariots saw Jehoshaphat, they said, “It is the king of Israel!” Therefore they turned around to fight against him. But Jehoshaphat cried out, and Yahweh helped him; and Elohim moved them to depart from him. 
+\v 31 When the captains of the chariots saw Jehoshaphat, they said, “It is the king of Israel!” Therefore they turned around to fight against him. But Jehoshaphat cried out, and Yahuah helped him; and Elohim moved them to depart from him. 
 \v 32 When the captains of the chariots saw that it was not the king of Israel, they turned back from pursuing him. 
 \v 33 A certain man drew his bow at random, and struck the king of Israel between the joints of the armor. Therefore he said to the driver of the chariot, “Turn around and carry me out of the battle, for I am severely wounded.” 
 \v 34 The battle increased that day. However, the king of Israel propped himself up in his chariot against the Syrians until the evening; and at about sunset, he died. 
 \c 19
 \p
 \v 1 Jehoshaphat the king of Judah returned to his house in peace to Jerusalem. 
-\v 2 Jehu the son of Hanani the seer went out to meet him, and said to King Jehoshaphat, “Should you help the wicked, and love those who hate Yahweh? Because of this, wrath is on you from before Yahweh. 
+\v 2 Jehu the son of Hanani the seer went out to meet him, and said to King Jehoshaphat, “Should you help the wicked, and love those who hate Yahuah? Because of this, wrath is on you from before Yahuah. 
 \v 3 Nevertheless there are good things found in you, in that you have put away the Asheroth out of the land, and have set your heart to seek Elohim.” 
 \p
-\v 4 Jehoshaphat lived at Jerusalem; and he went out again among the people from Beersheba to the hill country of Ephraim, and brought them back to Yahweh, the Elohim of their fathers. 
+\v 4 Jehoshaphat lived at Jerusalem; and he went out again among the people from Beersheba to the hill country of Ephraim, and brought them back to Yahuah, the Elohim of their fathers. 
 \v 5 He set judges in the land throughout all the fortified cities of Judah, city by city, 
-\v 6 and said to the judges, “Consider what you do, for you don’t judge for man, but for Yahweh; and he is with you in the judgment. 
-\v 7 Now therefore let the fear of Yahweh be on you. Take heed and do it; for there is no iniquity with Yahweh our Elohim, nor respect of persons, nor taking of bribes.” 
+\v 6 and said to the judges, “Consider what you do, for you don’t judge for man, but for Yahuah; and he is with you in the judgment. 
+\v 7 Now therefore let the fear of Yahuah be on you. Take heed and do it; for there is no iniquity with Yahuah our Elohim, nor respect of persons, nor taking of bribes.” 
 \p
-\v 8 Moreover in Jerusalem Jehoshaphat appointed certain Levites, priests, and heads of the fathers’ households of Israel to give judgment for Yahweh and for controversies. They returned to Jerusalem. 
-\v 9 He commanded them, saying, “You shall do this in the fear of Yahweh, faithfully, and with a perfect heart. 
-\v 10 Whenever any controversy comes to you from your brothers who dwell in their cities, between blood and blood, between law and commandment, statutes and ordinances, you must warn them, that they not be guilty toward Yahweh, and so wrath come on you and on your brothers. Do this, and you will not be guilty. 
-\v 11 Behold, Amariah the chief priest is over you in all matters of Yahweh; and Zebadiah the son of Ishmael, the ruler of the house of Judah, in all the king’s matters. Also the Levites shall be officers before you. Deal courageously, and may Yahweh be with the good.” 
+\v 8 Moreover in Jerusalem Jehoshaphat appointed certain Levites, priests, and heads of the fathers’ households of Israel to give judgment for Yahuah and for controversies. They returned to Jerusalem. 
+\v 9 He commanded them, saying, “You shall do this in the fear of Yahuah, faithfully, and with a perfect heart. 
+\v 10 Whenever any controversy comes to you from your brothers who dwell in their cities, between blood and blood, between law and commandment, statutes and ordinances, you must warn them, that they not be guilty toward Yahuah, and so wrath come on you and on your brothers. Do this, and you will not be guilty. 
+\v 11 Behold, Amariah the chief priest is over you in all matters of Yahuah; and Zebadiah the son of Ishmael, the ruler of the house of Judah, in all the king’s matters. Also the Levites shall be officers before you. Deal courageously, and may Yahuah be with the good.” 
 \c 20
 \p
 \v 1 After this, the children of Moab, the children of Ammon, and with them some of the Ammonites, came against Jehoshaphat to battle. 
 \v 2 Then some came who told Jehoshaphat, saying, “A great multitude is coming against you from beyond the sea from Syria. Behold, they are in Hazazon Tamar” (that is, En Gedi). 
-\v 3 Jehoshaphat was alarmed, and set himself to seek to Yahweh. He proclaimed a fast throughout all Judah. 
-\v 4 Judah gathered themselves together to seek help from Yahweh. They came out of all the cities of Judah to seek Yahweh. 
+\v 3 Jehoshaphat was alarmed, and set himself to seek to Yahuah. He proclaimed a fast throughout all Judah. 
+\v 4 Judah gathered themselves together to seek help from Yahuah. They came out of all the cities of Judah to seek Yahuah. 
 \p
-\v 5 Jehoshaphat stood in the assembly of Judah and Jerusalem, in Yahweh’s house, before the new court; 
-\v 6 and he said, “Yahweh, the Elohim of our fathers, aren’t you Elohim in heaven? Aren’t you ruler over all the kingdoms of the nations? Power and might are in your hand, so that no one is able to withstand you. 
+\v 5 Jehoshaphat stood in the assembly of Judah and Jerusalem, in Yahuah’s house, before the new court; 
+\v 6 and he said, “Yahuah, the Elohim of our fathers, aren’t you Elohim in heaven? Aren’t you ruler over all the kingdoms of the nations? Power and might are in your hand, so that no one is able to withstand you. 
 \v 7 Didn’t you, our Elohim, drive out the inhabitants of this land before your people Israel, and give it to the offspring of Abraham your friend forever? 
 \v 8 They lived in it, and have built you a sanctuary in it for your name, saying, 
 \v 9 ‘If evil comes on us—the sword, judgment, pestilence, or famine—we will stand before this house, and before you (for your name is in this house), and cry to you in our affliction, and you will hear and save.’ 
@@ -573,39 +573,39 @@
 \v 11 behold, how they reward us, to come to cast us out of your possession, which you have given us to inherit. 
 \v 12 Our Elohim, will you not judge them? For we have no might against this great company that comes against us. We don’t know what to do, but our eyes are on you.” 
 \p
-\v 13 All Judah stood before Yahweh, with their little ones, their women, and their children. 
+\v 13 All Judah stood before Yahuah, with their little ones, their women, and their children. 
 \p
-\v 14 Then Yahweh’s Spirit came on Jahaziel the son of Zechariah, the son of Benaiah, the son of Jeiel, the son of Mattaniah, the Levite, of the sons of Asaph, in the middle of the assembly; 
-\v 15 and he said, “Listen, all Judah, and you inhabitants of Jerusalem, and you, King Jehoshaphat. Yahweh says to you, ‘Don’t be afraid, and don’t be dismayed because of this great multitude; for the battle is not yours, but Elohim’s. 
+\v 14 Then Yahuah’s Spirit came on Jahaziel the son of Zechariah, the son of Benaiah, the son of Jeiel, the son of Mattaniah, the Levite, of the sons of Asaph, in the middle of the assembly; 
+\v 15 and he said, “Listen, all Judah, and you inhabitants of Jerusalem, and you, King Jehoshaphat. Yahuah says to you, ‘Don’t be afraid, and don’t be dismayed because of this great multitude; for the battle is not yours, but Elohim’s. 
 \v 16 Tomorrow, go down against them. Behold, they are coming up by the ascent of Ziz. You will find them at the end of the valley, before the wilderness of Jeruel. 
-\v 17 You will not need to fight this battle. Set yourselves, stand still, and see the salvation of Yahweh with you, O Judah and Jerusalem. Don’t be afraid, nor be dismayed. Go out against them tomorrow, for Yahweh is with you.’ ” 
+\v 17 You will not need to fight this battle. Set yourselves, stand still, and see the salvation of Yahuah with you, O Judah and Jerusalem. Don’t be afraid, nor be dismayed. Go out against them tomorrow, for Yahuah is with you.’ ” 
 \p
-\v 18 Jehoshaphat bowed his head with his face to the ground; and all Judah and the inhabitants of Jerusalem fell down before Yahweh, worshiping Yahweh. 
-\v 19 The Levites, of the children of the Kohathites and of the children of the Korahites, stood up to praise Yahweh, the Elohim of Israel, with an exceedingly loud voice. 
+\v 18 Jehoshaphat bowed his head with his face to the ground; and all Judah and the inhabitants of Jerusalem fell down before Yahuah, worshiping Yahuah. 
+\v 19 The Levites, of the children of the Kohathites and of the children of the Korahites, stood up to praise Yahuah, the Elohim of Israel, with an exceedingly loud voice. 
 \p
-\v 20 They rose early in the morning and went out into the wilderness of Tekoa. As they went out, Jehoshaphat stood and said, “Listen to me, Judah and you inhabitants of Jerusalem! Believe in Yahweh your Elohim, so you will be established! Believe his prophets, so you will prosper.” 
+\v 20 They rose early in the morning and went out into the wilderness of Tekoa. As they went out, Jehoshaphat stood and said, “Listen to me, Judah and you inhabitants of Jerusalem! Believe in Yahuah your Elohim, so you will be established! Believe his prophets, so you will prosper.” 
 \p
-\v 21 When he had taken counsel with the people, he appointed those who were to sing to Yahweh and give praise in set-apart array as they go out before the army, and say, “Give thanks to Yahweh, for his loving kindness endures forever.” 
-\v 22 When they began to sing and to praise, Yahweh set ambushers against the children of Ammon, Moab, and Mount Seir, who had come against Judah; and they were struck. 
+\v 21 When he had taken counsel with the people, he appointed those who were to sing to Yahuah and give praise in set-apart array as they go out before the army, and say, “Give thanks to Yahuah, for his loving kindness endures forever.” 
+\v 22 When they began to sing and to praise, Yahuah set ambushers against the children of Ammon, Moab, and Mount Seir, who had come against Judah; and they were struck. 
 \v 23 For the children of Ammon and Moab stood up against the inhabitants of Mount Seir to utterly kill and destroy them. When they had finished the inhabitants of Seir, everyone helped to destroy each other. 
 \p
 \v 24 When Judah came to the place overlooking the wilderness, they looked at the multitude; and behold, they were dead bodies fallen to the earth, and there were none who escaped. 
 \v 25 When Jehoshaphat and his people came to take their plunder, they found among them in abundance both riches and dead bodies with precious jewels, which they stripped off for themselves, more than they could carry away. They took plunder for three days, it was so much. 
-\v 26 On the fourth day, they assembled themselves in Beracah Valley, for there they blessed Yahweh. Therefore the name of that place was called “Beracah Valley” to this day. 
-\v 27 Then they returned, every man of Judah and Jerusalem, with Jehoshaphat in front of them, to go again to Jerusalem with joy; for Yahweh had made them to rejoice over their enemies. 
-\v 28 They came to Jerusalem with stringed instruments, harps, and trumpets to Yahweh’s house. 
-\v 29 The fear of Elohim was on all the kingdoms of the countries when they heard that Yahweh fought against the enemies of Israel. 
+\v 26 On the fourth day, they assembled themselves in Beracah Valley, for there they blessed Yahuah. Therefore the name of that place was called “Beracah Valley” to this day. 
+\v 27 Then they returned, every man of Judah and Jerusalem, with Jehoshaphat in front of them, to go again to Jerusalem with joy; for Yahuah had made them to rejoice over their enemies. 
+\v 28 They came to Jerusalem with stringed instruments, harps, and trumpets to Yahuah’s house. 
+\v 29 The fear of Elohim was on all the kingdoms of the countries when they heard that Yahuah fought against the enemies of Israel. 
 \v 30 So the realm of Jehoshaphat was quiet, for his Elohim gave him rest all around. 
 \p
 \v 31 So Jehoshaphat reigned over Judah. He was thirty-five years old when he began to reign. He reigned twenty-five years in Jerusalem. His mother’s name was Azubah the daughter of Shilhi. 
-\v 32 He walked in the way of Asa his father, and didn’t turn away from it, doing that which was right in Yahweh’s eyes. 
+\v 32 He walked in the way of Asa his father, and didn’t turn away from it, doing that which was right in Yahuah’s eyes. 
 \v 33 However the high places were not taken away, and the people had still not set their hearts on the Elohim of their fathers. 
 \p
 \v 34 Now the rest of the acts of Jehoshaphat, first and last, behold, they are written in the history of Jehu the son of Hanani, which is included in the book of the kings of Israel. 
 \p
 \v 35 After this, Jehoshaphat king of Judah joined himself with Ahaziah king of Israel. The same did very wickedly. 
 \v 36 He joined himself with him to make ships to go to Tarshish. They made the ships in Ezion Geber. 
-\v 37 Then Eliezer the son of Dodavahu of Mareshah prophesied against Jehoshaphat, saying, “Because you have joined yourself with Ahaziah, Yahweh has destroyed your works.” The ships were wrecked, so that they were not able to go to Tarshish. 
+\v 37 Then Eliezer the son of Dodavahu of Mareshah prophesied against Jehoshaphat, saying, “Because you have joined yourself with Ahaziah, Yahuah has destroyed your works.” The ships were wrecked, so that they were not able to go to Tarshish. 
 \c 21
 \p
 \v 1 Jehoshaphat slept with his fathers, and was buried with his fathers in David’s city; and Jehoram his son reigned in his place. 
@@ -613,23 +613,23 @@
 \v 3 Their father gave them great gifts of silver, of gold, and of precious things, with fortified cities in Judah; but he gave the kingdom to Jehoram, because he was the firstborn. 
 \v 4 Now when Jehoram had risen up over the kingdom of his father, and had strengthened himself, he killed all his brothers with the sword, and also some of the princes of Israel. 
 \v 5 Jehoram was thirty-two years old when he began to reign, and he reigned eight years in Jerusalem. 
-\v 6 He walked in the way of the kings of Israel, as did Ahab’s house, for he had Ahab’s daughter as his woman. He did that which was evil in Yahweh’s sight. 
-\v 7 However Yahweh would not destroy David’s house, because of the covenant that he had made with David, and as he promised to give a lamp to him and to his children always. 
+\v 6 He walked in the way of the kings of Israel, as did Ahab’s house, for he had Ahab’s daughter as his woman. He did that which was evil in Yahuah’s sight. 
+\v 7 However Yahuah would not destroy David’s house, because of the covenant that he had made with David, and as he promised to give a lamp to him and to his children always. 
 \p
 \v 8 In his days Edom revolted from under the hand of Judah, and made a king over themselves. 
 \v 9 Then Jehoram went there with his captains and all his chariots with him. He rose up by night and struck the Edomites who surrounded him, along with the captains of the chariots. 
-\v 10 So Edom has been in revolt from under the hand of Judah to this day. Then Libnah revolted at the same time from under his hand, because he had forsaken Yahweh, the Elohim of his fathers. 
+\v 10 So Edom has been in revolt from under the hand of Judah to this day. Then Libnah revolted at the same time from under his hand, because he had forsaken Yahuah, the Elohim of his fathers. 
 \p
 \v 11 Moreover he made high places in the mountains of Judah, and made the inhabitants of Jerusalem play the prostitute, and led Judah astray. 
-\v 12 A letter came to him from Elijah the prophet, saying, “Yahweh, the Elohim of David your father, says, ‘Because you have not walked in the ways of Jehoshaphat your father, nor in the ways of Asa king of Judah, 
+\v 12 A letter came to him from Elijah the prophet, saying, “Yahuah, the Elohim of David your father, says, ‘Because you have not walked in the ways of Jehoshaphat your father, nor in the ways of Asa king of Judah, 
 \v 13 but have walked in the way of the kings of Israel, and have made Judah and the inhabitants of Jerusalem to play the prostitute like Ahab’s house did, and also have slain your brothers of your father’s house, who were better than yourself, 
-\v 14 behold, Yahweh will strike your people with a great plague, including your children, your women, and all your possessions; 
+\v 14 behold, Yahuah will strike your people with a great plague, including your children, your women, and all your possessions; 
 \v 15 and you will have great sickness with a disease of your bowels, until your bowels fall out by reason of the sickness, day by day.’ ” 
 \p
-\v 16 Yahweh stirred up against Jehoram the spirit of the Philistines and of the Arabians who are beside the Ethiopians; 
+\v 16 Yahuah stirred up against Jehoram the spirit of the Philistines and of the Arabians who are beside the Ethiopians; 
 \v 17 and they came up against Judah, broke into it, and carried away all the possessions that were found in the king’s house, including his sons and his women, so that there was no son left to him except Jehoahaz, the youngest of his sons. 
 \p
-\v 18 After all this Yahweh struck him in his bowels with an incurable disease. 
+\v 18 After all this Yahuah struck him in his bowels with an incurable disease. 
 \v 19 In process of time, at the end of two years, his bowels fell out by reason of his sickness, and he died of severe diseases. His people made no burning for him, like the burning of his fathers. 
 \v 20 He was thirty-two years old when he began to reign, and he reigned in Jerusalem eight years. He departed with no one’s regret. They buried him in David’s city, but not in the tombs of the kings. 
 \c 22
@@ -637,13 +637,13 @@
 \v 1 The inhabitants of Jerusalem made Ahaziah his youngest son king in his place, because the band of men who came with the Arabians to the camp had slain all the oldest. So Ahaziah the son of Jehoram king of Judah reigned. 
 \v 2 Ahaziah was forty-two years old when he began to reign, and he reigned one year in Jerusalem. His mother’s name was Athaliah the daughter of Omri. 
 \v 3 He also walked in the ways of Ahab’s house, because his mother was his counselor in acting wickedly. 
-\v 4 He did that which was evil in Yahweh’s sight, as did Ahab’s house, for they were his counselors after the death of his father, to his destruction. 
+\v 4 He did that which was evil in Yahuah’s sight, as did Ahab’s house, for they were his counselors after the death of his father, to his destruction. 
 \v 5 He also followed their counsel, and went with Jehoram the son of Ahab king of Israel to war against Hazael king of Syria at Ramoth Gilead; and the Syrians wounded Joram. 
 \v 6 He returned to be healed in Jezreel of the wounds which they had given him at Ramah, when he fought against Hazael king of Syria. Azariah the son of Jehoram, king of Judah, went down to see Jehoram the son of Ahab in Jezreel, because he was sick. 
 \p
-\v 7 Now the destruction of Ahaziah was of Elohim, in that he went to Joram; for when he had come, he went out with Jehoram against Jehu the son of Nimshi, whom Yahweh had anointed to cut off Ahab’s house. 
+\v 7 Now the destruction of Ahaziah was of Elohim, in that he went to Joram; for when he had come, he went out with Jehoram against Jehu the son of Nimshi, whom Yahuah had anointed to cut off Ahab’s house. 
 \v 8 When Jehu was executing judgment on Ahab’s house, he found the princes of Judah and the sons of the brothers of Ahaziah serving Ahaziah, and killed them. 
-\v 9 He sought Ahaziah, and they caught him (now he was hiding in Samaria), and they brought him to Jehu and killed him; and they buried him, for they said, “He is the son of Jehoshaphat, who sought Yahweh with all his heart.” The house of Ahaziah had no power to hold the kingdom. 
+\v 9 He sought Ahaziah, and they caught him (now he was hiding in Samaria), and they brought him to Jehu and killed him; and they buried him, for they said, “He is the son of Jehoshaphat, who sought Yahuah with all his heart.” The house of Ahaziah had no power to hold the kingdom. 
 \p
 \v 10 Now when Athaliah the mother of Ahaziah saw that her son was dead, she arose and destroyed all the royal offspring of the house of Judah. 
 \v 11 But Jehoshabeath, the king’s daughter, took Joash the son of Ahaziah, and stealthily rescued him from among the king’s sons who were slain, and put him and his nurse in the bedroom. So Jehoshabeath, the daughter of King Jehoram, the woman of Jehoiada the priest (for she was the sister of Ahaziah), hid him from Athaliah, so that she didn’t kill him. 
@@ -652,10 +652,10 @@
 \p
 \v 1 In the seventh year, Jehoiada strengthened himself, and took the captains of hundreds—Azariah the son of Jeroham, Ishmael the son of Jehohanan, Azariah the son of Obed, Maaseiah the son of Adaiah, and Elishaphat the son of Zichri—into a covenant with him. 
 \v 2 They went around in Judah and gathered the Levites out of all the cities of Judah, and the heads of fathers’ households of Israel, and they came to Jerusalem. 
-\v 3 All the assembly made a covenant with the king in Elohim’s house. Jehoiada said to them, “Behold, the king’s son must reign, as Yahweh has spoken concerning the sons of David. 
+\v 3 All the assembly made a covenant with the king in Elohim’s house. Jehoiada said to them, “Behold, the king’s son must reign, as Yahuah has spoken concerning the sons of David. 
 \v 4 This is the thing that you must do: a third part of you, who come in on the Sabbath, of the priests and of the Levites, shall be gatekeepers of the thresholds. 
-\v 5 A third part shall be at the king’s house; and a third part at the gate of the foundation. All the people will be in the courts of Yahweh’s house. 
-\v 6 But let no one come into Yahweh’s house except the priests and those who minister of the Levites. They shall come in, for they are set-apart, but all the people shall follow Yahweh’s instructions. 
+\v 5 A third part shall be at the king’s house; and a third part at the gate of the foundation. All the people will be in the courts of Yahuah’s house. 
+\v 6 But let no one come into Yahuah’s house except the priests and those who minister of the Levites. They shall come in, for they are set-apart, but all the people shall follow Yahuah’s instructions. 
 \v 7 The Levites shall surround the king, every man with his weapons in his hand. Whoever comes into the house, let him be slain. Be with the king when he comes in and when he goes out.” 
 \p
 \v 8 So the Levites and all Judah did according to all that Jehoiada the priest commanded. They each took his men, those who were to come in on the Sabbath, with those who were to go out on the Sabbath, for Jehoiada the priest didn’t dismiss the shift. 
@@ -663,51 +663,51 @@
 \v 10 He set all the people, every man with his weapon in his hand, from the right side of the house to the left side of the house, near the altar and the house, around the king. 
 \v 11 Then they brought out the king’s son, put the crown on him, gave him the covenant, and made him king. Jehoiada and his sons anointed him, and they said, “Long live the king!” 
 \p
-\v 12 When Athaliah heard the noise of the people running and praising the king, she came to the people into Yahweh’s house. 
+\v 12 When Athaliah heard the noise of the people running and praising the king, she came to the people into Yahuah’s house. 
 \v 13 Then she looked, and behold, the king stood by his pillar at the entrance, with the captains and the trumpeters by the king. All the people of the land rejoiced and blew trumpets. The singers also played musical instruments, and led the singing of praise. Then Athaliah tore her clothes, and said, “Treason! treason!” 
 \p
-\v 14 Jehoiada the priest brought out the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks; and whoever follows her, let him be slain with the sword.” For the priest said, “Don’t kill her in Yahweh’s house.” 
+\v 14 Jehoiada the priest brought out the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks; and whoever follows her, let him be slain with the sword.” For the priest said, “Don’t kill her in Yahuah’s house.” 
 \v 15 So they made way for her. She went to the entrance of the horse gate to the king’s house; and they killed her there. 
 \p
-\v 16 Jehoiada made a covenant between himself, all the people, and the king, that they should be Yahweh’s people. 
+\v 16 Jehoiada made a covenant between himself, all the people, and the king, that they should be Yahuah’s people. 
 \v 17 All the people went to the house of Baal, broke it down, broke his altars and his images in pieces, and killed Mattan the priest of Baal before the altars. 
-\v 18 Jehoiada appointed the officers of Yahweh’s house under the hand of the Levitical priests, whom David had distributed in Yahweh’s house, to offer the burnt offerings of Yahweh, as it is written in the law of Moses, with rejoicing and with singing, as David had ordered. 
-\v 19 He set the gatekeepers at the gates of Yahweh’s house, that no one who was unclean in anything should enter in. 
-\v 20 He took the captains of hundreds, the nobles, the governors of the people, and all the people of the land, and brought the king down from Yahweh’s house. They came through the upper gate to the king’s house, and set the king on the throne of the kingdom. 
+\v 18 Jehoiada appointed the officers of Yahuah’s house under the hand of the Levitical priests, whom David had distributed in Yahuah’s house, to offer the burnt offerings of Yahuah, as it is written in the law of Moses, with rejoicing and with singing, as David had ordered. 
+\v 19 He set the gatekeepers at the gates of Yahuah’s house, that no one who was unclean in anything should enter in. 
+\v 20 He took the captains of hundreds, the nobles, the governors of the people, and all the people of the land, and brought the king down from Yahuah’s house. They came through the upper gate to the king’s house, and set the king on the throne of the kingdom. 
 \v 21 So all the people of the land rejoiced, and the city was quiet. They had slain Athaliah with the sword. 
 \c 24
 \p
 \v 1 Joash was seven years old when he began to reign, and he reigned forty years in Jerusalem. His mother’s name was Zibiah, of Beersheba. 
-\v 2 Joash did that which was right in Yahweh’s eyes all the days of Jehoiada the priest. 
+\v 2 Joash did that which was right in Yahuah’s eyes all the days of Jehoiada the priest. 
 \v 3 Jehoiada took for him two women, and he brought forth sons and daughters. 
 \p
-\v 4 After this, Joash intended to restore Yahweh’s house. 
+\v 4 After this, Joash intended to restore Yahuah’s house. 
 \v 5 He gathered together the priests and the Levites, and said to them, “Go out to the cities of Judah, and gather money to repair the house of your Elohim from all Israel from year to year. See that you expedite this matter.” However the Levites didn’t do it right away. 
-\v 6 The king called for Jehoiada the chief, and said to him, “Why haven’t you required of the Levites to bring in the tax of Moses the servant of Yahweh, and of the assembly of Israel, out of Judah and out of Jerusalem, for the Tent of the Testimony?” 
-\v 7 For the sons of Athaliah, that wicked woman, had broken up Elohim’s house; and they also gave all the dedicated things of Yahweh’s house to the Baals. 
+\v 6 The king called for Jehoiada the chief, and said to him, “Why haven’t you required of the Levites to bring in the tax of Moses the servant of Yahuah, and of the assembly of Israel, out of Judah and out of Jerusalem, for the Tent of the Testimony?” 
+\v 7 For the sons of Athaliah, that wicked woman, had broken up Elohim’s house; and they also gave all the dedicated things of Yahuah’s house to the Baals. 
 \p
-\v 8 So the king commanded, and they made a chest, and set it outside at the gate of Yahweh’s house. 
-\v 9 They made a proclamation through Judah and Jerusalem, to bring in for Yahweh the tax that Moses the servant of Elohim laid on Israel in the wilderness. 
+\v 8 So the king commanded, and they made a chest, and set it outside at the gate of Yahuah’s house. 
+\v 9 They made a proclamation through Judah and Jerusalem, to bring in for Yahuah the tax that Moses the servant of Elohim laid on Israel in the wilderness. 
 \v 10 All the princes and all the people rejoiced, and brought in, and cast into the chest, until they had filled it. 
 \v 11 Whenever the chest was brought to the king’s officers by the hand of the Levites, and when they saw that there was much money, the king’s scribe and the chief priest’s officer came and emptied the chest, and took it, and carried it to its place again. Thus they did day by day, and gathered money in abundance. 
-\v 12 The king and Jehoiada gave it to those who did the work of the service of Yahweh’s house. They hired masons and carpenters to restore Yahweh’s house, and also those who worked iron and bronze to repair Yahweh’s house. 
+\v 12 The king and Jehoiada gave it to those who did the work of the service of Yahuah’s house. They hired masons and carpenters to restore Yahuah’s house, and also those who worked iron and bronze to repair Yahuah’s house. 
 \v 13 So the workmen worked, and the work of repairing went forward in their hands. They set up Elohim’s house as it was designed, and strengthened it. 
-\v 14 When they had finished, they brought the rest of the money before the king and Jehoiada, from which were made vessels for Yahweh’s house, even vessels with which to minister and to offer, including spoons and vessels of gold and silver. They offered burnt offerings in Yahweh’s house continually all the days of Jehoiada. 
+\v 14 When they had finished, they brought the rest of the money before the king and Jehoiada, from which were made vessels for Yahuah’s house, even vessels with which to minister and to offer, including spoons and vessels of gold and silver. They offered burnt offerings in Yahuah’s house continually all the days of Jehoiada. 
 \p
 \v 15 But Jehoiada grew old and was full of days, and he died. He was one hundred thirty years old when he died. 
 \v 16 They buried him in David’s city among the kings, because he had done good in Israel, and toward Elohim and his house. 
 \p
 \v 17 Now after the death of Jehoiada, the princes of Judah came and bowed down to the king. Then the king listened to them. 
-\v 18 They abandoned the house of Yahweh, the Elohim of their fathers, and served the Asherah poles and the idols, so wrath came on Judah and Jerusalem for this their guiltiness. 
-\v 19 Yet he sent prophets to them to bring them again to Yahweh, and they testified against them; but they would not listen. 
+\v 18 They abandoned the house of Yahuah, the Elohim of their fathers, and served the Asherah poles and the idols, so wrath came on Judah and Jerusalem for this their guiltiness. 
+\v 19 Yet he sent prophets to them to bring them again to Yahuah, and they testified against them; but they would not listen. 
 \p
-\v 20 The Spirit of Elohim came on Zechariah the son of Jehoiada the priest; and he stood above the people, and said to them, “Elohim says, ‘Why do you disobey Yahweh’s commandments, so that you can’t prosper? Because you have forsaken Yahweh, he has also forsaken you.’ ” 
+\v 20 The Spirit of Elohim came on Zechariah the son of Jehoiada the priest; and he stood above the people, and said to them, “Elohim says, ‘Why do you disobey Yahuah’s commandments, so that you can’t prosper? Because you have forsaken Yahuah, he has also forsaken you.’ ” 
 \p
-\v 21 They conspired against him, and stoned him with stones at the commandment of the king in the court of Yahweh’s house. 
-\v 22 Thus Joash the king didn’t remember the kindness which Jehoiada his father had done to him, but killed his son. When he died, he said, “May Yahweh look at it, and repay it.” 
+\v 21 They conspired against him, and stoned him with stones at the commandment of the king in the court of Yahuah’s house. 
+\v 22 Thus Joash the king didn’t remember the kindness which Jehoiada his father had done to him, but killed his son. When he died, he said, “May Yahuah look at it, and repay it.” 
 \p
 \v 23 At the end of the year, the army of the Syrians came up against him. They came to Judah and Jerusalem, and destroyed all the princes of the people from among the people, and sent all their plunder to the king of Damascus. 
-\v 24 For the army of the Syrians came with a small company of men; and Yahweh delivered a very great army into their hand, because they had forsaken Yahweh, the Elohim of their fathers. So they executed judgment on Joash. 
+\v 24 For the army of the Syrians came with a small company of men; and Yahuah delivered a very great army into their hand, because they had forsaken Yahuah, the Elohim of their fathers. So they executed judgment on Joash. 
 \p
 \v 25 When they had departed from him (for they left him seriously wounded), his own servants conspired against him for the blood of the sons of Jehoiada the priest, and killed him on his bed, and he died. They buried him in David’s city, but they didn’t bury him in the tombs of the kings. 
 \v 26 These are those who conspired against him: Zabad the son of Shimeath the Ammonitess and Jehozabad the son of Shimrith the Moabitess. 
@@ -715,17 +715,17 @@
 \c 25
 \p
 \v 1 Amaziah was twenty-five years old when he began to reign, and he reigned twenty-nine years in Jerusalem. His mother’s name was Jehoaddan, of Jerusalem. 
-\v 2 He did that which was right in Yahweh’s eyes, but not with a perfect heart. 
+\v 2 He did that which was right in Yahuah’s eyes, but not with a perfect heart. 
 \v 3 Now when the kingdom was established to him, he killed his servants who had killed his father the king. 
-\v 4 But he didn’t put their children to death, but did according to that which is written in the law in the book of Moses, as Yahweh commanded, saying, “The fathers shall not die for the children, neither shall the children die for the fathers; but every man shall die for his own sin.” 
+\v 4 But he didn’t put their children to death, but did according to that which is written in the law in the book of Moses, as Yahuah commanded, saying, “The fathers shall not die for the children, neither shall the children die for the fathers; but every man shall die for his own sin.” 
 \p
 \v 5 Moreover Amaziah gathered Judah together and ordered them according to their fathers’ houses, under captains of thousands and captains of hundreds, even all Judah and Benjamin. He counted them from twenty years old and upward, and found that there were three hundred thousand chosen men, able to go out to war, who could handle spear and shield. 
 \v 6 He also hired one hundred thousand mighty men of valor out of Israel for one hundred talents of silver. 
-\v 7 A man of Elohim came to him, saying, “O king, don’t let the army of Israel go with you, for Yahweh is not with Israel, with all the children of Ephraim. 
+\v 7 A man of Elohim came to him, saying, “O king, don’t let the army of Israel go with you, for Yahuah is not with Israel, with all the children of Ephraim. 
 \v 8 But if you will go, take action, and be strong for the battle. Elohim will overthrow you before the enemy; for Elohim has power to help, and to overthrow.” 
 \p
 \v 9 Amaziah said to the man of Elohim, “But what shall we do for the hundred talents which I have given to the army of Israel?” 
-\p The man of Elohim answered, “Yahweh is able to give you much more than this.” 
+\p The man of Elohim answered, “Yahuah is able to give you much more than this.” 
 \p
 \v 10 Then Amaziah separated them, the army that had come to him out of Ephraim, to go home again. Therefore their anger was greatly kindled against Judah, and they returned home in fierce anger. 
 \p
@@ -734,7 +734,7 @@
 \v 13 But the men of the army whom Amaziah sent back, that they should not go with him to battle, fell on the cities of Judah from Samaria even to Beth Horon, and struck of them three thousand, and took much plunder. 
 \p
 \v 14 Now after Amaziah had come from the slaughter of the Edomites, he brought the elohims of the children of Seir, and set them up to be his elohims, and bowed down himself before them and burned incense to them. 
-\v 15 Therefore Yahweh’s anger burned against Amaziah, and he sent to him a prophet who said to him, “Why have you sought after the elohims of the people, which have not delivered their own people out of your hand?” 
+\v 15 Therefore Yahuah’s anger burned against Amaziah, and he sent to him a prophet who said to him, “Why have you sought after the elohims of the people, which have not delivered their own people out of your hand?” 
 \p
 \v 16 As he talked with him, the king said to him, “Have we made you one of the king’s counselors? Stop! Why should you be struck down?” 
 \p Then the prophet stopped, and said, “I know that Elohim has determined to destroy you, because you have done this and have not listened to my counsel.” 
@@ -753,15 +753,15 @@
 \p
 \v 25 Amaziah the son of Joash, king of Judah, lived for fifteen years after the death of Joash, son of Jehoahaz, king of Israel. 
 \v 26 Now the rest of the acts of Amaziah, first and last, behold, aren’t they written in the book of the kings of Judah and Israel? 
-\v 27 Now from the time that Amaziah turned away from following Yahweh, they made a conspiracy against him in Jerusalem. He fled to Lachish, but they sent after him to Lachish and killed him there. 
+\v 27 Now from the time that Amaziah turned away from following Yahuah, they made a conspiracy against him in Jerusalem. He fled to Lachish, but they sent after him to Lachish and killed him there. 
 \v 28 They brought him on horses and buried him with his fathers in the City of Judah. 
 \c 26
 \p
 \v 1 All the people of Judah took Uzziah, who was sixteen years old, and made him king in the place of his father Amaziah. 
 \v 2 He built Eloth and restored it to Judah. After that the king slept with his fathers. 
 \v 3 Uzziah was sixteen years old when he began to reign; and he reigned fifty-two years in Jerusalem. His mother’s name was Jechiliah, of Jerusalem. 
-\v 4 He did that which was right in Yahweh’s eyes, according to all that his father Amaziah had done. 
-\v 5 He set himself to seek Elohim in the days of Zechariah, who had understanding in the vision of Elohim; and as long as he sought Yahweh, Elohim made him prosper. 
+\v 4 He did that which was right in Yahuah’s eyes, according to all that his father Amaziah had done. 
+\v 5 He set himself to seek Elohim in the days of Zechariah, who had understanding in the vision of Elohim; and as long as he sought Yahuah, Elohim made him prosper. 
 \p
 \v 6 He went out and fought against the Philistines, and broke down the wall of Gath, the wall of Jabneh, and the wall of Ashdod; and he built cities in the country of Ashdod, and among the Philistines. 
 \v 7 Elohim helped him against the Philistines, and against the Arabians who lived in Gur Baal, and the Meunim. 
@@ -774,43 +774,43 @@
 \v 14 Uzziah prepared for them, even for all the army, shields, spears, helmets, coats of mail, bows, and stones for slinging. 
 \v 15 In Jerusalem, he made devices, invented by skillful men, to be on the towers and on the battlements, with which to shoot arrows and great stones. His name spread far abroad, because he was marvelously helped until he was strong. 
 \p
-\v 16 But when he was strong, his heart was lifted up, so that he did corruptly and he trespassed against Yahweh his Elohim, for he went into Yahweh’s temple to burn incense on the altar of incense. 
-\v 17 Azariah the priest went in after him, and with him eighty priests of Yahweh, who were valiant men. 
-\v 18 They resisted Uzziah the king, and said to him, “It isn’t for you, Uzziah, to burn incense to Yahweh, but for the priests the sons of Aaron, who are consecrated to burn incense. Go out of the sanctuary, for you have trespassed. It will not be for your honor from Yahweh Elohim.” 
+\v 16 But when he was strong, his heart was lifted up, so that he did corruptly and he trespassed against Yahuah his Elohim, for he went into Yahuah’s temple to burn incense on the altar of incense. 
+\v 17 Azariah the priest went in after him, and with him eighty priests of Yahuah, who were valiant men. 
+\v 18 They resisted Uzziah the king, and said to him, “It isn’t for you, Uzziah, to burn incense to Yahuah, but for the priests the sons of Aaron, who are consecrated to burn incense. Go out of the sanctuary, for you have trespassed. It will not be for your honor from Yahuah Elohim.” 
 \p
-\v 19 Then Uzziah was angry. He had a censer in his hand to burn incense, and while he was angry with the priests, the leprosy broke out on his forehead before the priests in Yahweh’s house, beside the altar of incense. 
-\v 20 Azariah the chief priest and all the priests looked at him, and behold, he was leprous in his forehead; and they thrust him out quickly from there. Indeed, he himself also hurried to go out, because Yahweh had struck him. 
-\v 21 Uzziah the king was a leper to the day of his death, and lived in a separate house, being a leper; for he was cut off from Yahweh’s house. Jotham his son was over the king’s house, judging the people of the land. 
+\v 19 Then Uzziah was angry. He had a censer in his hand to burn incense, and while he was angry with the priests, the leprosy broke out on his forehead before the priests in Yahuah’s house, beside the altar of incense. 
+\v 20 Azariah the chief priest and all the priests looked at him, and behold, he was leprous in his forehead; and they thrust him out quickly from there. Indeed, he himself also hurried to go out, because Yahuah had struck him. 
+\v 21 Uzziah the king was a leper to the day of his death, and lived in a separate house, being a leper; for he was cut off from Yahuah’s house. Jotham his son was over the king’s house, judging the people of the land. 
 \p
 \v 22 Now the rest of the acts of Uzziah, first and last, Isaiah the prophet, the son of Amoz, wrote. 
 \v 23 So Uzziah slept with his fathers; and they buried him with his fathers in the field of burial which belonged to the kings, for they said, “He is a leper.” Jotham his son reigned in his place. 
 \c 27
 \p
 \v 1 Jotham was twenty-five years old when he began to reign, and he reigned sixteen years in Jerusalem. His mother’s name was Jerushah the daughter of Zadok. 
-\v 2 He did that which was right in Yahweh’s eyes, according to all that his father Uzziah had done. However he didn’t enter into Yahweh’s temple. The people still acted corruptly. 
-\v 3 He built the upper gate of Yahweh’s house, and he built much on the wall of Ophel. 
+\v 2 He did that which was right in Yahuah’s eyes, according to all that his father Uzziah had done. However he didn’t enter into Yahuah’s temple. The people still acted corruptly. 
+\v 3 He built the upper gate of Yahuah’s house, and he built much on the wall of Ophel. 
 \v 4 Moreover he built cities in the hill country of Judah, and in the forests he built fortresses and towers. 
 \v 5 He also fought with the king of the children of Ammon, and prevailed against them. The children of Ammon gave him the same year one hundred talents of silver, ten thousand cors of wheat, and ten thousand cors of barley. The children of Ammon also gave that much to him in the second year, and in the third. 
-\v 6 So Jotham became mighty, because he ordered his ways before Yahweh his Elohim. 
+\v 6 So Jotham became mighty, because he ordered his ways before Yahuah his Elohim. 
 \v 7 Now the rest of the acts of Jotham, and all his wars and his ways, behold, they are written in the book of the kings of Israel and Judah. 
 \v 8 He was twenty-five years old when he began to reign, and reigned sixteen years in Jerusalem. 
 \v 9 Jotham slept with his fathers, and they buried him in David’s city; and Ahaz his son reigned in his place. 
 \c 28
 \p
-\v 1 Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahweh’s eyes, like David his father, 
+\v 1 Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahuah’s eyes, like David his father, 
 \v 2 but he walked in the ways of the kings of Israel, and also made molten images for the Baals. 
-\v 3 Moreover he burned incense in the valley of the son of Hinnom, and burned his children in the fire, according to the abominations of the nations whom Yahweh cast out before the children of Israel. 
+\v 3 Moreover he burned incense in the valley of the son of Hinnom, and burned his children in the fire, according to the abominations of the nations whom Yahuah cast out before the children of Israel. 
 \v 4 He sacrificed and burned incense in the high places, and on the hills, and under every green tree. 
 \p
-\v 5 Therefore Yahweh his Elohim delivered him into the hand of the king of Syria. They struck him, and carried away from him a great multitude of captives, and brought them to Damascus. He was also delivered into the hand of the king of Israel, who struck him with a great slaughter. 
-\v 6 For Pekah the son of Remaliah killed in Judah one hundred twenty thousand in one day, all of them valiant men, because they had forsaken Yahweh, the Elohim of their fathers. 
+\v 5 Therefore Yahuah his Elohim delivered him into the hand of the king of Syria. They struck him, and carried away from him a great multitude of captives, and brought them to Damascus. He was also delivered into the hand of the king of Israel, who struck him with a great slaughter. 
+\v 6 For Pekah the son of Remaliah killed in Judah one hundred twenty thousand in one day, all of them valiant men, because they had forsaken Yahuah, the Elohim of their fathers. 
 \v 7 Zichri, a mighty man of Ephraim, killed Maaseiah the king’s son, Azrikam the ruler of the house, and Elkanah who was next to the king. 
 \v 8 The children of Israel carried away captive of their brothers two hundred thousand women, sons, and daughters, and also took away much plunder from them, and brought the plunder to Samaria. 
-\v 9 But a prophet of Yahweh was there, whose name was Oded; and he went out to meet the army that came to Samaria, and said to them, “Behold, because Yahweh, the Elohim of your fathers, was angry with Judah, he has delivered them into your hand, and you have slain them in a rage which has reached up to heaven. 
-\v 10 Now you intend to degrade the children of Judah and Jerusalem as male and female slaves for yourselves. Aren’t there even with you trespasses of your own against Yahweh your Elohim? 
-\v 11 Now hear me therefore, and send back the captives that you have taken captive from your brothers, for the fierce wrath of Yahweh is on you.” 
+\v 9 But a prophet of Yahuah was there, whose name was Oded; and he went out to meet the army that came to Samaria, and said to them, “Behold, because Yahuah, the Elohim of your fathers, was angry with Judah, he has delivered them into your hand, and you have slain them in a rage which has reached up to heaven. 
+\v 10 Now you intend to degrade the children of Judah and Jerusalem as male and female slaves for yourselves. Aren’t there even with you trespasses of your own against Yahuah your Elohim? 
+\v 11 Now hear me therefore, and send back the captives that you have taken captive from your brothers, for the fierce wrath of Yahuah is on you.” 
 \v 12 Then some of the heads of the children of Ephraim, Azariah the son of Johanan, Berechiah the son of Meshillemoth, Jehizkiah the son of Shallum, and Amasa the son of Hadlai, stood up against those who came from the war, 
-\v 13 and said to them, “You must not bring in the captives here, for you intend that which will bring on us a trespass against Yahweh, to add to our sins and to our guilt; for our guilt is great, and there is fierce wrath against Israel.” 
+\v 13 and said to them, “You must not bring in the captives here, for you intend that which will bring on us a trespass against Yahuah, to add to our sins and to our guilt; for our guilt is great, and there is fierce wrath against Israel.” 
 \p
 \v 14 So the armed men left the captives and the plunder before the princes and all the assembly. 
 \v 15 The men who have been mentioned by name rose up and took the captives, and with the plunder clothed all who were naked among them, dressed them, gave them sandals, gave them something to eat and to drink, anointed them, carried all the feeble of them on donkeys, and brought them to Jericho, the city of palm trees, to their brothers. Then they returned to Samaria. 
@@ -818,88 +818,88 @@
 \v 16 At that time King Ahaz sent to the kings of Assyria to help him. 
 \v 17 For again the Edomites had come and struck Judah, and carried away captives. 
 \v 18 The Philistines also had invaded the cities of the lowland and of the South of Judah, and had taken Beth Shemesh, Aijalon, Gederoth, Soco with its villages, Timnah with its villages, and also Gimzo and its villages; and they lived there. 
-\v 19 For Yahweh brought Judah low because of Ahaz king of Israel, because he acted without restraint in Judah and trespassed severely against Yahweh. 
+\v 19 For Yahuah brought Judah low because of Ahaz king of Israel, because he acted without restraint in Judah and trespassed severely against Yahuah. 
 \v 20 Tilgath-pilneser king of Assyria came to him and gave him trouble, but didn’t strengthen him. 
-\v 21 For Ahaz took away a portion out of Yahweh’s house, and out of the house of the king and of the princes, and gave it to the king of Assyria; but it didn’t help him. 
+\v 21 For Ahaz took away a portion out of Yahuah’s house, and out of the house of the king and of the princes, and gave it to the king of Assyria; but it didn’t help him. 
 \p
-\v 22 In the time of his distress, he trespassed yet more against Yahweh, this same King Ahaz. 
+\v 22 In the time of his distress, he trespassed yet more against Yahuah, this same King Ahaz. 
 \v 23 For he sacrificed to the elohims of Damascus which had defeated him. He said, “Because the elohims of the kings of Syria helped them, I will sacrifice to them, that they may help me.” But they were the ruin of him and of all Israel. 
-\v 24 Ahaz gathered together the vessels of Elohim’s house, cut the vessels of Elohim’s house in pieces, and shut up the doors of Yahweh’s house; and he made himself altars in every corner of Jerusalem. 
-\v 25 In every city of Judah he made high places to burn incense to other elohims, and provoked Yahweh, the Elohim of his fathers, to anger. 
+\v 24 Ahaz gathered together the vessels of Elohim’s house, cut the vessels of Elohim’s house in pieces, and shut up the doors of Yahuah’s house; and he made himself altars in every corner of Jerusalem. 
+\v 25 In every city of Judah he made high places to burn incense to other elohims, and provoked Yahuah, the Elohim of his fathers, to anger. 
 \p
 \v 26 Now the rest of his acts, and all his ways, first and last, behold, they are written in the book of the kings of Judah and Israel. 
 \v 27 Ahaz slept with his fathers, and they buried him in the city, even in Jerusalem, because they didn’t bring him into the tombs of the kings of Israel; and Hezekiah his son reigned in his place. 
 \c 29
 \p
 \v 1 Hezekiah began to reign when he was twenty-five years old, and he reigned twenty-nine years in Jerusalem. His mother’s name was Abijah, the daughter of Zechariah. 
-\v 2 He did that which was right in Yahweh’s eyes, according to all that David his father had done. 
-\v 3 In the first year of his reign, in the first month, he opened the doors of Yahweh’s house and repaired them. 
+\v 2 He did that which was right in Yahuah’s eyes, according to all that David his father had done. 
+\v 3 In the first year of his reign, in the first month, he opened the doors of Yahuah’s house and repaired them. 
 \v 4 He brought in the priests and the Levites and gathered them together into the wide place on the east, 
-\v 5 and said to them, “Listen to me, you Levites! Now sanctify yourselves, and sanctify the house of Yahweh, the Elohim of your fathers, and carry the filthiness out of the set-apart place. 
-\v 6 For our fathers were unfaithful, and have done that which was evil in Yahweh our Elohim’s sight, and have forsaken him, and have turned away their faces from the habitation of Yahweh, and turned their backs. 
+\v 5 and said to them, “Listen to me, you Levites! Now sanctify yourselves, and sanctify the house of Yahuah, the Elohim of your fathers, and carry the filthiness out of the set-apart place. 
+\v 6 For our fathers were unfaithful, and have done that which was evil in Yahuah our Elohim’s sight, and have forsaken him, and have turned away their faces from the habitation of Yahuah, and turned their backs. 
 \v 7 Also they have shut up the doors of the porch, and put out the lamps, and have not burned incense nor offered burnt offerings in the set-apart place to the Elohim of Israel. 
-\v 8 Therefore Yahweh’s wrath was on Judah and Jerusalem, and he has delivered them to be tossed back and forth, to be an astonishment and a hissing, as you see with your eyes. 
+\v 8 Therefore Yahuah’s wrath was on Judah and Jerusalem, and he has delivered them to be tossed back and forth, to be an astonishment and a hissing, as you see with your eyes. 
 \v 9 For behold, our fathers have fallen by the sword, and our sons and our daughters and our women are in captivity for this. 
-\v 10 Now it is in my heart to make a covenant with Yahweh, the Elohim of Israel, that his fierce anger may turn away from us. 
-\v 11 My sons, don’t be negligent now; for Yahweh has chosen you to stand before him, to minister to him, and that you should be his ministers and burn incense.” 
+\v 10 Now it is in my heart to make a covenant with Yahuah, the Elohim of Israel, that his fierce anger may turn away from us. 
+\v 11 My sons, don’t be negligent now; for Yahuah has chosen you to stand before him, to minister to him, and that you should be his ministers and burn incense.” 
 \p
 \v 12 Then the Levites arose: Mahath, the son of Amasai, and Joel the son of Azariah, of the sons of the Kohathites; and of the sons of Merari, Kish the son of Abdi, and Azariah the son of Jehallelel; and of the Gershonites, Joah the son of Zimmah, and Eden the son of Joah; 
 \v 13 and of the sons of Elizaphan, Shimri and Jeuel; and of the sons of Asaph, Zechariah and Mattaniah; 
 \v 14 and of the sons of Heman, Jehuel and Shimei; and of the sons of Jeduthun, Shemaiah and Uzziel. 
-\v 15 They gathered their brothers, sanctified themselves, and went in, according to the commandment of the king by Yahweh’s words, to cleanse Yahweh’s house. 
-\v 16 The priests went into the inner part of Yahweh’s house to cleanse it, and brought out all the uncleanness that they found in Yahweh’s temple into the court of Yahweh’s house. The Levites took it from there to carry it out to the brook Kidron. 
-\v 17 Now they began on the first day of the first month to sanctify, and on the eighth day of the month they came to Yahweh’s porch. They sanctified Yahweh’s house in eight days, and on the sixteenth day of the first month they finished. 
-\v 18 Then they went in to Hezekiah the king within the palace and said, “We have cleansed all Yahweh’s house, including the altar of burnt offering with all its vessels, and the table of show bread with all its vessels. 
-\v 19 Moreover, we have prepared and sanctified all the vessels which King Ahaz threw away in his reign when he was unfaithful. Behold, they are before Yahweh’s altar.” 
+\v 15 They gathered their brothers, sanctified themselves, and went in, according to the commandment of the king by Yahuah’s words, to cleanse Yahuah’s house. 
+\v 16 The priests went into the inner part of Yahuah’s house to cleanse it, and brought out all the uncleanness that they found in Yahuah’s temple into the court of Yahuah’s house. The Levites took it from there to carry it out to the brook Kidron. 
+\v 17 Now they began on the first day of the first month to sanctify, and on the eighth day of the month they came to Yahuah’s porch. They sanctified Yahuah’s house in eight days, and on the sixteenth day of the first month they finished. 
+\v 18 Then they went in to Hezekiah the king within the palace and said, “We have cleansed all Yahuah’s house, including the altar of burnt offering with all its vessels, and the table of show bread with all its vessels. 
+\v 19 Moreover, we have prepared and sanctified all the vessels which King Ahaz threw away in his reign when he was unfaithful. Behold, they are before Yahuah’s altar.” 
 \p
-\v 20 Then Hezekiah the king arose early, gathered the princes of the city, and went up to Yahweh’s house. 
-\v 21 They brought seven bulls, seven rams, seven lambs, and seven male goats, for a sin offering for the kingdom, for the sanctuary, and for Judah. He commanded the priests the sons of Aaron to offer them on Yahweh’s altar. 
+\v 20 Then Hezekiah the king arose early, gathered the princes of the city, and went up to Yahuah’s house. 
+\v 21 They brought seven bulls, seven rams, seven lambs, and seven male goats, for a sin offering for the kingdom, for the sanctuary, and for Judah. He commanded the priests the sons of Aaron to offer them on Yahuah’s altar. 
 \v 22 So they killed the bulls, and the priests received the blood and sprinkled it on the altar. They killed the rams and sprinkled the blood on the altar. They also killed the lambs and sprinkled the blood on the altar. 
 \v 23 They brought near the male goats for the sin offering before the king and the assembly; and they laid their hands on them. 
 \v 24 Then the priests killed them, and they made a sin offering with their blood on the altar, to make atonement for all Israel; for the king commanded that the burnt offering and the sin offering should be made for all Israel. 
 \p
-\v 25 He set the Levites in Yahweh’s house with cymbals, with stringed instruments, and with harps, according to the commandment of David, of Gad the king’s seer, and Nathan the prophet; for the commandment was from Yahweh by his prophets. 
+\v 25 He set the Levites in Yahuah’s house with cymbals, with stringed instruments, and with harps, according to the commandment of David, of Gad the king’s seer, and Nathan the prophet; for the commandment was from Yahuah by his prophets. 
 \v 26 The Levites stood with David’s instruments, and the priests with the trumpets. 
-\v 27 Hezekiah commanded them to offer the burnt offering on the altar. When the burnt offering began, Yahweh’s song also began, along with the trumpets and instruments of David king of Israel. 
+\v 27 Hezekiah commanded them to offer the burnt offering on the altar. When the burnt offering began, Yahuah’s song also began, along with the trumpets and instruments of David king of Israel. 
 \v 28 All the assembly worshiped, the singers sang, and the trumpeters sounded. All this continued until the burnt offering was finished. 
 \p
 \v 29 When they had finished offering, the king and all who were present with him bowed themselves and worshiped. 
-\v 30 Moreover Hezekiah the king and the princes commanded the Levites to sing praises to Yahweh with the words of David, and of Asaph the seer. They sang praises with gladness, and they bowed their heads and worshiped. 
+\v 30 Moreover Hezekiah the king and the princes commanded the Levites to sing praises to Yahuah with the words of David, and of Asaph the seer. They sang praises with gladness, and they bowed their heads and worshiped. 
 \p
-\v 31 Then Hezekiah answered, “Now you have consecrated yourselves to Yahweh. Come near and bring sacrifices and thank offerings into Yahweh’s house.” The assembly brought in sacrifices and thank offerings, and as many as were of a willing heart brought burnt offerings. 
-\v 32 The number of the burnt offerings which the assembly brought was seventy bulls, one hundred rams, and two hundred lambs. All these were for a burnt offering to Yahweh. 
+\v 31 Then Hezekiah answered, “Now you have consecrated yourselves to Yahuah. Come near and bring sacrifices and thank offerings into Yahuah’s house.” The assembly brought in sacrifices and thank offerings, and as many as were of a willing heart brought burnt offerings. 
+\v 32 The number of the burnt offerings which the assembly brought was seventy bulls, one hundred rams, and two hundred lambs. All these were for a burnt offering to Yahuah. 
 \v 33 The consecrated things were six hundred head of cattle and three thousand sheep. 
 \v 34 But the priests were too few, so that they could not skin all the burnt offerings. Therefore their brothers the Levites helped them until the work was ended, and until the priests had sanctified themselves, for the Levites were more upright in heart to sanctify themselves than the priests. 
-\v 35 Also the burnt offerings were in abundance, with the fat of the peace offerings and with the drink offerings for every burnt offering. So the service of Yahweh’s house was set in order. 
+\v 35 Also the burnt offerings were in abundance, with the fat of the peace offerings and with the drink offerings for every burnt offering. So the service of Yahuah’s house was set in order. 
 \v 36 Hezekiah and all the people rejoiced because of that which Elohim had prepared for the people; for the thing was done suddenly. 
 \c 30
 \p
-\v 1 Hezekiah sent to all Israel and Judah, and wrote letters also to Ephraim and Manasseh, that they should come to Yahweh’s house at Jerusalem, to keep the Passover to Yahweh, the Elohim of Israel. 
+\v 1 Hezekiah sent to all Israel and Judah, and wrote letters also to Ephraim and Manasseh, that they should come to Yahuah’s house at Jerusalem, to keep the Passover to Yahuah, the Elohim of Israel. 
 \v 2 For the king had taken counsel with his princes and all the assembly in Jerusalem to keep the Passover in the second month. 
 \v 3 For they could not keep it at that time, because the priests had not sanctified themselves in sufficient number, and the people had not gathered themselves together to Jerusalem. 
 \v 4 The thing was right in the eyes of the king and of all the assembly. 
-\v 5 So they established a decree to make proclamation throughout all Israel, from Beersheba even to Dan, that they should come to keep the Passover to Yahweh, the Elohim of Israel, at Jerusalem, for they had not kept it in great numbers in the way it is written. 
+\v 5 So they established a decree to make proclamation throughout all Israel, from Beersheba even to Dan, that they should come to keep the Passover to Yahuah, the Elohim of Israel, at Jerusalem, for they had not kept it in great numbers in the way it is written. 
 \p
-\v 6 So the couriers went with the letters from the king and his princes throughout all Israel and Judah, according to the commandment of the king, saying, “You children of Israel, turn again to Yahweh, the Elohim of Abraham, Isaac, and Israel, that he may return to the remnant of you that have escaped out of the hand of the kings of Assyria. 
-\v 7 Don’t be like your fathers and like your brothers, who trespassed against Yahweh, the Elohim of their fathers, so that he gave them up to desolation, as you see. 
-\v 8 Now don’t be stiff-necked, as your fathers were, but yield yourselves to Yahweh, and enter into his sanctuary, which he has sanctified forever, and serve Yahweh your Elohim, that his fierce anger may turn away from you. 
-\v 9 For if you turn again to Yahweh, your brothers and your children will find compassion with those who led them captive, and will come again into this land, because Yahweh your Elohim is gracious and merciful, and will not turn away his face from you if you return to him.” 
+\v 6 So the couriers went with the letters from the king and his princes throughout all Israel and Judah, according to the commandment of the king, saying, “You children of Israel, turn again to Yahuah, the Elohim of Abraham, Isaac, and Israel, that he may return to the remnant of you that have escaped out of the hand of the kings of Assyria. 
+\v 7 Don’t be like your fathers and like your brothers, who trespassed against Yahuah, the Elohim of their fathers, so that he gave them up to desolation, as you see. 
+\v 8 Now don’t be stiff-necked, as your fathers were, but yield yourselves to Yahuah, and enter into his sanctuary, which he has sanctified forever, and serve Yahuah your Elohim, that his fierce anger may turn away from you. 
+\v 9 For if you turn again to Yahuah, your brothers and your children will find compassion with those who led them captive, and will come again into this land, because Yahuah your Elohim is gracious and merciful, and will not turn away his face from you if you return to him.” 
 \p
 \v 10 So the couriers passed from city to city through the country of Ephraim and Manasseh, even to Zebulun, but people ridiculed them and mocked them. 
 \v 11 Nevertheless some men of Asher, Manasseh, and Zebulun humbled themselves and came to Jerusalem. 
-\v 12 Also the hand of Elohim came on Judah to give them one heart, to do the commandment of the king and of the princes by Yahweh’s word. 
+\v 12 Also the hand of Elohim came on Judah to give them one heart, to do the commandment of the king and of the princes by Yahuah’s word. 
 \p
 \v 13 Many people assembled at Jerusalem to keep the feast of unleavened bread in the second month, a very great assembly. 
 \v 14 They arose and took away the altars that were in Jerusalem, and they took away all the altars for incense and threw them into the brook Kidron. 
-\v 15 Then they killed the Passover on the fourteenth day of the second month. The priests and the Levites were ashamed, and sanctified themselves, and brought burnt offerings into Yahweh’s house. 
+\v 15 Then they killed the Passover on the fourteenth day of the second month. The priests and the Levites were ashamed, and sanctified themselves, and brought burnt offerings into Yahuah’s house. 
 \v 16 They stood in their place after their order, according to the law of Moses the man of Elohim. The priests sprinkled the blood which they received of the hand of the Levites. 
-\v 17 For there were many in the assembly who had not sanctified themselves; therefore the Levites were in charge of killing the Passovers for everyone who was not clean, to sanctify them to Yahweh. 
-\v 18 For a multitude of the people, even many of Ephraim, Manasseh, Issachar, and Zebulun, had not cleansed themselves, yet they ate the Passover other than the way it is written. For Hezekiah had prayed for them, saying, “May the good Yahweh pardon everyone 
-\v 19 who sets his heart to seek Elohim, Yahweh, the Elohim of his fathers, even if they aren’t clean according to the purification of the sanctuary.” 
+\v 17 For there were many in the assembly who had not sanctified themselves; therefore the Levites were in charge of killing the Passovers for everyone who was not clean, to sanctify them to Yahuah. 
+\v 18 For a multitude of the people, even many of Ephraim, Manasseh, Issachar, and Zebulun, had not cleansed themselves, yet they ate the Passover other than the way it is written. For Hezekiah had prayed for them, saying, “May the good Yahuah pardon everyone 
+\v 19 who sets his heart to seek Elohim, Yahuah, the Elohim of his fathers, even if they aren’t clean according to the purification of the sanctuary.” 
 \p
-\v 20 Yahweh listened to Hezekiah, and healed the people. 
-\v 21 The children of Israel who were present at Jerusalem kept the feast of unleavened bread seven days with great gladness. The Levites and the priests praised Yahweh day by day, singing with loud instruments to Yahweh. 
-\v 22 Hezekiah spoke encouragingly to all the Levites who had good understanding in the service of Yahweh. So they ate throughout the feast for the seven days, offering sacrifices of peace offerings and making confession to Yahweh, the Elohim of their fathers. 
+\v 20 Yahuah listened to Hezekiah, and healed the people. 
+\v 21 The children of Israel who were present at Jerusalem kept the feast of unleavened bread seven days with great gladness. The Levites and the priests praised Yahuah day by day, singing with loud instruments to Yahuah. 
+\v 22 Hezekiah spoke encouragingly to all the Levites who had good understanding in the service of Yahuah. So they ate throughout the feast for the seven days, offering sacrifices of peace offerings and making confession to Yahuah, the Elohim of their fathers. 
 \p
 \v 23 The whole assembly took counsel to keep another seven days, and they kept another seven days with gladness. 
 \v 24 For Hezekiah king of Judah gave to the assembly for offerings one thousand bulls and seven thousand sheep; and the princes gave to the assembly a thousand bulls and ten thousand sheep; and a great number of priests sanctified themselves. 
@@ -910,28 +910,28 @@
 \p
 \v 1 Now when all this was finished, all Israel who were present went out to the cities of Judah and broke the pillars in pieces, cut down the Asherah poles, and broke down the high places and the altars out of all Judah and Benjamin, also in Ephraim and Manasseh, until they had destroyed them all. Then all the children of Israel returned, every man to his possession, into their own cities. 
 \p
-\v 2 Hezekiah appointed the divisions of the priests and the Levites after their divisions, every man according to his service, both the priests and the Levites, for burnt offerings and for peace offerings, to minister, to give thanks, and to praise in the gates of Yahweh’s camp. 
-\v 3 He also appointed the king’s portion of his possessions for the burnt offerings: for the morning and evening burnt offerings, and the burnt offerings for the Sabbaths, for the new moons, and for the set feasts, as it is written in Yahweh’s law. 
-\v 4 Moreover he commanded the people who lived in Jerusalem to give the portion of the priests and the Levites, that they might give themselves to Yahweh’s law. 
+\v 2 Hezekiah appointed the divisions of the priests and the Levites after their divisions, every man according to his service, both the priests and the Levites, for burnt offerings and for peace offerings, to minister, to give thanks, and to praise in the gates of Yahuah’s camp. 
+\v 3 He also appointed the king’s portion of his possessions for the burnt offerings: for the morning and evening burnt offerings, and the burnt offerings for the Sabbaths, for the new moons, and for the set feasts, as it is written in Yahuah’s law. 
+\v 4 Moreover he commanded the people who lived in Jerusalem to give the portion of the priests and the Levites, that they might give themselves to Yahuah’s law. 
 \v 5 As soon as the commandment went out, the children of Israel gave in abundance the first fruits of grain, new wine, oil, honey, and of all the increase of the field; and they brought in the tithe of all things abundantly. 
-\v 6 The children of Israel and Judah, who lived in the cities of Judah, also brought in the tithe of cattle and sheep, and the tithe of dedicated things which were consecrated to Yahweh their Elohim, and laid them in heaps. 
+\v 6 The children of Israel and Judah, who lived in the cities of Judah, also brought in the tithe of cattle and sheep, and the tithe of dedicated things which were consecrated to Yahuah their Elohim, and laid them in heaps. 
 \p
 \v 7 In the third month, they began to lay the foundation of the heaps, and finished them in the seventh month. 
-\v 8 When Hezekiah and the princes came and saw the heaps, they blessed Yahweh and his people Israel. 
+\v 8 When Hezekiah and the princes came and saw the heaps, they blessed Yahuah and his people Israel. 
 \v 9 Then Hezekiah questioned the priests and the Levites about the heaps. 
-\v 10 Azariah the chief priest, of the house of Zadok, answered him and said, “Since people began to bring the offerings into Yahweh’s house, we have eaten and had enough, and have plenty left over, for Yahweh has blessed his people; and that which is left is this great store.” 
+\v 10 Azariah the chief priest, of the house of Zadok, answered him and said, “Since people began to bring the offerings into Yahuah’s house, we have eaten and had enough, and have plenty left over, for Yahuah has blessed his people; and that which is left is this great store.” 
 \p
-\v 11 Then Hezekiah commanded them to prepare rooms in Yahweh’s house, and they prepared them. 
+\v 11 Then Hezekiah commanded them to prepare rooms in Yahuah’s house, and they prepared them. 
 \v 12 They brought in the offerings, the tithes, and the dedicated things faithfully. Conaniah the Levite was ruler over them, and Shimei his brother was second. 
 \v 13 Jehiel, Azaziah, Nahath, Asahel, Jerimoth, Jozabad, Eliel, Ismachiah, Mahath, and Benaiah were overseers under the hand of Conaniah and Shimei his brother, by the appointment of Hezekiah the king and Azariah the ruler of Elohim’s house. 
-\v 14 Kore the son of Imnah the Levite, the gatekeeper at the east gate, was over the free will offerings of Elohim, to distribute Yahweh’s offerings and the most set-apart things. 
+\v 14 Kore the son of Imnah the Levite, the gatekeeper at the east gate, was over the free will offerings of Elohim, to distribute Yahuah’s offerings and the most set-apart things. 
 \v 15 Under him were Eden, Miniamin, Jeshua, Shemaiah, Amariah, and Shecaniah, in the cities of the priests, in their office of trust, to give to their brothers by divisions, to the great as well as to the small; 
-\v 16 in addition to those who were listed by genealogy of males, from three years old and upward, even everyone who entered into Yahweh’s house, as the duty of every day required, for their service in their offices according to their divisions; 
+\v 16 in addition to those who were listed by genealogy of males, from three years old and upward, even everyone who entered into Yahuah’s house, as the duty of every day required, for their service in their offices according to their divisions; 
 \v 17 and those who were listed by genealogy of the priests by their fathers’ houses, and the Levites from twenty years old and upward, in their offices by their divisions; 
 \v 18 and those who were listed by genealogy of all their little ones, their women, their sons, and their daughters, through all the congregation; for in their office of trust they sanctified themselves in set-apartness. 
 \v 19 Also for the sons of Aaron the priests, who were in the fields of the pasture lands of their cities, in every city, there were men who were mentioned by name to give portions to all the males among the priests and to all who were listed by genealogy among the Levites. 
 \p
-\v 20 Hezekiah did so throughout all Judah; and he did that which was good, right, and faithful before Yahweh his Elohim. 
+\v 20 Hezekiah did so throughout all Judah; and he did that which was good, right, and faithful before Yahuah his Elohim. 
 \v 21 In every work that he began in the service of Elohim’s house, in the law, and in the commandments, to seek his Elohim, he did it with all his heart and prospered. 
 \c 32
 \p
@@ -943,30 +943,30 @@
 \v 5 He took courage, built up all the wall that was broken down, and raised it up to the towers, with the other wall outside, and strengthened Millo in David’s city, and made weapons and shields in abundance. 
 \v 6 He set captains of war over the people, gathered them together to him in the wide place at the gate of the city, and spoke encouragingly to them, saying, 
 \v 7 “Be strong and courageous. Don’t be afraid or dismayed because of the king of Assyria, nor for all the multitude who is with him; for there is a greater one with us than with him. 
-\v 8 An arm of flesh is with him, but Yahweh our Elohim is with us to help us and to fight our battles.” The people rested themselves on the words of Hezekiah king of Judah. 
+\v 8 An arm of flesh is with him, but Yahuah our Elohim is with us to help us and to fight our battles.” The people rested themselves on the words of Hezekiah king of Judah. 
 \p
 \v 9 After this, Sennacherib king of Assyria sent his servants to Jerusalem, (now he was attacking Lachish, and all his forces were with him), to Hezekiah king of Judah, and to all Judah who were at Jerusalem, saying, 
 \v 10 Sennacherib king of Assyria says, “In whom do you trust, that you remain under siege in Jerusalem? 
-\v 11 Doesn’t Hezekiah persuade you to give you over to die by famine and by thirst, saying, ‘Yahweh our Elohim will deliver us out of the hand of the king of Assyria’? 
+\v 11 Doesn’t Hezekiah persuade you to give you over to die by famine and by thirst, saying, ‘Yahuah our Elohim will deliver us out of the hand of the king of Assyria’? 
 \v 12 Hasn’t the same Hezekiah taken away his high places and his altars, and commanded Judah and Jerusalem, saying, ‘You shall worship before one altar, and you shall burn incense on it’? 
 \v 13 Don’t you know what I and my fathers have done to all the peoples of the lands? Were the elohims of the nations of those lands in any way able to deliver their land out of my hand? 
 \v 14 Who was there among all the elohims of those nations which my fathers utterly destroyed that could deliver his people out of my hand, that your Elohim should be able to deliver you out of my hand? 
 \v 15 Now therefore don’t let Hezekiah deceive you nor persuade you in this way. Don’t believe him, for no elohim of any nation or kingdom was able to deliver his people out of my hand, and out of the hand of my fathers. How much less will your Elohim deliver you out of my hand?” 
 \p
-\v 16 His servants spoke yet more against Yahweh Elohim and against his servant Hezekiah. 
-\v 17 He also wrote letters insulting Yahweh, the Elohim of Israel, and speaking against him, saying, “As the elohims of the nations of the lands, which have not delivered their people out of my hand, so shall the Elohim of Hezekiah not deliver his people out of my hand.” 
+\v 16 His servants spoke yet more against Yahuah Elohim and against his servant Hezekiah. 
+\v 17 He also wrote letters insulting Yahuah, the Elohim of Israel, and speaking against him, saying, “As the elohims of the nations of the lands, which have not delivered their people out of my hand, so shall the Elohim of Hezekiah not deliver his people out of my hand.” 
 \v 18 They called out with a loud voice in the Jews’ language to the people of Jerusalem who were on the wall, to frighten them and to trouble them, that they might take the city. 
 \v 19 They spoke of the Elohim of Jerusalem as of the elohims of the peoples of the earth, which are the work of men’s hands. 
 \p
 \v 20 Hezekiah the king and Isaiah the prophet, the son of Amoz, prayed because of this, and cried to heaven. 
 \p
-\v 21 Yahweh sent an angel, who cut off all the mighty men of valor, the leaders, and captains in the camp of the king of Assyria. So he returned with shame of face to his own land. When he had come into the house of his elohim, those who came out of his own body killed him there with the sword. 
-\v 22 Thus Yahweh saved Hezekiah and the inhabitants of Jerusalem from the hand of Sennacherib the king of Assyria and from the hand of all others, and guided them on every side. 
-\v 23 Many brought gifts to Yahweh to Jerusalem, and precious things to Hezekiah king of Judah, so that he was exalted in the sight of all nations from then on. 
+\v 21 Yahuah sent an angel, who cut off all the mighty men of valor, the leaders, and captains in the camp of the king of Assyria. So he returned with shame of face to his own land. When he had come into the house of his elohim, those who came out of his own body killed him there with the sword. 
+\v 22 Thus Yahuah saved Hezekiah and the inhabitants of Jerusalem from the hand of Sennacherib the king of Assyria and from the hand of all others, and guided them on every side. 
+\v 23 Many brought gifts to Yahuah to Jerusalem, and precious things to Hezekiah king of Judah, so that he was exalted in the sight of all nations from then on. 
 \p
-\v 24 In those days Hezekiah was terminally ill, and he prayed to Yahweh; and he spoke to him, and gave him a sign. 
+\v 24 In those days Hezekiah was terminally ill, and he prayed to Yahuah; and he spoke to him, and gave him a sign. 
 \v 25 But Hezekiah didn’t reciprocate appropriate to the benefit done for him, because his heart was lifted up. Therefore there was wrath on him, Judah, and Jerusalem. 
-\v 26 However, Hezekiah humbled himself for the pride of his heart, both he and the inhabitants of Jerusalem, so that Yahweh’s wrath didn’t come on them in the days of Hezekiah. 
+\v 26 However, Hezekiah humbled himself for the pride of his heart, both he and the inhabitants of Jerusalem, so that Yahuah’s wrath didn’t come on them in the days of Hezekiah. 
 \p
 \v 27 Hezekiah had exceedingly great riches and honor. He provided himself with treasuries for silver, for gold, for precious stones, for spices, for shields, and for all kinds of valuable vessels; 
 \v 28 also storehouses for the increase of grain, new wine, and oil; and stalls for all kinds of animals, and flocks in folds. 
@@ -980,86 +980,86 @@
 \c 33
 \p
 \v 1 Manasseh was twelve years old when he began to reign, and he reigned fifty-five years in Jerusalem. 
-\v 2 He did that which was evil in Yahweh’s sight, after the abominations of the nations whom Yahweh cast out before the children of Israel. 
+\v 2 He did that which was evil in Yahuah’s sight, after the abominations of the nations whom Yahuah cast out before the children of Israel. 
 \v 3 For he built again the high places which Hezekiah his father had broken down; and he raised up altars for the Baals, made Asheroth, and worshiped all the army of the sky, and served them. 
-\v 4 He built altars in Yahweh’s house, of which Yahweh said, “My name shall be in Jerusalem forever.” 
-\v 5 He built altars for all the army of the sky in the two courts of Yahweh’s house. 
-\v 6 He also made his children to pass through the fire in the valley of the son of Hinnom. He practiced sorcery, divination, and witchcraft, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahweh’s sight, to provoke him to anger. 
+\v 4 He built altars in Yahuah’s house, of which Yahuah said, “My name shall be in Jerusalem forever.” 
+\v 5 He built altars for all the army of the sky in the two courts of Yahuah’s house. 
+\v 6 He also made his children to pass through the fire in the valley of the son of Hinnom. He practiced sorcery, divination, and witchcraft, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahuah’s sight, to provoke him to anger. 
 \v 7 He set the engraved image of the idol, which he had made, in Elohim’s house, of which Elohim said to David and to Solomon his son, “In this house, and in Jerusalem, which I have chosen out of all the tribes of Israel, I will put my name forever. 
 \v 8 I will not any more remove the foot of Israel from off the land which I have appointed for your fathers, if only they will observe to do all that I have commanded them, even all the law, the statutes, and the ordinances given by Moses.” 
-\v 9 Manasseh seduced Judah and the inhabitants of Jerusalem, so that they did more evil than did the nations whom Yahweh destroyed before the children of Israel. 
+\v 9 Manasseh seduced Judah and the inhabitants of Jerusalem, so that they did more evil than did the nations whom Yahuah destroyed before the children of Israel. 
 \p
-\v 10 Yahweh spoke to Manasseh and to his people, but they didn’t listen. 
-\v 11 Therefore Yahweh brought on them the captains of the army of the king of Assyria, who took Manasseh in chains, bound him with fetters, and carried him to Babylon. 
+\v 10 Yahuah spoke to Manasseh and to his people, but they didn’t listen. 
+\v 11 Therefore Yahuah brought on them the captains of the army of the king of Assyria, who took Manasseh in chains, bound him with fetters, and carried him to Babylon. 
 \p
-\v 12 When he was in distress, he begged Yahweh his Elohim, and humbled himself greatly before the Elohim of his fathers. 
-\v 13 He prayed to him; and he was entreated by him, and heard his supplication, and brought him again to Jerusalem into his kingdom. Then Manasseh knew that Yahweh was Elohim. 
+\v 12 When he was in distress, he begged Yahuah his Elohim, and humbled himself greatly before the Elohim of his fathers. 
+\v 13 He prayed to him; and he was entreated by him, and heard his supplication, and brought him again to Jerusalem into his kingdom. Then Manasseh knew that Yahuah was Elohim. 
 \p
 \v 14 Now after this, he built an outer wall to David’s city on the west side of Gihon, in the valley, even to the entrance at the fish gate. He encircled Ophel with it, and raised it up to a very great height; and he put valiant captains in all the fortified cities of Judah. 
-\v 15 He took away the foreign elohims and the idol out of Yahweh’s house, and all the altars that he had built in the mountain of Yahweh’s house and in Jerusalem, and cast them out of the city. 
-\v 16 He built up Yahweh’s altar, and offered sacrifices of peace offerings and of thanksgiving on it, and commanded Judah to serve Yahweh, the Elohim of Israel. 
-\v 17 Nevertheless the people still sacrificed in the high places, but only to Yahweh their Elohim. 
+\v 15 He took away the foreign elohims and the idol out of Yahuah’s house, and all the altars that he had built in the mountain of Yahuah’s house and in Jerusalem, and cast them out of the city. 
+\v 16 He built up Yahuah’s altar, and offered sacrifices of peace offerings and of thanksgiving on it, and commanded Judah to serve Yahuah, the Elohim of Israel. 
+\v 17 Nevertheless the people still sacrificed in the high places, but only to Yahuah their Elohim. 
 \p
-\v 18 Now the rest of the acts of Manasseh, and his prayer to his Elohim, and the words of the seers who spoke to him in the name of Yahweh, the Elohim of Israel, behold, they are written among the acts of the kings of Israel. 
+\v 18 Now the rest of the acts of Manasseh, and his prayer to his Elohim, and the words of the seers who spoke to him in the name of Yahuah, the Elohim of Israel, behold, they are written among the acts of the kings of Israel. 
 \v 19 His prayer also, and how Elohim listened to his request, and all his sin and his trespass, and the places in which he built high places and set up the Asherah poles and the engraved images before he humbled himself: behold, they are written in the history of Hozai. 
 \v 20 So Manasseh slept with his fathers, and they buried him in his own house; and Amon his son reigned in his place. 
 \p
 \v 21 Amon was twenty-two years old when he began to reign; and he reigned two years in Jerusalem. 
-\v 22 He did that which was evil in Yahweh’s sight, as did Manasseh his father; and Amon sacrificed to all the engraved images which Manasseh his father had made, and served them. 
-\v 23 He didn’t humble himself before Yahweh, as Manasseh his father had humbled himself; but this same Amon trespassed more and more. 
+\v 22 He did that which was evil in Yahuah’s sight, as did Manasseh his father; and Amon sacrificed to all the engraved images which Manasseh his father had made, and served them. 
+\v 23 He didn’t humble himself before Yahuah, as Manasseh his father had humbled himself; but this same Amon trespassed more and more. 
 \v 24 His servants conspired against him, and put him to death in his own house. 
 \v 25 But the people of the land killed all those who had conspired against King Amon; and the people of the land made Josiah his son king in his place. 
 \c 34
 \p
 \v 1 Josiah was eight years old when he began to reign, and he reigned thirty-one years in Jerusalem. 
-\v 2 He did that which was right in Yahweh’s eyes, and walked in the ways of David his father, and didn’t turn away to the right hand or to the left. 
+\v 2 He did that which was right in Yahuah’s eyes, and walked in the ways of David his father, and didn’t turn away to the right hand or to the left. 
 \v 3 For in the eighth year of his reign, while he was yet young, he began to seek after the Elohim of David his father; and in the twelfth year he began to purge Judah and Jerusalem from the high places, the Asherah poles, the engraved images, and the molten images. 
 \v 4 They broke down the altars of the Baals in his presence; and he cut down the incense altars that were on high above them. He broke the Asherah poles, the engraved images, and the molten images in pieces, made dust of them, and scattered it on the graves of those who had sacrificed to them. 
 \v 5 He burned the bones of the priests on their altars, and purged Judah and Jerusalem. 
 \v 6 He did this in the cities of Manasseh, Ephraim, and Simeon, even to Naphtali, around in their ruins. 
 \v 7 He broke down the altars, beat the Asherah poles and the engraved images into powder, and cut down all the incense altars throughout all the land of Israel, then returned to Jerusalem. 
 \p
-\v 8 Now in the eighteenth year of his reign, when he had purged the land and the house, he sent Shaphan the son of Azaliah, Maaseiah the governor of the city, and Joah the son of Joahaz the recorder to repair the house of Yahweh his Elohim. 
+\v 8 Now in the eighteenth year of his reign, when he had purged the land and the house, he sent Shaphan the son of Azaliah, Maaseiah the governor of the city, and Joah the son of Joahaz the recorder to repair the house of Yahuah his Elohim. 
 \v 9 They came to Hilkiah the high priest and delivered the money that was brought into Elohim’s house, which the Levites, the keepers of the threshold, had gathered from the hands of Manasseh, Ephraim, of all the remnant of Israel, of all Judah and Benjamin, and of the inhabitants of Jerusalem. 
-\v 10 They delivered it into the hands of the workmen who had the oversight of Yahweh’s house; and the workmen who labored in Yahweh’s house gave it to mend and repair the house. 
+\v 10 They delivered it into the hands of the workmen who had the oversight of Yahuah’s house; and the workmen who labored in Yahuah’s house gave it to mend and repair the house. 
 \v 11 They gave it to the carpenters and to the builders to buy cut stone and timber for couplings, and to make beams for the houses which the kings of Judah had destroyed. 
 \v 12 The men did the work faithfully. Their overseers were Jahath and Obadiah the Levites, of the sons of Merari; and Zechariah and Meshullam, of the sons of the Kohathites, to give direction; and others of the Levites, who were all skillful with musical instruments. 
 \v 13 Also they were over the bearers of burdens, and directed all who did the work in every kind of service. Of the Levites, there were scribes, officials, and gatekeepers. 
 \p
-\v 14 When they brought out the money that was brought into Yahweh’s house, Hilkiah the priest found the book of Yahweh’s law given by Moses. 
-\v 15 Hilkiah answered Shaphan the scribe, “I have found the book of the law in Yahweh’s house.” So Hilkiah delivered the book to Shaphan. 
+\v 14 When they brought out the money that was brought into Yahuah’s house, Hilkiah the priest found the book of Yahuah’s law given by Moses. 
+\v 15 Hilkiah answered Shaphan the scribe, “I have found the book of the law in Yahuah’s house.” So Hilkiah delivered the book to Shaphan. 
 \p
 \v 16 Shaphan carried the book to the king, and moreover brought back word to the king, saying, “All that was committed to your servants, they are doing. 
-\v 17 They have emptied out the money that was found in Yahweh’s house, and have delivered it into the hand of the overseers and into the hand of the workmen.” 
+\v 17 They have emptied out the money that was found in Yahuah’s house, and have delivered it into the hand of the overseers and into the hand of the workmen.” 
 \v 18 Shaphan the scribe told the king, saying, “Hilkiah the priest has delivered me a book.” Shaphan read from it to the king. 
 \p
 \v 19 When the king had heard the words of the law, he tore his clothes. 
 \v 20 The king commanded Hilkiah, Ahikam the son of Shaphan, Abdon the son of Micah, Shaphan the scribe, and Asaiah the king’s servant, saying, 
-\v 21 “Go inquire of Yahweh for me, and for those who are left in Israel and in Judah, concerning the words of the book that is found; for great is Yahweh’s wrath that is poured out on us, because our fathers have not kept Yahweh’s word, to do according to all that is written in this book.” 
+\v 21 “Go inquire of Yahuah for me, and for those who are left in Israel and in Judah, concerning the words of the book that is found; for great is Yahuah’s wrath that is poured out on us, because our fathers have not kept Yahuah’s word, to do according to all that is written in this book.” 
 \p
 \v 22 So Hilkiah and those whom the king had commanded went to Huldah the prophetess, the woman of Shallum the son of Tokhath, the son of Hasrah, keeper of the wardrobe (now she lived in Jerusalem in the second quarter), and they spoke to her to that effect. 
 \p
-\v 23 She said to them, “Yahweh, the Elohim of Israel says: ‘Tell the man who sent you to me, 
-\v 24 “Yahweh says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the curses that are written in the book which they have read before the king of Judah. 
+\v 23 She said to them, “Yahuah, the Elohim of Israel says: ‘Tell the man who sent you to me, 
+\v 24 “Yahuah says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the curses that are written in the book which they have read before the king of Judah. 
 \v 25 Because they have forsaken me, and have burned incense to other elohims, that they might provoke me to anger with all the works of their hands, therefore my wrath is poured out on this place, and it will not be quenched.’ ” ’ 
-\v 26 But to the king of Judah, who sent you to inquire of Yahweh, you shall tell him this, ‘Yahweh, the Elohim of Israel says: “About the words which you have heard, 
-\v 27 because your heart was tender, and you humbled yourself before Elohim when you heard his words against this place and against its inhabitants, and have humbled yourself before me, and have torn your clothes and wept before me, I also have heard you,” says Yahweh. 
+\v 26 But to the king of Judah, who sent you to inquire of Yahuah, you shall tell him this, ‘Yahuah, the Elohim of Israel says: “About the words which you have heard, 
+\v 27 because your heart was tender, and you humbled yourself before Elohim when you heard his words against this place and against its inhabitants, and have humbled yourself before me, and have torn your clothes and wept before me, I also have heard you,” says Yahuah. 
 \v 28 “Behold, I will gather you to your fathers, and you will be gathered to your grave in peace. Your eyes won’t see all the evil that I will bring on this place and on its inhabitants.” ’ ” 
 \p They brought back this message to the king. 
 \p
 \v 29 Then the king sent and gathered together all the elders of Judah and Jerusalem. 
-\v 30 The king went up to Yahweh’s house with all the men of Judah and the inhabitants of Jerusalem—the priests, the Levites, and all the people, both great and small—and he read in their hearing all the words of the book of the covenant that was found in Yahweh’s house. 
-\v 31 The king stood in his place and made a covenant before Yahweh, to walk after Yahweh, and to keep his commandments, his testimonies, and his statutes with all his heart and with all his soul, to perform the words of the covenant that were written in this book. 
+\v 30 The king went up to Yahuah’s house with all the men of Judah and the inhabitants of Jerusalem—the priests, the Levites, and all the people, both great and small—and he read in their hearing all the words of the book of the covenant that was found in Yahuah’s house. 
+\v 31 The king stood in his place and made a covenant before Yahuah, to walk after Yahuah, and to keep his commandments, his testimonies, and his statutes with all his heart and with all his soul, to perform the words of the covenant that were written in this book. 
 \v 32 He caused all who were found in Jerusalem and Benjamin to stand. The inhabitants of Jerusalem did according to the covenant of Elohim, the Elohim of their fathers. 
-\v 33 Josiah took away all the abominations out of all the countries that belonged to the children of Israel, and made all who were found in Israel to serve, even to serve Yahweh their Elohim. All his days they didn’t depart from following Yahweh, the Elohim of their fathers. 
+\v 33 Josiah took away all the abominations out of all the countries that belonged to the children of Israel, and made all who were found in Israel to serve, even to serve Yahuah their Elohim. All his days they didn’t depart from following Yahuah, the Elohim of their fathers. 
 \c 35
 \p
-\v 1 Josiah kept a Passover to Yahweh in Jerusalem. They killed the Passover on the fourteenth day of the first month. 
-\v 2 He set the priests in their offices and encouraged them in the service of Yahweh’s house. 
-\v 3 He said to the Levites who taught all Israel, who were set-apart to Yahweh, “Put the set-apart ark in the house which Solomon the son of David king of Israel built. It will no longer be a burden on your shoulders. Now serve Yahweh your Elohim and his people Israel. 
+\v 1 Josiah kept a Passover to Yahuah in Jerusalem. They killed the Passover on the fourteenth day of the first month. 
+\v 2 He set the priests in their offices and encouraged them in the service of Yahuah’s house. 
+\v 3 He said to the Levites who taught all Israel, who were set-apart to Yahuah, “Put the set-apart ark in the house which Solomon the son of David king of Israel built. It will no longer be a burden on your shoulders. Now serve Yahuah your Elohim and his people Israel. 
 \v 4 Prepare yourselves after your fathers’ houses by your divisions, according to the writing of David king of Israel, and according to the writing of Solomon his son. 
 \v 5 Stand in the set-apart place according to the divisions of the fathers’ houses of your brothers the children of the people, and let there be for each a portion of a fathers’ house of the Levites. 
-\v 6 Kill the Passover lamb, sanctify yourselves, and prepare for your brothers, to do according to Yahweh’s word by Moses.” 
+\v 6 Kill the Passover lamb, sanctify yourselves, and prepare for your brothers, to do according to Yahuah’s word by Moses.” 
 \p
 \v 7 Josiah gave to the children of the people, of the flock, lambs and young goats, all of them for the Passover offerings, to all who were present, to the number of thirty thousand, and three thousand bulls. These were of the king’s substance. 
 \v 8 His princes gave a free will offering to the people, to the priests, and to the Levites. Hilkiah, Zechariah, and Jehiel, the rulers of Elohim’s house, gave to the priests for the Passover offerings two thousand six hundred small livestock, and three hundred head of cattle. 
@@ -1067,12 +1067,12 @@
 \p
 \v 10 So the service was prepared, and the priests stood in their place, and the Levites by their divisions, according to the king’s commandment. 
 \v 11 They killed the Passover lambs, and the priests sprinkled the blood which they received from their hands, and the Levites skinned them. 
-\v 12 They removed the burnt offerings, that they might give them according to the divisions of the fathers’ houses of the children of the people, to offer to Yahweh, as it is written in the book of Moses. They did the same with the cattle. 
+\v 12 They removed the burnt offerings, that they might give them according to the divisions of the fathers’ houses of the children of the people, to offer to Yahuah, as it is written in the book of Moses. They did the same with the cattle. 
 \v 13 They roasted the Passover with fire according to the ordinance. They boiled the set-apart offerings in pots, in cauldrons, and in pans, and carried them quickly to all the children of the people. 
 \v 14 Afterward they prepared for themselves and for the priests, because the priests the sons of Aaron were busy with offering the burnt offerings and the fat until night. Therefore the Levites prepared for themselves and for the priests the sons of Aaron. 
 \v 15 The singers, the sons of Asaph, were in their place, according to the commandment of David, Asaph, Heman, and Jeduthun the king’s seer; and the gatekeepers were at every gate. They didn’t need to depart from their service, because their brothers the Levites prepared for them. 
 \p
-\v 16 So all the service of Yahweh was prepared the same day, to keep the Passover, and to offer burnt offerings on Yahweh’s altar, according to the commandment of King Josiah. 
+\v 16 So all the service of Yahuah was prepared the same day, to keep the Passover, and to offer burnt offerings on Yahuah’s altar, according to the commandment of King Josiah. 
 \v 17 The children of Israel who were present kept the Passover at that time, and the feast of unleavened bread seven days. 
 \v 18 There was no Passover like that kept in Israel from the days of Samuel the prophet, nor did any of the kings of Israel keep such a Passover as Josiah kept—with the priests, the Levites, and all Judah and Israel who were present, and the inhabitants of Jerusalem. 
 \v 19 This Passover was kept in the eighteenth year of the reign of Josiah. 
@@ -1085,7 +1085,7 @@
 \p
 \v 24 So his servants took him out of the chariot, and put him in the second chariot that he had, and brought him to Jerusalem; and he died, and was buried in the tombs of his fathers. All Judah and Jerusalem mourned for Josiah. 
 \v 25 Jeremiah lamented for Josiah, and all the singing men and singing women spoke of Josiah in their lamentations to this day; and they made them an ordinance in Israel. Behold, they are written in the lamentations. 
-\v 26 Now the rest of the acts of Josiah and his good deeds, according to that which is written in Yahweh’s law, 
+\v 26 Now the rest of the acts of Josiah and his good deeds, according to that which is written in Yahuah’s law, 
 \v 27 and his acts, first and last, behold, they are written in the book of the kings of Israel and Judah. 
 \c 36
 \p
@@ -1094,27 +1094,27 @@
 \v 3 The king of Egypt removed him from office at Jerusalem, and fined the land one hundred talents of silver and a talent of gold. 
 \v 4 The king of Egypt made Eliakim his brother king over Judah and Jerusalem, and changed his name to Jehoiakim. Neco took Joahaz his brother, and carried him to Egypt. 
 \p
-\v 5 Jehoiakim was twenty-five years old when he began to reign, and he reigned eleven years in Jerusalem. He did that which was evil in Yahweh his Elohim’s sight. 
+\v 5 Jehoiakim was twenty-five years old when he began to reign, and he reigned eleven years in Jerusalem. He did that which was evil in Yahuah his Elohim’s sight. 
 \v 6 Nebuchadnezzar king of Babylon came up against him, and bound him in fetters to carry him to Babylon. 
-\v 7 Nebuchadnezzar also carried some of the vessels of Yahweh’s house to Babylon, and put them in his temple at Babylon. 
+\v 7 Nebuchadnezzar also carried some of the vessels of Yahuah’s house to Babylon, and put them in his temple at Babylon. 
 \v 8 Now the rest of the acts of Jehoiakim, and his abominations which he did, and that which was found in him, behold, they are written in the book of the kings of Israel and Judah; and Jehoiachin his son reigned in his place. 
 \p
-\v 9 Jehoiachin was eight years old when he began to reign, and he reigned three months and ten days in Jerusalem. He did that which was evil in Yahweh’s sight. 
-\v 10 At the return of the year, King Nebuchadnezzar sent and brought him to Babylon, with the valuable vessels of Yahweh’s house, and made Zedekiah his brother king over Judah and Jerusalem. 
+\v 9 Jehoiachin was eight years old when he began to reign, and he reigned three months and ten days in Jerusalem. He did that which was evil in Yahuah’s sight. 
+\v 10 At the return of the year, King Nebuchadnezzar sent and brought him to Babylon, with the valuable vessels of Yahuah’s house, and made Zedekiah his brother king over Judah and Jerusalem. 
 \p
 \v 11 Zedekiah was twenty-one years old when he began to reign, and he reigned eleven years in Jerusalem. 
-\v 12 He did that which was evil in Yahweh his Elohim’s sight. He didn’t humble himself before Jeremiah the prophet speaking from Yahweh’s mouth. 
-\v 13 He also rebelled against King Nebuchadnezzar, who had made him swear by Elohim; but he stiffened his neck, and hardened his heart against turning to Yahweh, the Elohim of Israel. 
-\v 14 Moreover all the chiefs of the priests and the people trespassed very greatly after all the abominations of the nations; and they polluted Yahweh’s house which he had made set-apart in Jerusalem. 
+\v 12 He did that which was evil in Yahuah his Elohim’s sight. He didn’t humble himself before Jeremiah the prophet speaking from Yahuah’s mouth. 
+\v 13 He also rebelled against King Nebuchadnezzar, who had made him swear by Elohim; but he stiffened his neck, and hardened his heart against turning to Yahuah, the Elohim of Israel. 
+\v 14 Moreover all the chiefs of the priests and the people trespassed very greatly after all the abominations of the nations; and they polluted Yahuah’s house which he had made set-apart in Jerusalem. 
 \p
-\v 15 Yahweh, the Elohim of their fathers, sent to them by his messengers, rising up early and sending, because he had compassion on his people and on his dwelling place; 
-\v 16 but they mocked the messengers of Elohim, despised his words, and scoffed at his prophets, until Yahweh’s wrath arose against his people, until there was no remedy. 
+\v 15 Yahuah, the Elohim of their fathers, sent to them by his messengers, rising up early and sending, because he had compassion on his people and on his dwelling place; 
+\v 16 but they mocked the messengers of Elohim, despised his words, and scoffed at his prophets, until Yahuah’s wrath arose against his people, until there was no remedy. 
 \p
 \v 17 Therefore he brought on them the king of the Chaldeans, who killed their young men with the sword in the house of their sanctuary, and had no compassion on young man or virgin, old man or infirm. He gave them all into his hand. 
-\v 18 All the vessels of Elohim’s house, great and small, and the treasures of Yahweh’s house, and the treasures of the king and of his princes, all these he brought to Babylon. 
+\v 18 All the vessels of Elohim’s house, great and small, and the treasures of Yahuah’s house, and the treasures of the king and of his princes, all these he brought to Babylon. 
 \v 19 They burned Elohim’s house, broke down the wall of Jerusalem, burned all its palaces with fire, and destroyed all of its valuable vessels. 
 \v 20 He carried those who had escaped from the sword away to Babylon, and they were servants to him and his sons until the reign of the kingdom of Persia, 
-\v 21 to fulfill Yahweh’s word by Jeremiah’s mouth, until the land had enjoyed its Sabbaths. As long as it lay desolate, it kept Sabbath, to fulfill seventy years. 
+\v 21 to fulfill Yahuah’s word by Jeremiah’s mouth, until the land had enjoyed its Sabbaths. As long as it lay desolate, it kept Sabbath, to fulfill seventy years. 
 \p
-\v 22 Now in the first year of Cyrus king of Persia, that Yahweh’s word by the mouth of Jeremiah might be accomplished, Yahweh stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
-\v 23 “Cyrus king of Persia says, ‘Yahweh, the Elohim of heaven, has given all the kingdoms of the earth to me; and he has commanded me to build him a house in Jerusalem, which is in Judah. Whoever there is among you of all his people, Yahweh his Elohim be with him, and let him go up.’ ” 
+\v 22 Now in the first year of Cyrus king of Persia, that Yahuah’s word by the mouth of Jeremiah might be accomplished, Yahuah stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
+\v 23 “Cyrus king of Persia says, ‘Yahuah, the Elohim of heaven, has given all the kingdoms of the earth to me; and he has commanded me to build him a house in Jerusalem, which is in Judah. Whoever there is among you of all his people, Yahuah his Elohim be with him, and let him go up.’ ” 

--- a/usfm/2kings.usfm
+++ b/usfm/2kings.usfm
@@ -7,12 +7,12 @@
 \p
 \v 2 Ahaziah fell down through the lattice in his upper room that was in Samaria, and was sick. So he sent messengers, and said to them, “Go, inquire of Baal Zebub, the elohim of Ekron, whether I will recover of this sickness.” 
 \p
-\v 3 But Yahweh’s angel said to Elijah the Tishbite, “Arise, go up to meet the messengers of the king of Samaria, and tell them, ‘Is it because there is no Elohim in Israel that you go to inquire of Baal Zebub, the elohim of Ekron? 
-\v 4 Now therefore Yahweh says, “You will not come down from the bed where you have gone up, but you will surely die.” ’ ” Then Elijah departed. 
+\v 3 But Yahuah’s angel said to Elijah the Tishbite, “Arise, go up to meet the messengers of the king of Samaria, and tell them, ‘Is it because there is no Elohim in Israel that you go to inquire of Baal Zebub, the elohim of Ekron? 
+\v 4 Now therefore Yahuah says, “You will not come down from the bed where you have gone up, but you will surely die.” ’ ” Then Elijah departed. 
 \p
 \v 5 The messengers returned to him, and he said to them, “Why is it that you have returned?” 
 \p
-\v 6 They said to him, “A man came up to meet us, and said to us, ‘Go, return to the king who sent you, and tell him, “Yahweh says, ‘Is it because there is no Elohim in Israel that you send to inquire of Baal Zebub, the elohim of Ekron? Therefore you will not come down from the bed where you have gone up, but you will surely die.’ ” ’ ” 
+\v 6 They said to him, “A man came up to meet us, and said to us, ‘Go, return to the king who sent you, and tell him, “Yahuah says, ‘Is it because there is no Elohim in Israel that you send to inquire of Baal Zebub, the elohim of Ekron? Therefore you will not come down from the bed where you have gone up, but you will surely die.’ ” ’ ” 
 \p
 \v 7 He said to them, “What kind of man was he who came up to meet you and told you these words?” 
 \p
@@ -30,29 +30,29 @@
 \v 13 Again he sent the captain of a third fifty with his fifty. The third captain of fifty went up, and came and fell on his knees before Elijah, and begged him, and said to him, “Man of Elohim, please let my life and the life of these fifty of your servants be precious in your sight. 
 \v 14 Behold, fire came down from the sky and consumed the last two captains of fifty with their fifties. But now let my life be precious in your sight.” 
 \p
-\v 15 Yahweh’s angel said to Elijah, “Go down with him. Don’t be afraid of him.” 
+\v 15 Yahuah’s angel said to Elijah, “Go down with him. Don’t be afraid of him.” 
 \p Then he arose and went down with him to the king. 
-\v 16 He said to him, “Yahweh says, ‘Because you have sent messengers to inquire of Baal Zebub, the elohim of Ekron, is it because there is no Elohim in Israel to inquire of his word? Therefore you will not come down from the bed where you have gone up, but you will surely die.’ ” 
+\v 16 He said to him, “Yahuah says, ‘Because you have sent messengers to inquire of Baal Zebub, the elohim of Ekron, is it because there is no Elohim in Israel to inquire of his word? Therefore you will not come down from the bed where you have gone up, but you will surely die.’ ” 
 \p
-\v 17 So he died according to Yahweh’s word which Elijah had spoken. Jehoram began to reign in his place in the second year of Jehoram the son of Jehoshaphat king of Judah, because he had no son. 
+\v 17 So he died according to Yahuah’s word which Elijah had spoken. Jehoram began to reign in his place in the second year of Jehoram the son of Jehoshaphat king of Judah, because he had no son. 
 \v 18 Now the rest of the acts of Ahaziah which he did, aren’t they written in the book of the chronicles of the kings of Israel? 
 \c 2
 \p
-\v 1 When Yahweh was about to take Elijah up by a whirlwind into heaven, Elijah went with Elisha from Gilgal. 
-\v 2 Elijah said to Elisha, “Please wait here, for Yahweh has sent me as far as Bethel.” 
-\p Elisha said, “As Yahweh lives, and as your soul lives, I will not leave you.” So they went down to Bethel. 
+\v 1 When Yahuah was about to take Elijah up by a whirlwind into heaven, Elijah went with Elisha from Gilgal. 
+\v 2 Elijah said to Elisha, “Please wait here, for Yahuah has sent me as far as Bethel.” 
+\p Elisha said, “As Yahuah lives, and as your soul lives, I will not leave you.” So they went down to Bethel. 
 \p
-\v 3 The sons of the prophets who were at Bethel came out to Elisha, and said to him, “Do you know that Yahweh will take away your master from over you today?” 
+\v 3 The sons of the prophets who were at Bethel came out to Elisha, and said to him, “Do you know that Yahuah will take away your master from over you today?” 
 \p He said, “Yes, I know it. Hold your peace.” 
 \p
-\v 4 Elijah said to him, “Elisha, please wait here, for Yahweh has sent me to Jericho.” 
-\p He said, “As Yahweh lives, and as your soul lives, I will not leave you.” So they came to Jericho. 
+\v 4 Elijah said to him, “Elisha, please wait here, for Yahuah has sent me to Jericho.” 
+\p He said, “As Yahuah lives, and as your soul lives, I will not leave you.” So they came to Jericho. 
 \p
-\v 5 The sons of the prophets who were at Jericho came near to Elisha, and said to him, “Do you know that Yahweh will take away your master from over you today?” 
+\v 5 The sons of the prophets who were at Jericho came near to Elisha, and said to him, “Do you know that Yahuah will take away your master from over you today?” 
 \p He answered, “Yes, I know it. Hold your peace.” 
 \p
-\v 6 Elijah said to him, “Please wait here, for Yahweh has sent me to the Jordan.” 
-\p He said, “As Yahweh lives, and as your soul lives, I will not leave you.” Then they both went on. 
+\v 6 Elijah said to him, “Please wait here, for Yahuah has sent me to the Jordan.” 
+\p He said, “As Yahuah lives, and as your soul lives, I will not leave you.” Then they both went on. 
 \v 7 Fifty men of the sons of the prophets went and stood opposite them at a distance; and they both stood by the Jordan. 
 \v 8 Elijah took his mantle, and rolled it up, and struck the waters; and they were divided here and there, so that they both went over on dry ground. 
 \v 9 When they had gone over, Elijah said to Elisha, “Ask what I shall do for you, before I am taken from you.” 
@@ -64,10 +64,10 @@
 \v 12 Elisha saw it, and he cried, “My father, my father, the chariots of Israel and its horsemen!” 
 \p He saw him no more. Then he took hold of his own clothes and tore them in two pieces. 
 \v 13 He also took up Elijah’s mantle that fell from him, and went back and stood by the bank of the Jordan. 
-\v 14 He took Elijah’s mantle that fell from him, and struck the waters, and said, “Where is Yahweh, the Elohim of Elijah?” When he also had struck the waters, they were divided apart, and Elisha went over. 
+\v 14 He took Elijah’s mantle that fell from him, and struck the waters, and said, “Where is Yahuah, the Elohim of Elijah?” When he also had struck the waters, they were divided apart, and Elisha went over. 
 \p
 \v 15 When the sons of the prophets who were at Jericho facing him saw him, they said, “The spirit of Elijah rests on Elisha.” They came to meet him, and bowed themselves to the ground before him. 
-\v 16 They said to him, “See now, there are with your servants fifty strong men. Please let them go and seek your master. Perhaps Yahweh’s Spirit has taken him up, and put him on some mountain or into some valley.” 
+\v 16 They said to him, “See now, there are with your servants fifty strong men. Please let them go and seek your master. Perhaps Yahuah’s Spirit has taken him up, and put him on some mountain or into some valley.” 
 \p He said, “Don’t send them.” 
 \p
 \v 17 When they urged him until he was ashamed, he said, “Send them.” 
@@ -77,16 +77,16 @@
 \v 19 The men of the city said to Elisha, “Behold, please, the situation of this city is pleasant, as my lord sees; but the water is bad, and the land is barren.” 
 \p
 \v 20 He said, “Bring me a new jar, and put salt in it.” Then they brought it to him. 
-\v 21 He went out to the spring of the waters, and threw salt into it, and said, “Yahweh says, ‘I have healed these waters. There shall not be from there any more death or barren wasteland.’ ” 
+\v 21 He went out to the spring of the waters, and threw salt into it, and said, “Yahuah says, ‘I have healed these waters. There shall not be from there any more death or barren wasteland.’ ” 
 \v 22 So the waters were healed to this day, according to Elisha’s word which he spoke. 
 \p
 \v 23 He went up from there to Bethel. As he was going up by the way, some youths came out of the city and mocked him, and said to him, “Go up, you baldy! Go up, you baldy!” 
-\v 24 He looked behind him and saw them, and cursed them in Yahweh’s name. Then two female bears came out of the woods and mauled forty-two of those youths. 
+\v 24 He looked behind him and saw them, and cursed them in Yahuah’s name. Then two female bears came out of the woods and mauled forty-two of those youths. 
 \v 25 He went from there to Mount Carmel, and from there he returned to Samaria. 
 \c 3
 \p
 \v 1 Now Jehoram the son of Ahab began to reign over Israel in Samaria in the eighteenth year of Jehoshaphat king of Judah, and reigned twelve years. 
-\v 2 He did that which was evil in Yahweh’s sight, but not like his father and like his mother, for he put away the pillar of Baal that his father had made. 
+\v 2 He did that which was evil in Yahuah’s sight, but not like his father and like his mother, for he put away the pillar of Baal that his father had made. 
 \v 3 Nevertheless he held to the sins of Jeroboam the son of Nebat, with which he made Israel to sin. He didn’t depart from them. 
 \p
 \v 4 Now Mesha king of Moab was a sheep breeder; and he supplied the king of Israel with one hundred thousand lambs and the wool of one hundred thousand rams. 
@@ -98,21 +98,21 @@
 \p Jehoram answered, “The way of the wilderness of Edom.” 
 \p
 \v 9 So the king of Israel went with the king of Judah and the king of Edom, and they marched for seven days along a circuitous route. There was no water for the army or for the animals that followed them. 
-\v 10 The king of Israel said, “Alas! For Yahweh has called these three kings together to deliver them into the hand of Moab.” 
+\v 10 The king of Israel said, “Alas! For Yahuah has called these three kings together to deliver them into the hand of Moab.” 
 \p
-\v 11 But Jehoshaphat said, “Isn’t there a prophet of Yahweh here, that we may inquire of Yahweh by him?” 
+\v 11 But Jehoshaphat said, “Isn’t there a prophet of Yahuah here, that we may inquire of Yahuah by him?” 
 \p One of the king of Israel’s servants answered, “Elisha the son of Shaphat, who poured water on the hands of Elijah, is here.” 
 \p
-\v 12 Jehoshaphat said, “Yahweh’s word is with him.” So the king of Israel and Jehoshaphat and the king of Edom went down to him. 
+\v 12 Jehoshaphat said, “Yahuah’s word is with him.” So the king of Israel and Jehoshaphat and the king of Edom went down to him. 
 \p
 \v 13 Elisha said to the king of Israel, “What have I to do with you? Go to the prophets of your father, and to the prophets of your mother.” 
-\p The king of Israel said to him, “No, for Yahweh has called these three kings together to deliver them into the hand of Moab.” 
+\p The king of Israel said to him, “No, for Yahuah has called these three kings together to deliver them into the hand of Moab.” 
 \p
-\v 14 Elisha said, “As Yahweh of Armies lives, before whom I stand, surely, were it not that I respect the presence of Jehoshaphat the king of Judah, I would not look toward you, nor see you. 
-\v 15 But now bring me a musician.” When the musician played, Yahweh’s hand came on him. 
-\v 16 He said, “Yahweh says, ‘Make this valley full of trenches.’ 
-\v 17 For Yahweh says, ‘You will not see wind, neither will you see rain, yet that valley will be filled with water, and you will drink, both you and your livestock and your other animals. 
-\v 18 This is an easy thing in Yahweh’s sight. He will also deliver the Moabites into your hand. 
+\v 14 Elisha said, “As Yahuah of Armies lives, before whom I stand, surely, were it not that I respect the presence of Jehoshaphat the king of Judah, I would not look toward you, nor see you. 
+\v 15 But now bring me a musician.” When the musician played, Yahuah’s hand came on him. 
+\v 16 He said, “Yahuah says, ‘Make this valley full of trenches.’ 
+\v 17 For Yahuah says, ‘You will not see wind, neither will you see rain, yet that valley will be filled with water, and you will drink, both you and your livestock and your other animals. 
+\v 18 This is an easy thing in Yahuah’s sight. He will also deliver the Moabites into your hand. 
 \v 19 You shall strike every fortified city and every choice city, and shall fell every good tree, and stop all springs of water, and mar every good piece of land with stones.’ ” 
 \p
 \v 20 In the morning, about the time of offering the sacrifice, behold, water came by the way of Edom, and the country was filled with water. 
@@ -127,7 +127,7 @@
 \v 27 Then he took his oldest son who would have reigned in his place, and offered him for a burnt offering on the wall. There was great wrath against Israel; and they departed from him, and returned to their own land. 
 \c 4
 \p
-\v 1 Now a certain woman of the women of the sons of the prophets cried out to Elisha, saying, “Your servant my man is dead. You know that your servant feared Yahweh. Now the creditor has come to take for himself my two children to be slaves.” 
+\v 1 Now a certain woman of the women of the sons of the prophets cried out to Elisha, saying, “Your servant my man is dead. You know that your servant feared Yahuah. Now the creditor has come to take for himself my two children to be slaves.” 
 \p
 \v 2 Elisha said to her, “What should I do for you? Tell me, what do you have in the house?” 
 \p She said, “Your servant has nothing in the house, except a pot of oil.” 
@@ -175,19 +175,19 @@
 \v 26 Please run now to meet her, and ask her, ‘Is it well with you? Is it well with your man? Is it well with your child?’ ” 
 \p She answered, “It is well.” 
 \p
-\v 27 When she came to the man of Elohim to the hill, she caught hold of his feet. Gehazi came near to thrust her away; but the man of Elohim said, “Leave her alone, for her soul is troubled within her; and Yahweh has hidden it from me, and has not told me.” 
+\v 27 When she came to the man of Elohim to the hill, she caught hold of his feet. Gehazi came near to thrust her away; but the man of Elohim said, “Leave her alone, for her soul is troubled within her; and Yahuah has hidden it from me, and has not told me.” 
 \p
 \v 28 Then she said, “Did I ask you for a son, my lord? Didn’t I say, ‘Do not deceive me’?” 
 \p
 \v 29 Then he said to Gehazi, “Tuck your cloak into your belt, take my staff in your hand, and go your way. If you meet any man, don’t greet him; and if anyone greets you, don’t answer him again. Then lay my staff on the child’s face.” 
 \p
-\v 30 The child’s mother said, “As Yahweh lives, and as your soul lives, I will not leave you.” 
+\v 30 The child’s mother said, “As Yahuah lives, and as your soul lives, I will not leave you.” 
 \p So he arose, and followed her. 
 \p
 \v 31 Gehazi went ahead of them, and laid the staff on the child’s face; but there was no voice and no hearing. Therefore he returned to meet him, and told him, “The child has not awakened.” 
 \p
 \v 32 When Elisha had come into the house, behold, the child was dead, and lying on his bed. 
-\v 33 He went in therefore, and shut the door on them both, and prayed to Yahweh. 
+\v 33 He went in therefore, and shut the door on them both, and prayed to Yahuah. 
 \v 34 He went up and lay on the child, and put his mouth on his mouth, and his eyes on his eyes, and his hands on his hands. He stretched himself on him; and the child’s flesh grew warm. 
 \v 35 Then he returned, and walked in the house once back and forth, then went up and stretched himself out on him. Then the child sneezed seven times, and the child opened his eyes. 
 \v 36 He called Gehazi, and said, “Call this Shunammite!” So he called her. 
@@ -205,12 +205,12 @@
 \v 42 A man from Baal Shalishah came, and brought the man of Elohim some bread of the first fruits: twenty loaves of barley and fresh ears of grain in his sack. Elisha said, “Give to the people, that they may eat.” 
 \p
 \v 43 His servant said, “What, should I set this before a hundred men?” 
-\p But he said, “Give it to the people, that they may eat; for Yahweh says, ‘They will eat, and will have some left over.’ ” 
+\p But he said, “Give it to the people, that they may eat; for Yahuah says, ‘They will eat, and will have some left over.’ ” 
 \p
-\v 44 So he set it before them and they ate and had some left over, according to Yahweh’s word. 
+\v 44 So he set it before them and they ate and had some left over, according to Yahuah’s word. 
 \c 5
 \p
-\v 1 Now Naaman, captain of the army of the king of Syria, was a great man with his master, and honorable, because by him Yahweh had given victory to Syria; he was also a mighty man of valor, but he was a leper. 
+\v 1 Now Naaman, captain of the army of the king of Syria, was a great man with his master, and honorable, because by him Yahuah had given victory to Syria; he was also a mighty man of valor, but he was a leper. 
 \v 2 The Syrians had gone out in bands, and had brought away captive out of the land of Israel a little girl, and she waited on Naaman’s woman. 
 \v 3 She said to her mistress, “I wish that my lord were with the prophet who is in Samaria! Then he would heal him of his leprosy.” 
 \p
@@ -227,7 +227,7 @@
 \v 9 So Naaman came with his horses and with his chariots, and stood at the door of the house of Elisha. 
 \v 10 Elisha sent a messenger to him, saying, “Go and wash in the Jordan seven times, and your flesh shall come again to you, and you shall be clean.” 
 \p
-\v 11 But Naaman was angry, and went away and said, “Behold, I thought, ‘He will surely come out to me, and stand, and call on the name of Yahweh his Elohim, and wave his hand over the place, and heal the leper.’ 
+\v 11 But Naaman was angry, and went away and said, “Behold, I thought, ‘He will surely come out to me, and stand, and call on the name of Yahuah his Elohim, and wave his hand over the place, and heal the leper.’ 
 \v 12 Aren’t Abanah and Pharpar, the rivers of Damascus, better than all the waters of Israel? Couldn’t I wash in them and be clean?” So he turned and went away in a rage. 
 \p
 \v 13 His servants came near and spoke to him, and said, “My father, if the prophet had asked you do some great thing, wouldn’t you have done it? How much rather then, when he says to you, ‘Wash, and be clean’?” 
@@ -235,14 +235,14 @@
 \v 14 Then went he down and dipped himself seven times in the Jordan, according to the saying of the man of Elohim; and his flesh was restored like the flesh of a little child, and he was clean. 
 \v 15 He returned to the man of Elohim, he and all his company, and came, and stood before him; and he said, “See now, I know that there is no Elohim in all the earth, but in Israel. Now therefore, please take a gift from your servant.” 
 \p
-\v 16 But he said, “As Yahweh lives, before whom I stand, I will receive none.” 
+\v 16 But he said, “As Yahuah lives, before whom I stand, I will receive none.” 
 \p He urged him to take it; but he refused. 
-\v 17 Naaman said, “If not, then, please let two mules’ load of earth be given to your servant; for your servant will from now on offer neither burnt offering nor sacrifice to other elohims, but to Yahweh. 
-\v 18 In this thing may Yahweh pardon your servant: when my master goes into the house of Rimmon to worship there, and he leans on my hand, and I bow myself in the house of Rimmon. When I bow myself in the house of Rimmon, may Yahweh pardon your servant in this thing.” 
+\v 17 Naaman said, “If not, then, please let two mules’ load of earth be given to your servant; for your servant will from now on offer neither burnt offering nor sacrifice to other elohims, but to Yahuah. 
+\v 18 In this thing may Yahuah pardon your servant: when my master goes into the house of Rimmon to worship there, and he leans on my hand, and I bow myself in the house of Rimmon. When I bow myself in the house of Rimmon, may Yahuah pardon your servant in this thing.” 
 \p
 \v 19 He said to him, “Go in peace.” 
 \p So he departed from him a little way. 
-\v 20 But Gehazi the servant of Elisha the man of Elohim, said, “Behold, my master has spared this Naaman the Syrian, in not receiving at his hands that which he brought. As Yahweh lives, I will run after him, and take something from him.” 
+\v 20 But Gehazi the servant of Elisha the man of Elohim, said, “Behold, my master has spared this Naaman the Syrian, in not receiving at his hands that which he brought. As Yahuah lives, I will run after him, and take something from him.” 
 \p
 \v 21 So Gehazi followed after Naaman. When Naaman saw one running after him, he came down from the chariot to meet him, and said, “Is all well?” 
 \p
@@ -285,13 +285,13 @@
 \v 15 When the servant of the man of Elohim had risen early and gone out, behold, an army with horses and chariots was around the city. His servant said to him, “Alas, my master! What shall we do?” 
 \p
 \v 16 He answered, “Don’t be afraid, for those who are with us are more than those who are with them.” 
-\v 17 Elisha prayed, and said, “Yahweh, please open his eyes, that he may see.” Yahweh opened the young man’s eyes, and he saw; and behold, the mountain was full of horses and chariots of fire around Elisha. 
-\v 18 When they came down to him, Elisha prayed to Yahweh, and said, “Please strike this people with blindness.” 
+\v 17 Elisha prayed, and said, “Yahuah, please open his eyes, that he may see.” Yahuah opened the young man’s eyes, and he saw; and behold, the mountain was full of horses and chariots of fire around Elisha. 
+\v 18 When they came down to him, Elisha prayed to Yahuah, and said, “Please strike this people with blindness.” 
 \p He struck them with blindness according to Elisha’s word. 
 \p
 \v 19 Elisha said to them, “This is not the way, neither is this the city. Follow me, and I will bring you to the man whom you seek.” He led them to Samaria. 
-\v 20 When they had come into Samaria, Elisha said, “Yahweh, open these men’s eyes, that they may see.” 
-\p Yahweh opened their eyes, and they saw; and behold, they were in the middle of Samaria. 
+\v 20 When they had come into Samaria, Elisha said, “Yahuah, open these men’s eyes, that they may see.” 
+\p Yahuah opened their eyes, and they saw; and behold, they were in the middle of Samaria. 
 \p
 \v 21 The king of Israel said to Elisha, when he saw them, “My father, shall I strike them? Shall I strike them?” 
 \p
@@ -303,7 +303,7 @@
 \v 25 There was a great famine in Samaria. Behold, they besieged it until a donkey’s head was sold for eighty pieces of silver, and the fourth part of a kab of dove’s dung for five pieces of silver. 
 \v 26 As the king of Israel was passing by on the wall, a woman cried to him, saying, “Help, my lord, O king!” 
 \p
-\v 27 He said, “If Yahweh doesn’t help you, where could I get help for you? From the threshing floor, or from the wine press?” 
+\v 27 He said, “If Yahuah doesn’t help you, where could I get help for you? From the threshing floor, or from the wine press?” 
 \v 28 Then the king asked her, “What is your problem?” 
 \p She answered, “This woman said to me, ‘Give your son, that we may eat him today, and we will eat my son tomorrow.’ 
 \v 29 So we boiled my son and ate him; and I said to her on the next day, ‘Give up your son, that we may eat him;’ and she has hidden her son.” 
@@ -313,12 +313,12 @@
 \p
 \v 32 But Elisha was sitting in his house, and the elders were sitting with him. Then the king sent a man from before him; but before the messenger came to him, he said to the elders, “Do you see how this son of a murderer has sent to take away my head? Behold, when the messenger comes, shut the door, and hold the door shut against him. Isn’t the sound of his master’s feet behind him?” 
 \p
-\v 33 While he was still talking with them, behold, the messenger came down to him. Then he said, “Behold, this evil is from Yahweh. Why should I wait for Yahweh any longer?” 
+\v 33 While he was still talking with them, behold, the messenger came down to him. Then he said, “Behold, this evil is from Yahuah. Why should I wait for Yahuah any longer?” 
 \c 7
 \p
-\v 1 Elisha said, “Hear Yahweh’s word. Yahweh says, ‘Tomorrow about this time a seah of fine flour will be sold for a shekel, and two seahs of barley for a shekel, in the gate of Samaria.’ ” 
+\v 1 Elisha said, “Hear Yahuah’s word. Yahuah says, ‘Tomorrow about this time a seah of fine flour will be sold for a shekel, and two seahs of barley for a shekel, in the gate of Samaria.’ ” 
 \p
-\v 2 Then the captain on whose hand the king leaned answered the man of Elohim, and said, “Behold, if Yahweh made windows in heaven, could this thing be?” 
+\v 2 Then the captain on whose hand the king leaned answered the man of Elohim, and said, “Behold, if Yahuah made windows in heaven, could this thing be?” 
 \p He said, “Behold, you will see it with your eyes, but will not eat of it.” 
 \p
 \v 3 Now there were four leprous men at the entrance of the gate. They said to one another, “Why do we sit here until we die? 
@@ -341,14 +341,14 @@
 \v 14 Therefore they took two chariots with horses; and the king sent them out to the Syrian army, saying, “Go and see.” 
 \p
 \v 15 They went after them to the Jordan; and behold, all the path was full of garments and equipment which the Syrians had cast away in their haste. The messengers returned and told the king. 
-\v 16 The people went out and plundered the camp of the Syrians. So a seah of fine flour was sold for a shekel, and two measures of barley for a shekel, according to Yahweh’s word. 
+\v 16 The people went out and plundered the camp of the Syrians. So a seah of fine flour was sold for a shekel, and two measures of barley for a shekel, according to Yahuah’s word. 
 \v 17 The king had appointed the captain on whose hand he leaned to be in charge of the gate; and the people trampled over him in the gate, and he died as the man of Elohim had said, who spoke when the king came down to him. 
 \v 18 It happened as the man of Elohim had spoken to the king, saying, “Two seahs of barley for a shekel, and a seah of fine flour for a shekel, shall be tomorrow about this time in the gate of Samaria;” 
-\v 19 and that captain answered the man of Elohim, and said, “Now, behold, if Yahweh made windows in heaven, might such a thing be?” and he said, “Behold, you will see it with your eyes, but will not eat of it.” 
+\v 19 and that captain answered the man of Elohim, and said, “Now, behold, if Yahuah made windows in heaven, might such a thing be?” and he said, “Behold, you will see it with your eyes, but will not eat of it.” 
 \v 20 It happened like that to him, for the people trampled over him in the gate, and he died. 
 \c 8
 \p
-\v 1 Now Elisha had spoken to the woman whose son he had restored to life, saying, “Arise, and go, you and your household, and stay for a while wherever you can; for Yahweh has called for a famine. It will also come on the land for seven years.” 
+\v 1 Now Elisha had spoken to the woman whose son he had restored to life, saying, “Arise, and go, you and your household, and stay for a while wherever you can; for Yahuah has called for a famine. It will also come on the land for seven years.” 
 \p
 \v 2 The woman arose, and did according to the man of Elohim’s word. She went with her household, and lived in the land of the Philistines for seven years. 
 \v 3 At the end of seven years, the woman returned from the land of the Philistines. Then she went out to beg the king for her house and for her land. 
@@ -359,18 +359,18 @@
 \p
 \v 7 Elisha came to Damascus; and Benhadad the king of Syria was sick. He was told, “The man of Elohim has come here.” 
 \p
-\v 8 The king said to Hazael, “Take a present in your hand, and go meet the man of Elohim, and inquire of Yahweh by him, saying, ‘Will I recover from this sickness?’ ” 
+\v 8 The king said to Hazael, “Take a present in your hand, and go meet the man of Elohim, and inquire of Yahuah by him, saying, ‘Will I recover from this sickness?’ ” 
 \p
 \v 9 So Hazael went to meet him and took a present with him, even of every good thing of Damascus, forty camels’ burden, and came and stood before him and said, “Your son Benhadad king of Syria has sent me to you, saying, ‘Will I recover from this sickness?’ ” 
 \p
-\v 10 Elisha said to him, “Go, tell him, ‘You will surely recover;’ however Yahweh has shown me that he will surely die.” 
+\v 10 Elisha said to him, “Go, tell him, ‘You will surely recover;’ however Yahuah has shown me that he will surely die.” 
 \v 11 He settled his gaze steadfastly on him, until he was ashamed. Then the man of Elohim wept. 
 \p
 \v 12 Hazael said, “Why do you weep, my lord?” 
 \p He answered, “Because I know the evil that you will do to the children of Israel. You will set their strongholds on fire, and you will kill their young men with the sword, and will dash their little ones in pieces, and rip up their pregnant women.” 
 \p
 \v 13 Hazael said, “But what is your servant, who is but a dog, that he could do this great thing?” 
-\p Elisha answered, “Yahweh has shown me that you will be king over Syria.” 
+\p Elisha answered, “Yahuah has shown me that you will be king over Syria.” 
 \p
 \v 14 Then he departed from Elisha, and came to his master, who said to him, “What did Elisha say to you?” 
 \p He answered, “He told me that you would surely recover.” 
@@ -379,8 +379,8 @@
 \p
 \v 16 In the fifth year of Joram the son of Ahab king of Israel, Jehoshaphat being king of Judah then, Jehoram the son of Jehoshaphat king of Judah began to reign. 
 \v 17 He was thirty-two years old when he began to reign. He reigned eight years in Jerusalem. 
-\v 18 He walked in the way of the kings of Israel, as did Ahab’s house, for he took to himself Ahab’s daughter. He did that which was evil in Yahweh’s sight. 
-\v 19 However, Yahweh would not destroy Judah, for David his servant’s sake, as he promised him to give to him a lamp for his children always. 
+\v 18 He walked in the way of the kings of Israel, as did Ahab’s house, for he took to himself Ahab’s daughter. He did that which was evil in Yahuah’s sight. 
+\v 19 However, Yahuah would not destroy Judah, for David his servant’s sake, as he promised him to give to him a lamp for his children always. 
 \p
 \v 20 In his days Edom revolted from under the hand of Judah, and made a king over themselves. 
 \v 21 Then Joram crossed over to Zair, and all his chariots with him; and he rose up by night and struck the Edomites who surrounded him with the captains of the chariots; and the people fled to their tents. 
@@ -390,7 +390,7 @@
 \p
 \v 25 In the twelfth year of Joram the son of Ahab king of Israel, Ahaziah the son of Jehoram king of Judah began to reign. 
 \v 26 Ahaziah was twenty-two years old when he began to reign; and he reigned one year in Jerusalem. His mother’s name was Athaliah the daughter of Omri king of Israel. 
-\v 27 He walked in the way of Ahab’s house and did that which was evil in Yahweh’s sight, as did Ahab’s house, for he was the son-in-law of Ahab’s house. 
+\v 27 He walked in the way of Ahab’s house and did that which was evil in Yahuah’s sight, as did Ahab’s house, for he was the son-in-law of Ahab’s house. 
 \p
 \v 28 He went with Joram the son of Ahab to war against Hazael king of Syria at Ramoth Gilead, and the Syrians wounded Joram. 
 \v 29 King Joram returned to be healed in Jezreel from the wounds which the Syrians had given him at Ramah, when he fought against Hazael king of Syria. Ahaziah the son of Jehoram, king of Judah, went down to see Joram the son of Ahab in Jezreel, because he was sick. 
@@ -398,14 +398,14 @@
 \p
 \v 1 Elisha the prophet called one of the sons of the prophets, and said to him, “Put your belt on your waist, take this vial of oil in your hand, and go to Ramoth Gilead. 
 \v 2 When you come there, find Jehu the son of Jehoshaphat the son of Nimshi, and go in and make him rise up from among his brothers, and take him to an inner room. 
-\v 3 Then take the vial of oil, and pour it on his head, and say, ‘Yahweh says, “I have anointed you king over Israel.” ’ Then open the door, flee, and don’t wait.” 
+\v 3 Then take the vial of oil, and pour it on his head, and say, ‘Yahuah says, “I have anointed you king over Israel.” ’ Then open the door, flee, and don’t wait.” 
 \p
 \v 4 So the young man, the young prophet, went to Ramoth Gilead. 
 \v 5 When he came, behold, the captains of the army were sitting. Then he said, “I have a message for you, captain.” 
 \p Jehu said, “To which one of us?” 
 \p He said, “To you, O captain.” 
-\v 6 He arose, and went into the house. Then he poured the oil on his head, and said to him, “Yahweh, the Elohim of Israel, says, ‘I have anointed you king over the people of Yahweh, even over Israel. 
-\v 7 You must strike your master Ahab’s house, that I may avenge the blood of my servants the prophets, and the blood of all the servants of Yahweh, at the hand of Jezebel. 
+\v 6 He arose, and went into the house. Then he poured the oil on his head, and said to him, “Yahuah, the Elohim of Israel, says, ‘I have anointed you king over the people of Yahuah, even over Israel. 
+\v 7 You must strike your master Ahab’s house, that I may avenge the blood of my servants the prophets, and the blood of all the servants of Yahuah, at the hand of Jezebel. 
 \v 8 For the whole house of Ahab will perish. I will cut off from Ahab everyone who urinates against a wall, both him who is shut up and him who is left at large in Israel. 
 \v 9 I will make Ahab’s house like the house of Jeroboam the son of Nebat, and like the house of Baasha the son of Ahijah. 
 \v 10 The dogs will eat Jezebel on the plot of ground of Jezreel, and there shall be no one to bury her.’ ” Then he opened the door and fled. 
@@ -414,7 +414,7 @@
 \p He said to them, “You know the man and how he talks.” 
 \p
 \v 12 They said, “That is a lie. Tell us now.” 
-\p He said, “He said to me, ‘Yahweh says, I have anointed you king over Israel.’ ” 
+\p He said, “He said to me, ‘Yahuah says, I have anointed you king over Israel.’ ” 
 \p
 \v 13 Then they hurried, and each man took his cloak, and put it under him on the top of the stairs, and blew the trumpet, saying, “Jehu is king.” 
 \p
@@ -441,8 +441,8 @@
 \v 23 Joram turned his hands and fled, and said to Ahaziah, “This is treason, Ahaziah!” 
 \p
 \v 24 Jehu drew his bow with his full strength, and struck Joram between his arms; and the arrow went out at his heart, and he sunk down in his chariot. 
-\v 25 Then Jehu said to Bidkar his captain, “Pick him up, and throw him in the plot of the field of Naboth the Jezreelite; for remember how, when you and I rode together after Ahab his father, Yahweh laid this burden on him: 
-\v 26 ‘Surely I have seen yesterday the blood of Naboth, and the blood of his sons,’ says Yahweh; ‘and I will repay you in this plot of ground,’ says Yahweh. Now therefore take and cast him onto the plot of ground, according to Yahweh’s word.” 
+\v 25 Then Jehu said to Bidkar his captain, “Pick him up, and throw him in the plot of the field of Naboth the Jezreelite; for remember how, when you and I rode together after Ahab his father, Yahuah laid this burden on him: 
+\v 26 ‘Surely I have seen yesterday the blood of Naboth, and the blood of his sons,’ says Yahuah; ‘and I will repay you in this plot of ground,’ says Yahuah. Now therefore take and cast him onto the plot of ground, according to Yahuah’s word.” 
 \p
 \v 27 But when Ahaziah the king of Judah saw this, he fled by the way of the garden house. Jehu followed after him, and said, “Strike him also in the chariot!” They struck him at the ascent of Gur, which is by Ibleam. He fled to Megiddo, and died there. 
 \v 28 His servants carried him in a chariot to Jerusalem, and buried him in his tomb with his fathers in David’s city. 
@@ -460,7 +460,7 @@
 \p
 \v 35 They went to bury her, but they found no more of her than the skull, the feet, and the palms of her hands. 
 \v 36 Therefore they came back, and told him. 
-\p He said, “This is Yahweh’s word, which he spoke by his servant Elijah the Tishbite, saying, ‘The dogs will eat the flesh of Jezebel on the plot of Jezreel, 
+\p He said, “This is Yahuah’s word, which he spoke by his servant Elijah the Tishbite, saying, ‘The dogs will eat the flesh of Jezebel on the plot of Jezreel, 
 \v 37 and the body of Jezebel will be as dung on the surface of the field on Jezreel’s land, so that they won’t say, “This is Jezebel.” ’ ” 
 \c 10
 \p
@@ -477,7 +477,7 @@
 \v 8 A messenger came and told him, “They have brought the heads of the king’s sons.” 
 \p He said, “Lay them in two heaps at the entrance of the gate until the morning.” 
 \v 9 In the morning, he went out and stood, and said to all the people, “You are righteous. Behold, I conspired against my master and killed him, but who killed all these? 
-\v 10 Know now that nothing will fall to the earth of Yahweh’s word, which Yahweh spoke concerning Ahab’s house. For Yahweh has done that which he spoke by his servant Elijah.” 
+\v 10 Know now that nothing will fall to the earth of Yahuah’s word, which Yahuah spoke concerning Ahab’s house. For Yahuah has done that which he spoke by his servant Elijah.” 
 \p
 \v 11 So Jehu struck all that remained of Ahab’s house in Jezreel, with all his great men, his familiar friends, and his priests, until he left him no one remaining. 
 \p
@@ -491,8 +491,8 @@
 \v 15 When he had departed from there, he met Jehonadab the son of Rechab coming to meet him. He greeted him, and said to him, “Is your heart right, as my heart is with your heart?” 
 \p Jehonadab answered, “It is.” 
 \p “If it is, give me your hand.” He gave him his hand; and he took him up to him into the chariot. 
-\v 16 He said, “Come with me, and see my zeal for Yahweh.” So they made him ride in his chariot. 
-\v 17 When he came to Samaria, he struck all who remained to Ahab in Samaria, until he had destroyed them, according to Yahweh’s word which he spoke to Elijah. 
+\v 16 He said, “Come with me, and see my zeal for Yahuah.” So they made him ride in his chariot. 
+\v 17 When he came to Samaria, he struck all who remained to Ahab in Samaria, until he had destroyed them, according to Yahuah’s word which he spoke to Elijah. 
 \p
 \v 18 Jehu gathered all the people together, and said to them, “Ahab served Baal a little, but Jehu will serve him much. 
 \v 19 Now therefore call to me all the prophets of Baal, all of his worshipers, and all of his priests. Let no one be absent, for I have a great sacrifice to Baal. Whoever is absent, he shall not live.” But Jehu did deceptively, intending to destroy the worshipers of Baal. 
@@ -502,7 +502,7 @@
 \v 21 Jehu sent through all Israel; and all the worshipers of Baal came, so that there was not a man left that didn’t come. They came into the house of Baal; and the house of Baal was filled from one end to another. 
 \v 22 He said to him who kept the wardrobe, “Bring out robes for all the worshipers of Baal!” 
 \p So he brought robes out to them. 
-\v 23 Jehu went with Jehonadab the son of Rechab into the house of Baal. Then he said to the worshipers of Baal, “Search, and see that none of the servants of Yahweh are here with you, but only the worshipers of Baal.” 
+\v 23 Jehu went with Jehonadab the son of Rechab into the house of Baal. Then he said to the worshipers of Baal, “Search, and see that none of the servants of Yahuah are here with you, but only the worshipers of Baal.” 
 \p
 \v 24 So they went in to offer sacrifices and burnt offerings. Now Jehu had appointed for himself eighty men outside, and said, “If any of the men whom I bring into your hands escape, he who lets him go, his life shall be for the life of him.” 
 \p
@@ -512,11 +512,11 @@
 \v 28 Thus Jehu destroyed Baal out of Israel. 
 \p
 \v 29 However, Jehu didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin—the golden calves that were in Bethel and that were in Dan. 
-\v 30 Yahweh said to Jehu, “Because you have done well in executing that which is right in my eyes, and have done to Ahab’s house according to all that was in my heart, your descendants shall sit on the throne of Israel to the fourth generation.” 
+\v 30 Yahuah said to Jehu, “Because you have done well in executing that which is right in my eyes, and have done to Ahab’s house according to all that was in my heart, your descendants shall sit on the throne of Israel to the fourth generation.” 
 \p
-\v 31 But Jehu took no heed to walk in the law of Yahweh, the Elohim of Israel, with all his heart. He didn’t depart from the sins of Jeroboam, with which he made Israel to sin. 
+\v 31 But Jehu took no heed to walk in the law of Yahuah, the Elohim of Israel, with all his heart. He didn’t depart from the sins of Jeroboam, with which he made Israel to sin. 
 \p
-\v 32 In those days Yahweh began to cut away parts of Israel; and Hazael struck them in all the borders of Israel 
+\v 32 In those days Yahuah began to cut away parts of Israel; and Hazael struck them in all the borders of Israel 
 \v 33 from the Jordan eastward, all the land of Gilead, the Gadites, and the Reubenites, and the Manassites, from Aroer, which is by the valley of the Arnon, even Gilead and Bashan. 
 \v 34 Now the rest of the acts of Jehu, and all that he did, and all his might, aren’t they written in the book of the chronicles of the kings of Israel? 
 \v 35 Jehu slept with his fathers; and they buried him in Samaria. Jehoahaz his son reigned in his place. 
@@ -525,55 +525,55 @@
 \p
 \v 1 Now when Athaliah the mother of Ahaziah saw that her son was dead, she arose and destroyed all the royal offspring. 
 \v 2 But Jehosheba, the daughter of King Joram, sister of Ahaziah, took Joash the son of Ahaziah, and stole him away from among the king’s sons who were slain, even him and his nurse, and put them in the bedroom; and they hid him from Athaliah, so that he was not slain. 
-\v 3 He was with her hidden in Yahweh’s house six years while Athaliah reigned over the land. 
+\v 3 He was with her hidden in Yahuah’s house six years while Athaliah reigned over the land. 
 \p
-\v 4 In the seventh year Jehoiada sent and fetched the captains over hundreds of the Carites and of the guard, and brought them to him into Yahweh’s house; and he made a covenant with them, and made a covenant with them in Yahweh’s house, and showed them the king’s son. 
+\v 4 In the seventh year Jehoiada sent and fetched the captains over hundreds of the Carites and of the guard, and brought them to him into Yahuah’s house; and he made a covenant with them, and made a covenant with them in Yahuah’s house, and showed them the king’s son. 
 \v 5 He commanded them, saying, “This is what you must do: a third of you, who come in on the Sabbath, shall be keepers of the watch of the king’s house; 
 \v 6 a third of you shall be at the gate Sur; and a third of you at the gate behind the guard. So you shall keep the watch of the house, and be a barrier. 
-\v 7 The two companies of you, even all who go out on the Sabbath, shall keep the watch of Yahweh’s house around the king. 
+\v 7 The two companies of you, even all who go out on the Sabbath, shall keep the watch of Yahuah’s house around the king. 
 \v 8 You shall surround the king, every man with his weapons in his hand; and he who comes within the ranks, let him be slain. Be with the king when he goes out, and when he comes in.” 
 \p
 \v 9 The captains over hundreds did according to all that Jehoiada the priest commanded; and they each took his men, those who were to come in on the Sabbath with those who were to go out on the Sabbath, and came to Jehoiada the priest. 
-\v 10 The priest delivered to the captains over hundreds the spears and shields that had been King David’s, which were in Yahweh’s house. 
+\v 10 The priest delivered to the captains over hundreds the spears and shields that had been King David’s, which were in Yahuah’s house. 
 \v 11 The guard stood, every man with his weapons in his hand, from the right side of the house to the left side of the house, along by the altar and the house, around the king. 
 \v 12 Then he brought out the king’s son, and put the crown on him, and gave him the covenant; and they made him king and anointed him; and they clapped their hands, and said, “Long live the king!” 
 \p
-\v 13 When Athaliah heard the noise of the guard and of the people, she came to the people into Yahweh’s house; 
+\v 13 When Athaliah heard the noise of the guard and of the people, she came to the people into Yahuah’s house; 
 \v 14 and she looked, and behold, the king stood by the pillar, as the tradition was, with the captains and the trumpets by the king; and all the people of the land rejoiced, and blew trumpets. Then Athaliah tore her clothes and cried, “Treason! Treason!” 
 \p
-\v 15 Jehoiada the priest commanded the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks. Kill anyone who follows her with the sword.” For the priest said, “Don’t let her be slain in Yahweh’s house.” 
+\v 15 Jehoiada the priest commanded the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks. Kill anyone who follows her with the sword.” For the priest said, “Don’t let her be slain in Yahuah’s house.” 
 \v 16 So they seized her; and she went by the way of the horses’ entry to the king’s house, and she was slain there. 
 \p
-\v 17 Jehoiada made a covenant between Yahweh and the king and the people, that they should be Yahweh’s people; also between the king and the people. 
-\v 18 All the people of the land went to the house of Baal, and broke it down. They broke his altars and his images in pieces thoroughly, and killed Mattan the priest of Baal before the altars. The priest appointed officers over Yahweh’s house. 
-\v 19 He took the captains over hundreds, and the Carites, and the guard, and all the people of the land; and they brought down the king from Yahweh’s house, and came by the way of the gate of the guard to the king’s house. He sat on the throne of the kings. 
+\v 17 Jehoiada made a covenant between Yahuah and the king and the people, that they should be Yahuah’s people; also between the king and the people. 
+\v 18 All the people of the land went to the house of Baal, and broke it down. They broke his altars and his images in pieces thoroughly, and killed Mattan the priest of Baal before the altars. The priest appointed officers over Yahuah’s house. 
+\v 19 He took the captains over hundreds, and the Carites, and the guard, and all the people of the land; and they brought down the king from Yahuah’s house, and came by the way of the gate of the guard to the king’s house. He sat on the throne of the kings. 
 \v 20 So all the people of the land rejoiced, and the city was quiet. They had slain Athaliah with the sword at the king’s house. 
 \p
 \v 21 Jehoash was seven years old when he began to reign. 
 \c 12
 \p
 \v 1 Jehoash began to reign in the seventh year of Jehu, and he reigned forty years in Jerusalem. His mother’s name was Zibiah of Beersheba. 
-\v 2 Jehoash did that which was right in Yahweh’s eyes all his days in which Jehoiada the priest instructed him. 
+\v 2 Jehoash did that which was right in Yahuah’s eyes all his days in which Jehoiada the priest instructed him. 
 \v 3 However, the high places were not taken away. The people still sacrificed and burned incense in the high places. 
 \p
-\v 4 Jehoash said to the priests, “All the money of the set-apart things that is brought into Yahweh’s house, in current money, the money of the people for whom each man is evaluated, and all the money that it comes into any man’s heart to bring into Yahweh’s house, 
+\v 4 Jehoash said to the priests, “All the money of the set-apart things that is brought into Yahuah’s house, in current money, the money of the people for whom each man is evaluated, and all the money that it comes into any man’s heart to bring into Yahuah’s house, 
 \v 5 let the priests take it to them, each man from his donor; and they shall repair the damage to the house, wherever any damage is found.” 
 \p
 \v 6 But it was so, that in the twenty-third year of King Jehoash the priests had not repaired the damage to the house. 
 \v 7 Then King Jehoash called for Jehoiada the priest, and for the other priests, and said to them, “Why aren’t you repairing the damage to the house? Now therefore take no more money from your treasurers, but deliver it for repair of the damage to the house.” 
 \p
 \v 8 The priests consented that they should take no more money from the people, and not repair the damage to the house. 
-\v 9 But Jehoiada the priest took a chest and bored a hole in its lid, and set it beside the altar, on the right side as one comes into Yahweh’s house; and the priests who kept the threshold put all the money that was brought into Yahweh’s house into it. 
-\v 10 When they saw that there was much money in the chest, the king’s scribe and the high priest came up, and they put it in bags and counted the money that was found in Yahweh’s house. 
-\v 11 They gave the money that was weighed out into the hands of those who did the work, who had the oversight of Yahweh’s house; and they paid it out to the carpenters and the builders who worked on Yahweh’s house, 
-\v 12 and to the masons and the stone cutters, and for buying timber and cut stone to repair the damage to Yahweh’s house, and for all that was laid out for the house to repair it. 
-\v 13 But there were not made for Yahweh’s house cups of silver, snuffers, basins, trumpets, any vessels of gold or vessels of silver, of the money that was brought into Yahweh’s house; 
-\v 14 for they gave that to those who did the work, and repaired Yahweh’s house with it. 
+\v 9 But Jehoiada the priest took a chest and bored a hole in its lid, and set it beside the altar, on the right side as one comes into Yahuah’s house; and the priests who kept the threshold put all the money that was brought into Yahuah’s house into it. 
+\v 10 When they saw that there was much money in the chest, the king’s scribe and the high priest came up, and they put it in bags and counted the money that was found in Yahuah’s house. 
+\v 11 They gave the money that was weighed out into the hands of those who did the work, who had the oversight of Yahuah’s house; and they paid it out to the carpenters and the builders who worked on Yahuah’s house, 
+\v 12 and to the masons and the stone cutters, and for buying timber and cut stone to repair the damage to Yahuah’s house, and for all that was laid out for the house to repair it. 
+\v 13 But there were not made for Yahuah’s house cups of silver, snuffers, basins, trumpets, any vessels of gold or vessels of silver, of the money that was brought into Yahuah’s house; 
+\v 14 for they gave that to those who did the work, and repaired Yahuah’s house with it. 
 \v 15 Moreover they didn’t demand an accounting from the men into whose hand they delivered the money to give to those who did the work; for they dealt faithfully. 
-\v 16 The money for the trespass offerings and the money for the sin offerings was not brought into Yahweh’s house. It was the priests’. 
+\v 16 The money for the trespass offerings and the money for the sin offerings was not brought into Yahuah’s house. It was the priests’. 
 \p
 \v 17 Then Hazael king of Syria went up and fought against Gath, and took it; and Hazael set his face to go up to Jerusalem. 
-\v 18 Jehoash king of Judah took all the set-apart things that Jehoshaphat and Jehoram and Ahaziah, his fathers, kings of Judah, had dedicated, and his own set-apart things, and all the gold that was found in the treasures of Yahweh’s house, and of the king’s house, and sent it to Hazael king of Syria; and he went away from Jerusalem. 
+\v 18 Jehoash king of Judah took all the set-apart things that Jehoshaphat and Jehoram and Ahaziah, his fathers, kings of Judah, had dedicated, and his own set-apart things, and all the gold that was found in the treasures of Yahuah’s house, and of the king’s house, and sent it to Hazael king of Syria; and he went away from Jerusalem. 
 \p
 \v 19 Now the rest of the acts of Joash, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 \v 20 His servants arose and made a conspiracy, and struck Joash at the house of Millo, on the way that goes down to Silla. 
@@ -581,17 +581,17 @@
 \c 13
 \p
 \v 1 In the twenty-third year of Joash the son of Ahaziah, king of Judah, Jehoahaz the son of Jehu began to reign over Israel in Samaria for seventeen years. 
-\v 2 He did that which was evil in Yahweh’s sight, and followed the sins of Jeroboam the son of Nebat, with which he made Israel to sin. He didn’t depart from it. 
-\v 3 Yahweh’s anger burned against Israel, and he delivered them into the hand of Hazael king of Syria, and into the hand of Benhadad the son of Hazael, continually. 
-\v 4 Jehoahaz begged Yahweh, and Yahweh listened to him; for he saw the oppression of Israel, how the king of Syria oppressed them. 
-\v 5 (Yahweh gave Israel a savior, so that they went out from under the hand of the Syrians; and the children of Israel lived in their tents as before. 
+\v 2 He did that which was evil in Yahuah’s sight, and followed the sins of Jeroboam the son of Nebat, with which he made Israel to sin. He didn’t depart from it. 
+\v 3 Yahuah’s anger burned against Israel, and he delivered them into the hand of Hazael king of Syria, and into the hand of Benhadad the son of Hazael, continually. 
+\v 4 Jehoahaz begged Yahuah, and Yahuah listened to him; for he saw the oppression of Israel, how the king of Syria oppressed them. 
+\v 5 (Yahuah gave Israel a savior, so that they went out from under the hand of the Syrians; and the children of Israel lived in their tents as before. 
 \v 6 Nevertheless they didn’t depart from the sins of the house of Jeroboam, with which he made Israel to sin, but walked in them; and the Asherah also remained in Samaria.) 
 \v 7 For he didn’t leave to Jehoahaz of the people any more than fifty horsemen, and ten chariots, and ten thousand footmen; for the king of Syria destroyed them and made them like the dust in threshing. 
 \v 8 Now the rest of the acts of Jehoahaz, and all that he did, and his might, aren’t they written in the book of the chronicles of the kings of Israel? 
 \v 9 Jehoahaz slept with his fathers; and they buried him in Samaria; and Joash his son reigned in his place. 
 \p
 \v 10 In the thirty-seventh year of Joash king of Judah, Jehoash the son of Jehoahaz began to reign over Israel in Samaria for sixteen years. 
-\v 11 He did that which was evil in Yahweh’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin; but he walked in them. 
+\v 11 He did that which was evil in Yahuah’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin; but he walked in them. 
 \v 12 Now the rest of the acts of Joash, and all that he did, and his might with which he fought against Amaziah king of Judah, aren’t they written in the book of the chronicles of the kings of Israel? 
 \v 13 Joash slept with his fathers; and Jeroboam sat on his throne. Joash was buried in Samaria with the kings of Israel. 
 \p
@@ -599,7 +599,7 @@
 \p
 \v 15 Elisha said to him, “Take bow and arrows;” and he took bow and arrows for himself. 
 \v 16 He said to the king of Israel, “Put your hand on the bow;” and he put his hand on it. Elisha laid his hands on the king’s hands. 
-\v 17 He said, “Open the window eastward;” and he opened it. Then Elisha said, “Shoot!” and he shot. He said, “Yahweh’s arrow of victory, even the arrow of victory over Syria; for you will strike the Syrians in Aphek until you have consumed them.” 
+\v 17 He said, “Open the window eastward;” and he opened it. Then Elisha said, “Shoot!” and he shot. He said, “Yahuah’s arrow of victory, even the arrow of victory over Syria; for you will strike the Syrians in Aphek until you have consumed them.” 
 \p
 \v 18 He said, “Take the arrows;” and he took them. He said to the king of Israel, “Strike the ground;” and he struck three times, and stopped. 
 \v 19 The man of Elohim was angry with him, and said, “You should have struck five or six times. Then you would have struck Syria until you had consumed it, but now you will strike Syria just three times.” 
@@ -609,7 +609,7 @@
 \v 21 As they were burying a man, behold, they saw a band of raiders; and they threw the man into Elisha’s tomb. As soon as the man touched Elisha’s bones, he revived, and stood up on his feet. 
 \p
 \v 22 Hazael king of Syria oppressed Israel all the days of Jehoahaz. 
-\v 23 But Yahweh was gracious to them, and had compassion on them, and favored them because of his covenant with Abraham, Isaac, and Jacob, and would not destroy them and he didn’t cast them from his presence as yet. 
+\v 23 But Yahuah was gracious to them, and had compassion on them, and favored them because of his covenant with Abraham, Isaac, and Jacob, and would not destroy them and he didn’t cast them from his presence as yet. 
 \p
 \v 24 Hazael king of Syria died; and Benhadad his son reigned in his place. 
 \v 25 Jehoash the son of Jehoahaz took again out of the hand of Benhadad the son of Hazael the cities which he had taken out of the hand of Jehoahaz his father by war. Joash struck him three times, and recovered the cities of Israel. 
@@ -617,10 +617,10 @@
 \p
 \v 1 In the second year of Joash, son of Joahaz, king of Israel, Amaziah the son of Joash king of Judah began to reign. 
 \v 2 He was twenty-five years old when he began to reign; and he reigned twenty-nine years in Jerusalem. His mother’s name was Jehoaddin of Jerusalem. 
-\v 3 He did that which was right in Yahweh’s eyes, yet not like David his father. He did according to all that Joash his father had done. 
+\v 3 He did that which was right in Yahuah’s eyes, yet not like David his father. He did according to all that Joash his father had done. 
 \v 4 However the high places were not taken away. The people still sacrificed and burned incense in the high places. 
 \v 5 As soon as the kingdom was established in his hand, he killed his servants who had slain the king his father, 
-\v 6 but the children of the murderers he didn’t put to death, according to that which is written in the book of the law of Moses, as Yahweh commanded, saying, “The fathers shall not be put to death for the children, nor the children be put to death for the fathers; but every man shall die for his own sin.” 
+\v 6 but the children of the murderers he didn’t put to death, according to that which is written in the book of the law of Moses, as Yahuah commanded, saying, “The fathers shall not be put to death for the children, nor the children be put to death for the fathers; but every man shall die for his own sin.” 
 \p
 \v 7 He killed ten thousand Edomites in the Valley of Salt, and took Sela by war, and called its name Joktheel, to this day. 
 \v 8 Then Amaziah sent messengers to Jehoash, the son of Jehoahaz son of Jehu, king of Israel, saying, “Come, let’s look one another in the face.” 
@@ -631,7 +631,7 @@
 \v 11 But Amaziah would not listen. So Jehoash king of Israel went up; and he and Amaziah king of Judah looked one another in the face at Beth Shemesh, which belongs to Judah. 
 \v 12 Judah was defeated by Israel; and each man fled to his tent. 
 \v 13 Jehoash king of Israel took Amaziah king of Judah, the son of Jehoash the son of Ahaziah, at Beth Shemesh and came to Jerusalem, then broke down the wall of Jerusalem from the gate of Ephraim to the corner gate, four hundred cubits. 
-\v 14 He took all the gold and silver and all the vessels that were found in Yahweh’s house and in the treasures of the king’s house, the hostages also, and returned to Samaria. 
+\v 14 He took all the gold and silver and all the vessels that were found in Yahuah’s house and in the treasures of the king’s house, the hostages also, and returned to Samaria. 
 \p
 \v 15 Now the rest of the acts of Jehoash which he did, and his might, and how he fought with Amaziah king of Judah, aren’t they written in the book of the chronicles of the kings of Israel? 
 \v 16 Jehoash slept with his fathers, and was buried in Samaria with the kings of Israel; and Jeroboam his son reigned in his place. 
@@ -645,27 +645,27 @@
 \v 22 He built Elath and restored it to Judah. After that the king slept with his fathers. 
 \p
 \v 23 In the fifteenth year of Amaziah the son of Joash king of Judah, Jeroboam the son of Joash king of Israel began to reign in Samaria for forty-one years. 
-\v 24 He did that which was evil in Yahweh’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
-\v 25 He restored the border of Israel from the entrance of Hamath to the sea of the Arabah, according to Yahweh, the Elohim of Israel’s word, which he spoke by his servant Jonah the son of Amittai, the prophet, who was from Gath Hepher. 
-\v 26 For Yahweh saw the affliction of Israel, that it was very bitter for all, slave and free; and there was no helper for Israel. 
-\v 27 Yahweh didn’t say that he would blot out the name of Israel from under the sky; but he saved them by the hand of Jeroboam the son of Joash. 
+\v 24 He did that which was evil in Yahuah’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+\v 25 He restored the border of Israel from the entrance of Hamath to the sea of the Arabah, according to Yahuah, the Elohim of Israel’s word, which he spoke by his servant Jonah the son of Amittai, the prophet, who was from Gath Hepher. 
+\v 26 For Yahuah saw the affliction of Israel, that it was very bitter for all, slave and free; and there was no helper for Israel. 
+\v 27 Yahuah didn’t say that he would blot out the name of Israel from under the sky; but he saved them by the hand of Jeroboam the son of Joash. 
 \v 28 Now the rest of the acts of Jeroboam, and all that he did, and his might, how he fought, and how he recovered Damascus, and Hamath, which had belonged to Judah, for Israel, aren’t they written in the book of the chronicles of the kings of Israel? 
 \v 29 Jeroboam slept with his fathers, even with the kings of Israel; and Zechariah his son reigned in his place. 
 \c 15
 \p
 \v 1 In the twenty-seventh year of Jeroboam king of Israel, Azariah son of Amaziah king of Judah began to reign. 
 \v 2 He was sixteen years old when he began to reign, and he reigned fifty-two years in Jerusalem. His mother’s name was Jecoliah of Jerusalem. 
-\v 3 He did that which was right in Yahweh’s eyes, according to all that his father Amaziah had done. 
+\v 3 He did that which was right in Yahuah’s eyes, according to all that his father Amaziah had done. 
 \v 4 However, the high places were not taken away. The people still sacrificed and burned incense in the high places. 
-\v 5 Yahweh struck the king, so that he was a leper to the day of his death, and lived in a separate house. Jotham, the king’s son, was over the household, judging the people of the land. 
+\v 5 Yahuah struck the king, so that he was a leper to the day of his death, and lived in a separate house. Jotham, the king’s son, was over the household, judging the people of the land. 
 \v 6 Now the rest of the acts of Azariah, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 \v 7 Azariah slept with his fathers; and they buried him with his fathers in David’s city; and Jotham his son reigned in his place. 
 \p
 \v 8 In the thirty-eighth year of Azariah king of Judah, Zechariah the son of Jeroboam reigned over Israel in Samaria six months. 
-\v 9 He did that which was evil in Yahweh’s sight, as his fathers had done. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+\v 9 He did that which was evil in Yahuah’s sight, as his fathers had done. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
 \v 10 Shallum the son of Jabesh conspired against him, and struck him before the people and killed him, and reigned in his place. 
 \v 11 Now the rest of the acts of Zechariah, behold, they are written in the book of the chronicles of the kings of Israel. 
-\v 12 This was Yahweh’s word which he spoke to Jehu, saying, “Your sons to the fourth generation shall sit on the throne of Israel.” So it came to pass. 
+\v 12 This was Yahuah’s word which he spoke to Jehu, saying, “Your sons to the fourth generation shall sit on the throne of Israel.” So it came to pass. 
 \p
 \v 13 Shallum the son of Jabesh began to reign in the thirty-ninth year of Uzziah king of Judah, and he reigned for a month in Samaria. 
 \v 14 Menahem the son of Gadi went up from Tirzah, came to Samaria, struck Shallum the son of Jabesh in Samaria, killed him, and reigned in his place. 
@@ -674,135 +674,135 @@
 \v 16 Then Menahem attacked Tiphsah and all who were in it and its border areas, from Tirzah. He attacked it because they didn’t open their gates to him, and he ripped up all their women who were with child. 
 \p
 \v 17 In the thirty ninth year of Azariah king of Judah, Menahem the son of Gadi began to reign over Israel for ten years in Samaria. 
-\v 18 He did that which was evil in Yahweh’s sight. He didn’t depart all his days from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+\v 18 He did that which was evil in Yahuah’s sight. He didn’t depart all his days from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
 \v 19 Pul the king of Assyria came against the land, and Menahem gave Pul one thousand talents of silver, that his hand might be with him to confirm the kingdom in his hand. 
 \v 20 Menahem exacted the money from Israel, even from all the mighty men of wealth, from each man fifty shekels of silver, to give to the king of Assyria. So the king of Assyria turned back, and didn’t stay there in the land. 
 \v 21 Now the rest of the acts of Menahem, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
 \v 22 Menahem slept with his fathers, and Pekahiah his son reigned in his place. 
 \p
 \v 23 In the fiftieth year of Azariah king of Judah, Pekahiah the son of Menahem began to reign over Israel in Samaria for two years. 
-\v 24 He did that which was evil in Yahweh’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+\v 24 He did that which was evil in Yahuah’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
 \v 25 Pekah the son of Remaliah, his captain, conspired against him and attacked him in Samaria, in the fortress of the king’s house, with Argob and Arieh; and with him were fifty men of the Gileadites. He killed him, and reigned in his place. 
 \v 26 Now the rest of the acts of Pekahiah, and all that he did, behold, they are written in the book of the chronicles of the kings of Israel. 
 \p
 \v 27 In the fifty-second year of Azariah king of Judah, Pekah the son of Remaliah began to reign over Israel in Samaria for twenty years. 
-\v 28 He did that which was evil in Yahweh’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+\v 28 He did that which was evil in Yahuah’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
 \v 29 In the days of Pekah king of Israel, Tiglath Pileser king of Assyria came and took Ijon, Abel Beth Maacah, Janoah, Kedesh, Hazor, Gilead, and Galilee, all the land of Naphtali; and he carried them captive to Assyria. 
 \v 30 Hoshea the son of Elah made a conspiracy against Pekah the son of Remaliah, attacked him, killed him, and reigned in his place, in the twentieth year of Jotham the son of Uzziah. 
 \v 31 Now the rest of the acts of Pekah, and all that he did, behold, they are written in the book of the chronicles of the kings of Israel. 
 \p
 \v 32 In the second year of Pekah the son of Remaliah king of Israel, Jotham the son of Uzziah king of Judah began to reign. 
 \v 33 He was twenty-five years old when he began to reign, and he reigned sixteen years in Jerusalem. His mother’s name was Jerusha the daughter of Zadok. 
-\v 34 He did that which was right in Yahweh’s eyes. He did according to all that his father Uzziah had done. 
-\v 35 However the high places were not taken away. The people still sacrificed and burned incense in the high places. He built the upper gate of Yahweh’s house. 
+\v 34 He did that which was right in Yahuah’s eyes. He did according to all that his father Uzziah had done. 
+\v 35 However the high places were not taken away. The people still sacrificed and burned incense in the high places. He built the upper gate of Yahuah’s house. 
 \v 36 Now the rest of the acts of Jotham, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-\v 37 In those days, Yahweh began to send Rezin the king of Syria and Pekah the son of Remaliah against Judah. 
+\v 37 In those days, Yahuah began to send Rezin the king of Syria and Pekah the son of Remaliah against Judah. 
 \v 38 Jotham slept with his fathers, and was buried with his fathers in his father David’s city; and Ahaz his son reigned in his place. 
 \c 16
 \p
 \v 1 In the seventeenth year of Pekah the son of Remaliah, Ahaz the son of Jotham king of Judah began to reign. 
-\v 2 Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahweh his Elohim’s eyes, like David his father. 
-\v 3 But he walked in the way of the kings of Israel, and even made his son to pass through the fire, according to the abominations of the nations whom Yahweh cast out from before the children of Israel. 
+\v 2 Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahuah his Elohim’s eyes, like David his father. 
+\v 3 But he walked in the way of the kings of Israel, and even made his son to pass through the fire, according to the abominations of the nations whom Yahuah cast out from before the children of Israel. 
 \v 4 He sacrificed and burned incense in the high places, on the hills, and under every green tree. 
 \p
 \v 5 Then Rezin king of Syria and Pekah son of Remaliah king of Israel came up to Jerusalem to wage war. They besieged Ahaz, but could not overcome him. 
 \v 6 At that time Rezin king of Syria recovered Elath to Syria, and drove the Jews from Elath; and the Syrians came to Elath, and lived there to this day. 
 \v 7 So Ahaz sent messengers to Tiglath Pileser king of Assyria, saying, “I am your servant and your son. Come up and save me out of the hand of the king of Syria and out of the hand of the king of Israel, who rise up against me.” 
-\v 8 Ahaz took the silver and gold that was found in Yahweh’s house, and in the treasures of the king’s house, and sent it for a present to the king of Assyria. 
+\v 8 Ahaz took the silver and gold that was found in Yahuah’s house, and in the treasures of the king’s house, and sent it for a present to the king of Assyria. 
 \v 9 The king of Assyria listened to him; and the king of Assyria went up against Damascus and took it, and carried its people captive to Kir, and killed Rezin. 
 \p
 \v 10 King Ahaz went to Damascus to meet Tiglath Pileser king of Assyria, and saw the altar that was at Damascus; and King Ahaz sent to Urijah the priest a drawing of the altar and plans to build it. 
 \v 11 Urijah the priest built an altar. According to all that King Ahaz had sent from Damascus, so Urijah the priest made it for the coming of King Ahaz from Damascus. 
 \v 12 When the king had come from Damascus, the king saw the altar; and the king came near to the altar, and offered on it. 
 \v 13 He burned his burnt offering and his meal offering, poured his drink offering, and sprinkled the blood of his peace offerings on the altar. 
-\v 14 The bronze altar, which was before Yahweh, he brought from the front of the house, from between his altar and Yahweh’s house, and put it on the north side of his altar. 
+\v 14 The bronze altar, which was before Yahuah, he brought from the front of the house, from between his altar and Yahuah’s house, and put it on the north side of his altar. 
 \v 15 King Ahaz commanded Urijah the priest, saying, “On the great altar burn the morning burnt offering, the evening meal offering, the king’s burnt offering and his meal offering, with the burnt offering of all the people of the land, their meal offering, and their drink offerings; and sprinkle on it all the blood of the burnt offering, and all the blood of the sacrifice; but the bronze altar will be for me to inquire by.” 
 \v 16 Urijah the priest did so, according to all that King Ahaz commanded. 
 \p
 \v 17 King Ahaz cut off the panels of the bases, and removed the basin from off them, and took down the sea from off the bronze oxen that were under it, and put it on a pavement of stone. 
-\v 18 He removed the covered way for the Sabbath that they had built in the house, and the king’s outer entrance to Yahweh’s house, because of the king of Assyria. 
+\v 18 He removed the covered way for the Sabbath that they had built in the house, and the king’s outer entrance to Yahuah’s house, because of the king of Assyria. 
 \v 19 Now the rest of the acts of Ahaz which he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 \v 20 Ahaz slept with his fathers, and was buried with his fathers in David’s city; and Hezekiah his son reigned in his place. 
 \c 17
 \p
 \v 1 In the twelfth year of Ahaz king of Judah, Hoshea the son of Elah began to reign in Samaria over Israel for nine years. 
-\v 2 He did that which was evil in Yahweh’s sight, yet not as the kings of Israel who were before him. 
+\v 2 He did that which was evil in Yahuah’s sight, yet not as the kings of Israel who were before him. 
 \v 3 Shalmaneser king of Assyria came up against him; and Hoshea became his servant, and brought him tribute. 
 \v 4 The king of Assyria discovered a conspiracy in Hoshea; for he had sent messengers to So king of Egypt, and offered no tribute to the king of Assyria, as he had done year by year. Therefore the king of Assyria seized him, and bound him in prison. 
 \v 5 Then the king of Assyria came up throughout all the land, went up to Samaria, and besieged it three years. 
 \v 6 In the ninth year of Hoshea the king of Assyria took Samaria and carried Israel away to Assyria, and placed them in Halah, and on the Habor, the river of Gozan, and in the cities of the Medes. 
 \p
-\v 7 It was so because the children of Israel had sinned against Yahweh their Elohim, who brought them up out of the land of Egypt from under the hand of Pharaoh king of Egypt, and had feared other elohims, 
-\v 8 and walked in the statutes of the nations whom Yahweh cast out from before the children of Israel, and of the kings of Israel, which they made. 
-\v 9 The children of Israel secretly did things that were not right against Yahweh their Elohim; and they built high places for themselves in all their cities, from the tower of the watchmen to the fortified city; 
+\v 7 It was so because the children of Israel had sinned against Yahuah their Elohim, who brought them up out of the land of Egypt from under the hand of Pharaoh king of Egypt, and had feared other elohims, 
+\v 8 and walked in the statutes of the nations whom Yahuah cast out from before the children of Israel, and of the kings of Israel, which they made. 
+\v 9 The children of Israel secretly did things that were not right against Yahuah their Elohim; and they built high places for themselves in all their cities, from the tower of the watchmen to the fortified city; 
 \v 10 and they set up for themselves pillars and Asherah poles on every high hill and under every green tree; 
-\v 11 and there they burned incense in all the high places, as the nations whom Yahweh carried away before them did; and they did wicked things to provoke Yahweh to anger; 
-\v 12 and they served idols, of which Yahweh had said to them, “You shall not do this thing.” 
-\v 13 Yet Yahweh testified to Israel and to Judah, by every prophet and every seer, saying, “Turn from your evil ways, and keep my commandments and my statutes, according to all the law which I commanded your fathers, and which I sent to you by my servants the prophets.” 
-\v 14 Notwithstanding, they would not listen, but hardened their neck like the neck of their fathers who didn’t believe in Yahweh their Elohim. 
-\v 15 They rejected his statutes and his covenant that he made with their fathers, and his testimonies which he testified to them; and they followed vanity, and became vain, and followed the nations that were around them, concerning whom Yahweh had commanded them that they should not do like them. 
-\v 16 They abandoned all the commandments of Yahweh their Elohim, and made molten images for themselves, even two calves, and made an Asherah, and worshiped all the army of the sky, and served Baal. 
-\v 17 They caused their sons and their daughters to pass through the fire, used divination and enchantments, and sold themselves to do that which was evil in Yahweh’s sight, to provoke him to anger. 
-\v 18 Therefore Yahweh was very angry with Israel, and removed them out of his sight. There was none left but the tribe of Judah only. 
+\v 11 and there they burned incense in all the high places, as the nations whom Yahuah carried away before them did; and they did wicked things to provoke Yahuah to anger; 
+\v 12 and they served idols, of which Yahuah had said to them, “You shall not do this thing.” 
+\v 13 Yet Yahuah testified to Israel and to Judah, by every prophet and every seer, saying, “Turn from your evil ways, and keep my commandments and my statutes, according to all the law which I commanded your fathers, and which I sent to you by my servants the prophets.” 
+\v 14 Notwithstanding, they would not listen, but hardened their neck like the neck of their fathers who didn’t believe in Yahuah their Elohim. 
+\v 15 They rejected his statutes and his covenant that he made with their fathers, and his testimonies which he testified to them; and they followed vanity, and became vain, and followed the nations that were around them, concerning whom Yahuah had commanded them that they should not do like them. 
+\v 16 They abandoned all the commandments of Yahuah their Elohim, and made molten images for themselves, even two calves, and made an Asherah, and worshiped all the army of the sky, and served Baal. 
+\v 17 They caused their sons and their daughters to pass through the fire, used divination and enchantments, and sold themselves to do that which was evil in Yahuah’s sight, to provoke him to anger. 
+\v 18 Therefore Yahuah was very angry with Israel, and removed them out of his sight. There was none left but the tribe of Judah only. 
 \p
-\v 19 Also Judah didn’t keep the commandments of Yahweh their Elohim, but walked in the statutes of Israel which they made. 
-\v 20 Yahweh rejected all the offspring of Israel, afflicted them, and delivered them into the hands of raiders, until he had cast them out of his sight. 
-\v 21 For he tore Israel from David’s house; and they made Jeroboam the son of Nebat king; and Jeroboam drove Israel from following Yahweh, and made them sin a great sin. 
+\v 19 Also Judah didn’t keep the commandments of Yahuah their Elohim, but walked in the statutes of Israel which they made. 
+\v 20 Yahuah rejected all the offspring of Israel, afflicted them, and delivered them into the hands of raiders, until he had cast them out of his sight. 
+\v 21 For he tore Israel from David’s house; and they made Jeroboam the son of Nebat king; and Jeroboam drove Israel from following Yahuah, and made them sin a great sin. 
 \v 22 The children of Israel walked in all the sins of Jeroboam which he did; they didn’t depart from them 
-\v 23 until Yahweh removed Israel out of his sight, as he said by all his servants the prophets. So Israel was carried away out of their own land to Assyria to this day. 
+\v 23 until Yahuah removed Israel out of his sight, as he said by all his servants the prophets. So Israel was carried away out of their own land to Assyria to this day. 
 \p
 \v 24 The king of Assyria brought people from Babylon, from Cuthah, from Avva, and from Hamath and Sepharvaim, and placed them in the cities of Samaria instead of the children of Israel; and they possessed Samaria and lived in its cities. 
-\v 25 So it was, at the beginning of their dwelling there, that they didn’t fear Yahweh. Therefore Yahweh sent lions among them, which killed some of them. 
+\v 25 So it was, at the beginning of their dwelling there, that they didn’t fear Yahuah. Therefore Yahuah sent lions among them, which killed some of them. 
 \v 26 Therefore they spoke to the king of Assyria, saying, “The nations which you have carried away and placed in the cities of Samaria don’t know the law of the elohim of the land. Therefore he has sent lions among them; and behold, they kill them, because they don’t know the law of the elohim of the land.” 
 \p
 \v 27 Then the king of Assyria commanded, saying, “Carry there one of the priests whom you brought from there; and let him go and dwell there, and let him teach them the law of the elohim of the land.” 
 \p
-\v 28 So one of the priests whom they had carried away from Samaria came and lived in Bethel, and taught them how they should fear Yahweh. 
+\v 28 So one of the priests whom they had carried away from Samaria came and lived in Bethel, and taught them how they should fear Yahuah. 
 \p
 \v 29 However every nation made elohims of their own, and put them in the houses of the high places which the Samaritans had made, every nation in their cities in which they lived. 
 \v 30 The men of Babylon made Succoth Benoth, and the men of Cuth made Nergal, and the men of Hamath made Ashima, 
 \v 31 and the Avvites made Nibhaz and Tartak; and the Sepharvites burned their children in the fire to Adrammelech and Anammelech, the elohims of Sepharvaim. 
-\v 32 So they feared Yahweh, and also made from among themselves priests of the high places for themselves, who sacrificed for them in the houses of the high places. 
-\v 33 They feared Yahweh, and also served their own elohims, after the ways of the nations from among whom they had been carried away. 
-\v 34 To this day they do what they did before. They don’t fear Yahweh, and they do not follow the statutes, or the ordinances, or the law, or the commandment which Yahweh commanded the children of Jacob, whom he named Israel; 
-\v 35 with whom Yahweh had made a covenant and commanded them, saying, “You shall not fear other elohims, nor bow yourselves to them, nor serve them, nor sacrifice to them; 
-\v 36 but you shall fear Yahweh, who brought you up out of the land of Egypt with great power and with an outstretched arm, and you shall bow yourselves to him, and you shall sacrifice to him. 
+\v 32 So they feared Yahuah, and also made from among themselves priests of the high places for themselves, who sacrificed for them in the houses of the high places. 
+\v 33 They feared Yahuah, and also served their own elohims, after the ways of the nations from among whom they had been carried away. 
+\v 34 To this day they do what they did before. They don’t fear Yahuah, and they do not follow the statutes, or the ordinances, or the law, or the commandment which Yahuah commanded the children of Jacob, whom he named Israel; 
+\v 35 with whom Yahuah had made a covenant and commanded them, saying, “You shall not fear other elohims, nor bow yourselves to them, nor serve them, nor sacrifice to them; 
+\v 36 but you shall fear Yahuah, who brought you up out of the land of Egypt with great power and with an outstretched arm, and you shall bow yourselves to him, and you shall sacrifice to him. 
 \v 37 The statutes and the ordinances, and the law and the commandment which he wrote for you, you shall observe to do forever more. You shall not fear other elohims. 
 \v 38 You shall not forget the covenant that I have made with you. You shall not fear other elohims. 
-\v 39 But you shall fear Yahweh your Elohim, and he will deliver you out of the hand of all your enemies.” 
+\v 39 But you shall fear Yahuah your Elohim, and he will deliver you out of the hand of all your enemies.” 
 \p
 \v 40 However they didn’t listen, but they did what they did before. 
-\v 41 So these nations feared Yahweh, and also served their engraved images. Their children did likewise, and so did their children’s children. They do as their fathers did to this day. 
+\v 41 So these nations feared Yahuah, and also served their engraved images. Their children did likewise, and so did their children’s children. They do as their fathers did to this day. 
 \c 18
 \p
 \v 1 Now in the third year of Hoshea son of Elah king of Israel, Hezekiah the son of Ahaz king of Judah began to reign. 
 \v 2 He was twenty-five years old when he began to reign, and he reigned twenty-nine years in Jerusalem. His mother’s name was Abi the daughter of Zechariah. 
-\v 3 He did that which was right in Yahweh’s eyes, according to all that David his father had done. 
+\v 3 He did that which was right in Yahuah’s eyes, according to all that David his father had done. 
 \v 4 He removed the high places, broke the pillars, and cut down the Asherah. He also broke in pieces the bronze serpent that Moses had made, because in those days the children of Israel burned incense to it; and he called it Nehushtan. 
-\v 5 He trusted in Yahweh, the Elohim of Israel, so that after him was no one like him among all the kings of Judah, nor among them that were before him. 
-\v 6 For he joined with Yahweh. He didn’t depart from following him, but kept his commandments, which Yahweh commanded Moses. 
-\v 7 Yahweh was with him. Wherever he went, he prospered. He rebelled against the king of Assyria, and didn’t serve him. 
+\v 5 He trusted in Yahuah, the Elohim of Israel, so that after him was no one like him among all the kings of Judah, nor among them that were before him. 
+\v 6 For he joined with Yahuah. He didn’t depart from following him, but kept his commandments, which Yahuah commanded Moses. 
+\v 7 Yahuah was with him. Wherever he went, he prospered. He rebelled against the king of Assyria, and didn’t serve him. 
 \v 8 He struck the Philistines to Gaza and its borders, from the tower of the watchmen to the fortified city. 
 \p
 \v 9 In the fourth year of King Hezekiah, which was the seventh year of Hoshea son of Elah king of Israel, Shalmaneser king of Assyria came up against Samaria and besieged it. 
 \v 10 At the end of three years they took it. In the sixth year of Hezekiah, which was the ninth year of Hoshea king of Israel, Samaria was taken. 
 \v 11 The king of Assyria carried Israel away to Assyria, and put them in Halah, and on the Habor, the river of Gozan, and in the cities of the Medes, 
-\v 12 because they didn’t obey Yahweh their Elohim’s voice, but transgressed his covenant, even all that Moses the servant of Yahweh commanded, and would not hear it or do it. 
+\v 12 because they didn’t obey Yahuah their Elohim’s voice, but transgressed his covenant, even all that Moses the servant of Yahuah commanded, and would not hear it or do it. 
 \p
 \v 13 Now in the fourteenth year of King Hezekiah, Sennacherib king of Assyria came up against all the fortified cities of Judah and took them. 
 \v 14 Hezekiah king of Judah sent to the king of Assyria at Lachish, saying, “I have offended you. Withdraw from me. That which you put on me, I will bear.” The king of Assyria appointed to Hezekiah king of Judah three hundred talents of silver and thirty talents of gold. 
-\v 15 Hezekiah gave him all the silver that was found in Yahweh’s house and in the treasures of the king’s house. 
-\v 16 At that time, Hezekiah cut off the gold from the doors of Yahweh’s temple, and from the pillars which Hezekiah king of Judah had overlaid, and gave it to the king of Assyria. 
+\v 15 Hezekiah gave him all the silver that was found in Yahuah’s house and in the treasures of the king’s house. 
+\v 16 At that time, Hezekiah cut off the gold from the doors of Yahuah’s temple, and from the pillars which Hezekiah king of Judah had overlaid, and gave it to the king of Assyria. 
 \p
 \v 17 The king of Assyria sent Tartan, Rabsaris, and Rabshakeh from Lachish to King Hezekiah with a great army to Jerusalem. They went up and came to Jerusalem. When they had come up, they came and stood by the conduit of the upper pool, which is in the highway of the fuller’s field. 
 \v 18 When they had called to the king, Eliakim the son of Hilkiah, who was over the household, and Shebnah the scribe, and Joah the son of Asaph the recorder came out to them. 
 \v 19 Rabshakeh said to them, “Say now to Hezekiah, ‘The great king, the king of Assyria, says, “What confidence is this in which you trust? 
 \v 20 You say (but they are but vain words), ‘There is counsel and strength for war.’ Now on whom do you trust, that you have rebelled against me? 
 \v 21 Now, behold, you trust in the staff of this bruised reed, even in Egypt. If a man leans on it, it will go into his hand and pierce it. So is Pharaoh king of Egypt to all who trust on him. 
-\v 22 But if you tell me, ‘We trust in Yahweh our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar in Jerusalem’? 
+\v 22 But if you tell me, ‘We trust in Yahuah our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar in Jerusalem’? 
 \v 23 Now therefore, please give pledges to my master the king of Assyria, and I will give you two thousand horses if you are able on your part to set riders on them. 
 \v 24 How then can you turn away the face of one captain of the least of my master’s servants, and put your trust on Egypt for chariots and for horsemen? 
-\v 25 Have I now come up without Yahweh against this place to destroy it? Yahweh said to me, ‘Go up against this land, and destroy it.’ ” ’ ” 
+\v 25 Have I now come up without Yahuah against this place to destroy it? Yahuah said to me, ‘Go up against this land, and destroy it.’ ” ’ ” 
 \p
 \v 26 Then Eliakim the son of Hilkiah, Shebnah, and Joah, said to Rabshakeh, “Please speak to your servants in the Syrian language, for we understand it. Don’t speak with us in the Jews’ language, in the hearing of the people who are on the wall.” 
 \p
@@ -810,24 +810,24 @@
 \p
 \v 28 Then Rabshakeh stood and cried with a loud voice in the Jews’ language, and spoke, saying, “Hear the word of the great king, the king of Assyria. 
 \v 29 The king says, ‘Don’t let Hezekiah deceive you, for he will not be able to deliver you out of his hand. 
-\v 30 Don’t let Hezekiah make you trust in Yahweh, saying, “Yahweh will surely deliver us, and this city shall not be given into the hand of the king of Assyria.” 
+\v 30 Don’t let Hezekiah make you trust in Yahuah, saying, “Yahuah will surely deliver us, and this city shall not be given into the hand of the king of Assyria.” 
 \v 31 Don’t listen to Hezekiah.’ For the king of Assyria says, ‘Make your peace with me, and come out to me; and everyone of you eat from his own vine, and everyone from his own fig tree, and everyone drink water from his own cistern; 
-\v 32 until I come and take you away to a land like your own land, a land of grain and new wine, a land of bread and vineyards, a land of olive trees and of honey, that you may live and not die. Don’t listen to Hezekiah when he persuades you, saying, “Yahweh will deliver us.” 
+\v 32 until I come and take you away to a land like your own land, a land of grain and new wine, a land of bread and vineyards, a land of olive trees and of honey, that you may live and not die. Don’t listen to Hezekiah when he persuades you, saying, “Yahuah will deliver us.” 
 \v 33 Has any of the elohims of the nations ever delivered his land out of the hand of the king of Assyria? 
 \v 34 Where are the elohims of Hamath and of Arpad? Where are the elohims of Sepharvaim, of Hena, and Ivvah? Have they delivered Samaria out of my hand? 
-\v 35 Who are they among all the elohims of the countries, that have delivered their country out of my hand, that Yahweh should deliver Jerusalem out of my hand?’ ” 
+\v 35 Who are they among all the elohims of the countries, that have delivered their country out of my hand, that Yahuah should deliver Jerusalem out of my hand?’ ” 
 \p
 \v 36 But the people stayed quiet, and answered him not a word; for the king’s commandment was, “Don’t answer him.” 
 \v 37 Then Eliakim the son of Hilkiah, who was over the household, came with Shebna the scribe and Joah the son of Asaph the recorder to Hezekiah with their clothes torn, and told him Rabshakeh’s words. 
 \c 19
 \p
-\v 1 When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahweh’s house. 
+\v 1 When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahuah’s house. 
 \v 2 He sent Eliakim, who was over the household, Shebna the scribe, and the elders of the priests, covered with sackcloth, to Isaiah the prophet the son of Amoz. 
 \v 3 They said to him, “Hezekiah says, ‘Today is a day of trouble, of rebuke, and of rejection; for the children have come to the point of birth, and there is no strength to deliver them. 
-\v 4 It may be Yahweh your Elohim will hear all the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahweh your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’ ” 
+\v 4 It may be Yahuah your Elohim will hear all the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahuah your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’ ” 
 \p
 \v 5 So the servants of King Hezekiah came to Isaiah. 
-\v 6 Isaiah said to them, “Tell your master this: ‘Yahweh says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
+\v 6 Isaiah said to them, “Tell your master this: ‘Yahuah says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
 \v 7 Behold, I will put a spirit in him, and he will hear news, and will return to his own land. I will cause him to fall by the sword in his own land.” ’ ” 
 \p
 \v 8 So Rabshakeh returned and found the king of Assyria warring against Libnah; for he had heard that he had departed from Lachish. 
@@ -837,15 +837,15 @@
 \v 12 Have the elohims of the nations delivered them, which my fathers have destroyed—Gozan, Haran, Rezeph, and the children of Eden who were in Telassar? 
 \v 13 Where is the king of Hamath, the king of Arpad, and the king of the city of Sepharvaim, of Hena, and Ivvah?’ ” 
 \p
-\v 14 Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahweh’s house, and spread it before Yahweh. 
-\v 15 Hezekiah prayed before Yahweh, and said, “Yahweh, the Elohim of Israel, who are enthroned above the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
-\v 16 Incline your ear, Yahweh, and hear. Open your eyes, Yahweh, and see. Hear the words of Sennacherib, which he has sent to defy the living Elohim. 
-\v 17 Truly, Yahweh, the kings of Assyria have laid waste the nations and their lands, 
+\v 14 Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahuah’s house, and spread it before Yahuah. 
+\v 15 Hezekiah prayed before Yahuah, and said, “Yahuah, the Elohim of Israel, who are enthroned above the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
+\v 16 Incline your ear, Yahuah, and hear. Open your eyes, Yahuah, and see. Hear the words of Sennacherib, which he has sent to defy the living Elohim. 
+\v 17 Truly, Yahuah, the kings of Assyria have laid waste the nations and their lands, 
 \v 18 and have cast their elohims into the fire; for they were no elohims, but the work of men’s hands, wood and stone. Therefore they have destroyed them. 
-\v 19 Now therefore, Yahweh our Elohim, save us, I beg you, out of his hand, that all the kingdoms of the earth may know that you, Yahweh, are Elohim alone.” 
+\v 19 Now therefore, Yahuah our Elohim, save us, I beg you, out of his hand, that all the kingdoms of the earth may know that you, Yahuah, are Elohim alone.” 
 \p
-\v 20 Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahweh, the Elohim of Israel, says ‘You have prayed to me against Sennacherib king of Assyria, and I have heard you. 
-\v 21 This is the word that Yahweh has spoken concerning him: ‘The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
+\v 20 Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahuah, the Elohim of Israel, says ‘You have prayed to me against Sennacherib king of Assyria, and I have heard you. 
+\v 21 This is the word that Yahuah has spoken concerning him: ‘The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
 \v 22 Whom have you defied and blasphemed? Against whom have you exalted your voice and lifted up your eyes on high? Against the Set-Apart One of Israel! 
 \v 23 By your messengers, you have defied the Lord, and have said, “With the multitude of my chariots, I have come up to the height of the mountains, to the innermost parts of Lebanon, and I will cut down its tall cedars and its choice cypress trees; and I will enter into his farthest lodging place, the forest of his fruitful field. 
 \v 24 I have dug and drunk strange waters, and I will dry up all the rivers of Egypt with the sole of my feet.” 
@@ -856,36 +856,36 @@
 \p
 \v 29 “This will be the sign to you: This year, you will eat that which grows of itself, and in the second year that which springs from that; and in the third year sow and reap, and plant vineyards and eat their fruit. 
 \v 30 The remnant that has escaped of the house of Judah will again take root downward, and bear fruit upward. 
-\v 31 For out of Jerusalem a remnant will go out, and out of Mount Zion those who shall escape. Yahweh’s zeal will perform this. 
+\v 31 For out of Jerusalem a remnant will go out, and out of Mount Zion those who shall escape. Yahuah’s zeal will perform this. 
 \p
-\v 32 “Therefore Yahweh says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there. He will not come before it with shield, nor cast up a mound against it. 
-\v 33 He will return the same way that he came, and he will not come to this city,’ says Yahweh. 
+\v 32 “Therefore Yahuah says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there. He will not come before it with shield, nor cast up a mound against it. 
+\v 33 He will return the same way that he came, and he will not come to this city,’ says Yahuah. 
 \v 34 ‘For I will defend this city to save it, for my own sake and for my servant David’s sake.’ ” 
 \p
-\v 35 That night, Yahweh’s angel went out and struck one hundred eighty-five thousand in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
+\v 35 That night, Yahuah’s angel went out and struck one hundred eighty-five thousand in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
 \v 36 So Sennacherib king of Assyria departed, went home, and lived at Nineveh. 
 \v 37 As he was worshiping in the house of Nisroch his elohim, Adrammelech and Sharezer struck him with the sword; and they escaped into the land of Ararat. Esar Haddon his son reigned in his place. 
 \c 20
 \p
-\v 1 In those days Hezekiah was sick and dying. Isaiah the prophet the son of Amoz came to him, and said to him, “Yahweh says, ‘Set your house in order; for you will die, and not live.’ ” 
+\v 1 In those days Hezekiah was sick and dying. Isaiah the prophet the son of Amoz came to him, and said to him, “Yahuah says, ‘Set your house in order; for you will die, and not live.’ ” 
 \p
-\v 2 Then he turned his face to the wall, and prayed to Yahweh, saying, 
-\v 3 “Remember now, Yahweh, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” And Hezekiah wept bitterly. 
+\v 2 Then he turned his face to the wall, and prayed to Yahuah, saying, 
+\v 3 “Remember now, Yahuah, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” And Hezekiah wept bitterly. 
 \p
-\v 4 Before Isaiah had gone out into the middle part of the city, Yahweh’s word came to him, saying, 
-\v 5 “Turn back, and tell Hezekiah the prince of my people, ‘Yahweh, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will heal you. On the third day, you will go up to Yahweh’s house. 
+\v 4 Before Isaiah had gone out into the middle part of the city, Yahuah’s word came to him, saying, 
+\v 5 “Turn back, and tell Hezekiah the prince of my people, ‘Yahuah, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will heal you. On the third day, you will go up to Yahuah’s house. 
 \v 6 I will add to your days fifteen years. I will deliver you and this city out of the hand of the king of Assyria. I will defend this city for my own sake, and for my servant David’s sake.” ’ ” 
 \p
 \v 7 Isaiah said, “Take a cake of figs.” 
 \p They took and laid it on the boil, and he recovered. 
 \p
-\v 8 Hezekiah said to Isaiah, “What will be the sign that Yahweh will heal me, and that I will go up to Yahweh’s house the third day?” 
+\v 8 Hezekiah said to Isaiah, “What will be the sign that Yahuah will heal me, and that I will go up to Yahuah’s house the third day?” 
 \p
-\v 9 Isaiah said, “This will be the sign to you from Yahweh, that Yahweh will do the thing that he has spoken: should the shadow go forward ten steps, or go back ten steps?” 
+\v 9 Isaiah said, “This will be the sign to you from Yahuah, that Yahuah will do the thing that he has spoken: should the shadow go forward ten steps, or go back ten steps?” 
 \p
 \v 10 Hezekiah answered, “It is a light thing for the shadow to go forward ten steps. No, but let the shadow return backward ten steps.” 
 \p
-\v 11 Isaiah the prophet cried to Yahweh; and he brought the shadow ten steps backward, by which it had gone down on the sundial of Ahaz. 
+\v 11 Isaiah the prophet cried to Yahuah; and he brought the shadow ten steps backward, by which it had gone down on the sundial of Ahaz. 
 \p
 \v 12 At that time Berodach Baladan the son of Baladan, king of Babylon, sent letters and a present to Hezekiah, for he had heard that Hezekiah had been sick. 
 \v 13 Hezekiah listened to them, and showed them all the storehouse of his precious things—the silver, the gold, the spices, and the precious oil, and the house of his armor, and all that was found in his treasures. There was nothing in his house, or in all his dominion, that Hezekiah didn’t show them. 
@@ -896,42 +896,42 @@
 \v 15 He said, “What have they seen in your house?” 
 \p Hezekiah answered, “They have seen all that is in my house. There is nothing among my treasures that I have not shown them.” 
 \p
-\v 16 Isaiah said to Hezekiah, “Hear Yahweh’s word. 
-\v 17 ‘Behold, the days come that all that is in your house, and that which your fathers have laid up in store to this day, will be carried to Babylon. Nothing will be left,’ says Yahweh. 
+\v 16 Isaiah said to Hezekiah, “Hear Yahuah’s word. 
+\v 17 ‘Behold, the days come that all that is in your house, and that which your fathers have laid up in store to this day, will be carried to Babylon. Nothing will be left,’ says Yahuah. 
 \v 18 ‘They will take away some of your sons who will issue from you, whom you will father; and they will be eunuchs in the palace of the king of Babylon.’ ” 
 \p
-\v 19 Then Hezekiah said to Isaiah, “Yahweh’s word which you have spoken is good.” He said moreover, “Isn’t it so, if peace and truth will be in my days?” 
+\v 19 Then Hezekiah said to Isaiah, “Yahuah’s word which you have spoken is good.” He said moreover, “Isn’t it so, if peace and truth will be in my days?” 
 \p
 \v 20 Now the rest of the acts of Hezekiah, and all his might, and how he made the pool, and the conduit, and brought water into the city, aren’t they written in the book of the chronicles of the kings of Judah? 
 \v 21 Hezekiah slept with his fathers, and Manasseh his son reigned in his place. 
 \c 21
 \p
 \v 1 Manasseh was twelve years old when he began to reign, and he reigned fifty-five years in Jerusalem. His mother’s name was Hephzibah. 
-\v 2 He did that which was evil in Yahweh’s sight, after the abominations of the nations whom Yahweh cast out before the children of Israel. 
+\v 2 He did that which was evil in Yahuah’s sight, after the abominations of the nations whom Yahuah cast out before the children of Israel. 
 \v 3 For he built again the high places which Hezekiah his father had destroyed; and he raised up altars for Baal, and made an Asherah, as Ahab king of Israel did, and worshiped all the army of the sky, and served them. 
-\v 4 He built altars in Yahweh’s house, of which Yahweh said, “I will put my name in Jerusalem.” 
-\v 5 He built altars for all the army of the sky in the two courts of Yahweh’s house. 
-\v 6 He made his son to pass through the fire, practiced sorcery, used enchantments, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahweh’s sight, to provoke him to anger. 
-\v 7 He set the engraved image of Asherah that he had made in the house of which Yahweh said to David and to Solomon his son, “In this house, and in Jerusalem, which I have chosen out of all the tribes of Israel, I will put my name forever; 
+\v 4 He built altars in Yahuah’s house, of which Yahuah said, “I will put my name in Jerusalem.” 
+\v 5 He built altars for all the army of the sky in the two courts of Yahuah’s house. 
+\v 6 He made his son to pass through the fire, practiced sorcery, used enchantments, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahuah’s sight, to provoke him to anger. 
+\v 7 He set the engraved image of Asherah that he had made in the house of which Yahuah said to David and to Solomon his son, “In this house, and in Jerusalem, which I have chosen out of all the tribes of Israel, I will put my name forever; 
 \v 8 I will not cause the feet of Israel to wander any more out of the land which I gave their fathers, if only they will observe to do according to all that I have commanded them, and according to all the law that my servant Moses commanded them.” 
-\v 9 But they didn’t listen, and Manasseh seduced them to do that which is evil more than the nations did whom Yahweh destroyed before the children of Israel. 
+\v 9 But they didn’t listen, and Manasseh seduced them to do that which is evil more than the nations did whom Yahuah destroyed before the children of Israel. 
 \p
-\v 10 Yahweh spoke by his servants the prophets, saying, 
+\v 10 Yahuah spoke by his servants the prophets, saying, 
 \v 11 “Because Manasseh king of Judah has done these abominations, and has done wickedly above all that the Amorites did, who were before him, and has also made Judah to sin with his idols; 
-\v 12 therefore Yahweh the Elohim of Israel says, ‘Behold, I will bring such evil on Jerusalem and Judah that whoever hears of it, both his ears will tingle. 
+\v 12 therefore Yahuah the Elohim of Israel says, ‘Behold, I will bring such evil on Jerusalem and Judah that whoever hears of it, both his ears will tingle. 
 \v 13 I will stretch over Jerusalem the line of Samaria, and the plumb line of Ahab’s house; and I will wipe Jerusalem as a man wipes a dish, wiping it and turning it upside down. 
 \v 14 I will cast off the remnant of my inheritance and deliver them into the hands of their enemies. They will become a prey and a plunder to all their enemies, 
 \v 15 because they have done that which is evil in my sight, and have provoked me to anger since the day their fathers came out of Egypt, even to this day.’ ” 
 \p
-\v 16 Moreover Manasseh shed innocent blood very much, until he had filled Jerusalem from one end to another; in addition to his sin with which he made Judah to sin, in doing that which was evil in Yahweh’s sight. 
+\v 16 Moreover Manasseh shed innocent blood very much, until he had filled Jerusalem from one end to another; in addition to his sin with which he made Judah to sin, in doing that which was evil in Yahuah’s sight. 
 \p
 \v 17 Now the rest of the acts of Manasseh, and all that he did, and his sin that he sinned, aren’t they written in the book of the chronicles of the kings of Judah? 
 \v 18 Manasseh slept with his fathers, and was buried in the garden of his own house, in the garden of Uzza; and Amon his son reigned in his place. 
 \p
 \v 19 Amon was twenty-two years old when he began to reign; and he reigned two years in Jerusalem. His mother’s name was Meshullemeth the daughter of Haruz of Jotbah. 
-\v 20 He did that which was evil in Yahweh’s sight, as Manasseh his father did. 
+\v 20 He did that which was evil in Yahuah’s sight, as Manasseh his father did. 
 \v 21 He walked in all the ways that his father walked in, and served the idols that his father served, and worshiped them; 
-\v 22 and he abandoned Yahweh, the Elohim of his fathers, and didn’t walk in the way of Yahweh. 
+\v 22 and he abandoned Yahuah, the Elohim of his fathers, and didn’t walk in the way of Yahuah. 
 \v 23 The servants of Amon conspired against him, and put the king to death in his own house. 
 \v 24 But the people of the land killed all those who had conspired against King Amon; and the people of the land made Josiah his son king in his place. 
 \v 25 Now the rest of the acts of Amon which he did, aren’t they written in the book of the chronicles of the kings of Judah? 
@@ -939,101 +939,101 @@
 \c 22
 \p
 \v 1 Josiah was eight years old when he began to reign, and he reigned thirty-one years in Jerusalem. His mother’s name was Jedidah the daughter of Adaiah of Bozkath. 
-\v 2 He did that which was right in Yahweh’s eyes, and walked in all the ways of David his father, and didn’t turn away to the right hand or to the left. 
+\v 2 He did that which was right in Yahuah’s eyes, and walked in all the ways of David his father, and didn’t turn away to the right hand or to the left. 
 \p
-\v 3 In the eighteenth year of King Josiah, the king sent Shaphan, the son of Azaliah the son of Meshullam, the scribe, to Yahweh’s house, saying, 
-\v 4 “Go up to Hilkiah the high priest, that he may count the money which is brought into Yahweh’s house, which the keepers of the threshold have gathered of the people. 
-\v 5 Let them deliver it into the hand of the workers who have the oversight of Yahweh’s house; and let them give it to the workers who are in Yahweh’s house, to repair the damage to the house, 
+\v 3 In the eighteenth year of King Josiah, the king sent Shaphan, the son of Azaliah the son of Meshullam, the scribe, to Yahuah’s house, saying, 
+\v 4 “Go up to Hilkiah the high priest, that he may count the money which is brought into Yahuah’s house, which the keepers of the threshold have gathered of the people. 
+\v 5 Let them deliver it into the hand of the workers who have the oversight of Yahuah’s house; and let them give it to the workers who are in Yahuah’s house, to repair the damage to the house, 
 \v 6 to the carpenters, and to the builders, and to the masons, and for buying timber and cut stone to repair the house. 
 \v 7 However, no accounting shall be asked of them for the money delivered into their hand, for they deal faithfully.” 
 \p
-\v 8 Hilkiah the high priest said to Shaphan the scribe, “I have found the book of the law in Yahweh’s house.” Hilkiah delivered the book to Shaphan, and he read it. 
-\v 9 Shaphan the scribe came to the king, and brought the king word again, and said, “Your servants have emptied out the money that was found in the house, and have delivered it into the hands of the workmen who have the oversight of Yahweh’s house.” 
+\v 8 Hilkiah the high priest said to Shaphan the scribe, “I have found the book of the law in Yahuah’s house.” Hilkiah delivered the book to Shaphan, and he read it. 
+\v 9 Shaphan the scribe came to the king, and brought the king word again, and said, “Your servants have emptied out the money that was found in the house, and have delivered it into the hands of the workmen who have the oversight of Yahuah’s house.” 
 \v 10 Shaphan the scribe told the king, saying, “Hilkiah the priest has delivered a book to me.” Then Shaphan read it before the king. 
 \p
 \v 11 When the king had heard the words of the book of the law, he tore his clothes. 
 \v 12 The king commanded Hilkiah the priest, Ahikam the son of Shaphan, Achbor the son of Micaiah, Shaphan the scribe, and Asaiah the king’s servant, saying, 
-\v 13 “Go inquire of Yahweh for me, and for the people, and for all Judah, concerning the words of this book that is found; for great is Yahweh’s wrath that is kindled against us, because our fathers have not listened to the words of this book, to do according to all that which is written concerning us.” 
+\v 13 “Go inquire of Yahuah for me, and for the people, and for all Judah, concerning the words of this book that is found; for great is Yahuah’s wrath that is kindled against us, because our fathers have not listened to the words of this book, to do according to all that which is written concerning us.” 
 \p
 \v 14 So Hilkiah the priest, Ahikam, Achbor, Shaphan, and Asaiah went to Huldah the prophetess, the woman of Shallum the son of Tikvah, the son of Harhas, keeper of the wardrobe (now she lived in Jerusalem in the second quarter); and they talked with her. 
-\v 15 She said to them, “Yahweh the Elohim of Israel says, ‘Tell the man who sent you to me, 
-\v 16 “Yahweh says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the words of the book which the king of Judah has read. 
+\v 15 She said to them, “Yahuah the Elohim of Israel says, ‘Tell the man who sent you to me, 
+\v 16 “Yahuah says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the words of the book which the king of Judah has read. 
 \v 17 Because they have forsaken me and have burned incense to other elohims, that they might provoke me to anger with all the work of their hands, therefore my wrath shall be kindled against this place, and it will not be quenched.’ ” 
-\v 18 But to the king of Judah, who sent you to inquire of Yahweh, tell him, “Yahweh the Elohim of Israel says, ‘Concerning the words which you have heard, 
-\v 19 because your heart was tender, and you humbled yourself before Yahweh when you heard what I spoke against this place and against its inhabitants, that they should become a desolation and a curse, and have torn your clothes and wept before me, I also have heard you,’ says Yahweh. 
+\v 18 But to the king of Judah, who sent you to inquire of Yahuah, tell him, “Yahuah the Elohim of Israel says, ‘Concerning the words which you have heard, 
+\v 19 because your heart was tender, and you humbled yourself before Yahuah when you heard what I spoke against this place and against its inhabitants, that they should become a desolation and a curse, and have torn your clothes and wept before me, I also have heard you,’ says Yahuah. 
 \v 20 ‘Therefore behold, I will gather you to your fathers, and you will be gathered to your grave in peace. Your eyes will not see all the evil which I will bring on this place.’ ” ’ ” So they brought this message back to the king. 
 \c 23
 \p
 \v 1 The king sent, and they gathered to him all the elders of Judah and of Jerusalem. 
-\v 2 The king went up to Yahweh’s house, and all the men of Judah and all the inhabitants of Jerusalem with him—with the priests, the prophets, and all the people, both small and great; and he read in their hearing all the words of the book of the covenant which was found in Yahweh’s house. 
-\v 3 The king stood by the pillar and made a covenant before Yahweh to walk after Yahweh and to keep his commandments, his testimonies, and his statutes with all his heart and all his soul, to confirm the words of this covenant that were written in this book; and all the people agreed to the covenant. 
+\v 2 The king went up to Yahuah’s house, and all the men of Judah and all the inhabitants of Jerusalem with him—with the priests, the prophets, and all the people, both small and great; and he read in their hearing all the words of the book of the covenant which was found in Yahuah’s house. 
+\v 3 The king stood by the pillar and made a covenant before Yahuah to walk after Yahuah and to keep his commandments, his testimonies, and his statutes with all his heart and all his soul, to confirm the words of this covenant that were written in this book; and all the people agreed to the covenant. 
 \p
-\v 4 The king commanded Hilkiah the high priest, and the priests of the second order, and the keepers of the threshold, to bring out of Yahweh’s temple all the vessels that were made for Baal, for the Asherah, and for all the army of the sky; and he burned them outside of Jerusalem in the fields of the Kidron, and carried their ashes to Bethel. 
+\v 4 The king commanded Hilkiah the high priest, and the priests of the second order, and the keepers of the threshold, to bring out of Yahuah’s temple all the vessels that were made for Baal, for the Asherah, and for all the army of the sky; and he burned them outside of Jerusalem in the fields of the Kidron, and carried their ashes to Bethel. 
 \v 5 He got rid of the idolatrous priests whom the kings of Judah had ordained to burn incense in the high places in the cities of Judah and in the places around Jerusalem; those also who burned incense to Baal, to the sun, to the moon, to the planets, and to all the army of the sky. 
-\v 6 He brought out the Asherah from Yahweh’s house, outside of Jerusalem, to the brook Kidron, and burned it at the brook Kidron, and beat it to dust, and cast its dust on the graves of the common people. 
-\v 7 He broke down the houses of the male shrine prostitutes that were in Yahweh’s house, where the women wove hangings for the Asherah. 
+\v 6 He brought out the Asherah from Yahuah’s house, outside of Jerusalem, to the brook Kidron, and burned it at the brook Kidron, and beat it to dust, and cast its dust on the graves of the common people. 
+\v 7 He broke down the houses of the male shrine prostitutes that were in Yahuah’s house, where the women wove hangings for the Asherah. 
 \v 8 He brought all the priests out of the cities of Judah, and defiled the high places where the priests had burned incense, from Geba to Beersheba; and he broke down the high places of the gates that were at the entrance of the gate of Joshua the governor of the city, which were on a man’s left hand at the gate of the city. 
-\v 9 Nevertheless the priests of the high places didn’t come up to Yahweh’s altar in Jerusalem, but they ate unleavened bread among their brothers. 
+\v 9 Nevertheless the priests of the high places didn’t come up to Yahuah’s altar in Jerusalem, but they ate unleavened bread among their brothers. 
 \v 10 He defiled Topheth, which is in the valley of the children of Hinnom, that no man might make his son or his daughter to pass through the fire to Molech. 
-\v 11 He took away the horses that the kings of Judah had dedicated to the sun, at the entrance of Yahweh’s house, by the room of Nathan Melech the officer who was in the court; and he burned the chariots of the sun with fire. 
-\v 12 The king broke down the altars that were on the roof of the upper room of Ahaz, which the kings of Judah had made, and the altars which Manasseh had made in the two courts of Yahweh’s house, and beat them down from there, and cast their dust into the brook Kidron. 
+\v 11 He took away the horses that the kings of Judah had dedicated to the sun, at the entrance of Yahuah’s house, by the room of Nathan Melech the officer who was in the court; and he burned the chariots of the sun with fire. 
+\v 12 The king broke down the altars that were on the roof of the upper room of Ahaz, which the kings of Judah had made, and the altars which Manasseh had made in the two courts of Yahuah’s house, and beat them down from there, and cast their dust into the brook Kidron. 
 \v 13 The king defiled the high places that were before Jerusalem, which were on the right hand of the mountain of corruption, which Solomon the king of Israel had built for Ashtoreth the abomination of the Sidonians, and for Chemosh the abomination of Moab, and for Milcom the abomination of the children of Ammon. 
 \v 14 He broke in pieces the pillars, cut down the Asherah poles, and filled their places with men’s bones. 
 \p
 \v 15 Moreover the altar that was at Bethel and the high place which Jeroboam the son of Nebat, who made Israel to sin, had made, even that altar and the high place he broke down; and he burned the high place and beat it to dust, and burned the Asherah. 
-\v 16 As Josiah turned himself, he spied the tombs that were there in the mountain; and he sent, and took the bones out of the tombs, and burned them on the altar, and defiled it, according to Yahweh’s word which the man of Elohim proclaimed, who proclaimed these things. 
+\v 16 As Josiah turned himself, he spied the tombs that were there in the mountain; and he sent, and took the bones out of the tombs, and burned them on the altar, and defiled it, according to Yahuah’s word which the man of Elohim proclaimed, who proclaimed these things. 
 \v 17 Then he said, “What monument is that which I see?” 
 \p The men of the city told him, “It is the tomb of the man of Elohim who came from Judah and proclaimed these things that you have done against the altar of Bethel.” 
 \p
 \v 18 He said, “Let him be! Let no one move his bones.” So they let his bones alone, with the bones of the prophet who came out of Samaria. 
-\v 19 All the houses also of the high places that were in the cities of Samaria, which the kings of Israel had made to provoke Yahweh to anger, Josiah took away, and did to them according to all the acts that he had done in Bethel. 
+\v 19 All the houses also of the high places that were in the cities of Samaria, which the kings of Israel had made to provoke Yahuah to anger, Josiah took away, and did to them according to all the acts that he had done in Bethel. 
 \v 20 He killed all the priests of the high places that were there, on the altars, and burned men’s bones on them; and he returned to Jerusalem. 
 \p
-\v 21 The king commanded all the people, saying, “Keep the Passover to Yahweh your Elohim, as it is written in this book of the covenant.” 
+\v 21 The king commanded all the people, saying, “Keep the Passover to Yahuah your Elohim, as it is written in this book of the covenant.” 
 \v 22 Surely there was not kept such a Passover from the days of the judges who judged Israel, nor in all the days of the kings of Israel, nor of the kings of Judah; 
-\v 23 but in the eighteenth year of King Josiah, this Passover was kept to Yahweh in Jerusalem. 
+\v 23 but in the eighteenth year of King Josiah, this Passover was kept to Yahuah in Jerusalem. 
 \p
-\v 24 Moreover, Josiah removed those who had familiar spirits, the wizards, and the teraphim, and the idols, and all the abominations that were seen in the land of Judah and in Jerusalem, that he might confirm the words of the law which were written in the book that Hilkiah the priest found in Yahweh’s house. 
-\v 25 There was no king like him before him, who turned to Yahweh with all his heart, and with all his soul, and with all his might, according to all the law of Moses; and there was none like him who arose after him. 
-\v 26 Notwithstanding, Yahweh didn’t turn from the fierceness of his great wrath, with which his anger burned against Judah, because of all the provocation with which Manasseh had provoked him. 
-\v 27 Yahweh said, “I will also remove Judah out of my sight, as I have removed Israel; and I will cast off this city which I have chosen, even Jerusalem, and the house of which I said, ‘My name shall be there.’ ” 
+\v 24 Moreover, Josiah removed those who had familiar spirits, the wizards, and the teraphim, and the idols, and all the abominations that were seen in the land of Judah and in Jerusalem, that he might confirm the words of the law which were written in the book that Hilkiah the priest found in Yahuah’s house. 
+\v 25 There was no king like him before him, who turned to Yahuah with all his heart, and with all his soul, and with all his might, according to all the law of Moses; and there was none like him who arose after him. 
+\v 26 Notwithstanding, Yahuah didn’t turn from the fierceness of his great wrath, with which his anger burned against Judah, because of all the provocation with which Manasseh had provoked him. 
+\v 27 Yahuah said, “I will also remove Judah out of my sight, as I have removed Israel; and I will cast off this city which I have chosen, even Jerusalem, and the house of which I said, ‘My name shall be there.’ ” 
 \p
 \v 28 Now the rest of the acts of Josiah, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 \v 29 In his days Pharaoh Necoh king of Egypt went up against the king of Assyria to the river Euphrates; and King Josiah went against him, but Pharaoh Necoh killed him at Megiddo when he saw him. 
 \v 30 His servants carried him dead in a chariot from Megiddo, brought him to Jerusalem, and buried him in his own tomb. The people of the land took Jehoahaz the son of Josiah, and anointed him, and made him king in his father’s place. 
 \p
 \v 31 Jehoahaz was twenty-three years old when he began to reign; and he reigned three months in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
-\v 32 He did that which was evil in Yahweh’s sight, according to all that his fathers had done. 
+\v 32 He did that which was evil in Yahuah’s sight, according to all that his fathers had done. 
 \v 33 Pharaoh Necoh put him in bonds at Riblah in the land of Hamath, that he might not reign in Jerusalem; and put the land to a tribute of one hundred talents of silver and a talent of gold. 
 \v 34 Pharaoh Necoh made Eliakim the son of Josiah king in the place of Josiah his father, and changed his name to Jehoiakim; but he took Jehoahaz away, and he came to Egypt and died there. 
 \v 35 Jehoiakim gave the silver and the gold to Pharaoh; but he taxed the land to give the money according to the commandment of Pharaoh. He exacted the silver and the gold of the people of the land, from everyone according to his assessment, to give it to Pharaoh Necoh. 
 \v 36 Jehoiakim was twenty-five years old when he began to reign, and he reigned eleven years in Jerusalem. His mother’s name was Zebidah the daughter of Pedaiah of Rumah. 
-\v 37 He did that which was evil in Yahweh’s sight, according to all that his fathers had done. 
+\v 37 He did that which was evil in Yahuah’s sight, according to all that his fathers had done. 
 \c 24
 \p
 \v 1 In his days Nebuchadnezzar king of Babylon came up, and Jehoiakim became his servant three years. Then he turned and rebelled against him. 
-\v 2 Yahweh sent against him bands of the Chaldeans, bands of the Syrians, bands of the Moabites, and bands of the children of Ammon, and sent them against Judah to destroy it, according to Yahweh’s word which he spoke by his servants the prophets. 
-\v 3 Surely at the commandment of Yahweh this came on Judah, to remove them out of his sight for the sins of Manasseh, according to all that he did, 
-\v 4 and also for the innocent blood that he shed; for he filled Jerusalem with innocent blood, and Yahweh would not pardon. 
+\v 2 Yahuah sent against him bands of the Chaldeans, bands of the Syrians, bands of the Moabites, and bands of the children of Ammon, and sent them against Judah to destroy it, according to Yahuah’s word which he spoke by his servants the prophets. 
+\v 3 Surely at the commandment of Yahuah this came on Judah, to remove them out of his sight for the sins of Manasseh, according to all that he did, 
+\v 4 and also for the innocent blood that he shed; for he filled Jerusalem with innocent blood, and Yahuah would not pardon. 
 \v 5 Now the rest of the acts of Jehoiakim, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
 \v 6 So Jehoiakim slept with his fathers, and Jehoiachin his son reigned in his place. 
 \p
 \v 7 The king of Egypt didn’t come out of his land any more; for the king of Babylon had taken, from the brook of Egypt to the river Euphrates, all that belonged to the king of Egypt. 
 \p
 \v 8 Jehoiachin was eighteen years old when he began to reign, and he reigned in Jerusalem three months. His mother’s name was Nehushta the daughter of Elnathan of Jerusalem. 
-\v 9 He did that which was evil in Yahweh’s sight, according to all that his father had done. 
+\v 9 He did that which was evil in Yahuah’s sight, according to all that his father had done. 
 \v 10 At that time the servants of Nebuchadnezzar king of Babylon came up to Jerusalem, and the city was besieged. 
 \v 11 Nebuchadnezzar king of Babylon came to the city while his servants were besieging it, 
 \v 12 and Jehoiachin the king of Judah went out to the king of Babylon—he, his mother, his servants, his princes, and his officers; and the king of Babylon captured him in the eighth year of his reign. 
-\v 13 He carried out from there all the treasures of Yahweh’s house and the treasures of the king’s house, and cut in pieces all the vessels of gold which Solomon king of Israel had made in Yahweh’s temple, as Yahweh had said. 
+\v 13 He carried out from there all the treasures of Yahuah’s house and the treasures of the king’s house, and cut in pieces all the vessels of gold which Solomon king of Israel had made in Yahuah’s temple, as Yahuah had said. 
 \v 14 He carried away all Jerusalem, and all the princes, and all the mighty men of valor, even ten thousand captives, and all the craftsmen and the smiths. No one remained except the poorest people of the land. 
 \v 15 He carried away Jehoiachin to Babylon, with the king’s mother, the king’s women, his officers, and the chief men of the land. He carried them into captivity from Jerusalem to Babylon. 
 \v 16 All the men of might, even seven thousand, and the craftsmen and the smiths one thousand, all of them strong and fit for war, even them the king of Babylon brought captive to Babylon. 
 \v 17 The king of Babylon made Mattaniah, Jehoiachin’s father’s brother, king in his place, and changed his name to Zedekiah. 
 \p
 \v 18 Zedekiah was twenty-one years old when he began to reign, and he reigned eleven years in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
-\v 19 He did that which was evil in Yahweh’s sight, according to all that Jehoiakim had done. 
-\v 20 For through the anger of Yahweh, this happened in Jerusalem and Judah, until he had cast them out from his presence. 
+\v 19 He did that which was evil in Yahuah’s sight, according to all that Jehoiakim had done. 
+\v 20 For through the anger of Yahuah, this happened in Jerusalem and Judah, until he had cast them out from his presence. 
 \p Then Zedekiah rebelled against the king of Babylon. 
 \c 25
 \p
@@ -1046,15 +1046,15 @@
 \v 7 They killed Zedekiah’s sons before his eyes, then put out Zedekiah’s eyes, bound him in fetters, and carried him to Babylon. 
 \p
 \v 8 Now in the fifth month, on the seventh day of the month, which was the nineteenth year of King Nebuchadnezzar king of Babylon, Nebuzaradan the captain of the guard, a servant of the king of Babylon, came to Jerusalem. 
-\v 9 He burned Yahweh’s house, the king’s house, and all the houses of Jerusalem. He burned every great house with fire. 
+\v 9 He burned Yahuah’s house, the king’s house, and all the houses of Jerusalem. He burned every great house with fire. 
 \v 10 All the army of the Chaldeans, who were with the captain of the guard, broke down the walls around Jerusalem. 
 \v 11 Nebuzaradan the captain of the guard carried away captive the rest of the people who were left in the city and those who had deserted to the king of Babylon—all the rest of the multitude. 
 \v 12 But the captain of the guard left some of the poorest of the land to work the vineyards and fields. 
 \p
-\v 13 The Chaldeans broke up the pillars of bronze that were in Yahweh’s house and the bases and the bronze sea that were in Yahweh’s house, and carried the bronze pieces to Babylon. 
+\v 13 The Chaldeans broke up the pillars of bronze that were in Yahuah’s house and the bases and the bronze sea that were in Yahuah’s house, and carried the bronze pieces to Babylon. 
 \v 14 They took away the pots, the shovels, the snuffers, the spoons, and all the vessels of bronze with which they ministered. 
 \v 15 The captain of the guard took away the fire pans, the basins, that which was of gold, for gold, and that which was of silver, for silver. 
-\v 16 The two pillars, the one sea, and the bases, which Solomon had made for Yahweh’s house, the bronze of all these vessels was not weighed. 
+\v 16 The two pillars, the one sea, and the bases, which Solomon had made for Yahuah’s house, the bronze of all these vessels was not weighed. 
 \v 17 The height of the one pillar was eighteen cubits, and a capital of bronze was on it. The height of the capital was three cubits, with network and pomegranates on the capital around it, all of bronze; and the second pillar with its network was like these. 
 \p
 \v 18 The captain of the guard took Seraiah the chief priest, Zephaniah the second priest, and the three keepers of the threshold; 

--- a/usfm/2samuel.usfm
+++ b/usfm/2samuel.usfm
@@ -21,14 +21,14 @@
 \v 10 So I stood beside him and killed him, because I was sure that he could not live after he had fallen. I took the crown that was on his head and the bracelet that was on his arm, and have brought them here to my lord.” 
 \p
 \v 11 Then David took hold on his clothes and tore them; and all the men who were with him did likewise. 
-\v 12 They mourned, wept, and fasted until evening for Saul and for Jonathan his son, and for the people of Yahweh, and for the house of Israel, because they had fallen by the sword. 
+\v 12 They mourned, wept, and fasted until evening for Saul and for Jonathan his son, and for the people of Yahuah, and for the house of Israel, because they had fallen by the sword. 
 \p
 \v 13 David said to the young man who told him, “Where are you from?” 
 \p He answered, “I am the son of a foreigner, an Amalekite.” 
 \p
-\v 14 David said to him, “Why were you not afraid to stretch out your hand to destroy Yahweh’s anointed?” 
+\v 14 David said to him, “Why were you not afraid to stretch out your hand to destroy Yahuah’s anointed?” 
 \v 15 David called one of the young men and said, “Go near, and cut him down!” He struck him so that he died. 
-\v 16 David said to him, “Your blood be on your head, for your mouth has testified against you, saying, ‘I have slain Yahweh’s anointed.’ ” 
+\v 16 David said to him, “Your blood be on your head, for your mouth has testified against you, saying, ‘I have slain Yahuah’s anointed.’ ” 
 \p
 \v 17 David lamented with this lamentation over Saul and over Jonathan his son 
 \v 18 (and he commanded them to teach the children of Judah the song of the bow; behold, it is written in the book of Jashar): 
@@ -72,16 +72,16 @@
 \q2 and the weapons of war have perished!” 
 \c 2
 \p
-\v 1 After this, David inquired of Yahweh, saying, “Shall I go up into any of the cities of Judah?” 
-\p Yahweh said to him, “Go up.” 
+\v 1 After this, David inquired of Yahuah, saying, “Shall I go up into any of the cities of Judah?” 
+\p Yahuah said to him, “Go up.” 
 \p David said, “Where shall I go up?” 
 \p He said, “To Hebron.” 
 \p
 \v 2 So David went up there with his two women, Ahinoam the Jezreelitess, and Abigail the woman of Nabal the Carmelite. 
 \v 3 David brought up his men who were with him, every man with his household. They lived in the cities of Hebron. 
 \v 4 The men of Judah came, and there they anointed David king over the house of Judah. They told David, “The men of Jabesh Gilead were those who buried Saul.” 
-\v 5 David sent messengers to the men of Jabesh Gilead, and said to them, “Blessed are you by Yahweh, that you have shown this kindness to your lord, even to Saul, and have buried him. 
-\v 6 Now may Yahweh show loving kindness and truth to you. I also will reward you for this kindness, because you have done this thing. 
+\v 5 David sent messengers to the men of Jabesh Gilead, and said to them, “Blessed are you by Yahuah, that you have shown this kindness to your lord, even to Saul, and have buried him. 
+\v 6 Now may Yahuah show loving kindness and truth to you. I also will reward you for this kindness, because you have done this thing. 
 \v 7 Now therefore let your hands be strong, and be valiant; for Saul your lord is dead, and also the house of Judah have anointed me king over them.” 
 \p
 \v 8 Now Abner the son of Ner, captain of Saul’s army, had taken Ishbosheth the son of Saul and brought him over to Mahanaim. 
@@ -129,7 +129,7 @@
 \v 7 Now Saul had a concubine, whose name was Rizpah, the daughter of Aiah; and Ishbosheth said to Abner, “Why have you gone in to my father’s concubine?” 
 \p
 \v 8 Then Abner was very angry about Ishbosheth’s words, and said, “Am I a dog’s head that belongs to Judah? Today I show kindness to your father Saul’s house, to his brothers, and to his friends, and have not delivered you into the hand of David; and yet you charge me today with a fault concerning this woman! 
-\v 9 Elohim do so to Abner, and more also, if, as Yahweh has sworn to David, I don’t do even so to him: 
+\v 9 Elohim do so to Abner, and more also, if, as Yahuah has sworn to David, I don’t do even so to him: 
 \v 10 to transfer the kingdom from Saul’s house, and to set up David’s throne over Israel and over Judah, from Dan even to Beersheba.” 
 \p
 \v 11 He could not answer Abner another word, because he was afraid of him. 
@@ -143,7 +143,7 @@
 \v 16 Her man went with her, weeping as he went, and followed her to Bahurim. Then Abner said to him, “Go! Return!” and he returned. 
 \p
 \v 17 Abner had communication with the elders of Israel, saying, “In times past, you sought for David to be king over you. 
-\v 18 Now then do it! For Yahweh has spoken of David, saying, ‘By the hand of my servant David, I will save my people Israel out of the hand of the Philistines, and out of the hand of all their enemies.’ ” 
+\v 18 Now then do it! For Yahuah has spoken of David, saying, ‘By the hand of my servant David, I will save my people Israel out of the hand of the Philistines, and out of the hand of all their enemies.’ ” 
 \p
 \v 19 Abner also spoke in the ears of Benjamin; and Abner went also to speak in the ears of David in Hebron all that seemed good to Israel and to the whole house of Benjamin. 
 \v 20 So Abner came to David to Hebron, and twenty men with him. David made Abner and the men who were with him a feast. 
@@ -157,7 +157,7 @@
 \p
 \v 26 When Joab had come out from David, he sent messengers after Abner, and they brought him back from the well of Sirah; but David didn’t know it. 
 \v 27 When Abner had returned to Hebron, Joab took him aside into the middle of the gate to speak with him quietly, and struck him there in the body, so that he died for the blood of Asahel his brother. 
-\v 28 Afterward, when David heard it, he said, “I and my kingdom are guiltless before Yahweh forever of the blood of Abner the son of Ner. 
+\v 28 Afterward, when David heard it, he said, “I and my kingdom are guiltless before Yahuah forever of the blood of Abner the son of Ner. 
 \v 29 Let it fall on the head of Joab and on all his father’s house. Let there not fail from the house of Joab one who has a discharge, or who is a leper, or who leans on a staff, or who falls by the sword, or who lacks bread.” 
 \v 30 So Joab and Abishai his brother killed Abner, because he had killed their brother Asahel at Gibeon in the battle. 
 \p
@@ -171,7 +171,7 @@
 \v 36 All the people took notice of it, and it pleased them, as whatever the king did pleased all the people. 
 \v 37 So all the people and all Israel understood that day that it was not of the king to kill Abner the son of Ner. 
 \v 38 The king said to his servants, “Don’t you know that a prince and a great man has fallen today in Israel? 
-\v 39 I am weak today, though anointed king. These men, the sons of Zeruiah are too hard for me. May Yahweh reward the evildoer according to his wickedness.” 
+\v 39 I am weak today, though anointed king. These men, the sons of Zeruiah are too hard for me. May Yahuah reward the evildoer according to his wickedness.” 
 \c 4
 \p
 \v 1 When Saul’s son heard that Abner was dead in Hebron, his hands became feeble, and all the Israelites were troubled. 
@@ -183,17 +183,17 @@
 \v 5 The sons of Rimmon the Beerothite, Rechab and Baanah, went out and came at about the heat of the day to the house of Ishbosheth as he took his rest at noon. 
 \v 6 They came there into the middle of the house as though they would have fetched wheat, and they struck him in the body; and Rechab and Baanah his brother escaped. 
 \v 7 Now when they came into the house as he lay on his bed in his bedroom, they struck him, killed him, beheaded him, and took his head, and went by the way of the Arabah all night. 
-\v 8 They brought the head of Ishbosheth to David to Hebron, and said to the king, “Behold, the head of Ishbosheth, the son of Saul, your enemy, who sought your life! Yahweh has avenged my lord the king today of Saul and of his offspring.” 
+\v 8 They brought the head of Ishbosheth to David to Hebron, and said to the king, “Behold, the head of Ishbosheth, the son of Saul, your enemy, who sought your life! Yahuah has avenged my lord the king today of Saul and of his offspring.” 
 \p
-\v 9 David answered Rechab and Baanah his brother, the sons of Rimmon the Beerothite, and said to them, “As Yahweh lives, who has redeemed my soul out of all adversity, 
+\v 9 David answered Rechab and Baanah his brother, the sons of Rimmon the Beerothite, and said to them, “As Yahuah lives, who has redeemed my soul out of all adversity, 
 \v 10 when someone told me, ‘Behold, Saul is dead,’ thinking that he brought good news, I seized him and killed him in Ziklag, which was the reward I gave him for his news. 
 \v 11 How much more, when wicked men have slain a righteous person in his own house on his bed, should I not now require his blood from your hand, and rid the earth of you?” 
 \v 12 David commanded his young men, and they killed them, cut off their hands and their feet, and hanged them up beside the pool in Hebron. But they took the head of Ishbosheth and buried it in Abner’s grave in Hebron. 
 \c 5
 \p
 \v 1 Then all the tribes of Israel came to David at Hebron and spoke, saying, “Behold, we are your bone and your flesh. 
-\v 2 In times past, when Saul was king over us, it was you who led Israel out and in. Yahweh said to you, ‘You will be shepherd of my people Israel, and you will be prince over Israel.’ ” 
-\v 3 So all the elders of Israel came to the king to Hebron, and King David made a covenant with them in Hebron before Yahweh; and they anointed David king over Israel. 
+\v 2 In times past, when Saul was king over us, it was you who led Israel out and in. Yahuah said to you, ‘You will be shepherd of my people Israel, and you will be prince over Israel.’ ” 
+\v 3 So all the elders of Israel came to the king to Hebron, and King David made a covenant with them in Hebron before Yahuah; and they anointed David king over Israel. 
 \p
 \v 4 David was thirty years old when he began to reign, and he reigned forty years. 
 \v 5 In Hebron he reigned over Judah seven years and six months, and in Jerusalem he reigned thirty-three years over all Israel and Judah. 
@@ -203,9 +203,9 @@
 \v 8 David said on that day, “Whoever strikes the Jebusites, let him go up to the watercourse and strike those lame and blind, who are hated by David’s soul.” Therefore they say, “The blind and the lame can’t come into the house.” 
 \p
 \v 9 David lived in the stronghold, and called it David’s city. David built around from Millo and inward. 
-\v 10 David grew greater and greater, for Yahweh, the Elohim of Armies, was with him. 
+\v 10 David grew greater and greater, for Yahuah, the Elohim of Armies, was with him. 
 \v 11 Hiram king of Tyre sent messengers to David, with cedar trees, carpenters, and masons; and they built David a house. 
-\v 12 David perceived that Yahweh had established him king over Israel, and that he had exalted his kingdom for his people Israel’s sake. 
+\v 12 David perceived that Yahuah had established him king over Israel, and that he had exalted his kingdom for his people Israel’s sake. 
 \p
 \v 13 David took more concubines and women for himself out of Jerusalem, after he had come from Hebron; and more sons and daughters were born to David. 
 \v 14 These are the names of those who were born to him in Jerusalem: Shammua, Shobab, Nathan, Solomon, 
@@ -214,63 +214,63 @@
 \p
 \v 17 When the Philistines heard that they had anointed David king over Israel, all the Philistines went up to seek David, but David heard about it and went down to the stronghold. 
 \v 18 Now the Philistines had come and spread themselves in the valley of Rephaim. 
-\v 19 David inquired of Yahweh, saying, “Shall I go up against the Philistines? Will you deliver them into my hand?” 
-\p Yahweh said to David, “Go up; for I will certainly deliver the Philistines into your hand.” 
+\v 19 David inquired of Yahuah, saying, “Shall I go up against the Philistines? Will you deliver them into my hand?” 
+\p Yahuah said to David, “Go up; for I will certainly deliver the Philistines into your hand.” 
 \p
-\v 20 David came to Baal Perazim, and David struck them there. Then he said, “Yahweh has broken my enemies before me, like the breach of waters.” Therefore he called the name of that place Baal Perazim. 
+\v 20 David came to Baal Perazim, and David struck them there. Then he said, “Yahuah has broken my enemies before me, like the breach of waters.” Therefore he called the name of that place Baal Perazim. 
 \v 21 They left their images there, and David and his men took them away. 
 \p
 \v 22 The Philistines came up yet again and spread themselves in the valley of Rephaim. 
-\v 23 When David inquired of Yahweh, he said, “You shall not go up. Circle around behind them, and attack them in front of the mulberry trees. 
-\v 24 When you hear the sound of marching in the tops of the mulberry trees, then stir yourself up; for then Yahweh has gone out before you to strike the army of the Philistines.” 
+\v 23 When David inquired of Yahuah, he said, “You shall not go up. Circle around behind them, and attack them in front of the mulberry trees. 
+\v 24 When you hear the sound of marching in the tops of the mulberry trees, then stir yourself up; for then Yahuah has gone out before you to strike the army of the Philistines.” 
 \p
-\v 25 David did so, as Yahweh commanded him, and struck the Philistines all the way from Geba to Gezer. 
+\v 25 David did so, as Yahuah commanded him, and struck the Philistines all the way from Geba to Gezer. 
 \c 6
 \p
 \v 1 David again gathered together all the chosen men of Israel, thirty thousand. 
-\v 2 David arose and went with all the people who were with him from Baale Judah, to bring up from there Elohim’s ark, which is called by the Name, even the name of Yahweh of Armies who sits above the cherubim. 
+\v 2 David arose and went with all the people who were with him from Baale Judah, to bring up from there Elohim’s ark, which is called by the Name, even the name of Yahuah of Armies who sits above the cherubim. 
 \v 3 They set Elohim’s ark on a new cart, and brought it out of Abinadab’s house that was on the hill; and Uzzah and Ahio, the sons of Abinadab, drove the new cart. 
 \v 4 They brought it out of Abinadab’s house which was in the hill, with Elohim’s ark; and Ahio went before the ark. 
-\v 5 David and all the house of Israel played before Yahweh with all kinds of instruments made of cypress wood, with harps, with stringed instruments, with tambourines, with castanets, and with cymbals. 
+\v 5 David and all the house of Israel played before Yahuah with all kinds of instruments made of cypress wood, with harps, with stringed instruments, with tambourines, with castanets, and with cymbals. 
 \p
 \v 6 When they came to the threshing floor of Nacon, Uzzah reached for Elohim’s ark and took hold of it, for the cattle stumbled. 
-\v 7 Yahweh’s anger burned against Uzzah, and Elohim struck him there for his error; and he died there by Elohim’s ark. 
-\v 8 David was displeased because Yahweh had broken out against Uzzah; and he called that place Perez Uzzah to this day. 
-\v 9 David was afraid of Yahweh that day; and he said, “How could Yahweh’s ark come to me?” 
-\v 10 So David would not move Yahweh’s ark to be with him in David’s city; but David carried it aside into Obed-Edom the Gittite’s house. 
-\v 11 Yahweh’s ark remained in Obed-Edom the Gittite’s house three months; and Yahweh blessed Obed-Edom and all his house. 
-\v 12 King David was told, “Yahweh has blessed the house of Obed-Edom, and all that belongs to him, because of Elohim’s ark.” 
+\v 7 Yahuah’s anger burned against Uzzah, and Elohim struck him there for his error; and he died there by Elohim’s ark. 
+\v 8 David was displeased because Yahuah had broken out against Uzzah; and he called that place Perez Uzzah to this day. 
+\v 9 David was afraid of Yahuah that day; and he said, “How could Yahuah’s ark come to me?” 
+\v 10 So David would not move Yahuah’s ark to be with him in David’s city; but David carried it aside into Obed-Edom the Gittite’s house. 
+\v 11 Yahuah’s ark remained in Obed-Edom the Gittite’s house three months; and Yahuah blessed Obed-Edom and all his house. 
+\v 12 King David was told, “Yahuah has blessed the house of Obed-Edom, and all that belongs to him, because of Elohim’s ark.” 
 \p So David went and brought up Elohim’s ark from the house of Obed-Edom into David’s city with joy. 
-\v 13 When those who bore Yahweh’s ark had gone six paces, he sacrificed an ox and a fattened calf. 
-\v 14 David danced before Yahweh with all his might; and David was clothed in a linen ephod. 
-\v 15 So David and all the house of Israel brought up Yahweh’s ark with shouting and with the sound of the trumpet. 
+\v 13 When those who bore Yahuah’s ark had gone six paces, he sacrificed an ox and a fattened calf. 
+\v 14 David danced before Yahuah with all his might; and David was clothed in a linen ephod. 
+\v 15 So David and all the house of Israel brought up Yahuah’s ark with shouting and with the sound of the trumpet. 
 \p
-\v 16 As Yahweh’s ark came into David’s city, Michal the daughter of Saul looked out through the window and saw King David leaping and dancing before Yahweh; and she despised him in her heart. 
-\v 17 They brought in Yahweh’s ark, and set it in its place in the middle of the tent that David had pitched for it; and David offered burnt offerings and peace offerings before Yahweh. 
-\v 18 When David had finished offering the burnt offering and the peace offerings, he blessed the people in the name of Yahweh of Armies. 
+\v 16 As Yahuah’s ark came into David’s city, Michal the daughter of Saul looked out through the window and saw King David leaping and dancing before Yahuah; and she despised him in her heart. 
+\v 17 They brought in Yahuah’s ark, and set it in its place in the middle of the tent that David had pitched for it; and David offered burnt offerings and peace offerings before Yahuah. 
+\v 18 When David had finished offering the burnt offering and the peace offerings, he blessed the people in the name of Yahuah of Armies. 
 \v 19 He gave to all the people, even among the whole multitude of Israel, both to men and women, to everyone a portion of bread, dates, and raisins. So all the people departed, each to his own house. 
 \p
 \v 20 Then David returned to bless his household. Michal the daughter of Saul came out to meet David, and said, “How glorious the king of Israel was today, who uncovered himself today in the eyes of his servants’ maids, as one of the vain fellows shamelessly uncovers himself!” 
 \p
-\v 21 David said to Michal, “It was before Yahweh, who chose me above your father, and above all his house, to appoint me prince over the people of Yahweh, over Israel. Therefore I will celebrate before Yahweh. 
+\v 21 David said to Michal, “It was before Yahuah, who chose me above your father, and above all his house, to appoint me prince over the people of Yahuah, over Israel. Therefore I will celebrate before Yahuah. 
 \v 22 I will be yet more undignified than this, and will be worthless in my own sight. But the maids of whom you have spoken will honor me.” 
 \p
 \v 23 Michal the daughter of Saul had no child to the day of her death. 
 \c 7
 \p
-\v 1 When the king lived in his house, and Yahweh had given him rest from all his enemies all around, 
+\v 1 When the king lived in his house, and Yahuah had given him rest from all his enemies all around, 
 \v 2 the king said to Nathan the prophet, “See now, I dwell in a house of cedar, but Elohim’s ark dwells within curtains.” 
 \p
-\v 3 Nathan said to the king, “Go, do all that is in your heart, for Yahweh is with you.” 
+\v 3 Nathan said to the king, “Go, do all that is in your heart, for Yahuah is with you.” 
 \p
-\v 4 That same night, Yahweh’s word came to Nathan, saying, 
-\v 5 “Go and tell my servant David, ‘Yahweh says, “Should you build me a house for me to dwell in? 
+\v 4 That same night, Yahuah’s word came to Nathan, saying, 
+\v 5 “Go and tell my servant David, ‘Yahuah says, “Should you build me a house for me to dwell in? 
 \v 6 For I have not lived in a house since the day that I brought the children of Israel up out of Egypt, even to this day, but have moved around in a tent and in a tabernacle. 
 \v 7 In all places in which I have walked with all the children of Israel, did I say a word to anyone from the tribes of Israel whom I commanded to be shepherd of my people Israel, saying, ‘Why have you not built me a house of cedar?’ ” ’ 
-\v 8 Now therefore tell my servant David this: ‘Yahweh of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people, over Israel. 
+\v 8 Now therefore tell my servant David this: ‘Yahuah of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people, over Israel. 
 \v 9 I have been with you wherever you went, and have cut off all your enemies from before you. I will make you a great name, like the name of the great ones who are in the earth. 
 \v 10 I will appoint a place for my people Israel, and will plant them, that they may dwell in their own place and be moved no more. The children of wickedness will not afflict them any more, as at the first, 
-\v 11 and as from the day that I commanded judges to be over my people Israel. I will cause you to rest from all your enemies. Moreover Yahweh tells you that Yahweh will make you a house. 
+\v 11 and as from the day that I commanded judges to be over my people Israel. I will cause you to rest from all your enemies. Moreover Yahuah tells you that Yahuah will make you a house. 
 \v 12 When your days are fulfilled and you sleep with your fathers, I will set up your offspring after you, who will proceed out of your body, and I will establish his kingdom. 
 \v 13 He will build a house for my name, and I will establish the throne of his kingdom forever. 
 \v 14 I will be his father, and he will be my son. If he commits iniquity, I will chasten him with the rod of men and with the stripes of the children of men; 
@@ -278,20 +278,20 @@
 \v 16 Your house and your kingdom will be made sure forever before you. Your throne will be established forever.” ’ ” 
 \v 17 Nathan spoke to David all these words, and according to all this vision. 
 \p
-\v 18 Then David the king went in and sat before Yahweh; and he said, “Who am I, Lord Yahweh, and what is my house, that you have brought me this far? 
-\v 19 This was yet a small thing in your eyes, Lord Yahweh, but you have spoken also of your servant’s house for a great while to come; and this among men, Lord Yahweh! 
-\v 20 What more can David say to you? For you know your servant, Lord Yahweh. 
+\v 18 Then David the king went in and sat before Yahuah; and he said, “Who am I, Lord Yahuah, and what is my house, that you have brought me this far? 
+\v 19 This was yet a small thing in your eyes, Lord Yahuah, but you have spoken also of your servant’s house for a great while to come; and this among men, Lord Yahuah! 
+\v 20 What more can David say to you? For you know your servant, Lord Yahuah. 
 \v 21 For your word’s sake, and according to your own heart, you have worked all this greatness, to make your servant know it. 
-\v 22 Therefore you are great, Yahweh Elohim. For there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
+\v 22 Therefore you are great, Yahuah Elohim. For there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
 \v 23 What one nation in the earth is like your people, even like Israel, whom Elohim went to redeem to himself for a people, and to make himself a name, and to do great things for you, and awesome things for your land, before your people, whom you redeemed to yourself out of Egypt, from the nations and their elohims? 
-\v 24 You established for yourself your people Israel to be your people forever; and you, Yahweh, became their Elohim. 
+\v 24 You established for yourself your people Israel to be your people forever; and you, Yahuah, became their Elohim. 
 \p
-\v 25 “Now, Yahweh Elohim, the word that you have spoken concerning your servant, and concerning his house, confirm it forever, and do as you have spoken. 
-\v 26 Let your name be magnified forever, saying, ‘Yahweh of Armies is Elohim over Israel; and the house of your servant David will be established before you.’ 
-\v 27 For you, Yahweh of Armies, the Elohim of Israel, have revealed to your servant, saying, ‘I will build you a house.’ Therefore your servant has found in his heart to pray this prayer to you. 
+\v 25 “Now, Yahuah Elohim, the word that you have spoken concerning your servant, and concerning his house, confirm it forever, and do as you have spoken. 
+\v 26 Let your name be magnified forever, saying, ‘Yahuah of Armies is Elohim over Israel; and the house of your servant David will be established before you.’ 
+\v 27 For you, Yahuah of Armies, the Elohim of Israel, have revealed to your servant, saying, ‘I will build you a house.’ Therefore your servant has found in his heart to pray this prayer to you. 
 \p
-\v 28 “Now, O Lord Yahweh, you are Elohim, and your words are truth, and you have promised this good thing to your servant. 
-\v 29 Now therefore, let it please you to bless the house of your servant, that it may continue forever before you; for you, Lord Yahweh, have spoken it. Let the house of your servant be blessed forever with your blessing.” 
+\v 28 “Now, O Lord Yahuah, you are Elohim, and your words are truth, and you have promised this good thing to your servant. 
+\v 29 Now therefore, let it please you to bless the house of your servant, that it may continue forever before you; for you, Lord Yahuah, have spoken it. Let the house of your servant be blessed forever with your blessing.” 
 \c 8
 \p
 \v 1 After this, David struck the Philistines and subdued them; and David took the bridle of the mother city out of the hand of the Philistines. 
@@ -300,16 +300,16 @@
 \v 3 David also struck Hadadezer the son of Rehob, king of Zobah, as he went to recover his dominion at the River. 
 \v 4 David took from him one thousand seven hundred horsemen and twenty thousand footmen. David hamstrung the chariot horses, but reserved enough of them for one hundred chariots. 
 \v 5 When the Syrians of Damascus came to help Hadadezer king of Zobah, David struck twenty two thousand men of the Syrians. 
-\v 6 Then David put garrisons in Syria of Damascus; and the Syrians became servants to David, and brought tribute. Yahweh gave victory to David wherever he went. 
+\v 6 Then David put garrisons in Syria of Damascus; and the Syrians became servants to David, and brought tribute. Yahuah gave victory to David wherever he went. 
 \v 7 David took the shields of gold that were on the servants of Hadadezer, and brought them to Jerusalem. 
 \v 8 From Betah and from Berothai, cities of Hadadezer, King David took a great quantity of bronze. 
 \p
 \v 9 When Toi king of Hamath heard that David had struck all the army of Hadadezer, 
 \v 10 then Toi sent Joram his son to King David to greet him and to bless him, because he had fought against Hadadezer and struck him; for Hadadezer had wars with Toi. Joram brought with him vessels of silver, vessels of gold, and vessels of bronze. 
-\v 11 King David also dedicated these to Yahweh, with the silver and gold that he dedicated of all the nations which he subdued—\v 12 of Syria, of Moab, of the children of Ammon, of the Philistines, of Amalek, and of the plunder of Hadadezer, son of Rehob, king of Zobah. 
+\v 11 King David also dedicated these to Yahuah, with the silver and gold that he dedicated of all the nations which he subdued—\v 12 of Syria, of Moab, of the children of Ammon, of the Philistines, of Amalek, and of the plunder of Hadadezer, son of Rehob, king of Zobah. 
 \p
 \v 13 David earned a reputation when he returned from striking down eighteen thousand men of the Syrians in the Valley of Salt. 
-\v 14 He put garrisons in Edom. Throughout all Edom, he put garrisons, and all the Edomites became servants to David. Yahweh gave victory to David wherever he went. 
+\v 14 He put garrisons in Edom. Throughout all Edom, he put garrisons, and all the Edomites became servants to David. Yahuah gave victory to David wherever he went. 
 \p
 \v 15 David reigned over all Israel; and David executed justice and righteousness for all his people. 
 \v 16 Joab the son of Zeruiah was over the army, Jehoshaphat the son of Ahilud was recorder, 
@@ -357,7 +357,7 @@
 \v 9 Now when Joab saw that the battle was set against him before and behind, he chose of all the choice men of Israel and put them in array against the Syrians. 
 \v 10 The rest of the people he committed into the hand of Abishai his brother; and he put them in array against the children of Ammon. 
 \v 11 He said, “If the Syrians are too strong for me, then you shall help me; but if the children of Ammon are too strong for you, then I will come and help you. 
-\v 12 Be courageous, and let’s be strong for our people and for the cities of our Elohim; and may Yahweh do what seems good to him.” 
+\v 12 Be courageous, and let’s be strong for our people and for the cities of our Elohim; and may Yahuah do what seems good to him.” 
 \v 13 So Joab and the people who were with him came near to the battle against the Syrians, and they fled before him. 
 \v 14 When the children of Ammon saw that the Syrians had fled, they likewise fled before Abishai, and entered into the city. Then Joab returned from the children of Ammon and came to Jerusalem. 
 \p
@@ -402,30 +402,30 @@
 \v 25 Then David said to the messenger, “Tell Joab, ‘Don’t let this thing displease you, for the sword devours one as well as another. Make your battle stronger against the city, and overthrow it.’ Encourage him.” 
 \p
 \v 26 When Uriah’s woman heard that Uriah her man was dead, she mourned for her owner. 
-\v 27 When the mourning was past, David sent and took her home to his house, and she became his woman and bore him a son. But the thing that David had done displeased Yahweh. 
+\v 27 When the mourning was past, David sent and took her home to his house, and she became his woman and bore him a son. But the thing that David had done displeased Yahuah. 
 \c 12
 \p
-\v 1 Yahweh sent Nathan to David. He came to him, and said to him, “There were two men in one city: the one rich, and the other poor. 
+\v 1 Yahuah sent Nathan to David. He came to him, and said to him, “There were two men in one city: the one rich, and the other poor. 
 \v 2 The rich man had very many flocks and herds, 
 \v 3 but the poor man had nothing, except one little ewe lamb, which he had bought and raised. It grew up together with him and with his children. It ate of his own food, drank of his own cup, and lay in his bosom, and was like a daughter to him. 
 \v 4 A traveler came to the rich man, and he didn’t want to take of his own flock and of his own herd to prepare for the wayfaring man who had come to him, but took the poor man’s lamb and prepared it for the man who had come to him.” 
 \p
-\v 5 David’s anger burned hot against the man, and he said to Nathan, “As Yahweh lives, the man who has done this deserves to die! 
+\v 5 David’s anger burned hot against the man, and he said to Nathan, “As Yahuah lives, the man who has done this deserves to die! 
 \v 6 He must restore the lamb fourfold, because he did this thing and because he had no pity!” 
 \p
-\v 7 Nathan said to David, “You are the man! This is what Yahweh, the Elohim of Israel, says: ‘I anointed you king over Israel, and I delivered you out of the hand of Saul. 
+\v 7 Nathan said to David, “You are the man! This is what Yahuah, the Elohim of Israel, says: ‘I anointed you king over Israel, and I delivered you out of the hand of Saul. 
 \v 8 I gave you your master’s house and your master’s women into your bosom, and gave you the house of Israel and of Judah; and if that would have been too little, I would have added to you many more such things. 
-\v 9 Why have you despised Yahweh’s word, to do that which is evil in his sight? You have struck Uriah the Hittite with the sword, have taken his woman to be your woman, and have slain him with the sword of the children of Ammon. 
+\v 9 Why have you despised Yahuah’s word, to do that which is evil in his sight? You have struck Uriah the Hittite with the sword, have taken his woman to be your woman, and have slain him with the sword of the children of Ammon. 
 \v 10 Now therefore the sword will never depart from your house, because you have despised me and have taken Uriah the Hittite’s woman to be your woman.’ 
 \p
-\v 11 “This is what Yahweh says: ‘Behold, I will raise up evil against you out of your own house; and I will take your women before your eyes and give them to your neighbor, and he will lie with your women in the sight of this sun. 
+\v 11 “This is what Yahuah says: ‘Behold, I will raise up evil against you out of your own house; and I will take your women before your eyes and give them to your neighbor, and he will lie with your women in the sight of this sun. 
 \v 12 For you did this secretly, but I will do this thing before all Israel, and before the sun.’ ” 
 \p
-\v 13 David said to Nathan, “I have sinned against Yahweh.” 
-\p Nathan said to David, “Yahweh also has put away your sin. You will not die. 
-\v 14 However, because by this deed you have given great occasion to Yahweh’s enemies to blaspheme, the child also who is born to you will surely die.” 
+\v 13 David said to Nathan, “I have sinned against Yahuah.” 
+\p Nathan said to David, “Yahuah also has put away your sin. You will not die. 
+\v 14 However, because by this deed you have given great occasion to Yahuah’s enemies to blaspheme, the child also who is born to you will surely die.” 
 \v 15 Then Nathan departed to his house. 
-\p Yahweh struck the child that Uriah’s woman bore to David, and he was very sick. 
+\p Yahuah struck the child that Uriah’s woman bore to David, and he was very sick. 
 \v 16 David therefore begged Elohim for the child; and David fasted, and went in and lay all night on the ground. 
 \v 17 The elders of his house arose beside him, to raise him up from the earth; but he would not, and he didn’t eat bread with them. 
 \v 18 On the seventh day, the child died. David’s servants were afraid to tell him that the child was dead, for they said, “Behold, while the child was yet alive, we spoke to him and he didn’t listen to our voice. How will he then harm himself if we tell him that the child is dead?” 
@@ -433,14 +433,14 @@
 \v 19 But when David saw that his servants were whispering together, David perceived that the child was dead; and David said to his servants, “Is the child dead?” 
 \p They said, “He is dead.” 
 \p
-\v 20 Then David arose from the earth, and washed and anointed himself, and changed his clothing; and he came into Yahweh’s house, and worshiped. Then he came to his own house; and when he requested, they set bread before him and he ate. 
+\v 20 Then David arose from the earth, and washed and anointed himself, and changed his clothing; and he came into Yahuah’s house, and worshiped. Then he came to his own house; and when he requested, they set bread before him and he ate. 
 \v 21 Then his servants said to him, “What is this that you have done? You fasted and wept for the child while he was alive, but when the child was dead, you rose up and ate bread.” 
 \p
-\v 22 He said, “While the child was yet alive, I fasted and wept; for I said, ‘Who knows whether Yahweh will not be gracious to me, that the child may live?’ 
+\v 22 He said, “While the child was yet alive, I fasted and wept; for I said, ‘Who knows whether Yahuah will not be gracious to me, that the child may live?’ 
 \v 23 But now he is dead. Why should I fast? Can I bring him back again? I will go to him, but he will not return to me.” 
 \p
-\v 24 David comforted Bathsheba his woman, and went in to her, and lay with her. She bore a son, and he called his name Solomon. Yahweh loved him; 
-\v 25 and he sent by the hand of Nathan the prophet, and he named him Jedidiah, for Yahweh’s sake. 
+\v 24 David comforted Bathsheba his woman, and went in to her, and lay with her. She bore a son, and he called his name Solomon. Yahuah loved him; 
+\v 25 and he sent by the hand of Nathan the prophet, and he named him Jedidiah, for Yahuah’s sake. 
 \p
 \v 26 Now Joab fought against Rabbah of the children of Ammon, and took the royal city. 
 \v 27 Joab sent messengers to David, and said, “I have fought against Rabbah. Yes, I have taken the city of waters. 
@@ -528,8 +528,8 @@
 \p
 \v 10 The king said, “Whoever says anything to you, bring him to me, and he will not bother you any more.” 
 \p
-\v 11 Then she said, “Please let the king remember Yahweh your Elohim, that the avenger of blood destroy not any more, lest they destroy my son.” 
-\p He said, “As Yahweh lives, not one hair of your son shall fall to the earth.” 
+\v 11 Then she said, “Please let the king remember Yahuah your Elohim, that the avenger of blood destroy not any more, lest they destroy my son.” 
+\p He said, “As Yahuah lives, not one hair of your son shall fall to the earth.” 
 \p
 \v 12 Then the woman said, “Please let your servant speak a word to my lord the king.” 
 \p He said, “Say on.” 
@@ -538,7 +538,7 @@
 \v 14 For we must die, and are like water spilled on the ground, which can’t be gathered up again; neither does Elohim take away life, but devises means, that he who is banished not be an outcast from him. 
 \v 15 Now therefore, seeing that I have come to speak this word to my lord the king, it is because the people have made me afraid. Your servant said, ‘I will now speak to the king; it may be that the king will perform the request of his servant.’ 
 \v 16 For the king will hear, to deliver his servant out of the hand of the man who would destroy me and my son together out of the inheritance of Elohim. 
-\v 17 Then your servant said, ‘Please let the word of my lord the king bring rest; for as an angel of Elohim, so is my lord the king to discern good and bad. May Yahweh, your Elohim, be with you.’ ” 
+\v 17 Then your servant said, ‘Please let the word of my lord the king bring rest; for as an angel of Elohim, so is my lord the king to discern good and bad. May Yahuah, your Elohim, be with you.’ ” 
 \p
 \v 18 Then the king answered the woman, “Please don’t hide anything from me that I ask you.” 
 \p The woman said, “Let my lord the king now speak.” 
@@ -576,8 +576,8 @@
 \v 5 It was so, that when any man came near to bow down to him, he stretched out his hand, took hold of him, and kissed him. 
 \v 6 Absalom did this sort of thing to all Israel who came to the king for judgment. So Absalom stole the hearts of the men of Israel. 
 \p
-\v 7 At the end of forty years, Absalom said to the king, “Please let me go and pay my vow, which I have vowed to Yahweh, in Hebron. 
-\v 8 For your servant vowed a vow while I stayed at Geshur in Syria, saying, ‘If Yahweh shall indeed bring me again to Jerusalem, then I will serve Yahweh.’ ” 
+\v 7 At the end of forty years, Absalom said to the king, “Please let me go and pay my vow, which I have vowed to Yahuah, in Hebron. 
+\v 8 For your servant vowed a vow while I stayed at Geshur in Syria, saying, ‘If Yahuah shall indeed bring me again to Jerusalem, then I will serve Yahuah.’ ” 
 \p
 \v 9 The king said to him, “Go in peace.” 
 \p So he arose and went to Hebron. 
@@ -598,12 +598,12 @@
 \v 19 Then the king said to Ittai the Gittite, “Why do you also go with us? Return, and stay with the king; for you are a foreigner and also an exile. Return to your own place. 
 \v 20 Whereas you came but yesterday, should I today make you go up and down with us, since I go where I may? Return, and take back your brothers. Mercy and truth be with you.” 
 \p
-\v 21 Ittai answered the king and said, “As Yahweh lives, and as my lord the king lives, surely in what place my lord the king is, whether for death or for life, your servant will be there also.” 
+\v 21 Ittai answered the king and said, “As Yahuah lives, and as my lord the king lives, surely in what place my lord the king is, whether for death or for life, your servant will be there also.” 
 \p
 \v 22 David said to Ittai, “Go and pass over.” Ittai the Gittite passed over, and all his men, and all the little ones who were with him. 
 \v 23 All the country wept with a loud voice, and all the people passed over. The king also himself passed over the brook Kidron, and all the people passed over toward the way of the wilderness. 
 \v 24 Behold, Zadok also came, and all the Levites with him, bearing the ark of the covenant of Elohim; and they set down Elohim’s ark; and Abiathar went up until all the people finished passing out of the city. 
-\v 25 The king said to Zadok, “Carry Elohim’s ark back into the city. If I find favor in Yahweh’s eyes, he will bring me again, and show me both it and his habitation; 
+\v 25 The king said to Zadok, “Carry Elohim’s ark back into the city. If I find favor in Yahuah’s eyes, he will bring me again, and show me both it and his habitation; 
 \v 26 but if he says, ‘I have no delight in you,’ behold, here I am. Let him do to me as seems good to him.” 
 \v 27 The king said also to Zadok the priest, “Aren’t you a seer? Return into the city in peace, and your two sons with you, Ahimaaz your son and Jonathan the son of Abiathar. 
 \v 28 Behold, I will stay at the fords of the wilderness until word comes from you to inform me.” 
@@ -611,7 +611,7 @@
 \v 30 David went up by the ascent of the Mount of Olives, and wept as he went up; and he had his head covered and went barefoot. All the people who were with him each covered his head, and they went up, weeping as they went up. 
 \p
 \v 31 Someone told David, saying, “Ahithophel is among the conspirators with Absalom.” 
-\p David said, “Yahweh, please turn the counsel of Ahithophel into foolishness.” 
+\p David said, “Yahuah, please turn the counsel of Ahithophel into foolishness.” 
 \p
 \v 32 When David had come to the top, where Elohim was worshiped, behold, Hushai the Archite came to meet him with his tunic torn and earth on his head. 
 \v 33 David said to him, “If you pass on with me, then you will be a burden to me; 
@@ -635,13 +635,13 @@
 \v 5 When King David came to Bahurim, behold, a man of the family of Saul’s house came out, whose name was Shimei, the son of Gera. He came out and cursed as he came. 
 \v 6 He cast stones at David and at all the servants of King David, and all the people and all the mighty men were on his right hand and on his left. 
 \v 7 Shimei said when he cursed, “Be gone, be gone, you man of blood, and wicked fellow! 
-\v 8 Yahweh has returned on you all the blood of Saul’s house, in whose place you have reigned! Yahweh has delivered the kingdom into the hand of Absalom your son! Behold, you are caught by your own mischief, because you are a man of blood!” 
+\v 8 Yahuah has returned on you all the blood of Saul’s house, in whose place you have reigned! Yahuah has delivered the kingdom into the hand of Absalom your son! Behold, you are caught by your own mischief, because you are a man of blood!” 
 \p
 \v 9 Then Abishai the son of Zeruiah said to the king, “Why should this dead dog curse my lord the king? Please let me go over and take off his head.” 
-\v 10 The king said, “What have I to do with you, you sons of Zeruiah? Because he curses, and because Yahweh has said to him, ‘Curse David,’ who then shall say, ‘Why have you done so?’ ” 
+\v 10 The king said, “What have I to do with you, you sons of Zeruiah? Because he curses, and because Yahuah has said to him, ‘Curse David,’ who then shall say, ‘Why have you done so?’ ” 
 \p
-\v 11 David said to Abishai and to all his servants, “Behold, my son, who came out of my bowels, seeks my life. How much more this Benjamite, now? Leave him alone, and let him curse; for Yahweh has invited him. 
-\v 12 It may be that Yahweh will look on the wrong done to me, and that Yahweh will repay me good for the cursing of me today.” 
+\v 11 David said to Abishai and to all his servants, “Behold, my son, who came out of my bowels, seeks my life. How much more this Benjamite, now? Leave him alone, and let him curse; for Yahuah has invited him. 
+\v 12 It may be that Yahuah will look on the wrong done to me, and that Yahuah will repay me good for the cursing of me today.” 
 \v 13 So David and his men went by the way; and Shimei went along on the hillside opposite him and cursed as he went, threw stones at him, and threw dust. 
 \v 14 The king and all the people who were with him arrived weary; and he refreshed himself there. 
 \p
@@ -650,7 +650,7 @@
 \p
 \v 17 Absalom said to Hushai, “Is this your kindness to your friend? Why didn’t you go with your friend?” 
 \p
-\v 18 Hushai said to Absalom, “No; but whomever Yahweh and this people and all the men of Israel have chosen, I will be his, and I will stay with him. 
+\v 18 Hushai said to Absalom, “No; but whomever Yahuah and this people and all the men of Israel have chosen, I will be his, and I will stay with him. 
 \v 19 Again, whom should I serve? Shouldn’t I serve in the presence of his son? As I have served in your father’s presence, so I will be in your presence.” 
 \p
 \v 20 Then Absalom said to Ahithophel, “Give your counsel what we shall do.” 
@@ -679,7 +679,7 @@
 \v 12 So we will come on him in some place where he will be found, and we will light on him as the dew falls on the ground, then we will not leave so much as one of him and of all the men who are with him. 
 \v 13 Moreover, if he has gone into a city, then all Israel will bring ropes to that city, and we will draw it into the river, until there isn’t one small stone found there.” 
 \p
-\v 14 Absalom and all the men of Israel said, “The counsel of Hushai the Archite is better than the counsel of Ahithophel.” For Yahweh had ordained to defeat the good counsel of Ahithophel, to the intent that Yahweh might bring evil on Absalom. 
+\v 14 Absalom and all the men of Israel said, “The counsel of Hushai the Archite is better than the counsel of Ahithophel.” For Yahuah had ordained to defeat the good counsel of Ahithophel, to the intent that Yahuah might bring evil on Absalom. 
 \p
 \v 15 Then Hushai said to Zadok and to Abiathar the priests, “Ahithophel counseled Absalom and the elders of Israel that way; and I have counseled this way. 
 \v 16 Now therefore send quickly, and tell David, saying, ‘Don’t lodge tonight at the fords of the wilderness, but by all means pass over, lest the king be swallowed up, and all the people who are with him.’ ” 
@@ -733,7 +733,7 @@
 \p
 \v 18 Now Absalom in his lifetime had taken and reared up for himself the pillar which is in the king’s valley, for he said, “I have no son to keep my name in memory.” He called the pillar after his own name. It is called Absalom’s monument, to this day. 
 \p
-\v 19 Then Ahimaaz the son of Zadok said, “Let me now run and carry the king news, how Yahweh has avenged him of his enemies.” 
+\v 19 Then Ahimaaz the son of Zadok said, “Let me now run and carry the king news, how Yahuah has avenged him of his enemies.” 
 \p
 \v 20 Joab said to him, “You must not be the bearer of news today, but you must carry news another day. But today you must carry no news, because the king’s son is dead.” 
 \p
@@ -754,14 +754,14 @@
 \v 27 The watchman said, “I think the running of the first one is like the running of Ahimaaz the son of Zadok.” 
 \p The king said, “He is a good man, and comes with good news.” 
 \p
-\v 28 Ahimaaz called, and said to the king, “All is well.” He bowed himself before the king with his face to the earth, and said, “Blessed is Yahweh your Elohim, who has delivered up the men who lifted up their hand against my lord the king!” 
+\v 28 Ahimaaz called, and said to the king, “All is well.” He bowed himself before the king with his face to the earth, and said, “Blessed is Yahuah your Elohim, who has delivered up the men who lifted up their hand against my lord the king!” 
 \p
 \v 29 The king said, “Is it well with the young man Absalom?” 
 \p Ahimaaz answered, “When Joab sent the king’s servant, even me your servant, I saw a great tumult, but I don’t know what it was.” 
 \p
 \v 30 The king said, “Come and stand here.” He came and stood still. 
 \p
-\v 31 Behold, the Cushite came. The Cushite said, “Good news for my lord the king, for Yahweh has avenged you today of all those who rose up against you.” 
+\v 31 Behold, the Cushite came. The Cushite said, “Good news for my lord the king, for Yahuah has avenged you today of all those who rose up against you.” 
 \p
 \v 32 The king said to the Cushite, “Is it well with the young man Absalom?” 
 \p The Cushite answered, “May the enemies of my lord the king, and all who rise up against you to do you harm, be as that young man is.” 
@@ -777,7 +777,7 @@
 \p
 \v 5 Joab came into the house to the king, and said, “Today you have shamed the faces of all your servants who today have saved your life, and the lives of your sons and of your daughters, and the lives of your women, and the lives of your concubines; 
 \v 6 in that you love those who hate you and hate those who love you. For you have declared today that princes and servants are nothing to you. For today I perceive that if Absalom had lived and we had all died today, then it would have pleased you well. 
-\v 7 Now therefore arise, go out and speak to comfort your servants; for I swear by Yahweh, if you don’t go out, not a man will stay with you this night. That would be worse to you than all the evil that has happened to you from your youth until now.” 
+\v 7 Now therefore arise, go out and speak to comfort your servants; for I swear by Yahuah, if you don’t go out, not a man will stay with you this night. That would be worse to you than all the evil that has happened to you from your youth until now.” 
 \p
 \v 8 Then the king arose and sat in the gate. The people were all told, “Behold, the king is sitting in the gate.” All the people came before the king. Now Israel had fled every man to his tent. 
 \v 9 All the people were at strife throughout all the tribes of Israel, saying, “The king delivered us out of the hand of our enemies, and he saved us out of the hand of the Philistines; and now he has fled out of the land from Absalom. 
@@ -796,7 +796,7 @@
 \v 19 He said to the king, “Don’t let my lord impute iniquity to me, or remember that which your servant did perversely the day that my lord the king went out of Jerusalem, that the king should take it to his heart. 
 \v 20 For your servant knows that I have sinned. Therefore behold, I have come today as the first of all the house of Joseph to go down to meet my lord the king.” 
 \p
-\v 21 But Abishai the son of Zeruiah answered, “Shouldn’t Shimei be put to death for this, because he cursed Yahweh’s anointed?” 
+\v 21 But Abishai the son of Zeruiah answered, “Shouldn’t Shimei be put to death for this, because he cursed Yahuah’s anointed?” 
 \p
 \v 22 David said, “What have I to do with you, you sons of Zeruiah, that you should be adversaries to me today? Shall any man be put to death today in Israel? For don’t I know that I am king over Israel today?” 
 \v 23 The king said to Shimei, “You will not die.” The king swore to him. 
@@ -861,7 +861,7 @@
 \p He answered, “I’m listening.” 
 \p
 \v 18 Then she spoke, saying, “They used to say in old times, ‘They shall surely ask counsel at Abel,’ and so they settled a matter. 
-\v 19 I am among those who are peaceable and faithful in Israel. You seek to destroy a city and a mother in Israel. Why will you swallow up Yahweh’s inheritance?” 
+\v 19 I am among those who are peaceable and faithful in Israel. You seek to destroy a city and a mother in Israel. Why will you swallow up Yahuah’s inheritance?” 
 \p
 \v 20 Joab answered, “Far be it, far be it from me, that I should swallow up or destroy. 
 \v 21 The matter is not so. But a man of the hill country of Ephraim, Sheba the son of Bichri by name, has lifted up his hand against the king, even against David. Just deliver him, and I will depart from the city.” 
@@ -875,21 +875,21 @@
 \v 26 and Ira the Jairite was chief minister to David. 
 \c 21
 \p
-\v 1 There was a famine in the days of David for three years, year after year; and David sought the face of Yahweh. Yahweh said, “It is for Saul, and for his bloody house, because he put the Gibeonites to death.” 
+\v 1 There was a famine in the days of David for three years, year after year; and David sought the face of Yahuah. Yahuah said, “It is for Saul, and for his bloody house, because he put the Gibeonites to death.” 
 \p
 \v 2 The king called the Gibeonites and said to them (now the Gibeonites were not of the children of Israel, but of the remnant of the Amorites, and the children of Israel had sworn to them; and Saul sought to kill them in his zeal for the children of Israel and Judah); 
-\v 3 and David said to the Gibeonites, “What should I do for you? And with what should I make atonement, that you may bless Yahweh’s inheritance?” 
+\v 3 and David said to the Gibeonites, “What should I do for you? And with what should I make atonement, that you may bless Yahuah’s inheritance?” 
 \p
 \v 4 The Gibeonites said to him, “It is no matter of silver or gold between us and Saul or his house; neither is it for us to put any man to death in Israel.” 
 \p He said, “I will do for you whatever you say.” 
 \p
 \v 5 They said to the king, “The man who consumed us and who plotted against us, that we should be destroyed from remaining in any of the borders of Israel, 
-\v 6 let seven men of his sons be delivered to us, and we will hang them up to Yahweh in Gibeah of Saul, the chosen of Yahweh.” 
+\v 6 let seven men of his sons be delivered to us, and we will hang them up to Yahuah in Gibeah of Saul, the chosen of Yahuah.” 
 \p The king said, “I will give them.” 
 \p
-\v 7 But the king spared Mephibosheth the son of Jonathan the son of Saul, because of Yahweh’s oath that was between them, between David and Jonathan the son of Saul. 
+\v 7 But the king spared Mephibosheth the son of Jonathan the son of Saul, because of Yahuah’s oath that was between them, between David and Jonathan the son of Saul. 
 \v 8 But the king took the two sons of Rizpah the daughter of Aiah, whom she bore to Saul, Armoni and Mephibosheth; and the five sons of Merab the daughter of Saul, whom she bore to Adriel the son of Barzillai the Meholathite. 
-\v 9 He delivered them into the hands of the Gibeonites; and they hanged them on the mountain before Yahweh, and all seven of them fell together. They were put to death in the days of harvest, in the first days, at the beginning of barley harvest. 
+\v 9 He delivered them into the hands of the Gibeonites; and they hanged them on the mountain before Yahuah, and all seven of them fell together. They were put to death in the days of harvest, in the first days, at the beginning of barley harvest. 
 \p
 \v 10 Rizpah the daughter of Aiah took sackcloth and spread it for herself on the rock, from the beginning of harvest until water poured on them from the sky. She allowed neither the birds of the sky to rest on them by day, nor the animals of the field by night. 
 \v 11 David was told what Rizpah the daughter of Aiah, the concubine of Saul, had done. 
@@ -908,9 +908,9 @@
 \v 22 These four were born to the giant in Gath; and they fell by the hand of David and by the hand of his servants. 
 \c 22
 \p
-\v 1 David spoke to Yahweh the words of this song in the day that Yahweh delivered him out of the hand of all his enemies, and out of the hand of Saul, 
+\v 1 David spoke to Yahuah the words of this song in the day that Yahuah delivered him out of the hand of all his enemies, and out of the hand of Saul, 
 \v 2 and he said: 
-\q1 “Yahweh is my rock, 
+\q1 “Yahuah is my rock, 
 \q2 my fortress, 
 \q2 and my deliverer, even mine; 
 \q1
@@ -919,7 +919,7 @@
 \q2 my high tower, and my refuge. 
 \q2 My savior, you save me from violence. 
 \q1
-\v 4 I call on Yahweh, who is worthy to be praised; 
+\v 4 I call on Yahuah, who is worthy to be praised; 
 \q2 So shall I be saved from my enemies. 
 \b
 \q1
@@ -929,7 +929,7 @@
 \v 6 The cords of Sheol were around me. 
 \q2 The snares of death caught me. 
 \q1
-\v 7 In my distress, I called on Yahweh. 
+\v 7 In my distress, I called on Yahuah. 
 \q2 Yes, I called to my Elohim. 
 \q1 He heard my voice out of his temple. 
 \q2 My cry came into his ears. 
@@ -954,14 +954,14 @@
 \v 13 At the brightness before him, 
 \q2 coals of fire were kindled. 
 \q1
-\v 14 Yahweh thundered from heaven. 
+\v 14 Yahuah thundered from heaven. 
 \q2 The Most High uttered his voice. 
 \q1
 \v 15 He sent out arrows and scattered them, 
 \q2 lightning and confused them. 
 \q1
 \v 16 Then the channels of the sea appeared. 
-\q2 The foundations of the world were laid bare by Yahweh’s rebuke, 
+\q2 The foundations of the world were laid bare by Yahuah’s rebuke, 
 \q2 at the blast of the breath of his nostrils. 
 \b
 \q1
@@ -972,16 +972,16 @@
 \q2 from those who hated me, for they were too mighty for me. 
 \q1
 \v 19 They came on me in the day of my calamity, 
-\q2 but Yahweh was my support. 
+\q2 but Yahuah was my support. 
 \q1
 \v 20 He also brought me out into a large place. 
 \q2 He delivered me, because he delighted in me. 
 \b
 \q1
-\v 21 Yahweh rewarded me according to my righteousness. 
+\v 21 Yahuah rewarded me according to my righteousness. 
 \q2 He rewarded me according to the cleanness of my hands. 
 \q1
-\v 22 For I have kept Yahweh’s ways, 
+\v 22 For I have kept Yahuah’s ways, 
 \q2 and have not wickedly departed from my Elohim. 
 \q1
 \v 23 For all his ordinances were before me. 
@@ -990,7 +990,7 @@
 \v 24 I was also perfect toward him. 
 \q2 I kept myself from my iniquity. 
 \q1
-\v 25 Therefore Yahweh has rewarded me according to my righteousness, 
+\v 25 Therefore Yahuah has rewarded me according to my righteousness, 
 \q2 According to my cleanness in his eyesight. 
 \b
 \q1
@@ -1003,18 +1003,18 @@
 \v 28 You will save the afflicted people, 
 \q2 but your eyes are on the arrogant, that you may bring them down. 
 \q1
-\v 29 For you are my lamp, Yahweh. 
-\q2 Yahweh will light up my darkness. 
+\v 29 For you are my lamp, Yahuah. 
+\q2 Yahuah will light up my darkness. 
 \q1
 \v 30 For by you, I run against a troop. 
 \q2 By my Elohim, I leap over a wall. 
 \q1
 \v 31 As for Elohim, his way is perfect. 
-\q2 Yahweh’s word is tested. 
+\q2 Yahuah’s word is tested. 
 \q2 He is a shield to all those who take refuge in him. 
 \b
 \q1
-\v 32 For who is Elohim, besides Yahweh? 
+\v 32 For who is Elohim, besides Yahuah? 
 \q2 Who is a rock, besides our Elohim? 
 \q1
 \v 33 Elohim is my strong fortress. 
@@ -1047,7 +1047,7 @@
 \q2 that I might cut off those who hate me. 
 \q1
 \v 42 They looked, but there was no one to save; 
-\q2 even to Yahweh, but he didn’t answer them. 
+\q2 even to Yahuah, but he didn’t answer them. 
 \q1
 \v 43 Then I beat them as small as the dust of the earth. 
 \q2 I crushed them as the mire of the streets, and spread them abroad. 
@@ -1064,7 +1064,7 @@
 \q2 and will come trembling out of their close places. 
 \b
 \q1
-\v 47 Yahweh lives! 
+\v 47 Yahuah lives! 
 \q2 Blessed be my rock! 
 \q1 Exalted be Elohim, the rock of my salvation, 
 \q2
@@ -1075,7 +1075,7 @@
 \q1 Yes, you lift me up above those who rise up against me. 
 \q2 You deliver me from the violent man. 
 \q1
-\v 50 Therefore I will give thanks to you, Yahweh, among the nations, 
+\v 50 Therefore I will give thanks to you, Yahuah, among the nations, 
 \q2 and will sing praises to your name. 
 \q1
 \v 51 He gives great deliverance to his king, 
@@ -1089,7 +1089,7 @@
 \q2 the anointed of the Elohim of Jacob, 
 \q2 the sweet psalmist of Israel: 
 \q1
-\v 2 “Yahweh’s Spirit spoke by me. 
+\v 2 “Yahuah’s Spirit spoke by me. 
 \q2 His word was on my tongue. 
 \q1
 \v 3 The Elohim of Israel said, 
@@ -1117,16 +1117,16 @@
 \p
 \v 8 These are the names of the mighty men whom David had: Josheb Basshebeth a Tahchemonite, chief of the captains; he was called Adino the Eznite, who killed eight hundred at one time. 
 \v 9 After him was Eleazar the son of Dodai the son of an Ahohite, one of the three mighty men with David when they defied the Philistines who were there gathered together to battle, and the men of Israel had gone away. 
-\v 10 He arose and struck the Philistines until his hand was weary, and his hand froze to the sword; and Yahweh worked a great victory that day; and the people returned after him only to take plunder. 
+\v 10 He arose and struck the Philistines until his hand was weary, and his hand froze to the sword; and Yahuah worked a great victory that day; and the people returned after him only to take plunder. 
 \v 11 After him was Shammah the son of Agee a Hararite. The Philistines had gathered together into a troop where there was a plot of ground full of lentils; and the people fled from the Philistines. 
-\v 12 But he stood in the middle of the plot and defended it, and killed the Philistines; and Yahweh worked a great victory. 
+\v 12 But he stood in the middle of the plot and defended it, and killed the Philistines; and Yahuah worked a great victory. 
 \p
 \v 13 Three of the thirty chief men went down, and came to David in the harvest time to the cave of Adullam; and the troop of the Philistines was encamped in the valley of Rephaim. 
 \v 14 David was then in the stronghold; and the garrison of the Philistines was then in Bethlehem. 
 \v 15 David said longingly, “Oh that someone would give me water to drink from the well of Bethlehem, which is by the gate!” 
 \p
-\v 16 The three mighty men broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate and took it and brought it to David; but he would not drink of it, but poured it out to Yahweh. 
-\v 17 He said, “Be it far from me, Yahweh, that I should do this! Isn’t this the blood of the men who risked their lives to go?” Therefore he would not drink it. The three mighty men did these things. 
+\v 16 The three mighty men broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate and took it and brought it to David; but he would not drink of it, but poured it out to Yahuah. 
+\v 17 He said, “Be it far from me, Yahuah, that I should do this! Isn’t this the blood of the men who risked their lives to go?” Therefore he would not drink it. The three mighty men did these things. 
 \p
 \v 18 Abishai, the brother of Joab, the son of Zeruiah, was chief of the three. He lifted up his spear against three hundred and killed them, and had a name among the three. 
 \v 19 Wasn’t he most honorable of the three? Therefore he was made their captain. However he wasn’t included as one of the three. 
@@ -1154,10 +1154,10 @@
 \v 39 and Uriah the Hittite: thirty-seven in all. 
 \c 24
 \p
-\v 1 Again Yahweh’s anger burned against Israel, and he moved David against them, saying, “Go, count Israel and Judah.” 
+\v 1 Again Yahuah’s anger burned against Israel, and he moved David against them, saying, “Go, count Israel and Judah.” 
 \v 2 The king said to Joab the captain of the army, who was with him, “Now go back and forth through all the tribes of Israel, from Dan even to Beersheba, and count the people, that I may know the sum of the people.” 
 \p
-\v 3 Joab said to the king, “Now may Yahweh your Elohim add to the people, however many they may be, one hundred times; and may the eyes of my lord the king see it. But why does my lord the king delight in this thing?” 
+\v 3 Joab said to the king, “Now may Yahuah your Elohim add to the people, however many they may be, one hundred times; and may the eyes of my lord the king see it. But why does my lord the king delight in this thing?” 
 \p
 \v 4 Notwithstanding, the king’s word prevailed against Joab and against the captains of the army. Joab and the captains of the army went out from the presence of the king to count the people of Israel. 
 \v 5 They passed over the Jordan and encamped in Aroer, on the right side of the city that is in the middle of the valley of Gad, and to Jazer; 
@@ -1166,29 +1166,29 @@
 \v 8 So when they had gone back and forth through all the land, they came to Jerusalem at the end of nine months and twenty days. 
 \v 9 Joab gave up the sum of the counting of the people to the king; and there were in Israel eight hundred thousand valiant men who drew the sword, and the men of Judah were five hundred thousand men. 
 \p
-\v 10 David’s heart struck him after he had counted the people. David said to Yahweh, “I have sinned greatly in that which I have done. But now, Yahweh, put away, I beg you, the iniquity of your servant; for I have done very foolishly.” 
+\v 10 David’s heart struck him after he had counted the people. David said to Yahuah, “I have sinned greatly in that which I have done. But now, Yahuah, put away, I beg you, the iniquity of your servant; for I have done very foolishly.” 
 \p
-\v 11 When David rose up in the morning, Yahweh’s word came to the prophet Gad, David’s seer, saying, 
-\v 12 “Go and speak to David, ‘Yahweh says, “I offer you three things. Choose one of them, that I may do it to you.” ’ ” 
+\v 11 When David rose up in the morning, Yahuah’s word came to the prophet Gad, David’s seer, saying, 
+\v 12 “Go and speak to David, ‘Yahuah says, “I offer you three things. Choose one of them, that I may do it to you.” ’ ” 
 \p
 \v 13 So Gad came to David, and told him, saying, “Shall seven years of famine come to you in your land? Or will you flee three months before your foes while they pursue you? Or shall there be three days’ pestilence in your land? Now answer, and consider what answer I shall return to him who sent me.” 
 \p
-\v 14 David said to Gad, “I am in distress. Let us fall now into Yahweh’s hand, for his mercies are great. Let me not fall into man’s hand.” 
+\v 14 David said to Gad, “I am in distress. Let us fall now into Yahuah’s hand, for his mercies are great. Let me not fall into man’s hand.” 
 \p
-\v 15 So Yahweh sent a pestilence on Israel from the morning even to the appointed time; and seventy thousand men died of the people from Dan even to Beersheba. 
-\v 16 When the angel stretched out his hand toward Jerusalem to destroy it, Yahweh relented of the disaster, and said to the angel who destroyed the people, “It is enough. Now withdraw your hand.” Yahweh’s angel was by the threshing floor of Araunah the Jebusite. 
+\v 15 So Yahuah sent a pestilence on Israel from the morning even to the appointed time; and seventy thousand men died of the people from Dan even to Beersheba. 
+\v 16 When the angel stretched out his hand toward Jerusalem to destroy it, Yahuah relented of the disaster, and said to the angel who destroyed the people, “It is enough. Now withdraw your hand.” Yahuah’s angel was by the threshing floor of Araunah the Jebusite. 
 \p
-\v 17 David spoke to Yahweh when he saw the angel who struck the people, and said, “Behold, I have sinned, and I have done perversely; but these sheep, what have they done? Please let your hand be against me, and against my father’s house.” 
+\v 17 David spoke to Yahuah when he saw the angel who struck the people, and said, “Behold, I have sinned, and I have done perversely; but these sheep, what have they done? Please let your hand be against me, and against my father’s house.” 
 \p
-\v 18 Gad came that day to David and said to him, “Go up, build an altar to Yahweh on the threshing floor of Araunah the Jebusite.” 
+\v 18 Gad came that day to David and said to him, “Go up, build an altar to Yahuah on the threshing floor of Araunah the Jebusite.” 
 \p
-\v 19 David went up according to the saying of Gad, as Yahweh commanded. 
+\v 19 David went up according to the saying of Gad, as Yahuah commanded. 
 \v 20 Araunah looked out, and saw the king and his servants coming on toward him. Then Araunah went out and bowed himself before the king with his face to the ground. 
 \v 21 Araunah said, “Why has my lord the king come to his servant?” 
-\p David said, “To buy your threshing floor, to build an altar to Yahweh, that the plague may be stopped from afflicting the people.” 
+\p David said, “To buy your threshing floor, to build an altar to Yahuah, that the plague may be stopped from afflicting the people.” 
 \p
 \v 22 Araunah said to David, “Let my lord the king take and offer up what seems good to him. Behold, the cattle for the burnt offering, and the threshing sledges and the yokes of the oxen for the wood. 
-\v 23 All this, O king, does Araunah give to the king.” Araunah said to the king, “May Yahweh your Elohim accept you.” 
+\v 23 All this, O king, does Araunah give to the king.” Araunah said to the king, “May Yahuah your Elohim accept you.” 
 \p
-\v 24 The king said to Araunah, “No, but I will most certainly buy it from you for a price. I will not offer burnt offerings to Yahweh my Elohim which cost me nothing.” So David bought the threshing floor and the oxen for fifty shekels of silver. 
-\v 25 David built an altar to Yahweh there, and offered burnt offerings and peace offerings. So Yahweh was entreated for the land, and the plague was removed from Israel. 
+\v 24 The king said to Araunah, “No, but I will most certainly buy it from you for a price. I will not offer burnt offerings to Yahuah my Elohim which cost me nothing.” So David bought the threshing floor and the oxen for fifty shekels of silver. 
+\v 25 David built an altar to Yahuah there, and offered burnt offerings and peace offerings. So Yahuah was entreated for the land, and the plague was removed from Israel. 

--- a/usfm/amos.usfm
+++ b/usfm/amos.usfm
@@ -5,12 +5,12 @@
 \p
 \v 1 The words of Amos, who was among the herdsmen of Tekoa, which he saw concerning Israel in the days of Uzziah king of Judah and in the days of Jeroboam the son of Joash, king of Israel, two years before the earthquake. 
 \v 2 He said: 
-\q1 “Yahweh will roar from Zion, 
+\q1 “Yahuah will roar from Zion, 
 \q2 and utter his voice from Jerusalem; 
 \q1 and the pastures of the shepherds will mourn, 
 \q2 and the top of Carmel will wither.” 
 \p
-\v 3 Yahweh says: 
+\v 3 Yahuah says: 
 \q1 “For three transgressions of Damascus, yes, for four, 
 \q2 I will not turn away its punishment, 
 \q2 because they have threshed Gilead with threshing instruments of iron; 
@@ -22,9 +22,9 @@
 \q2 and cut off the inhabitant from the valley of Aven, 
 \q2 and him who holds the scepter from the house of Eden; 
 \q2 and the people of Syria shall go into captivity to Kir,” 
-\p says Yahweh. 
+\p says Yahuah. 
 \p
-\v 6 Yahweh says: 
+\v 6 Yahuah says: 
 \q1 “For three transgressions of Gaza, yes, for four, 
 \q2 I will not turn away its punishment, 
 \q2 because they carried away captive the whole community, 
@@ -37,9 +37,9 @@
 \q2 and him who holds the scepter from Ashkelon; 
 \q1 and I will turn my hand against Ekron; 
 \q2 and the remnant of the Philistines will perish,” 
-\p says the Lord Yahweh. 
+\p says the Lord Yahuah. 
 \p
-\v 9 Yahweh says: 
+\v 9 Yahuah says: 
 \q1 “For three transgressions of Tyre, yes, for four, 
 \q2 I will not turn away its punishment; 
 \q2 because they delivered up the whole community to Edom, 
@@ -48,7 +48,7 @@
 \v 10 but I will send a fire on the wall of Tyre, 
 \q2 and it will devour its palaces.” 
 \p
-\v 11 Yahweh says: 
+\v 11 Yahuah says: 
 \q1 “For three transgressions of Edom, yes, for four, 
 \q2 I will not turn away its punishment, 
 \q2 because he pursued his brother with the sword 
@@ -59,7 +59,7 @@
 \v 12 but I will send a fire on Teman, 
 \q2 and it will devour the palaces of Bozrah.” 
 \p
-\v 13 Yahweh says: 
+\v 13 Yahuah says: 
 \q1 “For three transgressions of the children of Ammon, yes, for four, 
 \q2 I will not turn away its punishment, 
 \q2 because they have ripped open the pregnant women of Gilead, 
@@ -72,10 +72,10 @@
 \q1
 \v 15 and their king will go into captivity, 
 \q2 he and his princes together,” 
-\p says Yahweh. 
+\p says Yahuah. 
 \c 2
 \p
-\v 1 Yahweh says: 
+\v 1 Yahuah says: 
 \q1 “For three transgressions of Moab, yes, for four, 
 \q2 I will not turn away its punishment, 
 \q2 because he burned the bones of the king of Edom into lime; 
@@ -86,12 +86,12 @@
 \q1
 \v 3 and I will cut off the judge from among them, 
 \q2 and will kill all its princes with him,” 
-\p says Yahweh. 
+\p says Yahuah. 
 \p
-\v 4 Yahweh says: 
+\v 4 Yahuah says: 
 \q1 “For three transgressions of Judah, yes, for four, 
 \q2 I will not turn away its punishment, 
-\q2 because they have rejected Yahweh’s law, 
+\q2 because they have rejected Yahuah’s law, 
 \q2 and have not kept his statutes, 
 \q2 and their lies have led them astray, 
 \q2 after which their fathers walked; 
@@ -99,7 +99,7 @@
 \v 5 but I will send a fire on Judah, 
 \q2 and it will devour the palaces of Jerusalem.” 
 \p
-\v 6 Yahweh says: 
+\v 6 Yahuah says: 
 \q1 “For three transgressions of Israel, yes, for four, 
 \q2 I will not turn away its punishment, 
 \q2 because they have sold the righteous for silver, 
@@ -125,7 +125,7 @@
 \v 11 I raised up some of your sons for prophets, 
 \q2 and some of your young men for Nazirites. 
 \q1 Isn’t this true, 
-\q2 you children of Israel?” says Yahweh. 
+\q2 you children of Israel?” says Yahuah. 
 \q1
 \v 12 “But you gave the Nazirites wine to drink, 
 \q2 and commanded the prophets, saying, ‘Don’t prophesy!’ 
@@ -143,10 +143,10 @@
 \q1
 \v 16 He who is courageous among the mighty 
 \q2 will flee away naked on that day,” 
-\p says Yahweh. 
+\p says Yahuah. 
 \c 3
 \p
-\v 1 Hear this word that Yahweh has spoken against you, children of Israel, against the whole family which I brought up out of the land of Egypt, saying: 
+\v 1 Hear this word that Yahuah has spoken against you, children of Israel, against the whole family which I brought up out of the land of Egypt, saying: 
 \q1
 \v 2 “I have only chosen you of all the families of the earth. 
 \q2 Therefore I will punish you for all of your sins.” 
@@ -167,14 +167,14 @@
 \v 6 Does the trumpet alarm sound in a city, 
 \q2 without the people being afraid? 
 \q1 Does evil happen to a city, 
-\q2 and Yahweh hasn’t done it? 
+\q2 and Yahuah hasn’t done it? 
 \q1
-\v 7 Surely the Lord Yahweh will do nothing, 
+\v 7 Surely the Lord Yahuah will do nothing, 
 \q2 unless he reveals his secret to his servants the prophets. 
 \q1
 \v 8 The lion has roared. 
 \q2 Who will not fear? 
-\q1 The Lord Yahweh has spoken. 
+\q1 The Lord Yahuah has spoken. 
 \q2 Who can but prophesy? 
 \q1
 \v 9 Proclaim in the palaces at Ashdod, 
@@ -183,21 +183,21 @@
 \q2 and see what unrest is in her, 
 \q2 and what oppression is among them.” 
 \q1
-\v 10 “Indeed they don’t know to do right,” says Yahweh, 
+\v 10 “Indeed they don’t know to do right,” says Yahuah, 
 \q2 “Who hoard plunder and loot in their palaces.” 
 \p
-\v 11 Therefore the Lord Yahweh says: 
+\v 11 Therefore the Lord Yahuah says: 
 \q1 “An adversary will overrun the land; 
 \q2 and he will pull down your strongholds, 
 \q2 and your fortresses will be plundered.” 
 \p
-\v 12 Yahweh says: 
+\v 12 Yahuah says: 
 \q1 “As the shepherd rescues out of the mouth of the lion two legs, 
 \q2 or a piece of an ear, 
 \q2 so shall the children of Israel be rescued who sit in Samaria on the corner of a couch, 
 \q2 and on the silken cushions of a bed.” 
 \p
-\v 13 “Listen, and testify against the house of Jacob,” says the Lord Yahweh, the Elohim of Armies. 
+\v 13 “Listen, and testify against the house of Jacob,” says the Lord Yahuah, the Elohim of Armies. 
 \q1
 \v 14 “For in the day that I visit the transgressions of Israel on him, 
 \q2 I will also visit the altars of Bethel; 
@@ -207,18 +207,18 @@
 \v 15 I will strike the winter house with the summer house; 
 \q2 and the houses of ivory will perish, 
 \q2 and the great houses will have an end,” 
-\p says Yahweh. 
+\p says Yahuah. 
 \c 4
 \p
 \v 1 Listen to this word, you cows of Bashan, who are on the mountain of Samaria, who oppress the poor, who crush the needy, who tell their lords, “Bring us drinks!” 
 \q1
-\v 2 The Lord Yahweh has sworn by his set-apartness, 
+\v 2 The Lord Yahuah has sworn by his set-apartness, 
 \q2 “Behold, the days shall come on you that they will take you away with hooks, 
 \q2 and the last of you with fish hooks. 
 \q1
 \v 3 You will go out at the breaks in the wall, 
 \q2 everyone straight before her; 
-\q2 and you will cast yourselves into Harmon,” says Yahweh. 
+\q2 and you will cast yourselves into Harmon,” says Yahuah. 
 \q1
 \v 4 “Go to Bethel, and sin; 
 \q2 to Gilgal, and sin more. 
@@ -227,11 +227,11 @@
 \q2
 \v 5 offer a sacrifice of thanksgiving of that which is leavened, 
 \q2 and proclaim free will offerings and brag about them; 
-\q2 for this pleases you, you children of Israel,” says the Lord Yahweh. 
+\q2 for this pleases you, you children of Israel,” says the Lord Yahuah. 
 \q1
 \v 6 “I also have given you cleanness of teeth in all your cities, 
 \q2 and lack of bread in every town; 
-\q2 yet you haven’t returned to me,” says Yahweh. 
+\q2 yet you haven’t returned to me,” says Yahuah. 
 \q1
 \v 7 “I also have withheld the rain from you, 
 \q2 when there were yet three months to the harvest; 
@@ -242,22 +242,22 @@
 \q1
 \v 8 So two or three cities staggered to one city to drink water, 
 \q2 and were not satisfied; 
-\q2 yet you haven’t returned to me,” says Yahweh. 
+\q2 yet you haven’t returned to me,” says Yahuah. 
 \q1
 \v 9 “I struck you with blight and mildew many times in your gardens and your vineyards, 
 \q2 and the swarming locusts have devoured your fig trees and your olive trees; 
-\q2 yet you haven’t returned to me,” says Yahweh. 
+\q2 yet you haven’t returned to me,” says Yahuah. 
 \q1
 \v 10 “I sent plagues among you like I did Egypt. 
 \q2 I have slain your young men with the sword, 
 \q2 and have carried away your horses. 
 \q1 I filled your nostrils with the stench of your camp, 
-\q2 yet you haven’t returned to me,” says Yahweh. 
+\q2 yet you haven’t returned to me,” says Yahuah. 
 \q1
 \v 11 “I have overthrown some of you, 
 \q2 as when Elohim overthrew Sodom and Gomorrah, 
 \q2 and you were like a burning stick plucked out of the fire; 
-\q2 yet you haven’t returned to me,” says Yahweh. 
+\q2 yet you haven’t returned to me,” says Yahuah. 
 \q1
 \v 12 “Therefore I will do this to you, Israel; 
 \q2 because I will do this to you, 
@@ -265,7 +265,7 @@
 \q1
 \v 13 For, behold, he who forms the mountains, creates the wind, declares to man what is his thought, 
 \q2 who makes the morning darkness, and treads on the high places of the earth: 
-\q2 Yahweh, the Elohim of Armies, is his name.” 
+\q2 Yahuah, the Elohim of Armies, is his name.” 
 \c 5
 \p
 \v 1 Listen to this word which I take up for a lamentation over you, O house of Israel: 
@@ -275,11 +275,11 @@
 \q1 She is cast down on her land; 
 \q2 there is no one to raise her up.” 
 \p
-\v 3 For the Lord Yahweh says: 
+\v 3 For the Lord Yahuah says: 
 \q1 “The city that went out a thousand shall have a hundred left, 
 \q2 and that which went out one hundred shall have ten left to the house of Israel.” 
 \p
-\v 4 For Yahweh says to the house of Israel: 
+\v 4 For Yahuah says to the house of Israel: 
 \q1 “Seek me, and you will live; 
 \q1
 \v 5 but don’t seek Bethel, 
@@ -288,7 +288,7 @@
 \q1 for Gilgal shall surely go into captivity, 
 \q2 and Bethel shall come to nothing. 
 \q1
-\v 6 Seek Yahweh, and you will live, 
+\v 6 Seek Yahuah, and you will live, 
 \q2 lest he break out like fire in the house of Joseph, 
 \q2 and it devour, and there be no one to quench it in Bethel. 
 \q1
@@ -299,7 +299,7 @@
 \q2 and turns the shadow of death into the morning, 
 \q2 and makes the day dark with night; 
 \q2 who calls for the waters of the sea, 
-\q2 and pours them out on the surface of the earth, Yahweh is his name, 
+\q2 and pours them out on the surface of the earth, Yahuah is his name, 
 \q1
 \v 9 who brings sudden destruction on the strong, 
 \q2 so that destruction comes on the fortress. 
@@ -322,24 +322,24 @@
 \q1
 \v 14 Seek good, and not evil, 
 \q2 that you may live; 
-\q2 and so Yahweh, the Elohim of Armies, will be with you, 
+\q2 and so Yahuah, the Elohim of Armies, will be with you, 
 \q2 as you say. 
 \q1
 \v 15 Hate evil, love good, 
 \q2 and establish justice in the courts. 
-\q2 It may be that Yahweh, the Elohim of Armies, will be gracious to the remnant of Joseph.” 
+\q2 It may be that Yahuah, the Elohim of Armies, will be gracious to the remnant of Joseph.” 
 \p
-\v 16 Therefore Yahweh, the Elohim of Armies, the Lord, says: 
+\v 16 Therefore Yahuah, the Elohim of Armies, the Lord, says: 
 \q1 “Wailing will be in all the wide ways. 
 \q2 They will say in all the streets, ‘Alas! Alas!’ 
 \q2 They will call the farmer to mourning, 
 \q2 and those who are skillful in lamentation to wailing. 
 \q1
 \v 17 In all vineyards there will be wailing, 
-\q2 for I will pass through the middle of you,” says Yahweh. 
+\q2 for I will pass through the middle of you,” says Yahuah. 
 \q1
-\v 18 “Woe to you who desire the day of Yahweh! 
-\q2 Why do you long for the day of Yahweh? 
+\v 18 “Woe to you who desire the day of Yahuah! 
+\q2 Why do you long for the day of Yahuah? 
 \q1 It is darkness, 
 \q2 and not light. 
 \q1
@@ -348,7 +348,7 @@
 \q1 or he went into the house and leaned his hand on the wall, 
 \q2 and a snake bit him. 
 \q1
-\v 20 Won’t the day of Yahweh be darkness, and not light? 
+\v 20 Won’t the day of Yahuah be darkness, and not light? 
 \q2 Even very dark, and no brightness in it? 
 \q1
 \v 21 I hate, I despise your feasts, 
@@ -366,7 +366,7 @@
 \p
 \v 25 “Did you bring to me sacrifices and offerings in the wilderness forty years, house of Israel? 
 \v 26 You also carried the tent of your king and the shrine of your images, the star of your elohim, which you made for yourselves. 
-\v 27 Therefore I will cause you to go into captivity beyond Damascus,” says Yahweh, whose name is the Elohim of Armies. 
+\v 27 Therefore I will cause you to go into captivity beyond Damascus,” says Yahuah, whose name is the Elohim of Armies. 
 \c 6
 \p
 \v 1 Woe to those who are at ease in Zion, 
@@ -398,7 +398,7 @@
 \v 7 Therefore they will now go captive with the first who go captive. 
 \q2 The feasting and lounging will end. 
 \q1
-\v 8 “The Lord Yahweh has sworn by himself,” says Yahweh, the Elohim of Armies: 
+\v 8 “The Lord Yahuah has sworn by himself,” says Yahuah, the Elohim of Armies: 
 \q2 “I abhor the pride of Jacob, 
 \q2 and detest his fortresses. 
 \q2 Therefore I will deliver up the city with all that is in it. 
@@ -406,10 +406,10 @@
 \v 9 It will happen that if ten men remain in one house, 
 \q2 they will die. 
 \p
-\v 10 “When a man’s relative carries him, even he who burns him, to bring bodies out of the house, and asks him who is in the innermost parts of the house, ‘Is there yet any with you?’ And he says, ‘No;’ then he will say, ‘Hush! Indeed we must not mention Yahweh’s name.’ 
+\v 10 “When a man’s relative carries him, even he who burns him, to bring bodies out of the house, and asks him who is in the innermost parts of the house, ‘Is there yet any with you?’ And he says, ‘No;’ then he will say, ‘Hush! Indeed we must not mention Yahuah’s name.’ 
 \b
 \q1
-\v 11 “For, behold, Yahweh commands, and the great house will be smashed to pieces, 
+\v 11 “For, behold, Yahuah commands, and the great house will be smashed to pieces, 
 \q2 and the little house into bits. 
 \q1
 \v 12 Do horses run on the rocky crags? 
@@ -421,22 +421,22 @@
 \q2 ‘Haven’t we taken for ourselves horns by our own strength?’ 
 \q1
 \v 14 For, behold, I will raise up against you a nation, house of Israel,” 
-\q2 says Yahweh, the Elohim of Armies; 
+\q2 says Yahuah, the Elohim of Armies; 
 \q2 “and they will afflict you from the entrance of Hamath to the brook of the Arabah.” 
 \c 7
 \p
-\v 1 Thus the Lord Yahweh showed me: behold, he formed locusts in the beginning of the shooting up of the latter growth; and behold, it was the latter growth after the king’s harvest. 
-\v 2 When they finished eating the grass of the land, then I said, “Lord Yahweh, forgive, I beg you! How could Jacob stand? For he is small.” 
+\v 1 Thus the Lord Yahuah showed me: behold, he formed locusts in the beginning of the shooting up of the latter growth; and behold, it was the latter growth after the king’s harvest. 
+\v 2 When they finished eating the grass of the land, then I said, “Lord Yahuah, forgive, I beg you! How could Jacob stand? For he is small.” 
 \p
-\v 3 Yahweh relented concerning this. “It shall not be,” says Yahweh. 
+\v 3 Yahuah relented concerning this. “It shall not be,” says Yahuah. 
 \p
-\v 4 Thus the Lord Yahweh showed me: behold, the Lord Yahweh called for judgment by fire; and it dried up the great deep, and would have devoured the land. 
-\v 5 Then I said, “Lord Yahweh, stop, I beg you! How could Jacob stand? For he is small.” 
+\v 4 Thus the Lord Yahuah showed me: behold, the Lord Yahuah called for judgment by fire; and it dried up the great deep, and would have devoured the land. 
+\v 5 Then I said, “Lord Yahuah, stop, I beg you! How could Jacob stand? For he is small.” 
 \p
-\v 6 Yahweh relented concerning this. “This also shall not be,” says the Lord Yahweh. 
+\v 6 Yahuah relented concerning this. “This also shall not be,” says the Lord Yahuah. 
 \p
 \v 7 Thus he showed me: behold, the Lord stood beside a wall made by a plumb line, with a plumb line in his hand. 
-\v 8 Yahweh said to me, “Amos, what do you see?” 
+\v 8 Yahuah said to me, “Amos, what do you see?” 
 \p I said, “A plumb line.” 
 \p Then the Lord said, “Behold, I will set a plumb line in the middle of my people Israel. I will not again pass by them any more. 
 \v 9 The high places of Isaac will be desolate, the sanctuaries of Israel will be laid waste; and I will rise against the house of Jeroboam with the sword.” 
@@ -448,20 +448,20 @@
 \v 13 but don’t prophesy again any more at Bethel; for it is the king’s sanctuary, and it is a royal house!” 
 \p
 \v 14 Then Amos answered Amaziah, “I was no prophet, neither was I a prophet’s son, but I was a herdsman, and a farmer of sycamore figs; 
-\v 15 and Yahweh took me from following the flock, and Yahweh said to me, ‘Go, prophesy to my people Israel.’ 
-\v 16 Now therefore listen to Yahweh’s word: ‘You say, Don’t prophesy against Israel, and don’t preach against the house of Isaac.’ 
-\v 17 Therefore Yahweh says: ‘Your woman shall be a prostitute in the city, and your sons and your daughters shall fall by the sword, and your land shall be divided by line; and you yourself shall die in a land that is unclean, and Israel shall surely be led away captive out of his land.’ ” 
+\v 15 and Yahuah took me from following the flock, and Yahuah said to me, ‘Go, prophesy to my people Israel.’ 
+\v 16 Now therefore listen to Yahuah’s word: ‘You say, Don’t prophesy against Israel, and don’t preach against the house of Isaac.’ 
+\v 17 Therefore Yahuah says: ‘Your woman shall be a prostitute in the city, and your sons and your daughters shall fall by the sword, and your land shall be divided by line; and you yourself shall die in a land that is unclean, and Israel shall surely be led away captive out of his land.’ ” 
 \c 8
 \p
-\v 1 Thus the Lord Yahweh showed me: behold, a basket of summer fruit. 
+\v 1 Thus the Lord Yahuah showed me: behold, a basket of summer fruit. 
 \p
 \v 2 He said, “Amos, what do you see?” 
 \p I said, “A basket of summer fruit.” 
-\p Then Yahweh said to me, 
+\p Then Yahuah said to me, 
 \q1 “The end has come on my people Israel. 
 \q2 I will not again pass by them any more. 
 \q1
-\v 3 The songs of the temple will be wailing in that day,” says the Lord Yahweh. 
+\v 3 The songs of the temple will be wailing in that day,” says the Lord Yahuah. 
 \q2 “The dead bodies will be many. In every place they will throw them out with silence. 
 \q1
 \v 4 Hear this, you who desire to swallow up the needy, 
@@ -476,7 +476,7 @@
 \q2 and the needy for a pair of sandals, 
 \q2 and sell the sweepings with the wheat?’ ” 
 \q1
-\v 7 Yahweh has sworn by the pride of Jacob, 
+\v 7 Yahuah has sworn by the pride of Jacob, 
 \q2 “Surely I will never forget any of their works. 
 \q1
 \v 8 Won’t the land tremble for this, 
@@ -484,7 +484,7 @@
 \q1 Yes, it will rise up wholly like the River; 
 \q2 and it will be stirred up and sink again, like the River of Egypt. 
 \q1
-\v 9 It will happen in that day,” says the Lord Yahweh, 
+\v 9 It will happen in that day,” says the Lord Yahuah, 
 \q2 “that I will cause the sun to go down at noon, 
 \q2 and I will darken the earth in the clear day. 
 \q1
@@ -495,15 +495,15 @@
 \q1 I will make it like the mourning for an only son, 
 \q2 and its end like a bitter day. 
 \q1
-\v 11 Behold, the days come,” says the Lord Yahweh, 
+\v 11 Behold, the days come,” says the Lord Yahuah, 
 \q2 “that I will send a famine in the land, 
 \q2 not a famine of bread, 
 \q2 nor a thirst for water, 
-\q2 but of hearing Yahweh’s words. 
+\q2 but of hearing Yahuah’s words. 
 \q1
 \v 12 They will wander from sea to sea, 
 \q2 and from the north even to the east; 
-\q2 they will run back and forth to seek Yahweh’s word, 
+\q2 they will run back and forth to seek Yahuah’s word, 
 \q2 and will not find it. 
 \q1
 \v 13 In that day the beautiful virgins 
@@ -519,16 +519,16 @@
 \v 2 Though they dig into Sheol, there my hand will take them; and though they climb up to heaven, there I will bring them down. 
 \v 3 Though they hide themselves in the top of Carmel, I will search and take them out from there; and though they be hidden from my sight in the bottom of the sea, there I will command the serpent, and it will bite them. 
 \v 4 Though they go into captivity before their enemies, there I will command the sword, and it will kill them. I will set my eyes on them for evil, and not for good. 
-\v 5 For the Lord, Yahweh of Armies, is he who touches the land and it melts, and all who dwell in it will mourn; and it will rise up wholly like the River, and will sink again, like the River of Egypt. 
-\v 6 It is he who builds his rooms in the heavens, and has founded his vault on the earth; he who calls for the waters of the sea, and pours them out on the surface of the earth—Yahweh is his name. 
-\v 7 Are you not like the children of the Ethiopians to me, children of Israel?” says Yahweh. “Haven’t I brought up Israel out of the land of Egypt, and the Philistines from Caphtor, and the Syrians from Kir? 
-\v 8 Behold, the eyes of the Lord Yahweh are on the sinful kingdom, and I will destroy it from off the surface of the earth, except that I will not utterly destroy the house of Jacob,” says Yahweh. 
+\v 5 For the Lord, Yahuah of Armies, is he who touches the land and it melts, and all who dwell in it will mourn; and it will rise up wholly like the River, and will sink again, like the River of Egypt. 
+\v 6 It is he who builds his rooms in the heavens, and has founded his vault on the earth; he who calls for the waters of the sea, and pours them out on the surface of the earth—Yahuah is his name. 
+\v 7 Are you not like the children of the Ethiopians to me, children of Israel?” says Yahuah. “Haven’t I brought up Israel out of the land of Egypt, and the Philistines from Caphtor, and the Syrians from Kir? 
+\v 8 Behold, the eyes of the Lord Yahuah are on the sinful kingdom, and I will destroy it from off the surface of the earth, except that I will not utterly destroy the house of Jacob,” says Yahuah. 
 \v 9 “For behold, I will command, and I will sift the house of Israel among all the nations as grain is sifted in a sieve, yet not the least kernel will fall on the earth. 
 \v 10 All the sinners of my people will die by the sword, who say, ‘Evil won’t overtake nor meet us.’ 
 \v 11 In that day I will raise up the tent of David who is fallen and close up its breaches, and I will raise up its ruins, and I will build it as in the days of old, 
-\v 12 that they may possess the remnant of Edom and all the nations who are called by my name,” says Yahweh who does this. 
+\v 12 that they may possess the remnant of Edom and all the nations who are called by my name,” says Yahuah who does this. 
 \q1
-\v 13 “Behold, the days come,” says Yahweh, 
+\v 13 “Behold, the days come,” says Yahuah, 
 \q2 “that the plowman shall overtake the reaper, 
 \q2 and the one treading grapes him who sows seed; 
 \q2 and sweet wine will drip from the mountains, 
@@ -542,4 +542,4 @@
 \q1
 \v 15 I will plant them on their land, 
 \q2 and they will no more be plucked up out of their land which I have given them,” 
-\q2 says Yahweh your Elohim. 
+\q2 says Yahuah your Elohim. 

--- a/usfm/daniel.usfm
+++ b/usfm/daniel.usfm
@@ -425,10 +425,10 @@
 \v 27 I, Daniel, fainted, and was sick for some days. Then I rose up and did the king’s business. I wondered at the vision, but no one understood it. 
 \c 9
 \p
-\v 1 In the first year of Darius the son of Ahasuerus, of the offspring of the Medes, who was made king over the realm of the Chaldeans—\v 2 in the first year of his reign I, Daniel, understood by the books the number of the years about which Yahweh’s word came to Jeremiah the prophet for the accomplishing of the desolations of Jerusalem, even seventy years. 
+\v 1 In the first year of Darius the son of Ahasuerus, of the offspring of the Medes, who was made king over the realm of the Chaldeans—\v 2 in the first year of his reign I, Daniel, understood by the books the number of the years about which Yahuah’s word came to Jeremiah the prophet for the accomplishing of the desolations of Jerusalem, even seventy years. 
 \v 3 I set my face to the Lord Elohim, to seek by prayer and petitions, with fasting and sackcloth and ashes. 
 \p
-\v 4 I prayed to Yahweh my Elohim, and made confession, and said, 
+\v 4 I prayed to Yahuah my Elohim, and made confession, and said, 
 \pi1 “Oh, Lord, the great and dreadful Elohim, who keeps covenant and loving kindness with those who love him and keep his commandments, 
 \v 5 we have sinned, and have dealt perversely, and have done wickedly, and have rebelled, even turning aside from your precepts and from your ordinances. 
 \v 6 We haven’t listened to your servants the prophets, who spoke in your name to our kings, our princes, and our fathers, and to all the people of the land. 
@@ -436,12 +436,12 @@
 \v 7 “Lord, righteousness belongs to you, but to us confusion of face, as it is today; to the men of Judah, and to the inhabitants of Jerusalem, and to all Israel, who are near and who are far off, through all the countries where you have driven them, because of their trespass that they have trespassed against you. 
 \v 8 Lord, to us belongs confusion of face, to our kings, to our princes, and to our fathers, because we have sinned against you. 
 \v 9 To the Lord our Elohim belong mercies and forgiveness, for we have rebelled against him. 
-\v 10 We haven’t obeyed Yahweh our Elohim’s voice, to walk in his laws, which he set before us by his servants the prophets. 
+\v 10 We haven’t obeyed Yahuah our Elohim’s voice, to walk in his laws, which he set before us by his servants the prophets. 
 \v 11 Yes, all Israel have transgressed your law, turning aside, that they should not obey your voice. 
 \pi1 “Therefore the curse and the oath written in the law of Moses the servant of Elohim has been poured out on us, for we have sinned against him. 
 \v 12 He has confirmed his words, which he spoke against us and against our judges who judged us, by bringing on us a great evil; for under the whole sky, such has not been done as has been done to Jerusalem. 
-\v 13 As it is written in the law of Moses, all this evil has come on us. Yet we have not entreated the favor of Yahweh our Elohim, that we should turn from our iniquities and have discernment in your truth. 
-\v 14 Therefore Yahweh has watched over the evil, and brought it on us; for Yahweh our Elohim is righteous in all his works which he does, and we have not obeyed his voice. 
+\v 13 As it is written in the law of Moses, all this evil has come on us. Yet we have not entreated the favor of Yahuah our Elohim, that we should turn from our iniquities and have discernment in your truth. 
+\v 14 Therefore Yahuah has watched over the evil, and brought it on us; for Yahuah our Elohim is righteous in all his works which he does, and we have not obeyed his voice. 
 \pi1
 \v 15 “Now, Lord our Elohim, who has brought your people out of the land of Egypt with a mighty hand, and have gotten yourself renown, as it is today, we have sinned. We have done wickedly. 
 \v 16 Lord, according to all your righteousness, please let your anger and your wrath be turned away from your city Jerusalem, your set-apart mountain; because for our sins and for the iniquities of our fathers, Jerusalem and your people have become a reproach to all who are around us. 
@@ -451,7 +451,7 @@
 \v 19 Lord, hear. Lord, forgive. Lord, listen and do. Don’t defer, for your own sake, my Elohim, because your city and your people are called by your name.” 
 \b
 \p
-\v 20 While I was speaking, praying, and confessing my sin and the sin of my people Israel, and presenting my supplication before Yahweh my Elohim for the set-apart mountain of my Elohim—\v 21 yes, while I was speaking in prayer—the man Gabriel, whom I had seen in the vision at the beginning, being caused to fly swiftly, touched me about the time of the evening offering. 
+\v 20 While I was speaking, praying, and confessing my sin and the sin of my people Israel, and presenting my supplication before Yahuah my Elohim for the set-apart mountain of my Elohim—\v 21 yes, while I was speaking in prayer—the man Gabriel, whom I had seen in the vision at the beginning, being caused to fly swiftly, touched me about the time of the evening offering. 
 \v 22 He instructed me and talked with me, and said, “Daniel, I have now come to give you wisdom and understanding. 
 \v 23 At the beginning of your petitions the commandment went out, and I have come to tell you, for you are greatly beloved. Therefore consider the matter and understand the vision. 
 \p

--- a/usfm/deuteronomy.usfm
+++ b/usfm/deuteronomy.usfm
@@ -5,16 +5,16 @@
 \p
 \v 1 These are the words which Moses spoke to all Israel beyond the Jordan in the wilderness, in the Arabah opposite Suf, between Paran, Tophel, Laban, Hazeroth, and Dizahab. 
 \v 2 It is eleven days’ journey from Horeb by the way of Mount Seir to Kadesh Barnea. 
-\v 3 In the fortieth year, in the eleventh month, on the first day of the month, Moses spoke to the children of Israel according to all that Yahweh had given him in commandment to them, 
+\v 3 In the fortieth year, in the eleventh month, on the first day of the month, Moses spoke to the children of Israel according to all that Yahuah had given him in commandment to them, 
 \v 4 after he had struck Sihon the king of the Amorites who lived in Heshbon, and Og the king of Bashan who lived in Ashtaroth, at Edrei. 
 \v 5 Beyond the Jordan, in the land of Moab, Moses began to declare this law, saying, 
-\v 6 “Yahweh our Elohim spoke to us in Horeb, saying, ‘You have lived long enough at this mountain. 
+\v 6 “Yahuah our Elohim spoke to us in Horeb, saying, ‘You have lived long enough at this mountain. 
 \v 7 Turn, and take your journey, and go to the hill country of the Amorites and to all the places near there: in the Arabah, in the hill country, in the lowland, in the South, by the seashore, in the land of the Canaanites, and in Lebanon as far as the great river, the river Euphrates. 
-\v 8 Behold, I have set the land before you. Go in and possess the land which Yahweh swore to your fathers—to Abraham, to Isaac, and to Jacob—to give to them and to their offspring after them.’ ” 
+\v 8 Behold, I have set the land before you. Go in and possess the land which Yahuah swore to your fathers—to Abraham, to Isaac, and to Jacob—to give to them and to their offspring after them.’ ” 
 \p
 \v 9 I spoke to you at that time, saying, “I am not able to bear you myself alone. 
-\v 10 Yahweh your Elohim has multiplied you, and behold, you are today as the stars of the sky for multitude. 
-\v 11 May Yahweh, the Elohim of your fathers, make you a thousand times as many as you are and bless you, as he has promised you! 
+\v 10 Yahuah your Elohim has multiplied you, and behold, you are today as the stars of the sky for multitude. 
+\v 11 May Yahuah, the Elohim of your fathers, make you a thousand times as many as you are and bless you, as he has promised you! 
 \v 12 How can I myself alone bear your problems, your burdens, and your strife? 
 \v 13 Take wise men of understanding who are respected among your tribes, and I will make them heads over you.” 
 \p
@@ -23,74 +23,74 @@
 \v 16 I commanded your judges at that time, saying, “Hear cases between your brothers and judge righteously between a man and his brother, and the foreigner who is living with him. 
 \v 17 You shall not show partiality in judgment; you shall hear the small and the great alike. You shall not be afraid of the face of man, for the judgment is Elohim’s. The case that is too hard for you, you shall bring to me, and I will hear it.” 
 \v 18 I commanded you at that time all the things which you should do. 
-\v 19 We traveled from Horeb and went through all that great and terrible wilderness which you saw, by the way to the hill country of the Amorites, as Yahweh our Elohim commanded us; and we came to Kadesh Barnea. 
-\v 20 I said to you, “You have come to the hill country of the Amorites, which Yahweh our Elohim gives to us. 
-\v 21 Behold, Yahweh your Elohim has set the land before you. Go up, take possession, as Yahweh the Elohim of your fathers has spoken to you. Don’t be afraid, neither be dismayed.” 
+\v 19 We traveled from Horeb and went through all that great and terrible wilderness which you saw, by the way to the hill country of the Amorites, as Yahuah our Elohim commanded us; and we came to Kadesh Barnea. 
+\v 20 I said to you, “You have come to the hill country of the Amorites, which Yahuah our Elohim gives to us. 
+\v 21 Behold, Yahuah your Elohim has set the land before you. Go up, take possession, as Yahuah the Elohim of your fathers has spoken to you. Don’t be afraid, neither be dismayed.” 
 \p
 \v 22 You came near to me, everyone of you, and said, “Let’s send men before us, that they may search the land for us, and bring back to us word of the way by which we must go up, and the cities to which we shall come.” 
 \p
 \v 23 The thing pleased me well. I took twelve of your men, one man for every tribe. 
 \v 24 They turned and went up into the hill country, and came to the valley of Eshcol, and spied it out. 
-\v 25 They took some of the fruit of the land in their hands and brought it down to us, and brought us word again, and said, “It is a good land which Yahweh our Elohim gives to us.” 
+\v 25 They took some of the fruit of the land in their hands and brought it down to us, and brought us word again, and said, “It is a good land which Yahuah our Elohim gives to us.” 
 \p
-\v 26 Yet you wouldn’t go up, but rebelled against the commandment of Yahweh your Elohim. 
-\v 27 You murmured in your tents, and said, “Because Yahweh hated us, he has brought us out of the land of Egypt, to deliver us into the hand of the Amorites to destroy us. 
+\v 26 Yet you wouldn’t go up, but rebelled against the commandment of Yahuah your Elohim. 
+\v 27 You murmured in your tents, and said, “Because Yahuah hated us, he has brought us out of the land of Egypt, to deliver us into the hand of the Amorites to destroy us. 
 \v 28 Where are we going up? Our brothers have made our heart melt, saying, ‘The people are greater and taller than we. The cities are great and fortified up to the sky. Moreover we have seen the sons of the Anakim there!’ ” 
 \p
 \v 29 Then I said to you, “Don’t be terrified. Don’t be afraid of them. 
-\v 30 Yahweh your Elohim, who goes before you, he will fight for you, according to all that he did for you in Egypt before your eyes, 
-\v 31 and in the wilderness where you have seen how that Yahweh your Elohim carried you, as a man carries his son, in all the way that you went, until you came to this place.” 
+\v 30 Yahuah your Elohim, who goes before you, he will fight for you, according to all that he did for you in Egypt before your eyes, 
+\v 31 and in the wilderness where you have seen how that Yahuah your Elohim carried you, as a man carries his son, in all the way that you went, until you came to this place.” 
 \p
-\v 32 Yet in this thing you didn’t believe Yahweh your Elohim, 
+\v 32 Yet in this thing you didn’t believe Yahuah your Elohim, 
 \v 33 who went before you on the way, to seek out a place for you to pitch your tents in: in fire by night, to show you by what way you should go, and in the cloud by day. 
-\v 34 Yahweh heard the voice of your words and was angry, and swore, saying, 
+\v 34 Yahuah heard the voice of your words and was angry, and swore, saying, 
 \v 35 “Surely not one of these men of this evil generation shall see the good land which I swore to give to your fathers, 
-\v 36 except Caleb the son of Jephunneh. He shall see it. I will give the land that he has trodden on to him and to his children, because he has wholly followed Yahweh.” 
+\v 36 except Caleb the son of Jephunneh. He shall see it. I will give the land that he has trodden on to him and to his children, because he has wholly followed Yahuah.” 
 \p
-\v 37 Also Yahweh was angry with me for your sakes, saying, “You also shall not go in there. 
+\v 37 Also Yahuah was angry with me for your sakes, saying, “You also shall not go in there. 
 \v 38 Joshua the son of Nun, who stands before you, shall go in there. Encourage him, for he shall cause Israel to inherit it. 
 \v 39 Moreover your little ones, whom you said would be captured or killed, your children, who today have no knowledge of good or evil, shall go in there. I will give it to them, and they shall possess it. 
 \v 40 But as for you, turn, and take your journey into the wilderness by the way to the Red Sea.” 
 \p
-\v 41 Then you answered and said to me, “We have sinned against Yahweh. We will go up and fight, according to all that Yahweh our Elohim commanded us.” Every man of you put on his weapons of war, and presumed to go up into the hill country. 
+\v 41 Then you answered and said to me, “We have sinned against Yahuah. We will go up and fight, according to all that Yahuah our Elohim commanded us.” Every man of you put on his weapons of war, and presumed to go up into the hill country. 
 \p
-\v 42 Yahweh said to me, “Tell them, ‘Don’t go up and don’t fight; for I am not among you, lest you be struck before your enemies.’ ” 
+\v 42 Yahuah said to me, “Tell them, ‘Don’t go up and don’t fight; for I am not among you, lest you be struck before your enemies.’ ” 
 \p
-\v 43 So I spoke to you, and you didn’t listen; but you rebelled against the commandment of Yahweh, and were presumptuous, and went up into the hill country. 
+\v 43 So I spoke to you, and you didn’t listen; but you rebelled against the commandment of Yahuah, and were presumptuous, and went up into the hill country. 
 \v 44 The Amorites, who lived in that hill country, came out against you and chased you as bees do, and beat you down in Seir, even to Hormah. 
-\v 45 You returned and wept before Yahweh, but Yahweh didn’t listen to your voice, nor turn his ear to you. 
+\v 45 You returned and wept before Yahuah, but Yahuah didn’t listen to your voice, nor turn his ear to you. 
 \v 46 So you stayed in Kadesh many days, according to the days that you remained. 
 \c 2
 \p
-\v 1 Then we turned, and took our journey into the wilderness by the way to the Red Sea, as Yahweh spoke to me; and we encircled Mount Seir many days. 
+\v 1 Then we turned, and took our journey into the wilderness by the way to the Red Sea, as Yahuah spoke to me; and we encircled Mount Seir many days. 
 \p
-\v 2 Yahweh spoke to me, saying, 
+\v 2 Yahuah spoke to me, saying, 
 \v 3 “You have encircled this mountain long enough. Turn northward. 
 \v 4 Command the people, saying, ‘You are to pass through the border of your brothers, the children of Esau, who dwell in Seir; and they will be afraid of you. Therefore be careful. 
 \v 5 Don’t contend with them; for I will not give you any of their land, no, not so much as for the sole of the foot to tread on, because I have given Mount Seir to Esau for a possession. 
 \v 6 You shall purchase food from them for money, that you may eat. You shall also buy water from them for money, that you may drink.’ ” 
 \p
-\v 7 For Yahweh your Elohim has blessed you in all the work of your hands. He has known your walking through this great wilderness. These forty years, Yahweh your Elohim has been with you. You have lacked nothing. 
+\v 7 For Yahuah your Elohim has blessed you in all the work of your hands. He has known your walking through this great wilderness. These forty years, Yahuah your Elohim has been with you. You have lacked nothing. 
 \p
 \v 8 So we passed by from our brothers, the children of Esau, who dwell in Seir, from the way of the Arabah from Elath and from Ezion Geber. We turned and passed by the way of the wilderness of Moab. 
 \p
-\v 9 Yahweh said to me, “Don’t bother Moab, neither contend with them in battle; for I will not give you any of his land for a possession, because I have given Ar to the children of Lot for a possession.” 
+\v 9 Yahuah said to me, “Don’t bother Moab, neither contend with them in battle; for I will not give you any of his land for a possession, because I have given Ar to the children of Lot for a possession.” 
 \p
 \v 10 (The Emim lived there before, a great and numerous people, and tall as the Anakim. 
 \v 11 These also are considered to be Rephaim, as the Anakim; but the Moabites call them Emim. 
-\v 12 The Horites also lived in Seir in the past, but the children of Esau succeeded them. They destroyed them from before them, and lived in their place, as Israel did to the land of his possession, which Yahweh gave to them.) 
+\v 12 The Horites also lived in Seir in the past, but the children of Esau succeeded them. They destroyed them from before them, and lived in their place, as Israel did to the land of his possession, which Yahuah gave to them.) 
 \p
 \v 13 “Now rise up and cross over the brook Zered.” We went over the brook Zered. 
 \p
-\v 14 The days in which we came from Kadesh Barnea until we had come over the brook Zered were thirty-eight years, until all the generation of the men of war were consumed from the middle of the camp, as Yahweh swore to them. 
-\v 15 Moreover Yahweh’s hand was against them, to destroy them from the middle of the camp, until they were consumed. 
+\v 14 The days in which we came from Kadesh Barnea until we had come over the brook Zered were thirty-eight years, until all the generation of the men of war were consumed from the middle of the camp, as Yahuah swore to them. 
+\v 15 Moreover Yahuah’s hand was against them, to destroy them from the middle of the camp, until they were consumed. 
 \v 16 So, when all the men of war were consumed and dead from among the people, 
-\v 17 Yahweh spoke to me, saying, 
+\v 17 Yahuah spoke to me, saying, 
 \v 18 “You are to pass over Ar, the border of Moab, today. 
 \v 19 When you come near the border of the children of Ammon, don’t bother them, nor contend with them; for I will not give you any of the land of the children of Ammon for a possession, because I have given it to the children of Lot for a possession.” 
 \p
 \v 20 (That also is considered a land of Rephaim. Rephaim lived there in the past, but the Ammonites call them Zamzummim, 
-\v 21 a great people, many, and tall, as the Anakim; but Yahweh destroyed them from before Israel, and they succeeded them, and lived in their place, 
+\v 21 a great people, many, and tall, as the Anakim; but Yahuah destroyed them from before Israel, and they succeeded them, and lived in their place, 
 \v 22 as he did for the children of Esau who dwell in Seir, when he destroyed the Horites from before them; and they succeeded them, and lived in their place even to this day. 
 \v 23 Then the Avvim, who lived in villages as far as Gaza: the Caphtorim, who came out of Caphtor, destroyed them and lived in their place.) 
 \p
@@ -100,22 +100,22 @@
 \v 26 I sent messengers out of the wilderness of Kedemoth to Sihon king of Heshbon with words of peace, saying, 
 \v 27 “Let me pass through your land. I will go along by the highway. I will turn neither to the right hand nor to the left. 
 \v 28 You shall sell me food for money, that I may eat; and give me water for money, that I may drink. Just let me pass through on my feet, 
-\v 29 as the children of Esau who dwell in Seir, and the Moabites who dwell in Ar, did to me, until I pass over the Jordan into the land which Yahweh our Elohim gives us.” 
-\v 30 But Sihon king of Heshbon would not let us pass by him, for Yahweh your Elohim hardened his spirit and made his heart obstinate, that he might deliver him into your hand, as it is today. 
+\v 29 as the children of Esau who dwell in Seir, and the Moabites who dwell in Ar, did to me, until I pass over the Jordan into the land which Yahuah our Elohim gives us.” 
+\v 30 But Sihon king of Heshbon would not let us pass by him, for Yahuah your Elohim hardened his spirit and made his heart obstinate, that he might deliver him into your hand, as it is today. 
 \p
-\v 31 Yahweh said to me, “Behold, I have begun to deliver up Sihon and his land before you. Begin to possess, that you may inherit his land.” 
+\v 31 Yahuah said to me, “Behold, I have begun to deliver up Sihon and his land before you. Begin to possess, that you may inherit his land.” 
 \v 32 Then Sihon came out against us, he and all his people, to battle at Jahaz. 
-\v 33 Yahweh our Elohim delivered him up before us; and we struck him, his sons, and all his people. 
+\v 33 Yahuah our Elohim delivered him up before us; and we struck him, his sons, and all his people. 
 \v 34 We took all his cities at that time, and utterly destroyed every inhabited city, with the women and the little ones. We left no one remaining. 
 \v 35 Only the livestock we took for plunder for ourselves, with the plunder of the cities which we had taken. 
-\v 36 From Aroer, which is on the edge of the valley of the Arnon, and the city that is in the valley, even to Gilead, there was not a city too high for us. Yahweh our Elohim delivered up all before us. 
-\v 37 Only to the land of the children of Ammon you didn’t come near: all the banks of the river Jabbok, and the cities of the hill country, and wherever Yahweh our Elohim forbade us. 
+\v 36 From Aroer, which is on the edge of the valley of the Arnon, and the city that is in the valley, even to Gilead, there was not a city too high for us. Yahuah our Elohim delivered up all before us. 
+\v 37 Only to the land of the children of Ammon you didn’t come near: all the banks of the river Jabbok, and the cities of the hill country, and wherever Yahuah our Elohim forbade us. 
 \c 3
 \p
 \v 1 Then we turned, and went up the way to Bashan. Og the king of Bashan came out against us, he and all his people, to battle at Edrei. 
-\v 2 Yahweh said to me, “Don’t fear him; for I have delivered him, with all his people and his land, into your hand. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
+\v 2 Yahuah said to me, “Don’t fear him; for I have delivered him, with all his people and his land, into your hand. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
 \p
-\v 3 So Yahweh our Elohim also delivered into our hand Og, the king of Bashan, and all his people. We struck him until no one was left to him remaining. 
+\v 3 So Yahuah our Elohim also delivered into our hand Og, the king of Bashan, and all his people. We struck him until no one was left to him remaining. 
 \v 4 We took all his cities at that time. There was not a city which we didn’t take from them: sixty cities, all the region of Argob, the kingdom of Og in Bashan. 
 \v 5 All these were cities fortified with high walls, gates, and bars, in addition to a great many villages without walls. 
 \v 6 We utterly destroyed them, as we did to Sihon king of Heshbon, utterly destroying every inhabited city, with the women and the little ones. 
@@ -131,63 +131,63 @@
 \v 16 To the Reubenites and to the Gadites I gave from Gilead even to the valley of the Arnon, the middle of the valley, and its border, even to the river Jabbok, which is the border of the children of Ammon; 
 \v 17 the Arabah also, and the Jordan and its border, from Chinnereth even to the sea of the Arabah, the Salt Sea, under the slopes of Pisgah eastward. 
 \p
-\v 18 I commanded you at that time, saying, “Yahweh your Elohim has given you this land to possess it. All of you men of valor shall pass over armed before your brothers, the children of Israel. 
+\v 18 I commanded you at that time, saying, “Yahuah your Elohim has given you this land to possess it. All of you men of valor shall pass over armed before your brothers, the children of Israel. 
 \v 19 But your women, and your little ones, and your livestock, (I know that you have much livestock), shall live in your cities which I have given you, 
-\v 20 until Yahweh gives rest to your brothers, as to you, and they also possess the land which Yahweh your Elohim gives them beyond the Jordan. Then you shall each return to his own possession, which I have given you.” 
+\v 20 until Yahuah gives rest to your brothers, as to you, and they also possess the land which Yahuah your Elohim gives them beyond the Jordan. Then you shall each return to his own possession, which I have given you.” 
 \p
-\v 21 I commanded Joshua at that time, saying, “Your eyes have seen all that Yahweh your Elohim has done to these two kings. So shall Yahweh do to all the kingdoms where you go over. 
-\v 22 You shall not fear them; for Yahweh your Elohim himself fights for you.” 
+\v 21 I commanded Joshua at that time, saying, “Your eyes have seen all that Yahuah your Elohim has done to these two kings. So shall Yahuah do to all the kingdoms where you go over. 
+\v 22 You shall not fear them; for Yahuah your Elohim himself fights for you.” 
 \p
-\v 23 I begged Yahweh at that time, saying, 
-\v 24 “Lord Yahweh, you have begun to show your servant your greatness, and your strong hand. For what elohim is there in heaven or in earth that can do works like yours, and mighty acts like yours? 
+\v 23 I begged Yahuah at that time, saying, 
+\v 24 “Lord Yahuah, you have begun to show your servant your greatness, and your strong hand. For what elohim is there in heaven or in earth that can do works like yours, and mighty acts like yours? 
 \v 25 Please let me go over and see the good land that is beyond the Jordan, that fine mountain, and Lebanon.” 
 \p
-\v 26 But Yahweh was angry with me because of you, and didn’t listen to me. Yahweh said to me, “That is enough! Speak no more to me of this matter. 
+\v 26 But Yahuah was angry with me because of you, and didn’t listen to me. Yahuah said to me, “That is enough! Speak no more to me of this matter. 
 \v 27 Go up to the top of Pisgah, and lift up your eyes westward, and northward, and southward, and eastward, and see with your eyes; for you shall not go over this Jordan. 
 \v 28 But commission Joshua, and encourage him, and strengthen him; for he shall go over before this people, and he shall cause them to inherit the land which you shall see.” 
 \v 29 So we stayed in the valley near Beth Peor. 
 \c 4
 \p
-\v 1 Now, Israel, listen to the statutes and to the ordinances which I teach you, to do them, that you may live and go in and possess the land which Yahweh, the Elohim of your fathers, gives you. 
-\v 2 You shall not add to the word which I command you, neither shall you take away from it, that you may keep the commandments of Yahweh your Elohim which I command you. 
-\v 3 Your eyes have seen what Yahweh did because of Baal Peor; for Yahweh your Elohim has destroyed all the men who followed Baal Peor from among you. 
-\v 4 But you who were faithful to Yahweh your Elohim are all alive today. 
-\v 5 Behold, I have taught you statutes and ordinances, even as Yahweh my Elohim commanded me, that you should do so in the middle of the land where you go in to possess it. 
+\v 1 Now, Israel, listen to the statutes and to the ordinances which I teach you, to do them, that you may live and go in and possess the land which Yahuah, the Elohim of your fathers, gives you. 
+\v 2 You shall not add to the word which I command you, neither shall you take away from it, that you may keep the commandments of Yahuah your Elohim which I command you. 
+\v 3 Your eyes have seen what Yahuah did because of Baal Peor; for Yahuah your Elohim has destroyed all the men who followed Baal Peor from among you. 
+\v 4 But you who were faithful to Yahuah your Elohim are all alive today. 
+\v 5 Behold, I have taught you statutes and ordinances, even as Yahuah my Elohim commanded me, that you should do so in the middle of the land where you go in to possess it. 
 \v 6 Keep therefore and do them; for this is your wisdom and your understanding in the sight of the peoples who shall hear all these statutes and say, “Surely this great nation is a wise and understanding people.” 
-\v 7 For what great nation is there that has an elohim so near to them as Yahweh our Elohim is whenever we call on him? 
+\v 7 For what great nation is there that has an elohim so near to them as Yahuah our Elohim is whenever we call on him? 
 \v 8 What great nation is there that has statutes and ordinances so righteous as all this law which I set before you today? 
 \p
-\v 9 Only be careful, and keep your soul diligently, lest you forget the things which your eyes saw, and lest they depart from your heart all the days of your life; but make them known to your children and your children’s children—\v 10 the day that you stood before Yahweh your Elohim in Horeb, when Yahweh said to me, “Assemble the people to me, and I will make them hear my words, that they may learn to fear me all the days that they live on the earth, and that they may teach their children.” 
+\v 9 Only be careful, and keep your soul diligently, lest you forget the things which your eyes saw, and lest they depart from your heart all the days of your life; but make them known to your children and your children’s children—\v 10 the day that you stood before Yahuah your Elohim in Horeb, when Yahuah said to me, “Assemble the people to me, and I will make them hear my words, that they may learn to fear me all the days that they live on the earth, and that they may teach their children.” 
 \v 11 You came near and stood under the mountain. The mountain burned with fire to the heart of the sky, with darkness, cloud, and thick darkness. 
-\v 12 Yahweh spoke to you out of the middle of the fire: you heard the voice of words, but you saw no form; you only heard a voice. 
+\v 12 Yahuah spoke to you out of the middle of the fire: you heard the voice of words, but you saw no form; you only heard a voice. 
 \v 13 He declared to you his covenant, which he commanded you to perform, even the ten commandments. He wrote them on two stone tablets. 
-\v 14 Yahweh commanded me at that time to teach you statutes and ordinances, that you might do them in the land where you go over to possess it. 
-\v 15 Be very careful, for you saw no kind of form on the day that Yahweh spoke to you in Horeb out of the middle of the fire, 
+\v 14 Yahuah commanded me at that time to teach you statutes and ordinances, that you might do them in the land where you go over to possess it. 
+\v 15 Be very careful, for you saw no kind of form on the day that Yahuah spoke to you in Horeb out of the middle of the fire, 
 \v 16 lest you corrupt yourselves, and make yourself a carved image in the form of any figure, the likeness of male or female, 
 \v 17 the likeness of any animal that is on the earth, the likeness of any winged bird that flies in the sky, 
 \v 18 the likeness of anything that creeps on the ground, the likeness of any fish that is in the water under the earth; 
-\v 19 and lest you lift up your eyes to the sky, and when you see the sun and the moon and the stars, even all the army of the sky, you are drawn away and worship them, and serve them, which Yahweh your Elohim has allotted to all the peoples under the whole sky. 
-\v 20 But Yahweh has taken you, and brought you out of the iron furnace, out of Egypt, to be to him a people of inheritance, as it is today. 
-\v 21 Furthermore Yahweh was angry with me for your sakes, and swore that I should not go over the Jordan, and that I should not go in to that good land which Yahweh your Elohim gives you for an inheritance; 
+\v 19 and lest you lift up your eyes to the sky, and when you see the sun and the moon and the stars, even all the army of the sky, you are drawn away and worship them, and serve them, which Yahuah your Elohim has allotted to all the peoples under the whole sky. 
+\v 20 But Yahuah has taken you, and brought you out of the iron furnace, out of Egypt, to be to him a people of inheritance, as it is today. 
+\v 21 Furthermore Yahuah was angry with me for your sakes, and swore that I should not go over the Jordan, and that I should not go in to that good land which Yahuah your Elohim gives you for an inheritance; 
 \v 22 but I must die in this land. I must not go over the Jordan, but you shall go over and possess that good land. 
-\v 23 Be careful, lest you forget the covenant of Yahweh your Elohim, which he made with you, and make yourselves a carved image in the form of anything which Yahweh your Elohim has forbidden you. 
-\v 24 For Yahweh your Elohim is a devouring fire, a jealous Elohim. 
-\v 25 When you father children and children’s children, and you have been long in the land, and then corrupt yourselves, and make a carved image in the form of anything, and do that which is evil in Yahweh your Elohim’s sight to provoke him to anger, 
+\v 23 Be careful, lest you forget the covenant of Yahuah your Elohim, which he made with you, and make yourselves a carved image in the form of anything which Yahuah your Elohim has forbidden you. 
+\v 24 For Yahuah your Elohim is a devouring fire, a jealous Elohim. 
+\v 25 When you father children and children’s children, and you have been long in the land, and then corrupt yourselves, and make a carved image in the form of anything, and do that which is evil in Yahuah your Elohim’s sight to provoke him to anger, 
 \v 26 I call heaven and earth to witness against you today, that you will soon utterly perish from off the land which you go over the Jordan to possess it. You will not prolong your days on it, but will utterly be destroyed. 
-\v 27 Yahweh will scatter you among the peoples, and you will be left few in number among the nations where Yahweh will lead you away. 
+\v 27 Yahuah will scatter you among the peoples, and you will be left few in number among the nations where Yahuah will lead you away. 
 \v 28 There you will serve elohims, the work of men’s hands, wood and stone, which neither see, nor hear, nor eat, nor smell. 
-\v 29 But from there you shall seek Yahweh your Elohim, and you will find him when you search after him with all your heart and with all your soul. 
-\v 30 When you are in oppression, and all these things have come on you, in the latter days you shall return to Yahweh your Elohim and listen to his voice. 
-\v 31 For Yahweh your Elohim is a merciful Elohim. He will not fail you nor destroy you, nor forget the covenant of your fathers which he swore to them. 
+\v 29 But from there you shall seek Yahuah your Elohim, and you will find him when you search after him with all your heart and with all your soul. 
+\v 30 When you are in oppression, and all these things have come on you, in the latter days you shall return to Yahuah your Elohim and listen to his voice. 
+\v 31 For Yahuah your Elohim is a merciful Elohim. He will not fail you nor destroy you, nor forget the covenant of your fathers which he swore to them. 
 \v 32 For ask now of the days that are past, which were before you, since the day that Elohim created man on the earth, and from the one end of the sky to the other, whether there has been anything as great as this thing is, or has been heard like it? 
 \v 33 Did a people ever hear the voice of Elohim speaking out of the middle of the fire, as you have heard, and live? 
-\v 34 Or has Elohim tried to go and take a nation for himself from among another nation, by trials, by signs, by wonders, by war, by a mighty hand, by an outstretched arm, and by great terrors, according to all that Yahweh your Elohim did for you in Egypt before your eyes? 
-\v 35 It was shown to you so that you might know that Yahweh is Elohim. There is no one else besides him. 
+\v 34 Or has Elohim tried to go and take a nation for himself from among another nation, by trials, by signs, by wonders, by war, by a mighty hand, by an outstretched arm, and by great terrors, according to all that Yahuah your Elohim did for you in Egypt before your eyes? 
+\v 35 It was shown to you so that you might know that Yahuah is Elohim. There is no one else besides him. 
 \v 36 Out of heaven he made you to hear his voice, that he might instruct you. On earth he made you to see his great fire; and you heard his words out of the middle of the fire. 
 \v 37 Because he loved your fathers, therefore he chose their offspring after them, and brought you out with his presence, with his great power, out of Egypt; 
 \v 38 to drive out nations from before you greater and mightier than you, to bring you in, to give you their land for an inheritance, as it is today. 
-\v 39 Know therefore today, and take it to heart, that Yahweh himself is Elohim in heaven above and on the earth beneath. There is no one else. 
-\v 40 You shall keep his statutes and his commandments which I command you today, that it may go well with you and with your children after you, and that you may prolong your days in the land which Yahweh your Elohim gives you for all time. 
+\v 39 Know therefore today, and take it to heart, that Yahuah himself is Elohim in heaven above and on the earth beneath. There is no one else. 
+\v 40 You shall keep his statutes and his commandments which I command you today, that it may go well with you and with your children after you, and that you may prolong your days in the land which Yahuah your Elohim gives you for all time. 
 \p
 \v 41 Then Moses set apart three cities beyond the Jordan toward the sunrise, 
 \v 42 that the man slayer might flee there, who kills his neighbor unintentionally and didn’t hate him in time past, and that fleeing to one of these cities he might live: 
@@ -202,27 +202,27 @@
 \c 5
 \p
 \v 1 Moses called to all Israel, and said to them, “Hear, Israel, the statutes and the ordinances which I speak in your ears today, that you may learn them, and observe to do them.” 
-\v 2 Yahweh our Elohim made a covenant with us in Horeb. 
-\v 3 Yahweh didn’t make this covenant with our fathers, but with us, even us, who are all of us here alive today. 
-\v 4 Yahweh spoke with you face to face on the mountain out of the middle of the fire, 
-\v 5 (I stood between Yahweh and you at that time, to show you Yahweh’s word; for you were afraid because of the fire, and didn’t go up onto the mountain) saying, 
+\v 2 Yahuah our Elohim made a covenant with us in Horeb. 
+\v 3 Yahuah didn’t make this covenant with our fathers, but with us, even us, who are all of us here alive today. 
+\v 4 Yahuah spoke with you face to face on the mountain out of the middle of the fire, 
+\v 5 (I stood between Yahuah and you at that time, to show you Yahuah’s word; for you were afraid because of the fire, and didn’t go up onto the mountain) saying, 
 \m
-\v 6 “I am Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
+\v 6 “I am Yahuah your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
 \p
 \v 7 “You shall have no other elohims before me. 
 \p
 \v 8 “You shall not make a carved image for yourself—any likeness of what is in heaven above, or what is in the earth beneath, or that is in the water under the earth. 
-\v 9 You shall not bow yourself down to them, nor serve them, for I, Yahweh your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children and on the third and on the fourth generation of those who hate me 
+\v 9 You shall not bow yourself down to them, nor serve them, for I, Yahuah your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children and on the third and on the fourth generation of those who hate me 
 \v 10 and showing loving kindness to thousands of those who love me and keep my commandments. 
 \p
-\v 11 “You shall not misuse the name of Yahweh your Elohim; for Yahweh will not hold him guiltless who misuses his name. 
+\v 11 “You shall not misuse the name of Yahuah your Elohim; for Yahuah will not hold him guiltless who misuses his name. 
 \p
-\v 12 “Observe the Sabbath day, to keep it set-apart, as Yahweh your Elohim commanded you. 
+\v 12 “Observe the Sabbath day, to keep it set-apart, as Yahuah your Elohim commanded you. 
 \v 13 You shall labor six days, and do all your work; 
-\v 14 but the seventh day is a Sabbath to Yahweh your Elohim, in which you shall not do any work—neither you, nor your son, nor your daughter, nor your male servant, nor your female servant, nor your ox, nor your donkey, nor any of your livestock, nor your stranger who is within your gates; that your male servant and your female servant may rest as well as you. 
-\v 15 You shall remember that you were a servant in the land of Egypt, and Yahweh your Elohim brought you out of there by a mighty hand and by an outstretched arm. Therefore Yahweh your Elohim commanded you to keep the Sabbath day. 
+\v 14 but the seventh day is a Sabbath to Yahuah your Elohim, in which you shall not do any work—neither you, nor your son, nor your daughter, nor your male servant, nor your female servant, nor your ox, nor your donkey, nor any of your livestock, nor your stranger who is within your gates; that your male servant and your female servant may rest as well as you. 
+\v 15 You shall remember that you were a servant in the land of Egypt, and Yahuah your Elohim brought you out of there by a mighty hand and by an outstretched arm. Therefore Yahuah your Elohim commanded you to keep the Sabbath day. 
 \p
-\v 16 “Honor your father and your mother, as Yahweh your Elohim commanded you, that your days may be long and that it may go well with you in the land which Yahweh your Elohim gives you. 
+\v 16 “Honor your father and your mother, as Yahuah your Elohim commanded you, that your days may be long and that it may go well with you in the land which Yahuah your Elohim gives you. 
 \p
 \v 17 “You shall not murder. 
 \p
@@ -234,261 +234,261 @@
 \p
 \v 21 “You shall not desire your neighbor’s woman. Neither shall you desire your neighbor’s house, his field, or his male servant, or his female servant, his ox, or his donkey, or anything that is your neighbor’s.” 
 \p
-\v 22 Yahweh spoke these words to all your assembly on the mountain out of the middle of the fire, of the cloud, and of the thick darkness, with a great voice. He added no more. He wrote them on two stone tablets, and gave them to me. 
+\v 22 Yahuah spoke these words to all your assembly on the mountain out of the middle of the fire, of the cloud, and of the thick darkness, with a great voice. He added no more. He wrote them on two stone tablets, and gave them to me. 
 \v 23 When you heard the voice out of the middle of the darkness, while the mountain was burning with fire, you came near to me, even all the heads of your tribes, and your elders; 
-\v 24 and you said, “Behold, Yahweh our Elohim has shown us his glory and his greatness, and we have heard his voice out of the middle of the fire. We have seen today that Elohim does speak with man, and he lives. 
-\v 25 Now therefore, why should we die? For this great fire will consume us. If we hear Yahweh our Elohim’s voice any more, then we shall die. 
+\v 24 and you said, “Behold, Yahuah our Elohim has shown us his glory and his greatness, and we have heard his voice out of the middle of the fire. We have seen today that Elohim does speak with man, and he lives. 
+\v 25 Now therefore, why should we die? For this great fire will consume us. If we hear Yahuah our Elohim’s voice any more, then we shall die. 
 \v 26 For who is there of all flesh who has heard the voice of the living Elohim speaking out of the middle of the fire, as we have, and lived? 
-\v 27 Go near, and hear all that Yahweh our Elohim shall say, and tell us all that Yahweh our Elohim tells you; and we will hear it, and do it.” 
+\v 27 Go near, and hear all that Yahuah our Elohim shall say, and tell us all that Yahuah our Elohim tells you; and we will hear it, and do it.” 
 \p
-\v 28 Yahweh heard the voice of your words when you spoke to me; and Yahweh said to me, “I have heard the voice of the words of this people which they have spoken to you. They have well said all that they have spoken. 
+\v 28 Yahuah heard the voice of your words when you spoke to me; and Yahuah said to me, “I have heard the voice of the words of this people which they have spoken to you. They have well said all that they have spoken. 
 \v 29 Oh that there were such a heart in them that they would fear me and keep all my commandments always, that it might be well with them and with their children forever! 
 \p
 \v 30 “Go tell them, ‘Return to your tents.’ 
 \v 31 But as for you, stand here by me, and I will tell you all the commandments, and the statutes, and the ordinances, which you shall teach them, that they may do them in the land which I give them to possess.” 
 \p
-\v 32 You shall observe to do therefore as Yahweh your Elohim has commanded you. You shall not turn away to the right hand or to the left. 
-\v 33 You shall walk in all the way which Yahweh your Elohim has commanded you, that you may live and that it may be well with you, and that you may prolong your days in the land which you shall possess. 
+\v 32 You shall observe to do therefore as Yahuah your Elohim has commanded you. You shall not turn away to the right hand or to the left. 
+\v 33 You shall walk in all the way which Yahuah your Elohim has commanded you, that you may live and that it may be well with you, and that you may prolong your days in the land which you shall possess. 
 \c 6
 \p
-\v 1 Now these are the commandments, the statutes, and the ordinances, which Yahweh your Elohim commanded to teach you, that you might do them in the land that you go over to possess; 
-\v 2 that you might fear Yahweh your Elohim, to keep all his statutes and his commandments, which I command you—you, your son, and your son’s son, all the days of your life; and that your days may be prolonged. 
-\v 3 Hear therefore, Israel, and observe to do it, that it may be well with you, and that you may increase mightily, as Yahweh, the Elohim of your fathers, has promised to you, in a land flowing with milk and honey. 
+\v 1 Now these are the commandments, the statutes, and the ordinances, which Yahuah your Elohim commanded to teach you, that you might do them in the land that you go over to possess; 
+\v 2 that you might fear Yahuah your Elohim, to keep all his statutes and his commandments, which I command you—you, your son, and your son’s son, all the days of your life; and that your days may be prolonged. 
+\v 3 Hear therefore, Israel, and observe to do it, that it may be well with you, and that you may increase mightily, as Yahuah, the Elohim of your fathers, has promised to you, in a land flowing with milk and honey. 
 \p
-\v 4 Hear, Israel: Yahweh is our Elohim. Yahweh is one. 
-\v 5 You shall love Yahweh your Elohim with all your heart, with all your soul, and with all your might. 
+\v 4 Hear, Israel: Yahuah is our Elohim. Yahuah is one. 
+\v 5 You shall love Yahuah your Elohim with all your heart, with all your soul, and with all your might. 
 \v 6 These words, which I command you today, shall be on your heart; 
 \v 7 and you shall teach them diligently to your children, and shall talk of them when you sit in your house, and when you walk by the way, and when you lie down, and when you rise up. 
 \v 8 You shall bind them for a sign on your hand, and they shall be for frontlets between your eyes. 
 \v 9 You shall write them on the door posts of your house and on your gates. 
 \p
-\v 10 It shall be, when Yahweh your Elohim brings you into the land which he swore to your fathers, to Abraham, to Isaac, and to Jacob, to give you, great and goodly cities which you didn’t build, 
+\v 10 It shall be, when Yahuah your Elohim brings you into the land which he swore to your fathers, to Abraham, to Isaac, and to Jacob, to give you, great and goodly cities which you didn’t build, 
 \v 11 and houses full of all good things which you didn’t fill, and cisterns dug out which you didn’t dig, vineyards and olive trees which you didn’t plant, and you shall eat and be full; 
-\v 12 then beware lest you forget Yahweh, who brought you out of the land of Egypt, out of the house of bondage. 
-\v 13 You shall fear Yahweh your Elohim; and you shall serve him, and shall swear by his name. 
+\v 12 then beware lest you forget Yahuah, who brought you out of the land of Egypt, out of the house of bondage. 
+\v 13 You shall fear Yahuah your Elohim; and you shall serve him, and shall swear by his name. 
 \v 14 You shall not go after other elohims, of the elohims of the peoples who are around you, 
-\v 15 for Yahweh your Elohim among you is a jealous Elohim, lest the anger of Yahweh your Elohim be kindled against you, and he destroy you from off the face of the earth. 
-\v 16 You shall not tempt Yahweh your Elohim, as you tempted him in Massah. 
-\v 17 You shall diligently keep the commandments of Yahweh your Elohim, and his testimonies, and his statutes, which he has commanded you. 
-\v 18 You shall do that which is right and good in Yahweh’s sight, that it may be well with you and that you may go in and possess the good land which Yahweh swore to your fathers, 
-\v 19 to thrust out all your enemies from before you, as Yahweh has spoken. 
+\v 15 for Yahuah your Elohim among you is a jealous Elohim, lest the anger of Yahuah your Elohim be kindled against you, and he destroy you from off the face of the earth. 
+\v 16 You shall not tempt Yahuah your Elohim, as you tempted him in Massah. 
+\v 17 You shall diligently keep the commandments of Yahuah your Elohim, and his testimonies, and his statutes, which he has commanded you. 
+\v 18 You shall do that which is right and good in Yahuah’s sight, that it may be well with you and that you may go in and possess the good land which Yahuah swore to your fathers, 
+\v 19 to thrust out all your enemies from before you, as Yahuah has spoken. 
 \p
-\v 20 When your son asks you in time to come, saying, “What do the testimonies, the statutes, and the ordinances, which Yahweh our Elohim has commanded you mean?” 
-\v 21 then you shall tell your son, “We were Pharaoh’s slaves in Egypt. Yahweh brought us out of Egypt with a mighty hand; 
-\v 22 and Yahweh showed great and awesome signs and wonders on Egypt, on Pharaoh, and on all his house, before our eyes; 
+\v 20 When your son asks you in time to come, saying, “What do the testimonies, the statutes, and the ordinances, which Yahuah our Elohim has commanded you mean?” 
+\v 21 then you shall tell your son, “We were Pharaoh’s slaves in Egypt. Yahuah brought us out of Egypt with a mighty hand; 
+\v 22 and Yahuah showed great and awesome signs and wonders on Egypt, on Pharaoh, and on all his house, before our eyes; 
 \v 23 and he brought us out from there, that he might bring us in, to give us the land which he swore to our fathers. 
-\v 24 Yahweh commanded us to do all these statutes, to fear Yahweh our Elohim, for our good always, that he might preserve us alive, as we are today. 
-\v 25 It shall be righteousness to us, if we observe to do all these commandments before Yahweh our Elohim, as he has commanded us.” 
+\v 24 Yahuah commanded us to do all these statutes, to fear Yahuah our Elohim, for our good always, that he might preserve us alive, as we are today. 
+\v 25 It shall be righteousness to us, if we observe to do all these commandments before Yahuah our Elohim, as he has commanded us.” 
 \c 7
 \p
-\v 1 When Yahweh your Elohim brings you into the land where you go to possess it, and casts out many nations before you—the Hittite, the Girgashite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite—seven nations greater and mightier than you; 
-\v 2 and when Yahweh your Elohim delivers them up before you, and you strike them, then you shall utterly destroy them. You shall make no covenant with them, nor show mercy to them. 
+\v 1 When Yahuah your Elohim brings you into the land where you go to possess it, and casts out many nations before you—the Hittite, the Girgashite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite—seven nations greater and mightier than you; 
+\v 2 and when Yahuah your Elohim delivers them up before you, and you strike them, then you shall utterly destroy them. You shall make no covenant with them, nor show mercy to them. 
 \v 3 You shall not make yourself a relative of them. You shall not give your daughter to his son, nor shall you take his daughter for your son. 
-\v 4 For that would turn away your sons from following me, that they may serve other elohims. So Yahweh’s anger would be kindled against you, and he would destroy you quickly. 
+\v 4 For that would turn away your sons from following me, that they may serve other elohims. So Yahuah’s anger would be kindled against you, and he would destroy you quickly. 
 \v 5 But you shall deal with them like this: you shall break down their altars, dash their pillars in pieces, cut down their Asherah poles, and burn their engraved images with fire. 
-\v 6 For you are a set-apart people to Yahweh your Elohim. Yahweh your Elohim has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
-\v 7 Yahweh didn’t set his love on you nor choose you, because you were more in number than any people; for you were the fewest of all peoples; 
-\v 8 but because Yahweh loves you, and because he desires to keep the oath which he swore to your fathers, Yahweh has brought you out with a mighty hand and redeemed you out of the house of bondage, from the hand of Pharaoh king of Egypt. 
-\v 9 Know therefore that Yahweh your Elohim himself is Elohim, the faithful Elohim, who keeps covenant and loving kindness to a thousand generations with those who love him and keep his commandments, 
+\v 6 For you are a set-apart people to Yahuah your Elohim. Yahuah your Elohim has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
+\v 7 Yahuah didn’t set his love on you nor choose you, because you were more in number than any people; for you were the fewest of all peoples; 
+\v 8 but because Yahuah loves you, and because he desires to keep the oath which he swore to your fathers, Yahuah has brought you out with a mighty hand and redeemed you out of the house of bondage, from the hand of Pharaoh king of Egypt. 
+\v 9 Know therefore that Yahuah your Elohim himself is Elohim, the faithful Elohim, who keeps covenant and loving kindness to a thousand generations with those who love him and keep his commandments, 
 \v 10 and repays those who hate him to their face, to destroy them. He will not be slack to him who hates him. He will repay him to his face. 
 \v 11 You shall therefore keep the commandments, the statutes, and the ordinances which I command you today, to do them. 
-\v 12 It shall happen, because you listen to these ordinances and keep and do them, that Yahweh your Elohim will keep with you the covenant and the loving kindness which he swore to your fathers. 
+\v 12 It shall happen, because you listen to these ordinances and keep and do them, that Yahuah your Elohim will keep with you the covenant and the loving kindness which he swore to your fathers. 
 \v 13 He will love you, bless you, and multiply you. He will also bless the fruit of your body and the fruit of your ground, your grain and your new wine and your oil, the increase of your livestock and the young of your flock, in the land which he swore to your fathers to give you. 
 \v 14 You will be blessed above all peoples. There won’t be male or female barren among you, or among your livestock. 
-\v 15 Yahweh will take away from you all sickness; and he will put none of the evil diseases of Egypt, which you know, on you, but will lay them on all those who hate you. 
-\v 16 You shall consume all the peoples whom Yahweh your Elohim shall deliver to you. Your eye shall not pity them. You shall not serve their elohims; for that would be a snare to you. 
+\v 15 Yahuah will take away from you all sickness; and he will put none of the evil diseases of Egypt, which you know, on you, but will lay them on all those who hate you. 
+\v 16 You shall consume all the peoples whom Yahuah your Elohim shall deliver to you. Your eye shall not pity them. You shall not serve their elohims; for that would be a snare to you. 
 \v 17 If you shall say in your heart, “These nations are more than I; how can I dispossess them?” 
-\v 18 you shall not be afraid of them. You shall remember well what Yahweh your Elohim did to Pharaoh and to all Egypt: 
-\v 19 the great trials which your eyes saw, the signs, the wonders, the mighty hand, and the outstretched arm, by which Yahweh your Elohim brought you out. So shall Yahweh your Elohim do to all the peoples of whom you are afraid. 
-\v 20 Moreover Yahweh your Elohim will send the hornet among them, until those who are left, and hide themselves, perish from before you. 
-\v 21 You shall not be scared of them; for Yahweh your Elohim is among you, a great and awesome Elohim. 
-\v 22 Yahweh your Elohim will cast out those nations before you little by little. You may not consume them at once, lest the animals of the field increase on you. 
-\v 23 But Yahweh your Elohim will deliver them up before you, and will confuse them with a great confusion, until they are destroyed. 
+\v 18 you shall not be afraid of them. You shall remember well what Yahuah your Elohim did to Pharaoh and to all Egypt: 
+\v 19 the great trials which your eyes saw, the signs, the wonders, the mighty hand, and the outstretched arm, by which Yahuah your Elohim brought you out. So shall Yahuah your Elohim do to all the peoples of whom you are afraid. 
+\v 20 Moreover Yahuah your Elohim will send the hornet among them, until those who are left, and hide themselves, perish from before you. 
+\v 21 You shall not be scared of them; for Yahuah your Elohim is among you, a great and awesome Elohim. 
+\v 22 Yahuah your Elohim will cast out those nations before you little by little. You may not consume them at once, lest the animals of the field increase on you. 
+\v 23 But Yahuah your Elohim will deliver them up before you, and will confuse them with a great confusion, until they are destroyed. 
 \v 24 He will deliver their kings into your hand, and you shall make their name perish from under the sky. No one will be able to stand before you until you have destroyed them. 
-\v 25 You shall burn the engraved images of their elohims with fire. You shall not desire the silver or the gold that is on them, nor take it for yourself, lest you be snared in it; for it is an abomination to Yahweh your Elohim. 
+\v 25 You shall burn the engraved images of their elohims with fire. You shall not desire the silver or the gold that is on them, nor take it for yourself, lest you be snared in it; for it is an abomination to Yahuah your Elohim. 
 \v 26 You shall not bring an abomination into your house and become a devoted thing like it. You shall utterly detest it. You shall utterly abhor it; for it is a devoted thing. 
 \c 8
 \p
-\v 1 You shall observe to do all the commandments which I command you today, that you may live, and multiply, and go in and possess the land which Yahweh swore to your fathers. 
-\v 2 You shall remember all the way which Yahweh your Elohim has led you these forty years in the wilderness, that he might humble you, to test you, to know what was in your heart, whether you would keep his commandments or not. 
-\v 3 He humbled you, allowed you to be hungry, and fed you with manna, which you didn’t know, neither did your fathers know, that he might teach you that man does not live by bread only, but man lives by every word that proceeds out of Yahweh’s mouth. 
+\v 1 You shall observe to do all the commandments which I command you today, that you may live, and multiply, and go in and possess the land which Yahuah swore to your fathers. 
+\v 2 You shall remember all the way which Yahuah your Elohim has led you these forty years in the wilderness, that he might humble you, to test you, to know what was in your heart, whether you would keep his commandments or not. 
+\v 3 He humbled you, allowed you to be hungry, and fed you with manna, which you didn’t know, neither did your fathers know, that he might teach you that man does not live by bread only, but man lives by every word that proceeds out of Yahuah’s mouth. 
 \v 4 Your clothing didn’t grow old on you, neither did your foot swell, these forty years. 
-\v 5 You shall consider in your heart that as a man disciplines his son, so Yahweh your Elohim disciplines you. 
-\v 6 You shall keep the commandments of Yahweh your Elohim, to walk in his ways, and to fear him. 
-\v 7 For Yahweh your Elohim brings you into a good land, a land of brooks of water, of springs, and underground water flowing into valleys and hills; 
+\v 5 You shall consider in your heart that as a man disciplines his son, so Yahuah your Elohim disciplines you. 
+\v 6 You shall keep the commandments of Yahuah your Elohim, to walk in his ways, and to fear him. 
+\v 7 For Yahuah your Elohim brings you into a good land, a land of brooks of water, of springs, and underground water flowing into valleys and hills; 
 \v 8 a land of wheat, barley, vines, fig trees, and pomegranates; a land of olive trees and honey; 
 \v 9 a land in which you shall eat bread without scarcity, you shall not lack anything in it; a land whose stones are iron, and out of whose hills you may dig copper. 
-\v 10 You shall eat and be full, and you shall bless Yahweh your Elohim for the good land which he has given you. 
+\v 10 You shall eat and be full, and you shall bless Yahuah your Elohim for the good land which he has given you. 
 \p
-\v 11 Beware lest you forget Yahweh your Elohim, in not keeping his commandments, his ordinances, and his statutes, which I command you today; 
+\v 11 Beware lest you forget Yahuah your Elohim, in not keeping his commandments, his ordinances, and his statutes, which I command you today; 
 \v 12 lest, when you have eaten and are full, and have built fine houses and lived in them; 
 \v 13 and when your herds and your flocks multiply, and your silver and your gold is multiplied, and all that you have is multiplied; 
-\v 14 then your heart might be lifted up, and you forget Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage; 
+\v 14 then your heart might be lifted up, and you forget Yahuah your Elohim, who brought you out of the land of Egypt, out of the house of bondage; 
 \v 15 who led you through the great and terrible wilderness, with venomous snakes and scorpions, and thirsty ground where there was no water; who poured water for you out of the rock of flint; 
 \v 16 who fed you in the wilderness with manna, which your fathers didn’t know, that he might humble you, and that he might prove you, to do you good at your latter end; 
 \v 17 and lest you say in your heart, “My power and the might of my hand has gotten me this wealth.” 
-\v 18 But you shall remember Yahweh your Elohim, for it is he who gives you power to get wealth, that he may establish his covenant which he swore to your fathers, as it is today. 
+\v 18 But you shall remember Yahuah your Elohim, for it is he who gives you power to get wealth, that he may establish his covenant which he swore to your fathers, as it is today. 
 \p
-\v 19 It shall be, if you shall forget Yahweh your Elohim, and walk after other elohims, and serve them and worship them, I testify against you today that you shall surely perish. 
-\v 20 As the nations that Yahweh makes to perish before you, so you shall perish, because you wouldn’t listen to Yahweh your Elohim’s voice. 
+\v 19 It shall be, if you shall forget Yahuah your Elohim, and walk after other elohims, and serve them and worship them, I testify against you today that you shall surely perish. 
+\v 20 As the nations that Yahuah makes to perish before you, so you shall perish, because you wouldn’t listen to Yahuah your Elohim’s voice. 
 \c 9
 \p
 \v 1 Hear, Israel! You are to pass over the Jordan today, to go in to dispossess nations greater and mightier than yourself, cities great and fortified up to the sky, 
 \v 2 a people great and tall, the sons of the Anakim, whom you know, and of whom you have heard say, “Who can stand before the sons of Anak?” 
-\v 3 Know therefore today that Yahweh your Elohim is he who goes over before you as a devouring fire. He will destroy them and he will bring them down before you. So you shall drive them out and make them perish quickly, as Yahweh has spoken to you. 
+\v 3 Know therefore today that Yahuah your Elohim is he who goes over before you as a devouring fire. He will destroy them and he will bring them down before you. So you shall drive them out and make them perish quickly, as Yahuah has spoken to you. 
 \p
-\v 4 Don’t say in your heart, after Yahweh your Elohim has thrust them out from before you, “For my righteousness Yahweh has brought me in to possess this land;” because Yahweh drives them out before you because of the wickedness of these nations. 
-\v 5 Not for your righteousness or for the uprightness of your heart do you go in to possess their land; but for the wickedness of these nations Yahweh your Elohim does drive them out from before you, and that he may establish the word which Yahweh swore to your fathers, to Abraham, to Isaac, and to Jacob. 
-\v 6 Know therefore that Yahweh your Elohim doesn’t give you this good land to possess for your righteousness, for you are a stiff-necked people. 
-\v 7 Remember, and don’t forget, how you provoked Yahweh your Elohim to wrath in the wilderness. From the day that you left the land of Egypt until you came to this place, you have been rebellious against Yahweh. 
-\v 8 Also in Horeb you provoked Yahweh to wrath, and Yahweh was angry with you to destroy you. 
-\v 9 When I had gone up onto the mountain to receive the stone tablets, even the tablets of the covenant which Yahweh made with you, then I stayed on the mountain forty days and forty nights. I neither ate bread nor drank water. 
-\v 10 Yahweh delivered to me the two stone tablets written with Elohim’s finger. On them were all the words which Yahweh spoke with you on the mountain out of the middle of the fire in the day of the assembly. 
+\v 4 Don’t say in your heart, after Yahuah your Elohim has thrust them out from before you, “For my righteousness Yahuah has brought me in to possess this land;” because Yahuah drives them out before you because of the wickedness of these nations. 
+\v 5 Not for your righteousness or for the uprightness of your heart do you go in to possess their land; but for the wickedness of these nations Yahuah your Elohim does drive them out from before you, and that he may establish the word which Yahuah swore to your fathers, to Abraham, to Isaac, and to Jacob. 
+\v 6 Know therefore that Yahuah your Elohim doesn’t give you this good land to possess for your righteousness, for you are a stiff-necked people. 
+\v 7 Remember, and don’t forget, how you provoked Yahuah your Elohim to wrath in the wilderness. From the day that you left the land of Egypt until you came to this place, you have been rebellious against Yahuah. 
+\v 8 Also in Horeb you provoked Yahuah to wrath, and Yahuah was angry with you to destroy you. 
+\v 9 When I had gone up onto the mountain to receive the stone tablets, even the tablets of the covenant which Yahuah made with you, then I stayed on the mountain forty days and forty nights. I neither ate bread nor drank water. 
+\v 10 Yahuah delivered to me the two stone tablets written with Elohim’s finger. On them were all the words which Yahuah spoke with you on the mountain out of the middle of the fire in the day of the assembly. 
 \p
-\v 11 It came to pass at the end of forty days and forty nights that Yahweh gave me the two stone tablets, even the tablets of the covenant. 
-\v 12 Yahweh said to me, “Arise, get down quickly from here; for your people whom you have brought out of Egypt have corrupted themselves. They have quickly turned away from the way which I commanded them. They have made a molten image for themselves!” 
+\v 11 It came to pass at the end of forty days and forty nights that Yahuah gave me the two stone tablets, even the tablets of the covenant. 
+\v 12 Yahuah said to me, “Arise, get down quickly from here; for your people whom you have brought out of Egypt have corrupted themselves. They have quickly turned away from the way which I commanded them. They have made a molten image for themselves!” 
 \p
-\v 13 Furthermore Yahweh spoke to me, saying, “I have seen these people, and behold, they are a stiff-necked people. 
+\v 13 Furthermore Yahuah spoke to me, saying, “I have seen these people, and behold, they are a stiff-necked people. 
 \v 14 Leave me alone, that I may destroy them, and blot out their name from under the sky; and I will make of you a nation mightier and greater than they.” 
 \p
 \v 15 So I turned and came down from the mountain, and the mountain was burning with fire. The two tablets of the covenant were in my two hands. 
-\v 16 I looked, and behold, you had sinned against Yahweh your Elohim. You had made yourselves a molded calf. You had quickly turned away from the way which Yahweh had commanded you. 
+\v 16 I looked, and behold, you had sinned against Yahuah your Elohim. You had made yourselves a molded calf. You had quickly turned away from the way which Yahuah had commanded you. 
 \v 17 I took hold of the two tablets, and threw them out of my two hands, and broke them before your eyes. 
-\v 18 I fell down before Yahweh, as at the first, forty days and forty nights. I neither ate bread nor drank water, because of all your sin which you sinned, in doing that which was evil in Yahweh’s sight, to provoke him to anger. 
-\v 19 For I was afraid of the anger and hot displeasure with which Yahweh was angry against you to destroy you. But Yahweh listened to me that time also. 
-\v 20 Yahweh was angry enough with Aaron to destroy him. I prayed for Aaron also at the same time. 
+\v 18 I fell down before Yahuah, as at the first, forty days and forty nights. I neither ate bread nor drank water, because of all your sin which you sinned, in doing that which was evil in Yahuah’s sight, to provoke him to anger. 
+\v 19 For I was afraid of the anger and hot displeasure with which Yahuah was angry against you to destroy you. But Yahuah listened to me that time also. 
+\v 20 Yahuah was angry enough with Aaron to destroy him. I prayed for Aaron also at the same time. 
 \v 21 I took your sin, the calf which you had made, and burned it with fire, and crushed it, grinding it very small, until it was as fine as dust. I threw its dust into the brook that descended out of the mountain. 
-\v 22 At Taberah, at Massah, and at Kibroth Hattaavah you provoked Yahweh to wrath. 
-\v 23 When Yahweh sent you from Kadesh Barnea, saying, “Go up and possess the land which I have given you,” you rebelled against the commandment of Yahweh your Elohim, and you didn’t believe him or listen to his voice. 
-\v 24 You have been rebellious against Yahweh from the day that I knew you. 
-\v 25 So I fell down before Yahweh the forty days and forty nights that I fell down, because Yahweh had said he would destroy you. 
-\v 26 I prayed to Yahweh, and said, “Lord Yahweh, don’t destroy your people and your inheritance that you have redeemed through your greatness, that you have brought out of Egypt with a mighty hand. 
+\v 22 At Taberah, at Massah, and at Kibroth Hattaavah you provoked Yahuah to wrath. 
+\v 23 When Yahuah sent you from Kadesh Barnea, saying, “Go up and possess the land which I have given you,” you rebelled against the commandment of Yahuah your Elohim, and you didn’t believe him or listen to his voice. 
+\v 24 You have been rebellious against Yahuah from the day that I knew you. 
+\v 25 So I fell down before Yahuah the forty days and forty nights that I fell down, because Yahuah had said he would destroy you. 
+\v 26 I prayed to Yahuah, and said, “Lord Yahuah, don’t destroy your people and your inheritance that you have redeemed through your greatness, that you have brought out of Egypt with a mighty hand. 
 \v 27 Remember your servants, Abraham, Isaac, and Jacob. Don’t look at the stubbornness of this people, nor at their wickedness, nor at their sin, 
-\v 28 lest the land you brought us out from say, ‘Because Yahweh was not able to bring them into the land which he promised to them, and because he hated them, he has brought them out to kill them in the wilderness.’ 
+\v 28 lest the land you brought us out from say, ‘Because Yahuah was not able to bring them into the land which he promised to them, and because he hated them, he has brought them out to kill them in the wilderness.’ 
 \v 29 Yet they are your people and your inheritance, which you brought out by your great power and by your outstretched arm.” 
 \c 10
 \p
-\v 1 At that time Yahweh said to me, “Cut two stone tablets like the first, and come up to me onto the mountain, and make an ark of wood. 
+\v 1 At that time Yahuah said to me, “Cut two stone tablets like the first, and come up to me onto the mountain, and make an ark of wood. 
 \v 2 I will write on the tablets the words that were on the first tablets which you broke, and you shall put them in the ark.” 
 \v 3 So I made an ark of acacia wood, and cut two stone tablets like the first, and went up onto the mountain, having the two tablets in my hand. 
-\v 4 He wrote on the tablets, according to the first writing, the ten commandments, which Yahweh spoke to you on the mountain out of the middle of the fire in the day of the assembly; and Yahweh gave them to me. 
-\v 5 I turned and came down from the mountain, and put the tablets in the ark which I had made; and there they are as Yahweh commanded me. 
+\v 4 He wrote on the tablets, according to the first writing, the ten commandments, which Yahuah spoke to you on the mountain out of the middle of the fire in the day of the assembly; and Yahuah gave them to me. 
+\v 5 I turned and came down from the mountain, and put the tablets in the ark which I had made; and there they are as Yahuah commanded me. 
 \p
 \v 6 (The children of Israel traveled from Beeroth Bene Jaakan to Moserah. There Aaron died, and there he was buried; and Eleazar his son ministered in the priest’s office in his place. 
 \v 7 From there they traveled to Gudgodah; and from Gudgodah to Jotbathah, a land of brooks of water. 
-\v 8 At that time Yahweh set apart the tribe of Levi to bear the ark of Yahweh’s covenant, to stand before Yahweh to minister to him, and to bless in his name, to this day. 
-\v 9 Therefore Levi has no portion nor inheritance with his brothers; Yahweh is his inheritance, according as Yahweh your Elohim spoke to him.) 
+\v 8 At that time Yahuah set apart the tribe of Levi to bear the ark of Yahuah’s covenant, to stand before Yahuah to minister to him, and to bless in his name, to this day. 
+\v 9 Therefore Levi has no portion nor inheritance with his brothers; Yahuah is his inheritance, according as Yahuah your Elohim spoke to him.) 
 \p
-\v 10 I stayed on the mountain, as at the first time, forty days and forty nights; and Yahweh listened to me that time also. Yahweh would not destroy you. 
-\v 11 Yahweh said to me, “Arise, take your journey before the people; and they shall go in and possess the land which I swore to their fathers to give to them.” 
+\v 10 I stayed on the mountain, as at the first time, forty days and forty nights; and Yahuah listened to me that time also. Yahuah would not destroy you. 
+\v 11 Yahuah said to me, “Arise, take your journey before the people; and they shall go in and possess the land which I swore to their fathers to give to them.” 
 \p
-\v 12 Now, Israel, what does Yahweh your Elohim require of you, but to fear Yahweh your Elohim, to walk in all his ways, to love him, and to serve Yahweh your Elohim with all your heart and with all your soul, 
-\v 13 to keep Yahweh’s commandments and statutes, which I command you today for your good? 
-\v 14 Behold, to Yahweh your Elohim belongs heaven, the heaven of heavens, and the earth, with all that is therein. 
-\v 15 Only Yahweh had a delight in your fathers to love them, and he chose their offspring after them, even you above all peoples, as it is today. 
+\v 12 Now, Israel, what does Yahuah your Elohim require of you, but to fear Yahuah your Elohim, to walk in all his ways, to love him, and to serve Yahuah your Elohim with all your heart and with all your soul, 
+\v 13 to keep Yahuah’s commandments and statutes, which I command you today for your good? 
+\v 14 Behold, to Yahuah your Elohim belongs heaven, the heaven of heavens, and the earth, with all that is therein. 
+\v 15 Only Yahuah had a delight in your fathers to love them, and he chose their offspring after them, even you above all peoples, as it is today. 
 \v 16 Circumcise therefore the foreskin of your heart, and be no more stiff-necked. 
-\v 17 For Yahweh your Elohim, he is Elohim of elohims and Lord of lords, the great Elohim, the mighty, and the awesome, who doesn’t respect persons or take bribes. 
+\v 17 For Yahuah your Elohim, he is Elohim of elohims and Lord of lords, the great Elohim, the mighty, and the awesome, who doesn’t respect persons or take bribes. 
 \v 18 He executes justice for the fatherless and widow and loves the foreigner in giving him food and clothing. 
 \v 19 Therefore love the foreigner, for you were foreigners in the land of Egypt. 
-\v 20 You shall fear Yahweh your Elohim. You shall serve him. You shall cling to him, and you shall swear by his name. 
+\v 20 You shall fear Yahuah your Elohim. You shall serve him. You shall cling to him, and you shall swear by his name. 
 \v 21 He is your praise, and he is your Elohim, who has done for you these great and awesome things which your eyes have seen. 
-\v 22 Your fathers went down into Egypt with seventy persons; and now Yahweh your Elohim has made you as the stars of the sky for multitude. 
+\v 22 Your fathers went down into Egypt with seventy persons; and now Yahuah your Elohim has made you as the stars of the sky for multitude. 
 \c 11
 \p
-\v 1 Therefore you shall love Yahweh your Elohim, and keep his instructions, his statutes, his ordinances, and his commandments, always. 
-\v 2 Know this day—for I don’t speak with your children who have not known, and who have not seen the chastisement of Yahweh your Elohim, his greatness, his mighty hand, his outstretched arm, 
+\v 1 Therefore you shall love Yahuah your Elohim, and keep his instructions, his statutes, his ordinances, and his commandments, always. 
+\v 2 Know this day—for I don’t speak with your children who have not known, and who have not seen the chastisement of Yahuah your Elohim, his greatness, his mighty hand, his outstretched arm, 
 \v 3 his signs, and his works, which he did in the middle of Egypt to Pharaoh the king of Egypt, and to all his land; 
-\v 4 and what he did to the army of Egypt, to their horses, and to their chariots; how he made the water of the Red Sea to overflow them as they pursued you, and how Yahweh has destroyed them to this day; 
+\v 4 and what he did to the army of Egypt, to their horses, and to their chariots; how he made the water of the Red Sea to overflow them as they pursued you, and how Yahuah has destroyed them to this day; 
 \v 5 and what he did to you in the wilderness until you came to this place; 
 \v 6 and what he did to Dathan and Abiram, the sons of Eliab, the son of Reuben—how the earth opened its mouth and swallowed them up, with their households, their tents, and every living thing that followed them, in the middle of all Israel; 
-\v 7 but your eyes have seen all of Yahweh’s great work which he did. 
+\v 7 but your eyes have seen all of Yahuah’s great work which he did. 
 \p
 \v 8 Therefore you shall keep the entire commandment which I command you today, that you may be strong, and go in and possess the land that you go over to possess; 
-\v 9 and that you may prolong your days in the land which Yahweh swore to your fathers to give to them and to their offspring, a land flowing with milk and honey. 
+\v 9 and that you may prolong your days in the land which Yahuah swore to your fathers to give to them and to their offspring, a land flowing with milk and honey. 
 \v 10 For the land, where you go in to possess isn’t like the land of Egypt that you came out of, where you sowed your seed and watered it with your foot, as a garden of herbs; 
 \v 11 but the land that you go over to possess is a land of hills and valleys which drinks water from the rain of the sky, 
-\v 12 a land which Yahweh your Elohim cares for. Yahweh your Elohim’s eyes are always on it, from the beginning of the year even to the end of the year. 
-\v 13 It shall happen, if you shall listen diligently to my commandments which I command you today, to love Yahweh your Elohim, and to serve him with all your heart and with all your soul, 
+\v 12 a land which Yahuah your Elohim cares for. Yahuah your Elohim’s eyes are always on it, from the beginning of the year even to the end of the year. 
+\v 13 It shall happen, if you shall listen diligently to my commandments which I command you today, to love Yahuah your Elohim, and to serve him with all your heart and with all your soul, 
 \v 14 that I will give the rain for your land in its season, the early rain and the latter rain, that you may gather in your grain, your new wine, and your oil. 
 \v 15 I will give grass in your fields for your livestock, and you shall eat and be full. 
 \v 16 Be careful, lest your heart be deceived, and you turn away to serve other elohims and worship them; 
-\v 17 and Yahweh’s anger be kindled against you, and he shut up the sky so that there is no rain, and the land doesn’t yield its fruit; and you perish quickly from off the good land which Yahweh gives you. 
+\v 17 and Yahuah’s anger be kindled against you, and he shut up the sky so that there is no rain, and the land doesn’t yield its fruit; and you perish quickly from off the good land which Yahuah gives you. 
 \v 18 Therefore you shall lay up these words of mine in your heart and in your soul. You shall bind them for a sign on your hand, and they shall be for frontlets between your eyes. 
 \v 19 You shall teach them to your children, talking of them when you sit in your house, when you walk by the way, when you lie down, and when you rise up. 
 \v 20 You shall write them on the door posts of your house and on your gates; 
-\v 21 that your days and your children’s days may be multiplied in the land which Yahweh swore to your fathers to give them, as the days of the heavens above the earth. 
-\v 22 For if you shall diligently keep all these commandments which I command you—to do them, to love Yahweh your Elohim, to walk in all his ways, and to cling to him—\v 23 then Yahweh will drive out all these nations from before you, and you shall dispossess nations greater and mightier than yourselves. 
+\v 21 that your days and your children’s days may be multiplied in the land which Yahuah swore to your fathers to give them, as the days of the heavens above the earth. 
+\v 22 For if you shall diligently keep all these commandments which I command you—to do them, to love Yahuah your Elohim, to walk in all his ways, and to cling to him—\v 23 then Yahuah will drive out all these nations from before you, and you shall dispossess nations greater and mightier than yourselves. 
 \v 24 Every place on which the sole of your foot treads shall be yours: from the wilderness and Lebanon, from the river, the river Euphrates, even to the western sea shall be your border. 
-\v 25 No man will be able to stand before you. Yahweh your Elohim will lay the fear of you and the dread of you on all the land that you tread on, as he has spoken to you. 
+\v 25 No man will be able to stand before you. Yahuah your Elohim will lay the fear of you and the dread of you on all the land that you tread on, as he has spoken to you. 
 \v 26 Behold, I set before you today a blessing and a curse: 
-\v 27 the blessing, if you listen to the commandments of Yahweh your Elohim, which I command you today; 
-\v 28 and the curse, if you do not listen to the commandments of Yahweh your Elohim, but turn away out of the way which I command you today, to go after other elohims which you have not known. 
-\v 29 It shall happen, when Yahweh your Elohim brings you into the land that you go to possess, that you shall set the blessing on Mount Gerizim, and the curse on Mount Ebal. 
+\v 27 the blessing, if you listen to the commandments of Yahuah your Elohim, which I command you today; 
+\v 28 and the curse, if you do not listen to the commandments of Yahuah your Elohim, but turn away out of the way which I command you today, to go after other elohims which you have not known. 
+\v 29 It shall happen, when Yahuah your Elohim brings you into the land that you go to possess, that you shall set the blessing on Mount Gerizim, and the curse on Mount Ebal. 
 \v 30 Aren’t they beyond the Jordan, behind the way of the going down of the sun, in the land of the Canaanites who dwell in the Arabah near Gilgal, beside the oaks of Moreh? 
-\v 31 For you are to pass over the Jordan to go in to possess the land which Yahweh your Elohim gives you, and you shall possess it and dwell in it. 
+\v 31 For you are to pass over the Jordan to go in to possess the land which Yahuah your Elohim gives you, and you shall possess it and dwell in it. 
 \v 32 You shall observe to do all the statutes and the ordinances which I set before you today. 
 \c 12
 \p
-\v 1 These are the statutes and the ordinances which you shall observe to do in the land which Yahweh, the Elohim of your fathers, has given you to possess all the days that you live on the earth. 
+\v 1 These are the statutes and the ordinances which you shall observe to do in the land which Yahuah, the Elohim of your fathers, has given you to possess all the days that you live on the earth. 
 \v 2 You shall surely destroy all the places in which the nations that you shall dispossess served their elohims: on the high mountains, and on the hills, and under every green tree. 
 \v 3 You shall break down their altars, dash their pillars in pieces, and burn their Asherah poles with fire. You shall cut down the engraved images of their elohims. You shall destroy their name out of that place. 
-\v 4 You shall not do so to Yahweh your Elohim. 
-\v 5 But to the place which Yahweh your Elohim shall choose out of all your tribes, to put his name there, you shall seek his habitation, and you shall come there. 
+\v 4 You shall not do so to Yahuah your Elohim. 
+\v 5 But to the place which Yahuah your Elohim shall choose out of all your tribes, to put his name there, you shall seek his habitation, and you shall come there. 
 \v 6 You shall bring your burnt offerings, your sacrifices, your tithes, the wave offering of your hand, your vows, your free will offerings, and the firstborn of your herd and of your flock there. 
-\v 7 There you shall eat before Yahweh your Elohim, and you shall rejoice in all that you put your hand to, you and your households, in which Yahweh your Elohim has blessed you. 
+\v 7 There you shall eat before Yahuah your Elohim, and you shall rejoice in all that you put your hand to, you and your households, in which Yahuah your Elohim has blessed you. 
 \v 8 You shall not do all the things that we do here today, every man whatever is right in his own eyes; 
-\v 9 for you haven’t yet come to the rest and to the inheritance which Yahweh your Elohim gives you. 
-\v 10 But when you go over the Jordan and dwell in the land which Yahweh your Elohim causes you to inherit, and he gives you rest from all your enemies around you, so that you dwell in safety, 
-\v 11 then it shall happen that to the place which Yahweh your Elohim shall choose, to cause his name to dwell there, there you shall bring all that I command you: your burnt offerings, your sacrifices, your tithes, the wave offering of your hand, and all your choice vows which you vow to Yahweh. 
-\v 12 You shall rejoice before Yahweh your Elohim—you, and your sons, your daughters, your male servants, your female servants, and the Levite who is within your gates, because he has no portion nor inheritance with you. 
+\v 9 for you haven’t yet come to the rest and to the inheritance which Yahuah your Elohim gives you. 
+\v 10 But when you go over the Jordan and dwell in the land which Yahuah your Elohim causes you to inherit, and he gives you rest from all your enemies around you, so that you dwell in safety, 
+\v 11 then it shall happen that to the place which Yahuah your Elohim shall choose, to cause his name to dwell there, there you shall bring all that I command you: your burnt offerings, your sacrifices, your tithes, the wave offering of your hand, and all your choice vows which you vow to Yahuah. 
+\v 12 You shall rejoice before Yahuah your Elohim—you, and your sons, your daughters, your male servants, your female servants, and the Levite who is within your gates, because he has no portion nor inheritance with you. 
 \v 13 Be careful that you don’t offer your burnt offerings in every place that you see; 
-\v 14 but in the place which Yahweh chooses in one of your tribes, there you shall offer your burnt offerings, and there you shall do all that I command you. 
+\v 14 but in the place which Yahuah chooses in one of your tribes, there you shall offer your burnt offerings, and there you shall do all that I command you. 
 \p
-\v 15 Yet you may kill and eat meat within all your gates, after all the desire of your soul, according to Yahweh your Elohim’s blessing which he has given you. The unclean and the clean may eat of it, as of the gazelle and the deer. 
+\v 15 Yet you may kill and eat meat within all your gates, after all the desire of your soul, according to Yahuah your Elohim’s blessing which he has given you. The unclean and the clean may eat of it, as of the gazelle and the deer. 
 \v 16 Only you shall not eat the blood. You shall pour it out on the earth like water. 
 \v 17 You may not eat within your gates the tithe of your grain, or of your new wine, or of your oil, or the firstborn of your herd or of your flock, nor any of your vows which you vow, nor your free will offerings, nor the wave offering of your hand; 
-\v 18 but you shall eat them before Yahweh your Elohim in the place which Yahweh your Elohim shall choose: you, your son, your daughter, your male servant, your female servant, and the Levite who is within your gates. You shall rejoice before Yahweh your Elohim in all that you put your hand to. 
+\v 18 but you shall eat them before Yahuah your Elohim in the place which Yahuah your Elohim shall choose: you, your son, your daughter, your male servant, your female servant, and the Levite who is within your gates. You shall rejoice before Yahuah your Elohim in all that you put your hand to. 
 \v 19 Be careful that you don’t forsake the Levite as long as you live in your land. 
 \p
-\v 20 When Yahweh your Elohim enlarges your border, as he has promised you, and you say, “I want to eat meat,” because your soul desires to eat meat, you may eat meat, after all the desire of your soul. 
-\v 21 If the place which Yahweh your Elohim shall choose to put his name is too far from you, then you shall kill of your herd and of your flock, which Yahweh has given you, as I have commanded you; and you may eat within your gates, after all the desire of your soul. 
+\v 20 When Yahuah your Elohim enlarges your border, as he has promised you, and you say, “I want to eat meat,” because your soul desires to eat meat, you may eat meat, after all the desire of your soul. 
+\v 21 If the place which Yahuah your Elohim shall choose to put his name is too far from you, then you shall kill of your herd and of your flock, which Yahuah has given you, as I have commanded you; and you may eat within your gates, after all the desire of your soul. 
 \v 22 Even as the gazelle and as the deer is eaten, so you shall eat of it. The unclean and the clean may eat of it alike. 
 \v 23 Only be sure that you don’t eat the blood; for the blood is the life. You shall not eat the life with the meat. 
 \v 24 You shall not eat it. You shall pour it out on the earth like water. 
-\v 25 You shall not eat it, that it may go well with you and with your children after you, when you do that which is right in Yahweh’s eyes. 
-\v 26 Only your set-apart things which you have, and your vows, you shall take and go to the place which Yahweh shall choose. 
-\v 27 You shall offer your burnt offerings, the meat and the blood, on Yahweh your Elohim’s altar. The blood of your sacrifices shall be poured out on Yahweh your Elohim’s altar, and you shall eat the meat. 
-\v 28 Observe and hear all these words which I command you, that it may go well with you and with your children after you forever, when you do that which is good and right in Yahweh your Elohim’s eyes. 
+\v 25 You shall not eat it, that it may go well with you and with your children after you, when you do that which is right in Yahuah’s eyes. 
+\v 26 Only your set-apart things which you have, and your vows, you shall take and go to the place which Yahuah shall choose. 
+\v 27 You shall offer your burnt offerings, the meat and the blood, on Yahuah your Elohim’s altar. The blood of your sacrifices shall be poured out on Yahuah your Elohim’s altar, and you shall eat the meat. 
+\v 28 Observe and hear all these words which I command you, that it may go well with you and with your children after you forever, when you do that which is good and right in Yahuah your Elohim’s eyes. 
 \p
-\v 29 When Yahweh your Elohim cuts off the nations from before you where you go in to dispossess them, and you dispossess them and dwell in their land, 
+\v 29 When Yahuah your Elohim cuts off the nations from before you where you go in to dispossess them, and you dispossess them and dwell in their land, 
 \v 30 be careful that you are not ensnared to follow them after they are destroyed from before you, and that you not inquire after their elohims, saying, “How do these nations serve their elohims? I will do likewise.” 
-\v 31 You shall not do so to Yahweh your Elohim; for every abomination to Yahweh, which he hates, they have done to their elohims; for they even burn their sons and their daughters in the fire to their elohims. 
+\v 31 You shall not do so to Yahuah your Elohim; for every abomination to Yahuah, which he hates, they have done to their elohims; for they even burn their sons and their daughters in the fire to their elohims. 
 \v 32 Whatever thing I command you, that you shall observe to do. You shall not add to it, nor take away from it. 
 \c 13
 \p
 \v 1 If a prophet or a dreamer of dreams arises among you, and he gives you a sign or a wonder, 
 \v 2 and the sign or the wonder comes to pass, of which he spoke to you, saying, “Let’s go after other elohims” (which you have not known) “and let’s serve them,” 
-\v 3 you shall not listen to the words of that prophet, or to that dreamer of dreams; for Yahweh your Elohim is testing you, to know whether you love Yahweh your Elohim with all your heart and with all your soul. 
-\v 4 You shall walk after Yahweh your Elohim, fear him, keep his commandments, and obey his voice. You shall serve him, and cling to him. 
-\v 5 That prophet, or that dreamer of dreams, shall be put to death, because he has spoken rebellion against Yahweh your Elohim, who brought you out of the land of Egypt and redeemed you out of the house of bondage, to draw you aside out of the way which Yahweh your Elohim commanded you to walk in. So you shall remove the evil from among you. 
+\v 3 you shall not listen to the words of that prophet, or to that dreamer of dreams; for Yahuah your Elohim is testing you, to know whether you love Yahuah your Elohim with all your heart and with all your soul. 
+\v 4 You shall walk after Yahuah your Elohim, fear him, keep his commandments, and obey his voice. You shall serve him, and cling to him. 
+\v 5 That prophet, or that dreamer of dreams, shall be put to death, because he has spoken rebellion against Yahuah your Elohim, who brought you out of the land of Egypt and redeemed you out of the house of bondage, to draw you aside out of the way which Yahuah your Elohim commanded you to walk in. So you shall remove the evil from among you. 
 \p
 \v 6 If your brother, the son of your mother, or your son, or your daughter, or the woman of your bosom, or your friend who is as your own soul, entices you secretly, saying, “Let’s go and serve other elohims”—which you have not known, you, nor your fathers; 
 \v 7 of the elohims of the peoples who are around you, near to you, or far off from you, from the one end of the earth even to the other end of the earth—\v 8 you shall not consent to him nor listen to him; neither shall your eye pity him, neither shall you spare, neither shall you conceal him; 
 \v 9 but you shall surely kill him. Your hand shall be first on him to put him to death, and afterwards the hands of all the people. 
-\v 10 You shall stone him to death with stones, because he has sought to draw you away from Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
+\v 10 You shall stone him to death with stones, because he has sought to draw you away from Yahuah your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
 \v 11 All Israel shall hear, and fear, and shall not do any more wickedness like this among you. 
 \p
-\v 12 If you hear about one of your cities, which Yahweh your Elohim gives you to dwell there, that 
+\v 12 If you hear about one of your cities, which Yahuah your Elohim gives you to dwell there, that 
 \v 13 certain wicked fellows have gone out from among you and have drawn away the inhabitants of their city, saying, “Let’s go and serve other elohims,” which you have not known, 
 \v 14 then you shall inquire, investigate, and ask diligently. Behold, if it is true, and the thing certain, that such abomination was done among you, 
 \v 15 you shall surely strike the inhabitants of that city with the edge of the sword, destroying it utterly, with all that is therein and its livestock, with the edge of the sword. 
-\v 16 You shall gather all its plunder into the middle of its street, and shall burn with fire the city, with all of its plunder, to Yahweh your Elohim. It shall be a heap forever. It shall not be built again. 
-\v 17 Nothing of the devoted thing shall cling to your hand, that Yahweh may turn from the fierceness of his anger and show you mercy, and have compassion on you and multiply you, as he has sworn to your fathers, 
-\v 18 when you listen to Yahweh your Elohim’s voice, to keep all his commandments which I command you today, to do that which is right in Yahweh your Elohim’s eyes. 
+\v 16 You shall gather all its plunder into the middle of its street, and shall burn with fire the city, with all of its plunder, to Yahuah your Elohim. It shall be a heap forever. It shall not be built again. 
+\v 17 Nothing of the devoted thing shall cling to your hand, that Yahuah may turn from the fierceness of his anger and show you mercy, and have compassion on you and multiply you, as he has sworn to your fathers, 
+\v 18 when you listen to Yahuah your Elohim’s voice, to keep all his commandments which I command you today, to do that which is right in Yahuah your Elohim’s eyes. 
 \c 14
 \p
-\v 1 You are the children of Yahweh your Elohim. You shall not cut yourselves, nor make any baldness between your eyes for the dead. 
-\v 2 For you are a set-apart people to Yahweh your Elohim, and Yahweh has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
+\v 1 You are the children of Yahuah your Elohim. You shall not cut yourselves, nor make any baldness between your eyes for the dead. 
+\v 2 For you are a set-apart people to Yahuah your Elohim, and Yahuah has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
 \p
 \v 3 You shall not eat any abominable thing. 
 \v 4 These are the animals which you may eat: the ox, the sheep, the goat, 
@@ -509,152 +509,152 @@
 \v 19 All winged creeping things are unclean to you. They shall not be eaten. 
 \v 20 Of all clean birds you may eat. 
 \p
-\v 21 You shall not eat of anything that dies of itself. You may give it to the foreigner living among you who is within your gates, that he may eat it; or you may sell it to a foreigner; for you are a set-apart people to Yahweh your Elohim. 
+\v 21 You shall not eat of anything that dies of itself. You may give it to the foreigner living among you who is within your gates, that he may eat it; or you may sell it to a foreigner; for you are a set-apart people to Yahuah your Elohim. 
 \p You shall not boil a young goat in its mother’s milk. 
 \p
 \v 22 You shall surely tithe all the increase of your seed, that which comes out of the field year by year. 
-\v 23 You shall eat before Yahweh your Elohim, in the place which he chooses to cause his name to dwell, the tithe of your grain, of your new wine, and of your oil, and the firstborn of your herd and of your flock; that you may learn to fear Yahweh your Elohim always. 
-\v 24 If the way is too long for you, so that you are not able to carry it because the place which Yahweh your Elohim shall choose to set his name there is too far from you, when Yahweh your Elohim blesses you, 
-\v 25 then you shall turn it into money, bind up the money in your hand, and shall go to the place which Yahweh your Elohim shall choose. 
-\v 26 You shall trade the money for whatever your soul desires: for cattle, or for sheep, or for wine, or for strong drink, or for whatever your soul asks of you. You shall eat there before Yahweh your Elohim, and you shall rejoice, you and your household. 
+\v 23 You shall eat before Yahuah your Elohim, in the place which he chooses to cause his name to dwell, the tithe of your grain, of your new wine, and of your oil, and the firstborn of your herd and of your flock; that you may learn to fear Yahuah your Elohim always. 
+\v 24 If the way is too long for you, so that you are not able to carry it because the place which Yahuah your Elohim shall choose to set his name there is too far from you, when Yahuah your Elohim blesses you, 
+\v 25 then you shall turn it into money, bind up the money in your hand, and shall go to the place which Yahuah your Elohim shall choose. 
+\v 26 You shall trade the money for whatever your soul desires: for cattle, or for sheep, or for wine, or for strong drink, or for whatever your soul asks of you. You shall eat there before Yahuah your Elohim, and you shall rejoice, you and your household. 
 \v 27 You shall not forsake the Levite who is within your gates, for he has no portion nor inheritance with you. 
 \v 28 At the end of every three years you shall bring all the tithe of your increase in the same year, and shall store it within your gates. 
-\v 29 The Levite, because he has no portion nor inheritance with you, as well as the foreigner living among you, the fatherless, and the widow who are within your gates shall come, and shall eat and be satisfied; that Yahweh your Elohim may bless you in all the work of your hand which you do. 
+\v 29 The Levite, because he has no portion nor inheritance with you, as well as the foreigner living among you, the fatherless, and the widow who are within your gates shall come, and shall eat and be satisfied; that Yahuah your Elohim may bless you in all the work of your hand which you do. 
 \c 15
 \p
 \v 1 At the end of every seven years, you shall cancel debts. 
-\v 2 This is the way it shall be done: every owner of a loan shall release that which he has lent to his neighbor. He shall not require payment from his neighbor and his brother, because Yahweh’s release has been proclaimed. 
+\v 2 This is the way it shall be done: every owner of a loan shall release that which he has lent to his neighbor. He shall not require payment from his neighbor and his brother, because Yahuah’s release has been proclaimed. 
 \v 3 Of a foreigner you may require it; but whatever of yours is with your brother, your hand shall release. 
-\v 4 However there will be no poor with you (for Yahweh will surely bless you in the land which Yahweh your Elohim gives you for an inheritance to possess) 
-\v 5 if only you diligently listen to Yahweh your Elohim’s voice, to observe to do all this commandment which I command you today. 
-\v 6 For Yahweh your Elohim will bless you, as he promised you. You will lend to many nations, but you will not borrow. You will rule over many nations, but they will not rule over you. 
-\v 7 If a poor man, one of your brothers, is with you within any of your gates in your land which Yahweh your Elohim gives you, you shall not harden your heart, nor shut your hand from your poor brother; 
+\v 4 However there will be no poor with you (for Yahuah will surely bless you in the land which Yahuah your Elohim gives you for an inheritance to possess) 
+\v 5 if only you diligently listen to Yahuah your Elohim’s voice, to observe to do all this commandment which I command you today. 
+\v 6 For Yahuah your Elohim will bless you, as he promised you. You will lend to many nations, but you will not borrow. You will rule over many nations, but they will not rule over you. 
+\v 7 If a poor man, one of your brothers, is with you within any of your gates in your land which Yahuah your Elohim gives you, you shall not harden your heart, nor shut your hand from your poor brother; 
 \v 8 but you shall surely open your hand to him, and shall surely lend him sufficient for his need, which he lacks. 
-\v 9 Beware that there not be a wicked thought in your heart, saying, “The seventh year, the year of release, is at hand,” and your eye be evil against your poor brother and you give him nothing; and he cry to Yahweh against you, and it be sin to you. 
-\v 10 You shall surely give, and your heart shall not be grieved when you give to him, because it is for this thing Yahweh your Elohim will bless you in all your work and in all that you put your hand to. 
+\v 9 Beware that there not be a wicked thought in your heart, saying, “The seventh year, the year of release, is at hand,” and your eye be evil against your poor brother and you give him nothing; and he cry to Yahuah against you, and it be sin to you. 
+\v 10 You shall surely give, and your heart shall not be grieved when you give to him, because it is for this thing Yahuah your Elohim will bless you in all your work and in all that you put your hand to. 
 \v 11 For the poor will never cease out of the land. Therefore I command you to surely open your hand to your brother, to your needy, and to your poor, in your land. 
 \v 12 If your brother, a Hebrew man, or a Hebrew woman, is sold to you and serves you six years, then in the seventh year you shall let him go free from you. 
 \v 13 When you let him go free from you, you shall not let him go empty. 
-\v 14 You shall furnish him liberally out of your flock, out of your threshing floor, and out of your wine press. As Yahweh your Elohim has blessed you, you shall give to him. 
-\v 15 You shall remember that you were a slave in the land of Egypt, and Yahweh your Elohim redeemed you. Therefore I command you this thing today. 
+\v 14 You shall furnish him liberally out of your flock, out of your threshing floor, and out of your wine press. As Yahuah your Elohim has blessed you, you shall give to him. 
+\v 15 You shall remember that you were a slave in the land of Egypt, and Yahuah your Elohim redeemed you. Therefore I command you this thing today. 
 \v 16 It shall be, if he tells you, “I will not go out from you,” because he loves you and your house, because he is well with you, 
 \v 17 then you shall take an awl, and thrust it through his ear to the door, and he shall be your servant forever. Also to your female servant you shall do likewise. 
-\v 18 It shall not seem hard to you when you let him go free from you, for he has been double the value of a hired hand as he served you six years. Yahweh your Elohim will bless you in all that you do. 
-\v 19 You shall dedicate all the firstborn males that are born of your herd and of your flock to Yahweh your Elohim. You shall do no work with the firstborn of your herd, nor shear the firstborn of your flock. 
-\v 20 You shall eat it before Yahweh your Elohim year by year in the place which Yahweh shall choose, you and your household. 
-\v 21 If it has any defect—is lame or blind, or has any defect whatever, you shall not sacrifice it to Yahweh your Elohim. 
+\v 18 It shall not seem hard to you when you let him go free from you, for he has been double the value of a hired hand as he served you six years. Yahuah your Elohim will bless you in all that you do. 
+\v 19 You shall dedicate all the firstborn males that are born of your herd and of your flock to Yahuah your Elohim. You shall do no work with the firstborn of your herd, nor shear the firstborn of your flock. 
+\v 20 You shall eat it before Yahuah your Elohim year by year in the place which Yahuah shall choose, you and your household. 
+\v 21 If it has any defect—is lame or blind, or has any defect whatever, you shall not sacrifice it to Yahuah your Elohim. 
 \v 22 You shall eat it within your gates. The unclean and the clean shall eat it alike, as the gazelle and as the deer. 
 \v 23 Only you shall not eat its blood. You shall pour it out on the ground like water. 
 \c 16
 \p
-\v 1 Observe the month of Abib, and keep the Passover to Yahweh your Elohim; for in the month of Abib Yahweh your Elohim brought you out of Egypt by night. 
-\v 2 You shall sacrifice the Passover to Yahweh your Elohim, of the flock and the herd, in the place which Yahweh shall choose to cause his name to dwell there. 
+\v 1 Observe the month of Abib, and keep the Passover to Yahuah your Elohim; for in the month of Abib Yahuah your Elohim brought you out of Egypt by night. 
+\v 2 You shall sacrifice the Passover to Yahuah your Elohim, of the flock and the herd, in the place which Yahuah shall choose to cause his name to dwell there. 
 \v 3 You shall eat no leavened bread with it. You shall eat unleavened bread with it seven days, even the bread of affliction (for you came out of the land of Egypt in haste) that you may remember the day when you came out of the land of Egypt all the days of your life. 
 \v 4 No yeast shall be seen with you in all your borders seven days; neither shall any of the meat, which you sacrifice the first day at evening, remain all night until the morning. 
-\v 5 You may not sacrifice the Passover within any of your gates which Yahweh your Elohim gives you; 
-\v 6 but at the place which Yahweh your Elohim shall choose to cause his name to dwell in, there you shall sacrifice the Passover at evening, at the going down of the sun, at the season that you came out of Egypt. 
-\v 7 You shall roast and eat it in the place which Yahweh your Elohim chooses. In the morning you shall return to your tents. 
-\v 8 Six days you shall eat unleavened bread. On the seventh day shall be a solemn assembly to Yahweh your Elohim. You shall do no work. 
+\v 5 You may not sacrifice the Passover within any of your gates which Yahuah your Elohim gives you; 
+\v 6 but at the place which Yahuah your Elohim shall choose to cause his name to dwell in, there you shall sacrifice the Passover at evening, at the going down of the sun, at the season that you came out of Egypt. 
+\v 7 You shall roast and eat it in the place which Yahuah your Elohim chooses. In the morning you shall return to your tents. 
+\v 8 Six days you shall eat unleavened bread. On the seventh day shall be a solemn assembly to Yahuah your Elohim. You shall do no work. 
 \p
 \v 9 You shall count for yourselves seven weeks. From the time you begin to put the sickle to the standing grain you shall begin to count seven weeks. 
-\v 10 You shall keep the feast of weeks to Yahweh your Elohim with a tribute of a free will offering of your hand, which you shall give according to how Yahweh your Elohim blesses you. 
-\v 11 You shall rejoice before Yahweh your Elohim: you, your son, your daughter, your male servant, your female servant, the Levite who is within your gates, the foreigner, the fatherless, and the widow who are among you, in the place which Yahweh your Elohim shall choose to cause his name to dwell there. 
+\v 10 You shall keep the feast of weeks to Yahuah your Elohim with a tribute of a free will offering of your hand, which you shall give according to how Yahuah your Elohim blesses you. 
+\v 11 You shall rejoice before Yahuah your Elohim: you, your son, your daughter, your male servant, your female servant, the Levite who is within your gates, the foreigner, the fatherless, and the widow who are among you, in the place which Yahuah your Elohim shall choose to cause his name to dwell there. 
 \v 12 You shall remember that you were a slave in Egypt. You shall observe and do these statutes. 
 \p
 \v 13 You shall keep the feast of booths seven days, after you have gathered in from your threshing floor and from your wine press. 
 \v 14 You shall rejoice in your feast, you, your son, your daughter, your male servant, your female servant, the Levite, the foreigner, the fatherless, and the widow who are within your gates. 
-\v 15 You shall keep a feast to Yahweh your Elohim seven days in the place which Yahweh chooses, because Yahweh your Elohim will bless you in all your increase and in all the work of your hands, and you shall be altogether joyful. 
-\v 16 Three times in a year all of your males shall appear before Yahweh your Elohim in the place which he chooses: in the feast of unleavened bread, in the feast of weeks, and in the feast of booths. They shall not appear before Yahweh empty. 
-\v 17 Every man shall give as he is able, according to Yahweh your Elohim’s blessing which he has given you. 
-\v 18 You shall make judges and officers in all your gates, which Yahweh your Elohim gives you, according to your tribes; and they shall judge the people with righteous judgment. 
+\v 15 You shall keep a feast to Yahuah your Elohim seven days in the place which Yahuah chooses, because Yahuah your Elohim will bless you in all your increase and in all the work of your hands, and you shall be altogether joyful. 
+\v 16 Three times in a year all of your males shall appear before Yahuah your Elohim in the place which he chooses: in the feast of unleavened bread, in the feast of weeks, and in the feast of booths. They shall not appear before Yahuah empty. 
+\v 17 Every man shall give as he is able, according to Yahuah your Elohim’s blessing which he has given you. 
+\v 18 You shall make judges and officers in all your gates, which Yahuah your Elohim gives you, according to your tribes; and they shall judge the people with righteous judgment. 
 \v 19 You shall not pervert justice. You shall not show partiality. You shall not take a bribe, for a bribe blinds the eyes of the wise and perverts the words of the righteous. 
-\v 20 You shall follow that which is altogether just, that you may live and inherit the land which Yahweh your Elohim gives you. 
-\v 21 You shall not plant for yourselves an Asherah of any kind of tree beside Yahweh your Elohim’s altar, which you shall make for yourselves. 
-\v 22 Neither shall you set yourself up a sacred stone which Yahweh your Elohim hates. 
+\v 20 You shall follow that which is altogether just, that you may live and inherit the land which Yahuah your Elohim gives you. 
+\v 21 You shall not plant for yourselves an Asherah of any kind of tree beside Yahuah your Elohim’s altar, which you shall make for yourselves. 
+\v 22 Neither shall you set yourself up a sacred stone which Yahuah your Elohim hates. 
 \c 17
 \p
-\v 1 You shall not sacrifice to Yahweh your Elohim an ox or a sheep in which is a defect or anything evil; for that is an abomination to Yahweh your Elohim. 
+\v 1 You shall not sacrifice to Yahuah your Elohim an ox or a sheep in which is a defect or anything evil; for that is an abomination to Yahuah your Elohim. 
 \p
-\v 2 If there is found among you, within any of your gates which Yahweh your Elohim gives you, a man or woman who does that which is evil in Yahweh your Elohim’s sight in transgressing his covenant, 
+\v 2 If there is found among you, within any of your gates which Yahuah your Elohim gives you, a man or woman who does that which is evil in Yahuah your Elohim’s sight in transgressing his covenant, 
 \v 3 and has gone and served other elohims and worshiped them, or the sun, or the moon, or any of the stars of the sky, which I have not commanded, 
 \v 4 and you are told, and you have heard of it, then you shall inquire diligently. Behold, if it is true, and the thing certain, that such abomination is done in Israel, 
 \v 5 then you shall bring out that man or that woman who has done this evil thing to your gates, even that same man or woman; and you shall stone them to death with stones. 
 \v 6 At the mouth of two witnesses, or three witnesses, he who is to die shall be put to death. At the mouth of one witness he shall not be put to death. 
 \v 7 The hands of the witnesses shall be first on him to put him to death, and afterward the hands of all the people. So you shall remove the evil from among you. 
 \p
-\v 8 If there arises a matter too hard for you in judgment, between blood and blood, between plea and plea, and between stroke and stroke, being matters of controversy within your gates, then you shall arise, and go up to the place which Yahweh your Elohim chooses. 
+\v 8 If there arises a matter too hard for you in judgment, between blood and blood, between plea and plea, and between stroke and stroke, being matters of controversy within your gates, then you shall arise, and go up to the place which Yahuah your Elohim chooses. 
 \v 9 You shall come to the priests who are Levites and to the judge who shall be in those days. You shall inquire, and they shall give you the verdict. 
-\v 10 You shall do according to the decisions of the verdict which they shall give you from that place which Yahweh chooses. You shall observe to do according to all that they shall teach you. 
+\v 10 You shall do according to the decisions of the verdict which they shall give you from that place which Yahuah chooses. You shall observe to do according to all that they shall teach you. 
 \v 11 According to the decisions of the law which they shall teach you, and according to the judgment which they shall tell you, you shall do. You shall not turn away from the sentence which they announce to you, to the right hand, nor to the left. 
-\v 12 The man who does presumptuously in not listening to the priest who stands to minister there before Yahweh your Elohim, or to the judge, even that man shall die. You shall put away the evil from Israel. 
+\v 12 The man who does presumptuously in not listening to the priest who stands to minister there before Yahuah your Elohim, or to the judge, even that man shall die. You shall put away the evil from Israel. 
 \v 13 All the people shall hear and fear, and do no more presumptuously. 
 \p
-\v 14 When you have come to the land which Yahweh your Elohim gives you, and possess it and dwell in it, and say, “I will set a king over me, like all the nations that are around me,” 
-\v 15 you shall surely set him whom Yahweh your Elohim chooses as king over yourselves. You shall set as king over you one from among your brothers. You may not put a foreigner over you, who is not your brother. 
-\v 16 Only he shall not multiply horses to himself, nor cause the people to return to Egypt, to the end that he may multiply horses; because Yahweh has said to you, “You shall not go back that way again.” 
+\v 14 When you have come to the land which Yahuah your Elohim gives you, and possess it and dwell in it, and say, “I will set a king over me, like all the nations that are around me,” 
+\v 15 you shall surely set him whom Yahuah your Elohim chooses as king over yourselves. You shall set as king over you one from among your brothers. You may not put a foreigner over you, who is not your brother. 
+\v 16 Only he shall not multiply horses to himself, nor cause the people to return to Egypt, to the end that he may multiply horses; because Yahuah has said to you, “You shall not go back that way again.” 
 \v 17 He shall not multiply women to himself, that his heart not turn away. He shall not greatly multiply to himself silver and gold. 
 \p
 \v 18 It shall be, when he sits on the throne of his kingdom, that he shall write himself a copy of this law in a book, out of that which is before the Levitical priests. 
-\v 19 It shall be with him, and he shall read from it all the days of his life, that he may learn to fear Yahweh his Elohim, to keep all the words of this law and these statutes, to do them; 
+\v 19 It shall be with him, and he shall read from it all the days of his life, that he may learn to fear Yahuah his Elohim, to keep all the words of this law and these statutes, to do them; 
 \v 20 that his heart not be lifted up above his brothers, and that he not turn away from the commandment to the right hand, or to the left, to the end that he may prolong his days in his kingdom, he and his children, in the middle of Israel. 
 \c 18
 \p
-\v 1 The priests and the Levites—all the tribe of Levi—shall have no portion nor inheritance with Israel. They shall eat the offerings of Yahweh made by fire and his portion. 
-\v 2 They shall have no inheritance among their brothers. Yahweh is their inheritance, as he has spoken to them. 
+\v 1 The priests and the Levites—all the tribe of Levi—shall have no portion nor inheritance with Israel. They shall eat the offerings of Yahuah made by fire and his portion. 
+\v 2 They shall have no inheritance among their brothers. Yahuah is their inheritance, as he has spoken to them. 
 \v 3 This shall be the priests’ due from the people, from those who offer a sacrifice, whether it be ox or sheep, that they shall give to the priest: the shoulder, the two cheeks, and the inner parts. 
 \v 4 You shall give him the first fruits of your grain, of your new wine, and of your oil, and the first of the fleece of your sheep. 
-\v 5 For Yahweh your Elohim has chosen him out of all your tribes to stand to minister in Yahweh’s name, him and his sons forever. 
+\v 5 For Yahuah your Elohim has chosen him out of all your tribes to stand to minister in Yahuah’s name, him and his sons forever. 
 \p
-\v 6 If a Levite comes from any of your gates out of all Israel where he lives, and comes with all the desire of his soul to the place which Yahweh shall choose, 
-\v 7 then he shall minister in the name of Yahweh his Elohim, as all his brothers the Levites do, who stand there before Yahweh. 
+\v 6 If a Levite comes from any of your gates out of all Israel where he lives, and comes with all the desire of his soul to the place which Yahuah shall choose, 
+\v 7 then he shall minister in the name of Yahuah his Elohim, as all his brothers the Levites do, who stand there before Yahuah. 
 \v 8 They shall have like portions to eat, in addition to that which comes from the sale of his family possessions. 
 \p
-\v 9 When you have come into the land which Yahweh your Elohim gives you, you shall not learn to imitate the abominations of those nations. 
+\v 9 When you have come into the land which Yahuah your Elohim gives you, you shall not learn to imitate the abominations of those nations. 
 \v 10 There shall not be found with you anyone who makes his son or his daughter to pass through the fire, one who uses divination, one who tells fortunes, or an enchanter, or a sorcerer, 
 \v 11 or a charmer, or someone who consults with a familiar spirit, or a wizard, or a necromancer. 
-\v 12 For whoever does these things is an abomination to Yahweh. Because of these abominations, Yahweh your Elohim drives them out from before you. 
-\v 13 You shall be blameless with Yahweh your Elohim. 
-\v 14 For these nations that you shall dispossess listen to those who practice sorcery and to diviners; but as for you, Yahweh your Elohim has not allowed you so to do. 
-\v 15 Yahweh your Elohim will raise up to you a prophet from among you, of your brothers, like me. You shall listen to him. 
-\v 16 This is according to all that you desired of Yahweh your Elohim in Horeb in the day of the assembly, saying, “Let me not hear again Yahweh my Elohim’s voice, neither let me see this great fire any more, that I not die.” 
+\v 12 For whoever does these things is an abomination to Yahuah. Because of these abominations, Yahuah your Elohim drives them out from before you. 
+\v 13 You shall be blameless with Yahuah your Elohim. 
+\v 14 For these nations that you shall dispossess listen to those who practice sorcery and to diviners; but as for you, Yahuah your Elohim has not allowed you so to do. 
+\v 15 Yahuah your Elohim will raise up to you a prophet from among you, of your brothers, like me. You shall listen to him. 
+\v 16 This is according to all that you desired of Yahuah your Elohim in Horeb in the day of the assembly, saying, “Let me not hear again Yahuah my Elohim’s voice, neither let me see this great fire any more, that I not die.” 
 \p
-\v 17 Yahweh said to me, “They have well said that which they have spoken. 
+\v 17 Yahuah said to me, “They have well said that which they have spoken. 
 \v 18 I will raise them up a prophet from among their brothers, like you. I will put my words in his mouth, and he shall speak to them all that I shall command him. 
 \v 19 It shall happen, that whoever will not listen to my words which he shall speak in my name, I will require it of him. 
 \v 20 But the prophet who speaks a word presumptuously in my name, which I have not commanded him to speak, or who speaks in the name of other elohims, that same prophet shall die.” 
 \p
-\v 21 You may say in your heart, “How shall we know the word which Yahweh has not spoken?” 
-\v 22 When a prophet speaks in Yahweh’s name, if the thing doesn’t follow, nor happen, that is the thing which Yahweh has not spoken. The prophet has spoken it presumptuously. You shall not be afraid of him. 
+\v 21 You may say in your heart, “How shall we know the word which Yahuah has not spoken?” 
+\v 22 When a prophet speaks in Yahuah’s name, if the thing doesn’t follow, nor happen, that is the thing which Yahuah has not spoken. The prophet has spoken it presumptuously. You shall not be afraid of him. 
 \c 19
 \p
-\v 1 When Yahweh your Elohim cuts off the nations whose land Yahweh your Elohim gives you, and you succeed them and dwell in their cities and in their houses, 
-\v 2 you shall set apart three cities for yourselves in the middle of your land, which Yahweh your Elohim gives you to possess. 
-\v 3 You shall prepare the way, and divide the borders of your land which Yahweh your Elohim causes you to inherit into three parts, that every man slayer may flee there. 
+\v 1 When Yahuah your Elohim cuts off the nations whose land Yahuah your Elohim gives you, and you succeed them and dwell in their cities and in their houses, 
+\v 2 you shall set apart three cities for yourselves in the middle of your land, which Yahuah your Elohim gives you to possess. 
+\v 3 You shall prepare the way, and divide the borders of your land which Yahuah your Elohim causes you to inherit into three parts, that every man slayer may flee there. 
 \v 4 This is the case of the man slayer who shall flee there and live: Whoever kills his neighbor unintentionally, and didn’t hate him in time past—\v 5 as when a man goes into the forest with his neighbor to chop wood and his hand swings the ax to cut down the tree, and the head slips from the handle and hits his neighbor so that he dies—he shall flee to one of these cities and live. 
 \v 6 Otherwise, the avenger of blood might pursue the man slayer while hot anger is in his heart and overtake him, because the way is long, and strike him mortally, even though he was not worthy of death, because he didn’t hate him in time past. 
 \v 7 Therefore I command you to set apart three cities for yourselves. 
-\v 8 If Yahweh your Elohim enlarges your border, as he has sworn to your fathers, and gives you all the land which he promised to give to your fathers; 
-\v 9 and if you keep all this commandment to do it, which I command you today, to love Yahweh your Elohim, and to walk ever in his ways, then you shall add three cities more for yourselves, in addition to these three. 
-\v 10 This is so that innocent blood will not be shed in the middle of your land which Yahweh your Elohim gives you for an inheritance, leaving blood guilt on you. 
+\v 8 If Yahuah your Elohim enlarges your border, as he has sworn to your fathers, and gives you all the land which he promised to give to your fathers; 
+\v 9 and if you keep all this commandment to do it, which I command you today, to love Yahuah your Elohim, and to walk ever in his ways, then you shall add three cities more for yourselves, in addition to these three. 
+\v 10 This is so that innocent blood will not be shed in the middle of your land which Yahuah your Elohim gives you for an inheritance, leaving blood guilt on you. 
 \v 11 But if any man hates his neighbor, lies in wait for him, rises up against him, strikes him mortally so that he dies, and he flees into one of these cities; 
 \v 12 then the elders of his city shall send and bring him there, and deliver him into the hand of the avenger of blood, that he may die. 
 \v 13 Your eye shall not pity him, but you shall purge the innocent blood from Israel that it may go well with you. 
 \p
-\v 14 You shall not remove your neighbor’s landmark, which they of old time have set, in your inheritance which you shall inherit, in the land that Yahweh your Elohim gives you to possess. 
+\v 14 You shall not remove your neighbor’s landmark, which they of old time have set, in your inheritance which you shall inherit, in the land that Yahuah your Elohim gives you to possess. 
 \p
 \v 15 One witness shall not rise up against a man for any iniquity, or for any sin that he sins. At the mouth of two witnesses, or at the mouth of three witnesses, shall a matter be established. 
 \v 16 If an unrighteous witness rises up against any man to testify against him of wrongdoing, 
-\v 17 then both the men, between whom the controversy is, shall stand before Yahweh, before the priests and the judges who shall be in those days; 
+\v 17 then both the men, between whom the controversy is, shall stand before Yahuah, before the priests and the judges who shall be in those days; 
 \v 18 and the judges shall make diligent inquisition; and behold, if the witness is a false witness, and has testified falsely against his brother, 
 \v 19 then you shall do to him as he had thought to do to his brother. So you shall remove the evil from among you. 
 \v 20 Those who remain shall hear, and fear, and will never again commit any such evil among you. 
 \v 21 Your eyes shall not pity: life for life, eye for eye, tooth for tooth, hand for hand, foot for foot. 
 \c 20
 \p
-\v 1 When you go out to battle against your enemies, and see horses, chariots, and a people more numerous than you, you shall not be afraid of them; for Yahweh your Elohim, who brought you up out of the land of Egypt, is with you. 
+\v 1 When you go out to battle against your enemies, and see horses, chariots, and a people more numerous than you, you shall not be afraid of them; for Yahuah your Elohim, who brought you up out of the land of Egypt, is with you. 
 \v 2 It shall be, when you draw near to the battle, that the priest shall approach and speak to the people, 
 \v 3 and shall tell them, “Hear, Israel, you draw near today to battle against your enemies. Don’t let your heart faint! Don’t be afraid, nor tremble, neither be scared of them; 
-\v 4 for Yahweh your Elohim is he who goes with you, to fight for you against your enemies, to save you.” 
+\v 4 for Yahuah your Elohim is he who goes with you, to fight for you against your enemies, to save you.” 
 \p
 \v 5 The officers shall speak to the people, saying, “What man is there who has built a new house, and has not dedicated it? Let him go and return to his house, lest he die in the battle, and another man dedicate it. 
 \v 6 What man is there who has planted a vineyard, and has not used its fruit? Let him go and return to his house, lest he die in the battle, and another man use its fruit. 
@@ -665,27 +665,27 @@
 \v 10 When you draw near to a city to fight against it, then proclaim peace to it. 
 \v 11 It shall be, if it gives you answer of peace and opens to you, then it shall be that all the people who are found therein shall become forced laborers to you, and shall serve you. 
 \v 12 If it will make no peace with you, but will make war against you, then you shall besiege it. 
-\v 13 When Yahweh your Elohim delivers it into your hand, you shall strike every male of it with the edge of the sword; 
-\v 14 but the women, the little ones, the livestock, and all that is in the city, even all its plunder, you shall take for plunder for yourself. You may use the plunder of your enemies, which Yahweh your Elohim has given you. 
+\v 13 When Yahuah your Elohim delivers it into your hand, you shall strike every male of it with the edge of the sword; 
+\v 14 but the women, the little ones, the livestock, and all that is in the city, even all its plunder, you shall take for plunder for yourself. You may use the plunder of your enemies, which Yahuah your Elohim has given you. 
 \v 15 Thus you shall do to all the cities which are very far off from you, which are not of the cities of these nations. 
-\v 16 But of the cities of these peoples that Yahweh your Elohim gives you for an inheritance, you shall save alive nothing that breathes; 
-\v 17 but you shall utterly destroy them: the Hittite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite, as Yahweh your Elohim has commanded you; 
-\v 18 that they not teach you to follow all their abominations, which they have done for their elohims; so would you sin against Yahweh your Elohim. 
+\v 16 But of the cities of these peoples that Yahuah your Elohim gives you for an inheritance, you shall save alive nothing that breathes; 
+\v 17 but you shall utterly destroy them: the Hittite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite, as Yahuah your Elohim has commanded you; 
+\v 18 that they not teach you to follow all their abominations, which they have done for their elohims; so would you sin against Yahuah your Elohim. 
 \v 19 When you shall besiege a city a long time, in making war against it to take it, you shall not destroy its trees by wielding an ax against them; for you may eat of them. You shall not cut them down, for is the tree of the field man, that it should be besieged by you? 
 \v 20 Only the trees that you know are not trees for food, you shall destroy and cut them down. You shall build bulwarks against the city that makes war with you, until it falls. 
 \c 21
 \p
-\v 1 If someone is found slain in the land which Yahweh your Elohim gives you to possess, lying in the field, and it isn’t known who has struck him, 
+\v 1 If someone is found slain in the land which Yahuah your Elohim gives you to possess, lying in the field, and it isn’t known who has struck him, 
 \v 2 then your elders and your judges shall come out, and they shall measure to the cities which are around him who is slain. 
 \v 3 It shall be that the elders of the city which is nearest to the slain man shall take a heifer of the herd, which hasn’t been worked with and which has not drawn in the yoke. 
 \v 4 The elders of that city shall bring the heifer down to a valley with running water, which is neither plowed nor sown, and shall break the heifer’s neck there in the valley. 
-\v 5 The priests the sons of Levi shall come near, for them Yahweh your Elohim has chosen to minister to him, and to bless in Yahweh’s name; and according to their word shall every controversy and every assault be decided. 
+\v 5 The priests the sons of Levi shall come near, for them Yahuah your Elohim has chosen to minister to him, and to bless in Yahuah’s name; and according to their word shall every controversy and every assault be decided. 
 \v 6 All the elders of that city which is nearest to the slain man shall wash their hands over the heifer whose neck was broken in the valley. 
 \v 7 They shall answer and say, “Our hands have not shed this blood, neither have our eyes seen it. 
-\v 8 Forgive, Yahweh, your people Israel, whom you have redeemed, and don’t allow innocent blood among your people Israel.” The blood shall be forgiven them. 
-\v 9 So you shall put away the innocent blood from among you, when you shall do that which is right in Yahweh’s eyes. 
+\v 8 Forgive, Yahuah, your people Israel, whom you have redeemed, and don’t allow innocent blood among your people Israel.” The blood shall be forgiven them. 
+\v 9 So you shall put away the innocent blood from among you, when you shall do that which is right in Yahuah’s eyes. 
 \p
-\v 10 When you go out to battle against your enemies, and Yahweh your Elohim delivers them into your hands and you carry them away captive, 
+\v 10 When you go out to battle against your enemies, and Yahuah your Elohim delivers them into your hands and you carry them away captive, 
 \v 11 and see among the captives a beautiful woman, and you are attracted to her, and desire to take her as your woman, 
 \v 12 then you shall bring her home to your house. She shall shave her head and trim her nails. 
 \v 13 She shall take off the clothing of her captivity, and shall remain in your house, and bewail her father and her mother a full month. After that you shall go in to her and be her owner, and she shall be your woman. 
@@ -701,7 +701,7 @@
 \v 21 All the men of his city shall stone him to death with stones. So you shall remove the evil from among you. All Israel shall hear, and fear. 
 \p
 \v 22 If a man has committed a sin worthy of death, and he is put to death, and you hang him on a tree, 
-\v 23 his body shall not remain all night on the tree, but you shall surely bury him the same day; for he who is hanged is accursed of Elohim. Don’t defile your land which Yahweh your Elohim gives you for an inheritance. 
+\v 23 his body shall not remain all night on the tree, but you shall surely bury him the same day; for he who is hanged is accursed of Elohim. Don’t defile your land which Yahuah your Elohim gives you for an inheritance. 
 \c 22
 \p
 \v 1 You shall not see your brother’s ox or his sheep go astray and hide yourself from them. You shall surely bring them again to your brother. 
@@ -709,7 +709,7 @@
 \v 3 So you shall do with his donkey. So you shall do with his garment. So you shall do with every lost thing of your brother’s, which he has lost and you have found. You may not hide yourself. 
 \v 4 You shall not see your brother’s donkey or his ox fallen down by the way, and hide yourself from them. You shall surely help him to lift them up again. 
 \p
-\v 5 A woman shall not wear men’s clothing, neither shall a man put on women’s clothing; for whoever does these things is an abomination to Yahweh your Elohim. 
+\v 5 A woman shall not wear men’s clothing, neither shall a man put on women’s clothing; for whoever does these things is an abomination to Yahuah your Elohim. 
 \p
 \v 6 If you come across a bird’s nest on the way, in any tree or on the ground, with young ones or eggs, and the hen sitting on the young, or on the eggs, you shall not take the hen with the young. 
 \v 7 You shall surely let the hen go, but the young you may take for yourself, that it may be well with you, and that you may prolong your days. 
@@ -744,34 +744,34 @@
 \v 30 A man shall not take his father’s woman, and shall not uncover his father’s skirt. 
 \c 23
 \p
-\v 1 He who is emasculated by crushing or cutting shall not enter into Yahweh’s assembly. 
-\v 2 A person born of a forbidden union shall not enter into Yahweh’s assembly; even to the tenth generation shall no one of his enter into Yahweh’s assembly. 
-\v 3 An Ammonite or a Moabite shall not enter into Yahweh’s assembly; even to the tenth generation shall no one belonging to them enter into Yahweh’s assembly forever, 
+\v 1 He who is emasculated by crushing or cutting shall not enter into Yahuah’s assembly. 
+\v 2 A person born of a forbidden union shall not enter into Yahuah’s assembly; even to the tenth generation shall no one of his enter into Yahuah’s assembly. 
+\v 3 An Ammonite or a Moabite shall not enter into Yahuah’s assembly; even to the tenth generation shall no one belonging to them enter into Yahuah’s assembly forever, 
 \v 4 because they didn’t meet you with bread and with water on the way when you came out of Egypt, and because they hired against you Balaam the son of Beor from Pethor of Mesopotamia, to curse you. 
-\v 5 Nevertheless Yahweh your Elohim wouldn’t listen to Balaam, but Yahweh your Elohim turned the curse into a blessing to you, because Yahweh your Elohim loved you. 
+\v 5 Nevertheless Yahuah your Elohim wouldn’t listen to Balaam, but Yahuah your Elohim turned the curse into a blessing to you, because Yahuah your Elohim loved you. 
 \v 6 You shall not seek their peace nor their prosperity all your days forever. 
 \v 7 You shall not abhor an Edomite, for he is your brother. You shall not abhor an Egyptian, because you lived as a foreigner in his land. 
-\v 8 The children of the third generation who are born to them may enter into Yahweh’s assembly. 
+\v 8 The children of the third generation who are born to them may enter into Yahuah’s assembly. 
 \p
 \v 9 When you go out and camp against your enemies, then you shall keep yourselves from every evil thing. 
 \v 10 If there is among you any man who is not clean by reason of that which happens to him by night, then shall he go outside of the camp. He shall not come within the camp; 
 \v 11 but it shall be, when evening comes, he shall bathe himself in water. When the sun is down, he shall come within the camp. 
 \v 12 You shall have a place also outside of the camp where you go relieve yourself. 
 \v 13 You shall have a trowel among your weapons. It shall be, when you relieve yourself, you shall dig with it, and shall turn back and cover your excrement; 
-\v 14 for Yahweh your Elohim walks in the middle of your camp, to deliver you, and to give up your enemies before you. Therefore your camp shall be set-apart, that he may not see an unclean thing in you, and turn away from you. 
+\v 14 for Yahuah your Elohim walks in the middle of your camp, to deliver you, and to give up your enemies before you. Therefore your camp shall be set-apart, that he may not see an unclean thing in you, and turn away from you. 
 \p
 \v 15 You shall not deliver to his master a servant who has escaped from his master to you. 
 \v 16 He shall dwell with you, among you, in the place which he shall choose within one of your gates, where it pleases him best. You shall not oppress him. 
 \p
 \v 17 There shall be no prostitute of the daughters of Israel, neither shall there be a sodomite of the sons of Israel. 
-\v 18 You shall not bring the hire of a prostitute, or the wages of a male prostitute, into the house of Yahweh your Elohim for any vow; for both of these are an abomination to Yahweh your Elohim. 
+\v 18 You shall not bring the hire of a prostitute, or the wages of a male prostitute, into the house of Yahuah your Elohim for any vow; for both of these are an abomination to Yahuah your Elohim. 
 \p
 \v 19 You shall not lend on interest to your brother: interest of money, interest of food, interest of anything that is lent on interest. 
-\v 20 You may charge a foreigner interest; but you shall not charge your brother interest, that Yahweh your Elohim may bless you in all that you put your hand to, in the land where you go in to possess it. 
+\v 20 You may charge a foreigner interest; but you shall not charge your brother interest, that Yahuah your Elohim may bless you in all that you put your hand to, in the land where you go in to possess it. 
 \p
-\v 21 When you vow a vow to Yahweh your Elohim, you shall not be slack to pay it, for Yahweh your Elohim will surely require it of you; and it would be sin in you. 
+\v 21 When you vow a vow to Yahuah your Elohim, you shall not be slack to pay it, for Yahuah your Elohim will surely require it of you; and it would be sin in you. 
 \v 22 But if you refrain from making a vow, it shall be no sin in you. 
-\v 23 You shall observe and do that which has gone out of your lips. Whatever you have vowed to Yahweh your Elohim as a free will offering, which you have promised with your mouth, you must do. 
+\v 23 You shall observe and do that which has gone out of your lips. Whatever you have vowed to Yahuah your Elohim as a free will offering, which you have promised with your mouth, you must do. 
 \v 24 When you come into your neighbor’s vineyard, then you may eat your fill of grapes at your own pleasure; but you shall not put any in your container. 
 \v 25 When you come into your neighbor’s standing grain, then you may pluck the ears with your hand; but you shall not use a sickle on your neighbor’s standing grain. 
 \c 24
@@ -779,7 +779,7 @@
 \v 1 When a man takes a woman and owns her, then it shall be, if she finds no favor in his eyes because he has found some unseemly thing in her, that he shall write her a certificate of divorce, put it in her hand, and send her out of his house. 
 \v 2 When she has departed out of his house, she may go and be another man’s woman. 
 \v 3 If the latter man hates her, and writes her a certificate of divorce, puts it in her hand, and sends her out of his house; or if the latter man dies, who took her to be his woman; 
-\v 4 her former owner, who sent her away, may not take her again to be his woman after she is defiled; for that would be an abomination to Yahweh. You shall not cause the land to sin, which Yahweh your Elohim gives you for an inheritance. 
+\v 4 her former owner, who sent her away, may not take her again to be his woman after she is defiled; for that would be an abomination to Yahuah. You shall not cause the land to sin, which Yahuah your Elohim gives you for an inheritance. 
 \v 5 When a man takes a new woman, he shall not go out in the army, neither shall he be assigned any business. He shall be free at home one year, and shall cheer his woman whom he has taken. 
 \p
 \v 6 No man shall take the mill or the upper millstone as a pledge, for he takes a life in pledge. 
@@ -787,22 +787,22 @@
 \v 7 If a man is found stealing any of his brothers of the children of Israel, and he deals with him as a slave, or sells him, then that thief shall die. So you shall remove the evil from among you. 
 \p
 \v 8 Be careful in the plague of leprosy, that you observe diligently and do according to all that the Levitical priests teach you. As I commanded them, so you shall observe to do. 
-\v 9 Remember what Yahweh your Elohim did to Miriam, by the way as you came out of Egypt. 
+\v 9 Remember what Yahuah your Elohim did to Miriam, by the way as you came out of Egypt. 
 \p
 \v 10 When you lend your neighbor any kind of loan, you shall not go into his house to get his pledge. 
 \v 11 You shall stand outside, and the man to whom you lend shall bring the pledge outside to you. 
 \v 12 If he is a poor man, you shall not sleep with his pledge. 
-\v 13 You shall surely restore to him the pledge when the sun goes down, that he may sleep in his garment and bless you. It shall be righteousness to you before Yahweh your Elohim. 
+\v 13 You shall surely restore to him the pledge when the sun goes down, that he may sleep in his garment and bless you. It shall be righteousness to you before Yahuah your Elohim. 
 \p
 \v 14 You shall not oppress a hired servant who is poor and needy, whether he is one of your brothers or one of the foreigners who are in your land within your gates. 
-\v 15 In his day you shall give him his wages, neither shall the sun go down on it, for he is poor and sets his heart on it, lest he cry against you to Yahweh, and it be sin to you. 
+\v 15 In his day you shall give him his wages, neither shall the sun go down on it, for he is poor and sets his heart on it, lest he cry against you to Yahuah, and it be sin to you. 
 \p
 \v 16 The fathers shall not be put to death for the children, neither shall the children be put to death for the fathers. Every man shall be put to death for his own sin. 
 \p
 \v 17 You shall not deprive the foreigner or the fatherless of justice, nor take a widow’s clothing in pledge; 
-\v 18 but you shall remember that you were a slave in Egypt, and Yahweh your Elohim redeemed you there. Therefore I command you to do this thing. 
+\v 18 but you shall remember that you were a slave in Egypt, and Yahuah your Elohim redeemed you there. Therefore I command you to do this thing. 
 \p
-\v 19 When you reap your harvest in your field, and have forgotten a sheaf in the field, you shall not go again to get it. It shall be for the foreigner, for the fatherless, and for the widow, that Yahweh your Elohim may bless you in all the work of your hands. 
+\v 19 When you reap your harvest in your field, and have forgotten a sheaf in the field, you shall not go again to get it. It shall be for the foreigner, for the fatherless, and for the widow, that Yahuah your Elohim may bless you in all the work of your hands. 
 \v 20 When you beat your olive tree, you shall not go over the boughs again. It shall be for the foreigner, for the fatherless, and for the widow. 
 \p
 \v 21 When you harvest your vineyard, you shall not glean it after yourselves. It shall be for the foreigner, for the fatherless, and for the widow. 
@@ -828,54 +828,54 @@
 \p
 \v 13 You shall not have in your bag diverse weights, one heavy and one light. 
 \v 14 You shall not have in your house diverse measures, one large and one small. 
-\v 15 You shall have a perfect and just weight. You shall have a perfect and just measure, that your days may be long in the land which Yahweh your Elohim gives you. 
-\v 16 For all who do such things, all who do unrighteously, are an abomination to Yahweh your Elohim. 
+\v 15 You shall have a perfect and just weight. You shall have a perfect and just measure, that your days may be long in the land which Yahuah your Elohim gives you. 
+\v 16 For all who do such things, all who do unrighteously, are an abomination to Yahuah your Elohim. 
 \p
 \v 17 Remember what Amalek did to you by the way as you came out of Egypt, 
 \v 18 how he met you by the way, and struck the rearmost of you, all who were feeble behind you, when you were faint and weary; and he didn’t fear Elohim. 
-\v 19 Therefore it shall be, when Yahweh your Elohim has given you rest from all your enemies all around, in the land which Yahweh your Elohim gives you for an inheritance to possess it, that you shall blot out the memory of Amalek from under the sky. You shall not forget. 
+\v 19 Therefore it shall be, when Yahuah your Elohim has given you rest from all your enemies all around, in the land which Yahuah your Elohim gives you for an inheritance to possess it, that you shall blot out the memory of Amalek from under the sky. You shall not forget. 
 \c 26
 \p
-\v 1 It shall be, when you have come in to the land which Yahweh your Elohim gives you for an inheritance, possess it, and dwell in it, 
-\v 2 that you shall take some of the first of all the fruit of the ground, which you shall bring in from your land that Yahweh your Elohim gives you. You shall put it in a basket, and shall go to the place which Yahweh your Elohim shall choose to cause his name to dwell there. 
-\v 3 You shall come to the priest who shall be in those days, and tell him, “I profess today to Yahweh your Elohim, that I have come to the land which Yahweh swore to our fathers to give us.” 
-\v 4 The priest shall take the basket out of your hand, and set it down before Yahweh your Elohim’s altar. 
-\v 5 You shall answer and say before Yahweh your Elohim, “My father was a Syrian ready to perish. He went down into Egypt, and lived there, few in number. There he became a great, mighty, and populous nation. 
+\v 1 It shall be, when you have come in to the land which Yahuah your Elohim gives you for an inheritance, possess it, and dwell in it, 
+\v 2 that you shall take some of the first of all the fruit of the ground, which you shall bring in from your land that Yahuah your Elohim gives you. You shall put it in a basket, and shall go to the place which Yahuah your Elohim shall choose to cause his name to dwell there. 
+\v 3 You shall come to the priest who shall be in those days, and tell him, “I profess today to Yahuah your Elohim, that I have come to the land which Yahuah swore to our fathers to give us.” 
+\v 4 The priest shall take the basket out of your hand, and set it down before Yahuah your Elohim’s altar. 
+\v 5 You shall answer and say before Yahuah your Elohim, “My father was a Syrian ready to perish. He went down into Egypt, and lived there, few in number. There he became a great, mighty, and populous nation. 
 \v 6 The Egyptians mistreated us, afflicted us, and imposed hard labor on us. 
-\v 7 Then we cried to Yahweh, the Elohim of our fathers. Yahweh heard our voice, and saw our affliction, our toil, and our oppression. 
-\v 8 Yahweh brought us out of Egypt with a mighty hand, with an outstretched arm, with great terror, with signs, and with wonders; 
+\v 7 Then we cried to Yahuah, the Elohim of our fathers. Yahuah heard our voice, and saw our affliction, our toil, and our oppression. 
+\v 8 Yahuah brought us out of Egypt with a mighty hand, with an outstretched arm, with great terror, with signs, and with wonders; 
 \v 9 and he has brought us into this place, and has given us this land, a land flowing with milk and honey. 
-\v 10 Now, behold, I have brought the first of the fruit of the ground, which you, Yahweh, have given me.” You shall set it down before Yahweh your Elohim, and worship before Yahweh your Elohim. 
-\v 11 You shall rejoice in all the good which Yahweh your Elohim has given to you, and to your house, you, and the Levite, and the foreigner who is among you. 
+\v 10 Now, behold, I have brought the first of the fruit of the ground, which you, Yahuah, have given me.” You shall set it down before Yahuah your Elohim, and worship before Yahuah your Elohim. 
+\v 11 You shall rejoice in all the good which Yahuah your Elohim has given to you, and to your house, you, and the Levite, and the foreigner who is among you. 
 \p
 \v 12 When you have finished tithing all the tithe of your increase in the third year, which is the year of tithing, then you shall give it to the Levite, to the foreigner, to the fatherless, and to the widow, that they may eat within your gates and be filled. 
-\v 13 You shall say before Yahweh your Elohim, “I have put away the set-apart things out of my house, and also have given them to the Levite, to the foreigner, to the fatherless, and to the widow, according to all your commandment which you have commanded me. I have not transgressed any of your commandments, neither have I forgotten them. 
-\v 14 I have not eaten of it in my mourning, neither have I removed any of it while I was unclean, nor given of it for the dead. I have listened to Yahweh my Elohim’s voice. I have done according to all that you have commanded me. 
+\v 13 You shall say before Yahuah your Elohim, “I have put away the set-apart things out of my house, and also have given them to the Levite, to the foreigner, to the fatherless, and to the widow, according to all your commandment which you have commanded me. I have not transgressed any of your commandments, neither have I forgotten them. 
+\v 14 I have not eaten of it in my mourning, neither have I removed any of it while I was unclean, nor given of it for the dead. I have listened to Yahuah my Elohim’s voice. I have done according to all that you have commanded me. 
 \v 15 Look down from your set-apart habitation, from heaven, and bless your people Israel, and the ground which you have given us, as you swore to our fathers, a land flowing with milk and honey.” 
 \p
-\v 16 Today Yahweh your Elohim commands you to do these statutes and ordinances. You shall therefore keep and do them with all your heart and with all your soul. 
-\v 17 You have declared today that Yahweh is your Elohim, and that you would walk in his ways, keep his statutes, his commandments, and his ordinances, and listen to his voice. 
-\v 18 Yahweh has declared today that you are a people for his own possession, as he has promised you, and that you should keep all his commandments. 
-\v 19 He will make you high above all nations that he has made, in praise, in name, and in honor, and that you may be a set-apart people to Yahweh your Elohim, as he has spoken. 
+\v 16 Today Yahuah your Elohim commands you to do these statutes and ordinances. You shall therefore keep and do them with all your heart and with all your soul. 
+\v 17 You have declared today that Yahuah is your Elohim, and that you would walk in his ways, keep his statutes, his commandments, and his ordinances, and listen to his voice. 
+\v 18 Yahuah has declared today that you are a people for his own possession, as he has promised you, and that you should keep all his commandments. 
+\v 19 He will make you high above all nations that he has made, in praise, in name, and in honor, and that you may be a set-apart people to Yahuah your Elohim, as he has spoken. 
 \c 27
 \p
 \v 1 Moses and the elders of Israel commanded the people, saying, “Keep all the commandment which I command you today. 
-\v 2 It shall be on the day when you shall pass over the Jordan to the land which Yahweh your Elohim gives you, that you shall set yourself up great stones, and coat them with plaster. 
-\v 3 You shall write on them all the words of this law, when you have passed over, that you may go in to the land which Yahweh your Elohim gives you, a land flowing with milk and honey, as Yahweh, the Elohim of your fathers, has promised you. 
+\v 2 It shall be on the day when you shall pass over the Jordan to the land which Yahuah your Elohim gives you, that you shall set yourself up great stones, and coat them with plaster. 
+\v 3 You shall write on them all the words of this law, when you have passed over, that you may go in to the land which Yahuah your Elohim gives you, a land flowing with milk and honey, as Yahuah, the Elohim of your fathers, has promised you. 
 \v 4 It shall be, when you have crossed over the Jordan, that you shall set up these stones, which I command you today, on Mount Ebal, and you shall coat them with plaster. 
-\v 5 There you shall build an altar to Yahweh your Elohim, an altar of stones. You shall not use any iron tool on them. 
-\v 6 You shall build Yahweh your Elohim’s altar of uncut stones. You shall offer burnt offerings on it to Yahweh your Elohim. 
-\v 7 You shall sacrifice peace offerings, and shall eat there. You shall rejoice before Yahweh your Elohim. 
+\v 5 There you shall build an altar to Yahuah your Elohim, an altar of stones. You shall not use any iron tool on them. 
+\v 6 You shall build Yahuah your Elohim’s altar of uncut stones. You shall offer burnt offerings on it to Yahuah your Elohim. 
+\v 7 You shall sacrifice peace offerings, and shall eat there. You shall rejoice before Yahuah your Elohim. 
 \v 8 You shall write on the stones all the words of this law very plainly.” 
 \p
-\v 9 Moses and the Levitical priests spoke to all Israel, saying, “Be silent and listen, Israel! Today you have become the people of Yahweh your Elohim. 
-\v 10 You shall therefore obey Yahweh your Elohim’s voice, and do his commandments and his statutes, which I command you today.” 
+\v 9 Moses and the Levitical priests spoke to all Israel, saying, “Be silent and listen, Israel! Today you have become the people of Yahuah your Elohim. 
+\v 10 You shall therefore obey Yahuah your Elohim’s voice, and do his commandments and his statutes, which I command you today.” 
 \p
 \v 11 Moses commanded the people the same day, saying, 
 \v 12 “These shall stand on Mount Gerizim to bless the people, when you have crossed over the Jordan: Simeon, Levi, Judah, Issachar, Joseph, and Benjamin. 
 \v 13 These shall stand on Mount Ebal for the curse: Reuben, Gad, Asher, Zebulun, Dan, and Naphtali. 
 \v 14 With a loud voice, the Levites shall say to all the men of Israel, 
-\v 15 ‘Cursed is the man who makes an engraved or molten image, an abomination to Yahweh, the work of the hands of the craftsman, and sets it up in secret.’ 
+\v 15 ‘Cursed is the man who makes an engraved or molten image, an abomination to Yahuah, the work of the hands of the craftsman, and sets it up in secret.’ 
 \p All the people shall answer and say, ‘Amen.’ 
 \p
 \v 16 ‘Cursed is he who dishonors his father or his mother.’ 
@@ -912,44 +912,44 @@
 \p All the people shall say, ‘Amen.’ ” 
 \c 28
 \p
-\v 1 It shall happen, if you shall listen diligently to Yahweh your Elohim’s voice, to observe to do all his commandments which I command you today, that Yahweh your Elohim will set you high above all the nations of the earth. 
-\v 2 All these blessings will come upon you, and overtake you, if you listen to Yahweh your Elohim’s voice. 
+\v 1 It shall happen, if you shall listen diligently to Yahuah your Elohim’s voice, to observe to do all his commandments which I command you today, that Yahuah your Elohim will set you high above all the nations of the earth. 
+\v 2 All these blessings will come upon you, and overtake you, if you listen to Yahuah your Elohim’s voice. 
 \v 3 You shall be blessed in the city, and you shall be blessed in the field. 
 \v 4 You shall be blessed in the fruit of your body, the fruit of your ground, the fruit of your animals, the increase of your livestock, and the young of your flock. 
 \v 5 Your basket and your kneading trough shall be blessed. 
 \v 6 You shall be blessed when you come in, and you shall be blessed when you go out. 
-\v 7 Yahweh will cause your enemies who rise up against you to be struck before you. They will come out against you one way, and will flee before you seven ways. 
-\v 8 Yahweh will command the blessing on you in your barns, and in all that you put your hand to. He will bless you in the land which Yahweh your Elohim gives you. 
-\v 9 Yahweh will establish you for a set-apart people to himself, as he has sworn to you, if you shall keep the commandments of Yahweh your Elohim, and walk in his ways. 
-\v 10 All the peoples of the earth shall see that you are called by Yahweh’s name, and they will be afraid of you. 
-\v 11 Yahweh will grant you abundant prosperity in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, in the land which Yahweh swore to your fathers to give you. 
-\v 12 Yahweh will open to you his good treasure in the sky, to give the rain of your land in its season, and to bless all the work of your hand. You will lend to many nations, and you will not borrow. 
-\v 13 Yahweh will make you the head, and not the tail. You will be above only, and you will not be beneath, if you listen to the commandments of Yahweh your Elohim which I command you today, to observe and to do, 
+\v 7 Yahuah will cause your enemies who rise up against you to be struck before you. They will come out against you one way, and will flee before you seven ways. 
+\v 8 Yahuah will command the blessing on you in your barns, and in all that you put your hand to. He will bless you in the land which Yahuah your Elohim gives you. 
+\v 9 Yahuah will establish you for a set-apart people to himself, as he has sworn to you, if you shall keep the commandments of Yahuah your Elohim, and walk in his ways. 
+\v 10 All the peoples of the earth shall see that you are called by Yahuah’s name, and they will be afraid of you. 
+\v 11 Yahuah will grant you abundant prosperity in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, in the land which Yahuah swore to your fathers to give you. 
+\v 12 Yahuah will open to you his good treasure in the sky, to give the rain of your land in its season, and to bless all the work of your hand. You will lend to many nations, and you will not borrow. 
+\v 13 Yahuah will make you the head, and not the tail. You will be above only, and you will not be beneath, if you listen to the commandments of Yahuah your Elohim which I command you today, to observe and to do, 
 \v 14 and shall not turn away from any of the words which I command you today, to the right hand or to the left, to go after other elohims to serve them. 
 \p
-\v 15 But it shall come to pass, if you will not listen to Yahweh your Elohim’s voice, to observe to do all his commandments and his statutes which I command you today, that all these curses will come on you and overtake you. 
+\v 15 But it shall come to pass, if you will not listen to Yahuah your Elohim’s voice, to observe to do all his commandments and his statutes which I command you today, that all these curses will come on you and overtake you. 
 \v 16 You will be cursed in the city, and you will be cursed in the field. 
 \v 17 Your basket and your kneading trough will be cursed. 
 \v 18 The fruit of your body, the fruit of your ground, the increase of your livestock, and the young of your flock will be cursed. 
 \v 19 You will be cursed when you come in, and you will be cursed when you go out. 
-\v 20 Yahweh will send on you cursing, confusion, and rebuke in all that you put your hand to do, until you are destroyed and until you perish quickly, because of the evil of your doings, by which you have forsaken me. 
-\v 21 Yahweh will make the pestilence cling to you, until he has consumed you from off the land where you go in to possess it. 
-\v 22 Yahweh will strike you with consumption, with fever, with inflammation, with fiery heat, with the sword, with blight, and with mildew. They will pursue you until you perish. 
+\v 20 Yahuah will send on you cursing, confusion, and rebuke in all that you put your hand to do, until you are destroyed and until you perish quickly, because of the evil of your doings, by which you have forsaken me. 
+\v 21 Yahuah will make the pestilence cling to you, until he has consumed you from off the land where you go in to possess it. 
+\v 22 Yahuah will strike you with consumption, with fever, with inflammation, with fiery heat, with the sword, with blight, and with mildew. They will pursue you until you perish. 
 \v 23 Your sky that is over your head will be bronze, and the earth that is under you will be iron. 
-\v 24 Yahweh will make the rain of your land powder and dust. It will come down on you from the sky, until you are destroyed. 
-\v 25 Yahweh will cause you to be struck before your enemies. You will go out one way against them, and will flee seven ways before them. You will be tossed back and forth among all the kingdoms of the earth. 
+\v 24 Yahuah will make the rain of your land powder and dust. It will come down on you from the sky, until you are destroyed. 
+\v 25 Yahuah will cause you to be struck before your enemies. You will go out one way against them, and will flee seven ways before them. You will be tossed back and forth among all the kingdoms of the earth. 
 \v 26 Your dead bodies will be food to all birds of the sky, and to the animals of the earth; and there will be no one to frighten them away. 
-\v 27 Yahweh will strike you with the boils of Egypt, with the tumors, with the scurvy, and with the itch, of which you can not be healed. 
-\v 28 Yahweh will strike you with madness, with blindness, and with astonishment of heart. 
+\v 27 Yahuah will strike you with the boils of Egypt, with the tumors, with the scurvy, and with the itch, of which you can not be healed. 
+\v 28 Yahuah will strike you with madness, with blindness, and with astonishment of heart. 
 \v 29 You will grope at noonday, as the blind gropes in darkness, and you shall not prosper in your ways. You will only be oppressed and robbed always, and there will be no one to save you. 
 \v 30 You will betroth a woman, and another man shall lie with her. You will build a house, and you won’t dwell in it. You will plant a vineyard, and not use its fruit. 
 \v 31 Your ox will be slain before your eyes, and you will not eat any of it. Your donkey will be violently taken away from before your face, and will not be restored to you. Your sheep will be given to your enemies, and you will have no one to save you. 
 \v 32 Your sons and your daughters will be given to another people. Your eyes will look and fail with longing for them all day long. There will be no power in your hand. 
 \v 33 A nation which you don’t know will eat the fruit of your ground and all of your work. You will only be oppressed and crushed always, 
 \v 34 so that the sights that you see with your eyes will drive you mad. 
-\v 35 Yahweh will strike you in the knees and in the legs with a sore boil, of which you cannot be healed, from the sole of your foot to the crown of your head. 
-\v 36 Yahweh will bring you, and your king whom you will set over yourselves, to a nation that you have not known, you nor your fathers. There you will serve other elohims of wood and stone. 
-\v 37 You will become an astonishment, a proverb, and a byword among all the peoples where Yahweh will lead you away. 
+\v 35 Yahuah will strike you in the knees and in the legs with a sore boil, of which you cannot be healed, from the sole of your foot to the crown of your head. 
+\v 36 Yahuah will bring you, and your king whom you will set over yourselves, to a nation that you have not known, you nor your fathers. There you will serve other elohims of wood and stone. 
+\v 37 You will become an astonishment, a proverb, and a byword among all the peoples where Yahuah will lead you away. 
 \v 38 You will carry much seed out into the field, and will gather little in, for the locust will consume it. 
 \v 39 You will plant vineyards and dress them, but you will neither drink of the wine, nor harvest, because worms will eat them. 
 \v 40 You will have olive trees throughout all your borders, but you won’t anoint yourself with the oil, for your olives will drop off. 
@@ -958,111 +958,111 @@
 \v 43 The foreigner who is among you will mount up above you higher and higher, and you will come down lower and lower. 
 \v 44 He will lend to you, and you won’t lend to him. He will be the head, and you will be the tail. 
 \p
-\v 45 All these curses will come on you, and will pursue you and overtake you, until you are destroyed, because you didn’t listen to Yahweh your Elohim’s voice, to keep his commandments and his statutes which he commanded you. 
+\v 45 All these curses will come on you, and will pursue you and overtake you, until you are destroyed, because you didn’t listen to Yahuah your Elohim’s voice, to keep his commandments and his statutes which he commanded you. 
 \v 46 They will be for a sign and for a wonder to you and to your offspring forever. 
-\v 47 Because you didn’t serve Yahweh your Elohim with joyfulness and with gladness of heart, by reason of the abundance of all things; 
-\v 48 therefore you will serve your enemies whom Yahweh sends against you, in hunger, in thirst, in nakedness, and in lack of all things. He will put an iron yoke on your neck until he has destroyed you. 
-\v 49 Yahweh will bring a nation against you from far away, from the end of the earth, as the eagle flies: a nation whose language you will not understand, 
+\v 47 Because you didn’t serve Yahuah your Elohim with joyfulness and with gladness of heart, by reason of the abundance of all things; 
+\v 48 therefore you will serve your enemies whom Yahuah sends against you, in hunger, in thirst, in nakedness, and in lack of all things. He will put an iron yoke on your neck until he has destroyed you. 
+\v 49 Yahuah will bring a nation against you from far away, from the end of the earth, as the eagle flies: a nation whose language you will not understand, 
 \v 50 a nation of fierce facial expressions, that doesn’t respect the elderly, nor show favor to the young. 
 \v 51 They will eat the fruit of your livestock and the fruit of your ground, until you are destroyed. They also won’t leave you grain, new wine, oil, the increase of your livestock, or the young of your flock, until they have caused you to perish. 
-\v 52 They will besiege you in all your gates until your high and fortified walls in which you trusted come down throughout all your land. They will besiege you in all your gates throughout all your land which Yahweh your Elohim has given you. 
-\v 53 You will eat the fruit of your own body, the flesh of your sons and of your daughters, whom Yahweh your Elohim has given you, in the siege and in the distress with which your enemies will distress you. 
+\v 52 They will besiege you in all your gates until your high and fortified walls in which you trusted come down throughout all your land. They will besiege you in all your gates throughout all your land which Yahuah your Elohim has given you. 
+\v 53 You will eat the fruit of your own body, the flesh of your sons and of your daughters, whom Yahuah your Elohim has given you, in the siege and in the distress with which your enemies will distress you. 
 \v 54 The man who is tender among you, and very delicate, his eye will be evil toward his brother, toward the woman whom he loves, and toward the remnant of his children whom he has remaining, 
 \v 55 so that he will not give to any of them of the flesh of his children whom he will eat, because he has nothing left to him, in the siege and in the distress with which your enemy will distress you in all your gates. 
 \v 56 The tender and delicate woman among you, who would not venture to set the sole of her foot on the ground for delicateness and tenderness, her eye will be evil toward the man that she loves, toward her son, toward her daughter, 
 \v 57 toward her young one who comes out from between her feet, and toward her children whom she bears; for she will eat them secretly for lack of all things in the siege and in the distress with which your enemy will distress you in your gates. 
-\v 58 If you will not observe to do all the words of this law that are written in this book, that you may fear this glorious and fearful name, YAHWEH your Elohim, 
-\v 59 then Yahweh will make your plagues and the plagues of your offspring fearful, even great plagues, and of long duration, and severe sicknesses, and of long duration. 
+\v 58 If you will not observe to do all the words of this law that are written in this book, that you may fear this glorious and fearful name, YAHUAH your Elohim, 
+\v 59 then Yahuah will make your plagues and the plagues of your offspring fearful, even great plagues, and of long duration, and severe sicknesses, and of long duration. 
 \v 60 He will bring on you again all the diseases of Egypt, which you were afraid of; and they will cling to you. 
-\v 61 Also every sickness and every plague which is not written in the book of this law, Yahweh will bring them on you until you are destroyed. 
-\v 62 You will be left few in number, even though you were as the stars of the sky for multitude, because you didn’t listen to Yahweh your Elohim’s voice. 
-\v 63 It will happen that as Yahweh rejoiced over you to do you good, and to multiply you, so Yahweh will rejoice over you to cause you to perish and to destroy you. You will be plucked from the land that you are going in to possess. 
-\v 64 Yahweh will scatter you among all peoples, from one end of the earth to the other end of the earth. There you will serve other elohims which you have not known, you nor your fathers, even wood and stone. 
-\v 65 Among these nations you will find no ease, and there will be no rest for the sole of your foot; but Yahweh will give you there a trembling heart, failing of eyes, and pining of soul. 
+\v 61 Also every sickness and every plague which is not written in the book of this law, Yahuah will bring them on you until you are destroyed. 
+\v 62 You will be left few in number, even though you were as the stars of the sky for multitude, because you didn’t listen to Yahuah your Elohim’s voice. 
+\v 63 It will happen that as Yahuah rejoiced over you to do you good, and to multiply you, so Yahuah will rejoice over you to cause you to perish and to destroy you. You will be plucked from the land that you are going in to possess. 
+\v 64 Yahuah will scatter you among all peoples, from one end of the earth to the other end of the earth. There you will serve other elohims which you have not known, you nor your fathers, even wood and stone. 
+\v 65 Among these nations you will find no ease, and there will be no rest for the sole of your foot; but Yahuah will give you there a trembling heart, failing of eyes, and pining of soul. 
 \v 66 Your life will hang in doubt before you. You will be afraid night and day, and will have no assurance of your life. 
 \v 67 In the morning you will say, “I wish it were evening!” and at evening you will say, “I wish it were morning!” for the fear of your heart which you will fear, and for the sights which your eyes will see. 
-\v 68 Yahweh will bring you into Egypt again with ships, by the way of which I told to you that you would never see it again. There you will offer yourselves to your enemies for male and female slaves, and nobody will buy you. 
+\v 68 Yahuah will bring you into Egypt again with ships, by the way of which I told to you that you would never see it again. There you will offer yourselves to your enemies for male and female slaves, and nobody will buy you. 
 \c 29
 \p
-\v 1 These are the words of the covenant which Yahweh commanded Moses to make with the children of Israel in the land of Moab, in addition to the covenant which he made with them in Horeb. 
+\v 1 These are the words of the covenant which Yahuah commanded Moses to make with the children of Israel in the land of Moab, in addition to the covenant which he made with them in Horeb. 
 \v 2 Moses called to all Israel, and said to them: 
-\p Your eyes have seen all that Yahweh did in the land of Egypt to Pharaoh, and to all his servants, and to all his land; 
+\p Your eyes have seen all that Yahuah did in the land of Egypt to Pharaoh, and to all his servants, and to all his land; 
 \v 3 the great trials which your eyes saw, the signs, and those great wonders. 
-\v 4 But Yahweh has not given you a heart to know, eyes to see, and ears to hear, to this day. 
+\v 4 But Yahuah has not given you a heart to know, eyes to see, and ears to hear, to this day. 
 \v 5 I have led you forty years in the wilderness. Your clothes have not grown old on you, and your sandals have not grown old on your feet. 
-\v 6 You have not eaten bread, neither have you drunk wine or strong drink, that you may know that I am Yahweh your Elohim. 
+\v 6 You have not eaten bread, neither have you drunk wine or strong drink, that you may know that I am Yahuah your Elohim. 
 \v 7 When you came to this place, Sihon the king of Heshbon and Og the king of Bashan came out against us to battle, and we struck them. 
 \v 8 We took their land, and gave it for an inheritance to the Reubenites, and to the Gadites, and to the half-tribe of the Manassites. 
 \v 9 Therefore keep the words of this covenant and do them, that you may prosper in all that you do. 
-\v 10 All of you stand today in the presence of Yahweh your Elohim: your heads, your tribes, your elders, and your officers, even all the men of Israel, 
+\v 10 All of you stand today in the presence of Yahuah your Elohim: your heads, your tribes, your elders, and your officers, even all the men of Israel, 
 \v 11 your little ones, your women, and the foreigners who are in the middle of your camps, from the one who cuts your wood to the one who draws your water, 
-\v 12 that you may enter into the covenant of Yahweh your Elohim, and into his oath, which Yahweh your Elohim makes with you today, 
+\v 12 that you may enter into the covenant of Yahuah your Elohim, and into his oath, which Yahuah your Elohim makes with you today, 
 \v 13 that he may establish you today as his people, and that he may be your Elohim, as he spoke to you and as he swore to your fathers, to Abraham, to Isaac, and to Jacob. 
 \v 14 Neither do I make this covenant and this oath with you only, 
-\v 15 but with those who stand here with us today before Yahweh our Elohim, and also with those who are not here with us today 
+\v 15 but with those who stand here with us today before Yahuah our Elohim, and also with those who are not here with us today 
 \v 16 (for you know how we lived in the land of Egypt, and how we came through the middle of the nations through which you passed; 
 \v 17 and you have seen their abominations and their idols of wood, stone, silver, and gold, which were among them); 
-\v 18 lest there should be among you man, woman, family, or tribe whose heart turns away today from Yahweh our Elohim, to go to serve the elohims of those nations; lest there should be among you a root that produces bitter poison; 
+\v 18 lest there should be among you man, woman, family, or tribe whose heart turns away today from Yahuah our Elohim, to go to serve the elohims of those nations; lest there should be among you a root that produces bitter poison; 
 \v 19 and it happen, when he hears the words of this curse, that he bless himself in his heart, saying, “I shall have peace, though I walk in the stubbornness of my heart,” to destroy the moist with the dry. 
-\v 20 Yahweh will not pardon him, but then Yahweh’s anger and his jealousy will smoke against that man, and all the curse that is written in this book will fall on him, and Yahweh will blot out his name from under the sky. 
-\v 21 Yahweh will set him apart for evil out of all the tribes of Israel, according to all the curses of the covenant written in this book of the law. 
+\v 20 Yahuah will not pardon him, but then Yahuah’s anger and his jealousy will smoke against that man, and all the curse that is written in this book will fall on him, and Yahuah will blot out his name from under the sky. 
+\v 21 Yahuah will set him apart for evil out of all the tribes of Israel, according to all the curses of the covenant written in this book of the law. 
 \p
-\v 22 The generation to come—your children who will rise up after you, and the foreigner who will come from a far land—will say, when they see the plagues of that land, and the sicknesses with which Yahweh has made it sick, 
-\v 23 that all of its land is sulfur, salt, and burning, that it is not sown, doesn’t produce, nor does any grass grow in it, like the overthrow of Sodom, Gomorrah, Admah, and Zeboiim, which Yahweh overthrew in his anger, and in his wrath. 
-\v 24 Even all the nations will say, “Why has Yahweh done this to this land? What does the heat of this great anger mean?” 
+\v 22 The generation to come—your children who will rise up after you, and the foreigner who will come from a far land—will say, when they see the plagues of that land, and the sicknesses with which Yahuah has made it sick, 
+\v 23 that all of its land is sulfur, salt, and burning, that it is not sown, doesn’t produce, nor does any grass grow in it, like the overthrow of Sodom, Gomorrah, Admah, and Zeboiim, which Yahuah overthrew in his anger, and in his wrath. 
+\v 24 Even all the nations will say, “Why has Yahuah done this to this land? What does the heat of this great anger mean?” 
 \p
-\v 25 Then men will say, “Because they abandoned the covenant of Yahweh, the Elohim of their fathers, which he made with them when he brought them out of the land of Egypt, 
+\v 25 Then men will say, “Because they abandoned the covenant of Yahuah, the Elohim of their fathers, which he made with them when he brought them out of the land of Egypt, 
 \v 26 and went and served other elohims and worshiped them, elohims that they didn’t know and that he had not given to them. 
-\v 27 Therefore Yahweh’s anger burned against this land, to bring on it all the curses that are written in this book. 
-\v 28 Yahweh rooted them out of their land in anger, in wrath, and in great indignation, and thrust them into another land, as it is today.” 
+\v 27 Therefore Yahuah’s anger burned against this land, to bring on it all the curses that are written in this book. 
+\v 28 Yahuah rooted them out of their land in anger, in wrath, and in great indignation, and thrust them into another land, as it is today.” 
 \p
-\v 29 The secret things belong to Yahweh our Elohim; but the things that are revealed belong to us and to our children forever, that we may do all the words of this law. 
+\v 29 The secret things belong to Yahuah our Elohim; but the things that are revealed belong to us and to our children forever, that we may do all the words of this law. 
 \c 30
 \p
-\v 1 It shall happen, when all these things have come on you, the blessing and the curse, which I have set before you, and you shall call them to mind among all the nations where Yahweh your Elohim has driven you, 
-\v 2 and return to Yahweh your Elohim and obey his voice according to all that I command you today, you and your children, with all your heart and with all your soul, 
-\v 3 that then Yahweh your Elohim will release you from captivity, have compassion on you, and will return and gather you from all the peoples where Yahweh your Elohim has scattered you. 
-\v 4 If your outcasts are in the uttermost parts of the heavens, from there Yahweh your Elohim will gather you, and from there he will bring you back. 
-\v 5 Yahweh your Elohim will bring you into the land which your fathers possessed, and you will possess it. He will do you good, and increase your numbers more than your fathers. 
-\v 6 Yahweh your Elohim will circumcise your heart, and the heart of your offspring, to love Yahweh your Elohim with all your heart and with all your soul, that you may live. 
-\v 7 Yahweh your Elohim will put all these curses on your enemies and on those who hate you, who persecuted you. 
-\v 8 You shall return and obey Yahweh’s voice, and do all his commandments which I command you today. 
-\v 9 Yahweh your Elohim will make you prosperous in all the work of your hand, in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, for good; for Yahweh will again rejoice over you for good, as he rejoiced over your fathers, 
-\v 10 if you will obey Yahweh your Elohim’s voice, to keep his commandments and his statutes which are written in this book of the law, if you turn to Yahweh your Elohim with all your heart and with all your soul. 
+\v 1 It shall happen, when all these things have come on you, the blessing and the curse, which I have set before you, and you shall call them to mind among all the nations where Yahuah your Elohim has driven you, 
+\v 2 and return to Yahuah your Elohim and obey his voice according to all that I command you today, you and your children, with all your heart and with all your soul, 
+\v 3 that then Yahuah your Elohim will release you from captivity, have compassion on you, and will return and gather you from all the peoples where Yahuah your Elohim has scattered you. 
+\v 4 If your outcasts are in the uttermost parts of the heavens, from there Yahuah your Elohim will gather you, and from there he will bring you back. 
+\v 5 Yahuah your Elohim will bring you into the land which your fathers possessed, and you will possess it. He will do you good, and increase your numbers more than your fathers. 
+\v 6 Yahuah your Elohim will circumcise your heart, and the heart of your offspring, to love Yahuah your Elohim with all your heart and with all your soul, that you may live. 
+\v 7 Yahuah your Elohim will put all these curses on your enemies and on those who hate you, who persecuted you. 
+\v 8 You shall return and obey Yahuah’s voice, and do all his commandments which I command you today. 
+\v 9 Yahuah your Elohim will make you prosperous in all the work of your hand, in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, for good; for Yahuah will again rejoice over you for good, as he rejoiced over your fathers, 
+\v 10 if you will obey Yahuah your Elohim’s voice, to keep his commandments and his statutes which are written in this book of the law, if you turn to Yahuah your Elohim with all your heart and with all your soul. 
 \p
 \v 11 For this commandment which I command you today is not too hard for you or too distant. 
 \v 12 It is not in heaven, that you should say, “Who will go up for us to heaven, bring it to us, and proclaim it to us, that we may do it?” 
 \v 13 Neither is it beyond the sea, that you should say, “Who will go over the sea for us, bring it to us, and proclaim it to us, that we may do it?” 
 \v 14 But the word is very near to you, in your mouth and in your heart, that you may do it. 
 \v 15 Behold, I have set before you today life and prosperity, and death and evil. 
-\v 16 For I command you today to love Yahweh your Elohim, to walk in his ways and to keep his commandments, his statutes, and his ordinances, that you may live and multiply, and that Yahweh your Elohim may bless you in the land where you go in to possess it. 
+\v 16 For I command you today to love Yahuah your Elohim, to walk in his ways and to keep his commandments, his statutes, and his ordinances, that you may live and multiply, and that Yahuah your Elohim may bless you in the land where you go in to possess it. 
 \v 17 But if your heart turns away, and you will not hear, but are drawn away and worship other elohims, and serve them, 
 \v 18 I declare to you today that you will surely perish. You will not prolong your days in the land where you pass over the Jordan to go in to possess it. 
 \v 19 I call heaven and earth to witness against you today that I have set before you life and death, the blessing and the curse. Therefore choose life, that you may live, you and your descendants, 
-\v 20 to love Yahweh your Elohim, to obey his voice, and to cling to him; for he is your life, and the length of your days, that you may dwell in the land which Yahweh swore to your fathers, to Abraham, to Isaac, and to Jacob, to give them. 
+\v 20 to love Yahuah your Elohim, to obey his voice, and to cling to him; for he is your life, and the length of your days, that you may dwell in the land which Yahuah swore to your fathers, to Abraham, to Isaac, and to Jacob, to give them. 
 \c 31
 \p
 \v 1 Moses went and spoke these words to all Israel. 
-\v 2 He said to them, “I am one hundred twenty years old today. I can no more go out and come in. Yahweh has said to me, ‘You shall not go over this Jordan.’ 
-\v 3 Yahweh your Elohim himself will go over before you. He will destroy these nations from before you, and you shall dispossess them. Joshua will go over before you, as Yahweh has spoken. 
-\v 4 Yahweh will do to them as he did to Sihon and to Og, the kings of the Amorites, and to their land, when he destroyed them. 
-\v 5 Yahweh will deliver them up before you, and you shall do to them according to all the commandment which I have commanded you. 
-\v 6 Be strong and courageous. Don’t be afraid or scared of them, for Yahweh your Elohim himself is who goes with you. He will not fail you nor forsake you.” 
+\v 2 He said to them, “I am one hundred twenty years old today. I can no more go out and come in. Yahuah has said to me, ‘You shall not go over this Jordan.’ 
+\v 3 Yahuah your Elohim himself will go over before you. He will destroy these nations from before you, and you shall dispossess them. Joshua will go over before you, as Yahuah has spoken. 
+\v 4 Yahuah will do to them as he did to Sihon and to Og, the kings of the Amorites, and to their land, when he destroyed them. 
+\v 5 Yahuah will deliver them up before you, and you shall do to them according to all the commandment which I have commanded you. 
+\v 6 Be strong and courageous. Don’t be afraid or scared of them, for Yahuah your Elohim himself is who goes with you. He will not fail you nor forsake you.” 
 \p
-\v 7 Moses called to Joshua, and said to him in the sight of all Israel, “Be strong and courageous, for you shall go with this people into the land which Yahweh has sworn to their fathers to give them; and you shall cause them to inherit it. 
-\v 8 Yahweh himself is who goes before you. He will be with you. He will not fail you nor forsake you. Don’t be afraid. Don’t be discouraged.” 
+\v 7 Moses called to Joshua, and said to him in the sight of all Israel, “Be strong and courageous, for you shall go with this people into the land which Yahuah has sworn to their fathers to give them; and you shall cause them to inherit it. 
+\v 8 Yahuah himself is who goes before you. He will be with you. He will not fail you nor forsake you. Don’t be afraid. Don’t be discouraged.” 
 \p
-\v 9 Moses wrote this law and delivered it to the priests the sons of Levi, who bore the ark of Yahweh’s covenant, and to all the elders of Israel. 
+\v 9 Moses wrote this law and delivered it to the priests the sons of Levi, who bore the ark of Yahuah’s covenant, and to all the elders of Israel. 
 \v 10 Moses commanded them, saying, “At the end of every seven years, in the set time of the year of release, in the feast of booths, 
-\v 11 when all Israel has come to appear before Yahweh your Elohim in the place which he will choose, you shall read this law before all Israel in their hearing. 
-\v 12 Assemble the people, the men and the women and the little ones, and the foreigners who are within your gates, that they may hear, learn, fear Yahweh your Elohim, and observe to do all the words of this law, 
-\v 13 and that their children, who have not known, may hear and learn to fear Yahweh your Elohim, as long as you live in the land where you go over the Jordan to possess it.” 
+\v 11 when all Israel has come to appear before Yahuah your Elohim in the place which he will choose, you shall read this law before all Israel in their hearing. 
+\v 12 Assemble the people, the men and the women and the little ones, and the foreigners who are within your gates, that they may hear, learn, fear Yahuah your Elohim, and observe to do all the words of this law, 
+\v 13 and that their children, who have not known, may hear and learn to fear Yahuah your Elohim, as long as you live in the land where you go over the Jordan to possess it.” 
 \p
-\v 14 Yahweh said to Moses, “Behold, your days approach that you must die. Call Joshua, and present yourselves in the Tent of Meeting, that I may commission him.” 
+\v 14 Yahuah said to Moses, “Behold, your days approach that you must die. Call Joshua, and present yourselves in the Tent of Meeting, that I may commission him.” 
 \p Moses and Joshua went, and presented themselves in the Tent of Meeting. 
 \p
-\v 15 Yahweh appeared in the Tent in a pillar of cloud, and the pillar of cloud stood over the Tent’s door. 
-\v 16 Yahweh said to Moses, “Behold, you shall sleep with your fathers. This people will rise up and play the prostitute after the strange elohims of the land where they go to be among them, and will forsake me and break my covenant which I have made with them. 
+\v 15 Yahuah appeared in the Tent in a pillar of cloud, and the pillar of cloud stood over the Tent’s door. 
+\v 16 Yahuah said to Moses, “Behold, you shall sleep with your fathers. This people will rise up and play the prostitute after the strange elohims of the land where they go to be among them, and will forsake me and break my covenant which I have made with them. 
 \v 17 Then my anger shall be kindled against them in that day, and I will forsake them, and I will hide my face from them, and they shall be devoured, and many evils and troubles shall come on them; so that they will say in that day, ‘Haven’t these evils come on us because our Elohim is not among us?’ 
 \v 18 I will surely hide my face in that day for all the evil which they have done, in that they have turned to other elohims. 
 \p
@@ -1075,11 +1075,11 @@
 \v 23 He commissioned Joshua the son of Nun, and said, “Be strong and courageous; for you shall bring the children of Israel into the land which I swore to them. I will be with you.” 
 \p
 \v 24 When Moses had finished writing the words of this law in a book, until they were finished, 
-\v 25 Moses commanded the Levites, who bore the ark of Yahweh’s covenant, saying, 
-\v 26 “Take this book of the law, and put it by the side of the ark of Yahweh your Elohim’s covenant, that it may be there for a witness against you. 
-\v 27 For I know your rebellion and your stiff neck. Behold, while I am yet alive with you today, you have been rebellious against Yahweh. How much more after my death? 
+\v 25 Moses commanded the Levites, who bore the ark of Yahuah’s covenant, saying, 
+\v 26 “Take this book of the law, and put it by the side of the ark of Yahuah your Elohim’s covenant, that it may be there for a witness against you. 
+\v 27 For I know your rebellion and your stiff neck. Behold, while I am yet alive with you today, you have been rebellious against Yahuah. How much more after my death? 
 \v 28 Assemble to me all the elders of your tribes and your officers, that I may speak these words in their ears, and call heaven and earth to witness against them. 
-\v 29 For I know that after my death you will utterly corrupt yourselves, and turn away from the way which I have commanded you; and evil will happen to you in the latter days, because you will do that which is evil in Yahweh’s sight, to provoke him to anger through the work of your hands.” 
+\v 29 For I know that after my death you will utterly corrupt yourselves, and turn away from the way which I have commanded you; and evil will happen to you in the latter days, because you will do that which is evil in Yahuah’s sight, to provoke him to anger through the work of your hands.” 
 \p
 \v 30 Moses spoke in the ears of all the assembly of Israel the words of this song, until they were finished. 
 \c 32
@@ -1092,7 +1092,7 @@
 \q2 as the misty rain on the tender grass, 
 \q2 as the showers on the herb. 
 \q1
-\v 3 For I will proclaim Yahweh’s name. 
+\v 3 For I will proclaim Yahuah’s name. 
 \q2 Ascribe greatness to our Elohim! 
 \q1
 \v 4 The Rock: his work is perfect, 
@@ -1104,7 +1104,7 @@
 \q2 They are not his children, because of their defect. 
 \q2 They are a perverse and crooked generation. 
 \q1
-\v 6 Is this the way you repay Yahweh, 
+\v 6 Is this the way you repay Yahuah, 
 \q2 foolish and unwise people? 
 \q1 Isn’t he your father who has bought you? 
 \q2 He has made you and established you. 
@@ -1119,7 +1119,7 @@
 \q1 he set the bounds of the peoples 
 \q2 according to the number of the children of Israel. 
 \q1
-\v 9 For Yahweh’s portion is his people. 
+\v 9 For Yahuah’s portion is his people. 
 \q2 Jacob is the lot of his inheritance. 
 \q1
 \v 10 He found him in a desert land, 
@@ -1134,7 +1134,7 @@
 \q2 he took them, 
 \q2 he bore them on his feathers. 
 \q1
-\v 12 Yahweh alone led him. 
+\v 12 Yahuah alone led him. 
 \q2 There was no foreign elohim with him. 
 \q1
 \v 13 He made him ride on the high places of the earth. 
@@ -1166,7 +1166,7 @@
 \v 18 Of the Rock who became your father, you are unmindful, 
 \q2 and have forgotten Elohim who gave you birth. 
 \q1
-\v 19 Yahweh saw and abhorred, 
+\v 19 Yahuah saw and abhorred, 
 \q2 because of the provocation of his sons and his daughters. 
 \q1
 \v 20 He said, “I will hide my face from them. 
@@ -1205,7 +1205,7 @@
 \v 27 were it not that I feared the provocation of the enemy, 
 \q2 lest their adversaries should judge wrongly, 
 \q2 lest they should say, ‘Our hand is exalted; 
-\q2 Yahweh has not done all this.’ ” 
+\q2 Yahuah has not done all this.’ ” 
 \b
 \q1
 \v 28 For they are a nation void of counsel. 
@@ -1217,7 +1217,7 @@
 \v 30 How could one chase a thousand, 
 \q2 and two put ten thousand to flight, 
 \q1 unless their Rock had sold them, 
-\q2 and Yahweh had delivered them up? 
+\q2 and Yahuah had delivered them up? 
 \q1
 \v 31 For their rock is not as our Rock, 
 \q2 even our enemies themselves concede. 
@@ -1240,7 +1240,7 @@
 \q2 Their doom rushes at them.” 
 \b
 \q1
-\v 36 For Yahweh will judge his people, 
+\v 36 For Yahuah will judge his people, 
 \q2 and have compassion on his servants, 
 \q1 when he sees that their power is gone, 
 \q2 that there is no one remaining, shut up or left at large. 
@@ -1283,7 +1283,7 @@
 \v 46 He said to them, “Set your heart to all the words which I testify to you today, which you shall command your children to observe to do, all the words of this law. 
 \v 47 For it is no vain thing for you, because it is your life, and through this thing you shall prolong your days in the land, where you go over the Jordan to possess it.” 
 \p
-\v 48 Yahweh spoke to Moses that same day, saying, 
+\v 48 Yahuah spoke to Moses that same day, saying, 
 \v 49 “Go up into this mountain of Abarim, to Mount Nebo, which is in the land of Moab, that is across from Jericho; and see the land of Canaan, which I give to the children of Israel for a possession. 
 \v 50 Die on the mountain where you go up, and be gathered to your people, as Aaron your brother died on Mount Hor, and was gathered to his people; 
 \v 51 because you trespassed against me among the children of Israel at the waters of Meribah of Kadesh, in the wilderness of Zin; because you didn’t uphold my set-apartness among the children of Israel. 
@@ -1292,7 +1292,7 @@
 \p
 \v 1 This is the blessing with which Moses the man of Elohim blessed the children of Israel before his death. 
 \v 2 He said, 
-\q1 “Yahweh came from Sinai, 
+\q1 “Yahuah came from Sinai, 
 \q2 and rose from Seir to them. 
 \q1 He shone from Mount Paran. 
 \q2 He came from the ten thousands of set-apart ones. 
@@ -1315,7 +1315,7 @@
 \q2 Nor let his men be few.” 
 \p
 \v 7 This is for Judah. He said, 
-\q1 “Hear, Yahweh, the voice of Judah. 
+\q1 “Hear, Yahuah, the voice of Judah. 
 \q2 Bring him in to his people. 
 \q1 With his hands he contended for himself. 
 \q2 You shall be a help against his adversaries.” 
@@ -1336,18 +1336,18 @@
 \q1 They shall put incense before you, 
 \q2 and whole burnt offering on your altar. 
 \q1
-\v 11 Yahweh, bless his skills. 
+\v 11 Yahuah, bless his skills. 
 \q2 Accept the work of his hands. 
 \q1 Strike through the hips of those who rise up against him, 
 \q2 of those who hate him, that they not rise again.” 
 \p
 \v 12 About Benjamin he said, 
-\q1 “The beloved of Yahweh will dwell in safety by him. 
+\q1 “The beloved of Yahuah will dwell in safety by him. 
 \q2 He covers him all day long. 
 \q2 He dwells between his shoulders.” 
 \p
 \v 13 About Joseph he said, 
-\q1 “His land is blessed by Yahweh, 
+\q1 “His land is blessed by Yahuah, 
 \q2 for the precious things of the heavens, for the dew, 
 \q2 for the deep that couches beneath, 
 \q1
@@ -1385,7 +1385,7 @@
 \v 21 He provided the first part for himself, 
 \q2 for the lawgiver’s portion was reserved for him. 
 \q1 He came with the heads of the people. 
-\q2 He executed the righteousness of Yahweh, 
+\q2 He executed the righteousness of Yahuah, 
 \q2 His ordinances with Israel.” 
 \p
 \v 22 About Dan he said, 
@@ -1394,7 +1394,7 @@
 \p
 \v 23 About Naphtali he said, 
 \q1 “Naphtali, satisfied with favor, 
-\q2 full of Yahweh’s blessing, 
+\q2 full of Yahuah’s blessing, 
 \q2 Possess the west and the south.” 
 \p
 \v 24 About Asher he said, 
@@ -1421,23 +1421,23 @@
 \q2 Yes, his heavens drop down dew. 
 \q1
 \v 29 You are happy, Israel! 
-\q2 Who is like you, a people saved by Yahweh, 
+\q2 Who is like you, a people saved by Yahuah, 
 \q2 the shield of your help, 
 \q2 the sword of your excellency? 
 \q1 Your enemies will submit themselves to you. 
 \q2 You will tread on their high places.” 
 \c 34
 \p
-\v 1 Moses went up from the plains of Moab to Mount Nebo, to the top of Pisgah, that is opposite Jericho. Yahweh showed him all the land of Gilead to Dan, 
+\v 1 Moses went up from the plains of Moab to Mount Nebo, to the top of Pisgah, that is opposite Jericho. Yahuah showed him all the land of Gilead to Dan, 
 \v 2 and all Naphtali, and the land of Ephraim and Manasseh, and all the land of Judah, to the Western Sea, 
 \v 3 and the south, and the Plain of the valley of Jericho the city of palm trees, to Zoar. 
-\v 4 Yahweh said to him, “This is the land which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ I have caused you to see it with your eyes, but you shall not go over there.” 
+\v 4 Yahuah said to him, “This is the land which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ I have caused you to see it with your eyes, but you shall not go over there.” 
 \p
-\v 5 So Moses the servant of Yahweh died there in the land of Moab, according to Yahweh’s word. 
+\v 5 So Moses the servant of Yahuah died there in the land of Moab, according to Yahuah’s word. 
 \v 6 He buried him in the valley in the land of Moab opposite Beth Peor, but no man knows where his tomb is to this day. 
 \v 7 Moses was one hundred twenty years old when he died. His eye was not dim, nor his strength gone. 
 \v 8 The children of Israel wept for Moses in the plains of Moab thirty days, until the days of weeping in the mourning for Moses were ended. 
-\v 9 Joshua the son of Nun was full of the spirit of wisdom, for Moses had laid his hands on him. The children of Israel listened to him, and did as Yahweh commanded Moses. 
-\v 10 Since then, there has not arisen a prophet in Israel like Moses, whom Yahweh knew face to face, 
-\v 11 in all the signs and the wonders which Yahweh sent him to do in the land of Egypt, to Pharaoh, and to all his servants, and to all his land, 
+\v 9 Joshua the son of Nun was full of the spirit of wisdom, for Moses had laid his hands on him. The children of Israel listened to him, and did as Yahuah commanded Moses. 
+\v 10 Since then, there has not arisen a prophet in Israel like Moses, whom Yahuah knew face to face, 
+\v 11 in all the signs and the wonders which Yahuah sent him to do in the land of Egypt, to Pharaoh, and to all his servants, and to all his land, 
 \v 12 and in all the mighty hand, and in all the awesome deeds, which Moses did in the sight of all Israel. 

--- a/usfm/exodus.usfm
+++ b/usfm/exodus.usfm
@@ -72,17 +72,17 @@
 \c 3
 \p
 \v 1 Now Moses was keeping the flock of Jethro, his father-in-law, the priest of Midian, and he led the flock to the back of the wilderness, and came to Elohim’s mountain, to Horeb. 
-\v 2 Yahweh’s angel appeared to him in a flame of fire out of the middle of a bush. He looked, and behold, the bush burned with fire, and the bush was not consumed. 
+\v 2 Yahuah’s angel appeared to him in a flame of fire out of the middle of a bush. He looked, and behold, the bush burned with fire, and the bush was not consumed. 
 \v 3 Moses said, “I will go now, and see this great sight, why the bush is not burned.” 
 \p
-\v 4 When Yahweh saw that he came over to see, Elohim called to him out of the middle of the bush, and said, “Moses! Moses!” 
+\v 4 When Yahuah saw that he came over to see, Elohim called to him out of the middle of the bush, and said, “Moses! Moses!” 
 \p He said, “Here I am.” 
 \p
 \v 5 He said, “Don’t come close. Take off your sandals, for the place you are standing on is set-apart ground.” 
 \v 6 Moreover he said, “I am the Elohim of your father, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob.” 
 \p Moses hid his face because he was afraid to look at Elohim. 
 \p
-\v 7 Yahweh said, “I have surely seen the affliction of my people who are in Egypt, and have heard their cry because of their taskmasters, for I know their sorrows. 
+\v 7 Yahuah said, “I have surely seen the affliction of my people who are in Egypt, and have heard their cry because of their taskmasters, for I know their sorrows. 
 \v 8 I have come down to deliver them out of the hand of the Egyptians, and to bring them up out of that land to a good and large land, to a land flowing with milk and honey; to the place of the Canaanite, the Hittite, the Amorite, the Perizzite, the Hivite, and the Jebusite. 
 \v 9 Now, behold, the cry of the children of Israel has come to me. Moreover I have seen the oppression with which the Egyptians oppress them. 
 \v 10 Come now therefore, and I will send you to Pharaoh, that you may bring my people, the children of Israel, out of Egypt.” 
@@ -94,29 +94,29 @@
 \v 13 Moses said to Elohim, “Behold, when I come to the children of Israel, and tell them, ‘The Elohim of your fathers has sent me to you,’ and they ask me, ‘What is his name?’ what should I tell them?” 
 \p
 \v 14 Elohim said to Moses, “I will be who I will be,” and he said, “You shall tell the children of Israel this: ‘I will be has sent me to you.’ ” 
-\v 15 Elohim said moreover to Moses, “You shall tell the children of Israel this, ‘Yahweh, the Elohim of your fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has sent me to you.’ This is my name forever, and this is my memorial to all generations. 
-\v 16 Go and gather the elders of Israel together, and tell them, ‘Yahweh, the Elohim of your fathers, the Elohim of Abraham, of Isaac, and of Jacob, has appeared to me, saying, “I have surely visited you, and seen that which is done to you in Egypt. 
+\v 15 Elohim said moreover to Moses, “You shall tell the children of Israel this, ‘Yahuah, the Elohim of your fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has sent me to you.’ This is my name forever, and this is my memorial to all generations. 
+\v 16 Go and gather the elders of Israel together, and tell them, ‘Yahuah, the Elohim of your fathers, the Elohim of Abraham, of Isaac, and of Jacob, has appeared to me, saying, “I have surely visited you, and seen that which is done to you in Egypt. 
 \v 17 I have said, I will bring you up out of the affliction of Egypt to the land of the Canaanite, the Hittite, the Amorite, the Perizzite, the Hivite, and the Jebusite, to a land flowing with milk and honey.” ’ 
-\v 18 They will listen to your voice. You shall come, you and the elders of Israel, to the king of Egypt, and you shall tell him, ‘Yahweh, the Elohim of the Hebrews, has met with us. Now please let us go three days’ journey into the wilderness, that we may sacrifice to Yahweh, our Elohim.’ 
+\v 18 They will listen to your voice. You shall come, you and the elders of Israel, to the king of Egypt, and you shall tell him, ‘Yahuah, the Elohim of the Hebrews, has met with us. Now please let us go three days’ journey into the wilderness, that we may sacrifice to Yahuah, our Elohim.’ 
 \v 19 I know that the king of Egypt won’t give you permission to go, no, not by a mighty hand. 
 \v 20 I will reach out my hand and strike Egypt with all my wonders which I will do among them, and after that he will let you go. 
 \v 21 I will give this people favor in the sight of the Egyptians, and it will happen that when you go, you shall not go empty-handed. 
 \v 22 But every woman shall ask of her neighbor, and of her who visits her house, jewels of silver, jewels of gold, and clothing. You shall put them on your sons, and on your daughters. You shall plunder the Egyptians.” 
 \c 4
 \p
-\v 1 Moses answered, “But, behold, they will not believe me, nor listen to my voice; for they will say, ‘Yahweh has not appeared to you.’ ” 
+\v 1 Moses answered, “But, behold, they will not believe me, nor listen to my voice; for they will say, ‘Yahuah has not appeared to you.’ ” 
 \p
-\v 2 Yahweh said to him, “What is that in your hand?” 
+\v 2 Yahuah said to him, “What is that in your hand?” 
 \p He said, “A rod.” 
 \p
 \v 3 He said, “Throw it on the ground.” 
 \p He threw it on the ground, and it became a snake; and Moses ran away from it. 
 \p
-\v 4 Yahweh said to Moses, “Stretch out your hand, and take it by the tail.” 
+\v 4 Yahuah said to Moses, “Stretch out your hand, and take it by the tail.” 
 \p He stretched out his hand, and took hold of it, and it became a rod in his hand. 
 \p
-\v 5 “This is so that they may believe that Yahweh, the Elohim of their fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has appeared to you.” 
-\v 6 Yahweh said furthermore to him, “Now put your hand inside your cloak.” 
+\v 5 “This is so that they may believe that Yahuah, the Elohim of their fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has appeared to you.” 
+\v 6 Yahuah said furthermore to him, “Now put your hand inside your cloak.” 
 \p He put his hand inside his cloak, and when he took it out, behold, his hand was leprous, as white as snow. 
 \p
 \v 7 He said, “Put your hand inside your cloak again.” 
@@ -125,14 +125,14 @@
 \v 8 “It will happen, if they will not believe you or listen to the voice of the first sign, that they will believe the voice of the latter sign. 
 \v 9 It will happen, if they will not believe even these two signs or listen to your voice, that you shall take of the water of the river, and pour it on the dry land. The water which you take out of the river will become blood on the dry land.” 
 \p
-\v 10 Moses said to Yahweh, “O Lord, I am not eloquent, neither before now, nor since you have spoken to your servant; for I am slow of speech, and of a slow tongue.” 
+\v 10 Moses said to Yahuah, “O Lord, I am not eloquent, neither before now, nor since you have spoken to your servant; for I am slow of speech, and of a slow tongue.” 
 \p
-\v 11 Yahweh said to him, “Who made man’s mouth? Or who makes one mute, or deaf, or seeing, or blind? Isn’t it I, Yahweh? 
+\v 11 Yahuah said to him, “Who made man’s mouth? Or who makes one mute, or deaf, or seeing, or blind? Isn’t it I, Yahuah? 
 \v 12 Now therefore go, and I will be with your mouth, and teach you what you shall speak.” 
 \p
 \v 13 Moses said, “Oh, Lord, please send someone else.” 
 \p
-\v 14 Yahweh’s anger burned against Moses, and he said, “What about Aaron, your brother, the Levite? I know that he can speak well. Also, behold, he is coming out to meet you. When he sees you, he will be glad in his heart. 
+\v 14 Yahuah’s anger burned against Moses, and he said, “What about Aaron, your brother, the Levite? I know that he can speak well. Also, behold, he is coming out to meet you. When he sees you, he will be glad in his heart. 
 \v 15 You shall speak to him, and put the words in his mouth. I will be with your mouth, and with his mouth, and will teach you what you shall do. 
 \v 16 He will be your spokesman to the people. It will happen that he will be to you a mouth, and you will be to him as Elohim. 
 \v 17 You shall take this rod in your hand, with which you shall do the signs.” 
@@ -140,31 +140,31 @@
 \v 18 Moses went and returned to Jethro his father-in-law, and said to him, “Please let me go and return to my brothers who are in Egypt, and see whether they are still alive.” 
 \p Jethro said to Moses, “Go in peace.” 
 \p
-\v 19 Yahweh said to Moses in Midian, “Go, return into Egypt; for all the men who sought your life are dead.” 
+\v 19 Yahuah said to Moses in Midian, “Go, return into Egypt; for all the men who sought your life are dead.” 
 \p
 \v 20 Moses took his woman and his sons, and set them on a donkey, and he returned to the land of Egypt. Moses took Elohim’s rod in his hand. 
-\v 21 Yahweh said to Moses, “When you go back into Egypt, see that you do before Pharaoh all the wonders which I have put in your hand, but I will harden his heart and he will not let the people go. 
-\v 22 You shall tell Pharaoh, ‘Yahweh says, Israel is my son, my firstborn, 
+\v 21 Yahuah said to Moses, “When you go back into Egypt, see that you do before Pharaoh all the wonders which I have put in your hand, but I will harden his heart and he will not let the people go. 
+\v 22 You shall tell Pharaoh, ‘Yahuah says, Israel is my son, my firstborn, 
 \v 23 and I have said to you, “Let my son go, that he may serve me;” and you have refused to let him go. Behold, I will kill your firstborn son.’ ” 
 \p
-\v 24 On the way at a lodging place, Yahweh met Moses and wanted to kill him. 
+\v 24 On the way at a lodging place, Yahuah met Moses and wanted to kill him. 
 \v 25 Then Zipporah took a flint, and cut off the foreskin of her son, and cast it at his feet; and she said, “Surely you are a bridegroom of blood to me.” 
 \p
 \v 26 So he let him alone. Then she said, “You are a bridegroom of blood,” because of the circumcision. 
 \p
-\v 27 Yahweh said to Aaron, “Go into the wilderness to meet Moses.” 
+\v 27 Yahuah said to Aaron, “Go into the wilderness to meet Moses.” 
 \p He went, and met him on Elohim’s mountain, and kissed him. 
-\v 28 Moses told Aaron all Yahweh’s words with which he had sent him, and all the signs with which he had instructed him. 
+\v 28 Moses told Aaron all Yahuah’s words with which he had sent him, and all the signs with which he had instructed him. 
 \v 29 Moses and Aaron went and gathered together all the elders of the children of Israel. 
-\v 30 Aaron spoke all the words which Yahweh had spoken to Moses, and did the signs in the sight of the people. 
-\v 31 The people believed, and when they heard that Yahweh had visited the children of Israel, and that he had seen their affliction, then they bowed their heads and worshiped. 
+\v 30 Aaron spoke all the words which Yahuah had spoken to Moses, and did the signs in the sight of the people. 
+\v 31 The people believed, and when they heard that Yahuah had visited the children of Israel, and that he had seen their affliction, then they bowed their heads and worshiped. 
 \c 5
 \p
-\v 1 Afterward Moses and Aaron came, and said to Pharaoh, “This is what Yahweh, the Elohim of Israel, says, ‘Let my people go, that they may hold a feast to me in the wilderness.’ ” 
+\v 1 Afterward Moses and Aaron came, and said to Pharaoh, “This is what Yahuah, the Elohim of Israel, says, ‘Let my people go, that they may hold a feast to me in the wilderness.’ ” 
 \p
-\v 2 Pharaoh said, “Who is Yahweh, that I should listen to his voice to let Israel go? I don’t know Yahweh, and moreover I will not let Israel go.” 
+\v 2 Pharaoh said, “Who is Yahuah, that I should listen to his voice to let Israel go? I don’t know Yahuah, and moreover I will not let Israel go.” 
 \p
-\v 3 They said, “The Elohim of the Hebrews has met with us. Please let us go three days’ journey into the wilderness, and sacrifice to Yahweh, our Elohim, lest he fall on us with pestilence, or with the sword.” 
+\v 3 They said, “The Elohim of the Hebrews has met with us. Please let us go three days’ journey into the wilderness, and sacrifice to Yahuah, our Elohim, lest he fall on us with pestilence, or with the sword.” 
 \p
 \v 4 The king of Egypt said to them, “Why do you, Moses and Aaron, take the people from their work? Get back to your burdens!” 
 \v 5 Pharaoh said, “Behold, the people of the land are now many, and you make them rest from their burdens.” 
@@ -182,35 +182,35 @@
 \v 15 Then the officers of the children of Israel came and cried to Pharaoh, saying, “Why do you deal this way with your servants? 
 \v 16 No straw is given to your servants, and they tell us, ‘Make brick!’ and behold, your servants are beaten; but the fault is in your own people.” 
 \p
-\v 17 But Pharaoh said, “You are idle! You are idle! Therefore you say, ‘Let’s go and sacrifice to Yahweh.’ 
+\v 17 But Pharaoh said, “You are idle! You are idle! Therefore you say, ‘Let’s go and sacrifice to Yahuah.’ 
 \v 18 Go therefore now, and work; for no straw shall be given to you; yet you shall deliver the same number of bricks!” 
 \p
 \v 19 The officers of the children of Israel saw that they were in trouble when it was said, “You shall not diminish anything from your daily quota of bricks!” 
 \p
 \v 20 They met Moses and Aaron, who stood along the way, as they came out from Pharaoh. 
-\v 21 They said to them, “May Yahweh look at you and judge, because you have made us a stench to be abhorred in the eyes of Pharaoh, and in the eyes of his servants, to put a sword in their hand to kill us!” 
+\v 21 They said to them, “May Yahuah look at you and judge, because you have made us a stench to be abhorred in the eyes of Pharaoh, and in the eyes of his servants, to put a sword in their hand to kill us!” 
 \p
-\v 22 Moses returned to Yahweh, and said, “Lord, why have you brought trouble on this people? Why is it that you have sent me? 
+\v 22 Moses returned to Yahuah, and said, “Lord, why have you brought trouble on this people? Why is it that you have sent me? 
 \v 23 For since I came to Pharaoh to speak in your name, he has brought trouble on this people. You have not rescued your people at all!” 
 \c 6
 \p
-\v 1 Yahweh said to Moses, “Now you shall see what I will do to Pharaoh, for by a strong hand he shall let them go, and by a strong hand he shall drive them out of his land.” 
+\v 1 Yahuah said to Moses, “Now you shall see what I will do to Pharaoh, for by a strong hand he shall let them go, and by a strong hand he shall drive them out of his land.” 
 \p
-\v 2 Elohim spoke to Moses, and said to him, “I am Yahweh. 
-\v 3 I appeared to Abraham, to Isaac, and to Jacob, as Elohim Almighty; but by my name Yahweh I was not known to them. 
+\v 2 Elohim spoke to Moses, and said to him, “I am Yahuah. 
+\v 3 I appeared to Abraham, to Isaac, and to Jacob, as Elohim Almighty; but by my name Yahuah I was not known to them. 
 \v 4 I have also established my covenant with them, to give them the land of Canaan, the land of their travels, in which they lived as aliens. 
 \v 5 Moreover I have heard the groaning of the children of Israel, whom the Egyptians keep in bondage, and I have remembered my covenant. 
-\v 6 Therefore tell the children of Israel, ‘I am Yahweh, and I will bring you out from under the burdens of the Egyptians, and I will rid you out of their bondage, and I will redeem you with an outstretched arm, and with great judgments. 
-\v 7 I will take you to myself for a people. I will be your Elohim; and you shall know that I am Yahweh your Elohim, who brings you out from under the burdens of the Egyptians. 
-\v 8 I will bring you into the land which I swore to give to Abraham, to Isaac, and to Jacob; and I will give it to you for a heritage: I am Yahweh.’ ” 
+\v 6 Therefore tell the children of Israel, ‘I am Yahuah, and I will bring you out from under the burdens of the Egyptians, and I will rid you out of their bondage, and I will redeem you with an outstretched arm, and with great judgments. 
+\v 7 I will take you to myself for a people. I will be your Elohim; and you shall know that I am Yahuah your Elohim, who brings you out from under the burdens of the Egyptians. 
+\v 8 I will bring you into the land which I swore to give to Abraham, to Isaac, and to Jacob; and I will give it to you for a heritage: I am Yahuah.’ ” 
 \p
 \v 9 Moses spoke so to the children of Israel, but they didn’t listen to Moses for anguish of spirit, and for cruel bondage. 
 \p
-\v 10 Yahweh spoke to Moses, saying, 
+\v 10 Yahuah spoke to Moses, saying, 
 \v 11 “Go in, speak to Pharaoh king of Egypt, that he let the children of Israel go out of his land.” 
 \p
-\v 12 Moses spoke before Yahweh, saying, “Behold, the children of Israel haven’t listened to me. How then shall Pharaoh listen to me, when I have uncircumcised lips?” 
-\v 13 Yahweh spoke to Moses and to Aaron, and gave them a command to the children of Israel, and to Pharaoh king of Egypt, to bring the children of Israel out of the land of Egypt. 
+\v 12 Moses spoke before Yahuah, saying, “Behold, the children of Israel haven’t listened to me. How then shall Pharaoh listen to me, when I have uncircumcised lips?” 
+\v 13 Yahuah spoke to Moses and to Aaron, and gave them a command to the children of Israel, and to Pharaoh king of Egypt, to bring the children of Israel out of the land of Egypt. 
 \p
 \v 14 These are the heads of their fathers’ houses. The sons of Reuben the firstborn of Israel: Hanoch, and Pallu, Hezron, and Carmi; these are the families of Reuben. 
 \v 15 The sons of Simeon: Jemuel, and Jamin, and Ohad, and Jachin, and Zohar, and Shaul the son of a Canaanite woman; these are the families of Simeon. 
@@ -224,108 +224,108 @@
 \v 23 Aaron took Elisheba, the daughter of Amminadab, the sister of Nahshon, as his woman; and she bore him Nadab and Abihu, Eleazar and Ithamar. 
 \v 24 The sons of Korah: Assir, Elkanah, and Abiasaph; these are the families of the Korahites. 
 \v 25 Eleazar Aaron’s son took one of the daughters of Putiel as his woman; and she bore him Phinehas. These are the heads of the fathers’ houses of the Levites according to their families. 
-\v 26 These are that Aaron and Moses to whom Yahweh said, “Bring out the children of Israel from the land of Egypt according to their armies.” 
+\v 26 These are that Aaron and Moses to whom Yahuah said, “Bring out the children of Israel from the land of Egypt according to their armies.” 
 \v 27 These are those who spoke to Pharaoh king of Egypt, to bring out the children of Israel from Egypt. These are that Moses and Aaron. 
 \p
-\v 28 On the day when Yahweh spoke to Moses in the land of Egypt, 
-\v 29 Yahweh said to Moses, “I am Yahweh. Tell Pharaoh king of Egypt all that I tell you.” 
+\v 28 On the day when Yahuah spoke to Moses in the land of Egypt, 
+\v 29 Yahuah said to Moses, “I am Yahuah. Tell Pharaoh king of Egypt all that I tell you.” 
 \p
-\v 30 Moses said before Yahweh, “Behold, I am of uncircumcised lips, and how shall Pharaoh listen to me?” 
+\v 30 Moses said before Yahuah, “Behold, I am of uncircumcised lips, and how shall Pharaoh listen to me?” 
 \c 7
 \p
-\v 1 Yahweh said to Moses, “Behold, I have made you as Elohim to Pharaoh; and Aaron your brother shall be your prophet. 
+\v 1 Yahuah said to Moses, “Behold, I have made you as Elohim to Pharaoh; and Aaron your brother shall be your prophet. 
 \v 2 You shall speak all that I command you; and Aaron your brother shall speak to Pharaoh, that he let the children of Israel go out of his land. 
 \v 3 I will harden Pharaoh’s heart, and multiply my signs and my wonders in the land of Egypt. 
 \v 4 But Pharaoh will not listen to you, so I will lay my hand on Egypt, and bring out my armies, my people the children of Israel, out of the land of Egypt by great judgments. 
-\v 5 The Egyptians shall know that I am Yahweh when I stretch out my hand on Egypt, and bring the children of Israel out from among them.” 
+\v 5 The Egyptians shall know that I am Yahuah when I stretch out my hand on Egypt, and bring the children of Israel out from among them.” 
 \p
-\v 6 Moses and Aaron did so. As Yahweh commanded them, so they did. 
+\v 6 Moses and Aaron did so. As Yahuah commanded them, so they did. 
 \v 7 Moses was eighty years old, and Aaron eighty-three years old, when they spoke to Pharaoh. 
 \p
-\v 8 Yahweh spoke to Moses and to Aaron, saying, 
+\v 8 Yahuah spoke to Moses and to Aaron, saying, 
 \v 9 “When Pharaoh speaks to you, saying, ‘Perform a miracle!’ then you shall tell Aaron, ‘Take your rod, and cast it down before Pharaoh, and it will become a serpent.’ ” 
 \p
-\v 10 Moses and Aaron went in to Pharaoh, and they did so, as Yahweh had commanded. Aaron cast down his rod before Pharaoh and before his servants, and it became a serpent. 
+\v 10 Moses and Aaron went in to Pharaoh, and they did so, as Yahuah had commanded. Aaron cast down his rod before Pharaoh and before his servants, and it became a serpent. 
 \v 11 Then Pharaoh also called for the wise men and the sorcerers. They also, the magicians of Egypt, did the same thing with their enchantments. 
 \v 12 For they each cast down their rods, and they became serpents; but Aaron’s rod swallowed up their rods. 
-\v 13 Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
+\v 13 Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahuah had spoken. 
 \p
-\v 14 Yahweh said to Moses, “Pharaoh’s heart is stubborn. He refuses to let the people go. 
+\v 14 Yahuah said to Moses, “Pharaoh’s heart is stubborn. He refuses to let the people go. 
 \v 15 Go to Pharaoh in the morning. Behold, he is going out to the water. You shall stand by the river’s bank to meet him. You shall take the rod which was turned to a serpent in your hand. 
-\v 16 You shall tell him, ‘Yahweh, the Elohim of the Hebrews, has sent me to you, saying, “Let my people go, that they may serve me in the wilderness. Behold, until now you haven’t listened.” 
-\v 17 Yahweh says, “In this you shall know that I am Yahweh. Behold: I will strike with the rod that is in my hand on the waters which are in the river, and they shall be turned to blood. 
+\v 16 You shall tell him, ‘Yahuah, the Elohim of the Hebrews, has sent me to you, saying, “Let my people go, that they may serve me in the wilderness. Behold, until now you haven’t listened.” 
+\v 17 Yahuah says, “In this you shall know that I am Yahuah. Behold: I will strike with the rod that is in my hand on the waters which are in the river, and they shall be turned to blood. 
 \v 18 The fish that are in the river will die and the river will become foul. The Egyptians will loathe to drink water from the river.” ’ ” 
-\v 19 Yahweh said to Moses, “Tell Aaron, ‘Take your rod, and stretch out your hand over the waters of Egypt, over their rivers, over their streams, and over their pools, and over all their ponds of water, that they may become blood. There will be blood throughout all the land of Egypt, both in vessels of wood and in vessels of stone.’ ” 
+\v 19 Yahuah said to Moses, “Tell Aaron, ‘Take your rod, and stretch out your hand over the waters of Egypt, over their rivers, over their streams, and over their pools, and over all their ponds of water, that they may become blood. There will be blood throughout all the land of Egypt, both in vessels of wood and in vessels of stone.’ ” 
 \p
-\v 20 Moses and Aaron did so, as Yahweh commanded; and he lifted up the rod, and struck the waters that were in the river, in the sight of Pharaoh, and in the sight of his servants; and all the waters that were in the river were turned to blood. 
+\v 20 Moses and Aaron did so, as Yahuah commanded; and he lifted up the rod, and struck the waters that were in the river, in the sight of Pharaoh, and in the sight of his servants; and all the waters that were in the river were turned to blood. 
 \v 21 The fish that were in the river died. The river became foul. The Egyptians couldn’t drink water from the river. The blood was throughout all the land of Egypt. 
-\v 22 The magicians of Egypt did the same thing with their enchantments. So Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
+\v 22 The magicians of Egypt did the same thing with their enchantments. So Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahuah had spoken. 
 \v 23 Pharaoh turned and went into his house, and he didn’t even take this to heart. 
 \v 24 All the Egyptians dug around the river for water to drink; for they couldn’t drink the river water. 
-\v 25 Seven days were fulfilled, after Yahweh had struck the river. 
+\v 25 Seven days were fulfilled, after Yahuah had struck the river. 
 \c 8
 \p
-\v 1 Yahweh spoke to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahweh says, “Let my people go, that they may serve me. 
+\v 1 Yahuah spoke to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahuah says, “Let my people go, that they may serve me. 
 \v 2 If you refuse to let them go, behold, I will plague all your borders with frogs. 
 \v 3 The river will swarm with frogs, which will go up and come into your house, and into your bedroom, and on your bed, and into the house of your servants, and on your people, and into your ovens, and into your kneading troughs. 
 \v 4 The frogs shall come up both on you, and on your people, and on all your servants.” ’ ” 
-\v 5 Yahweh said to Moses, “Tell Aaron, ‘Stretch out your hand with your rod over the rivers, over the streams, and over the pools, and cause frogs to come up on the land of Egypt.’ ” 
+\v 5 Yahuah said to Moses, “Tell Aaron, ‘Stretch out your hand with your rod over the rivers, over the streams, and over the pools, and cause frogs to come up on the land of Egypt.’ ” 
 \v 6 Aaron stretched out his hand over the waters of Egypt; and the frogs came up, and covered the land of Egypt. 
 \v 7 The magicians did the same thing with their enchantments, and brought up frogs on the land of Egypt. 
 \p
-\v 8 Then Pharaoh called for Moses and Aaron, and said, “Entreat Yahweh, that he take away the frogs from me and from my people; and I will let the people go, that they may sacrifice to Yahweh.” 
+\v 8 Then Pharaoh called for Moses and Aaron, and said, “Entreat Yahuah, that he take away the frogs from me and from my people; and I will let the people go, that they may sacrifice to Yahuah.” 
 \p
 \v 9 Moses said to Pharaoh, “I give you the honor of setting the time that I should pray for you, and for your servants, and for your people, that the frogs be destroyed from you and your houses, and remain in the river only.” 
 \p
 \v 10 Pharaoh said, “Tomorrow.” 
-\p Moses said, “Let it be according to your word, that you may know that there is no one like Yahweh our Elohim. 
+\p Moses said, “Let it be according to your word, that you may know that there is no one like Yahuah our Elohim. 
 \v 11 The frogs shall depart from you, and from your houses, and from your servants, and from your people. They shall remain in the river only.” 
 \p
-\v 12 Moses and Aaron went out from Pharaoh, and Moses cried to Yahweh concerning the frogs which he had brought on Pharaoh. 
-\v 13 Yahweh did according to the word of Moses, and the frogs died out of the houses, out of the courts, and out of the fields. 
+\v 12 Moses and Aaron went out from Pharaoh, and Moses cried to Yahuah concerning the frogs which he had brought on Pharaoh. 
+\v 13 Yahuah did according to the word of Moses, and the frogs died out of the houses, out of the courts, and out of the fields. 
 \v 14 They gathered them together in heaps, and the land stank. 
-\v 15 But when Pharaoh saw that there was a respite, he hardened his heart, and didn’t listen to them, as Yahweh had spoken. 
+\v 15 But when Pharaoh saw that there was a respite, he hardened his heart, and didn’t listen to them, as Yahuah had spoken. 
 \p
-\v 16 Yahweh said to Moses, “Tell Aaron, ‘Stretch out your rod, and strike the dust of the earth, that it may become lice throughout all the land of Egypt.’ ” 
+\v 16 Yahuah said to Moses, “Tell Aaron, ‘Stretch out your rod, and strike the dust of the earth, that it may become lice throughout all the land of Egypt.’ ” 
 \v 17 They did so; and Aaron stretched out his hand with his rod, and struck the dust of the earth, and there were lice on man, and on animal; all the dust of the earth became lice throughout all the land of Egypt. 
 \v 18 The magicians tried with their enchantments to produce lice, but they couldn’t. There were lice on man, and on animal. 
-\v 19 Then the magicians said to Pharaoh, “This is Elohim’s finger;” but Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
+\v 19 Then the magicians said to Pharaoh, “This is Elohim’s finger;” but Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahuah had spoken. 
 \p
-\v 20 Yahweh said to Moses, “Rise up early in the morning, and stand before Pharaoh; behold, he comes out to the water; and tell him, ‘This is what Yahweh says, “Let my people go, that they may serve me. 
+\v 20 Yahuah said to Moses, “Rise up early in the morning, and stand before Pharaoh; behold, he comes out to the water; and tell him, ‘This is what Yahuah says, “Let my people go, that they may serve me. 
 \v 21 Else, if you will not let my people go, behold, I will send swarms of flies on you, and on your servants, and on your people, and into your houses. The houses of the Egyptians shall be full of swarms of flies, and also the ground they are on. 
-\v 22 I will set apart in that day the land of Goshen, in which my people dwell, that no swarms of flies shall be there, to the end you may know that I am Yahweh on the earth. 
+\v 22 I will set apart in that day the land of Goshen, in which my people dwell, that no swarms of flies shall be there, to the end you may know that I am Yahuah on the earth. 
 \v 23 I will put a division between my people and your people. This sign shall happen by tomorrow.” ’ ” 
-\v 24 Yahweh did so; and there came grievous swarms of flies into the house of Pharaoh, and into his servants’ houses. In all the land of Egypt the land was corrupted by reason of the swarms of flies. 
+\v 24 Yahuah did so; and there came grievous swarms of flies into the house of Pharaoh, and into his servants’ houses. In all the land of Egypt the land was corrupted by reason of the swarms of flies. 
 \p
 \v 25 Pharaoh called for Moses and for Aaron, and said, “Go, sacrifice to your Elohim in the land!” 
 \p
-\v 26 Moses said, “It isn’t appropriate to do so; for we shall sacrifice the abomination of the Egyptians to Yahweh our Elohim. Behold, if we sacrifice the abomination of the Egyptians before their eyes, won’t they stone us? 
-\v 27 We will go three days’ journey into the wilderness, and sacrifice to Yahweh our Elohim, as he shall command us.” 
+\v 26 Moses said, “It isn’t appropriate to do so; for we shall sacrifice the abomination of the Egyptians to Yahuah our Elohim. Behold, if we sacrifice the abomination of the Egyptians before their eyes, won’t they stone us? 
+\v 27 We will go three days’ journey into the wilderness, and sacrifice to Yahuah our Elohim, as he shall command us.” 
 \p
-\v 28 Pharaoh said, “I will let you go, that you may sacrifice to Yahweh your Elohim in the wilderness, only you shall not go very far away. Pray for me.” 
+\v 28 Pharaoh said, “I will let you go, that you may sacrifice to Yahuah your Elohim in the wilderness, only you shall not go very far away. Pray for me.” 
 \p
-\v 29 Moses said, “Behold, I am going out from you. I will pray to Yahweh that the swarms of flies may depart from Pharaoh, from his servants, and from his people, tomorrow; only don’t let Pharaoh deal deceitfully any more in not letting the people go to sacrifice to Yahweh.” 
-\v 30 Moses went out from Pharaoh, and prayed to Yahweh. 
-\v 31 Yahweh did according to the word of Moses, and he removed the swarms of flies from Pharaoh, from his servants, and from his people. There remained not one. 
+\v 29 Moses said, “Behold, I am going out from you. I will pray to Yahuah that the swarms of flies may depart from Pharaoh, from his servants, and from his people, tomorrow; only don’t let Pharaoh deal deceitfully any more in not letting the people go to sacrifice to Yahuah.” 
+\v 30 Moses went out from Pharaoh, and prayed to Yahuah. 
+\v 31 Yahuah did according to the word of Moses, and he removed the swarms of flies from Pharaoh, from his servants, and from his people. There remained not one. 
 \v 32 Pharaoh hardened his heart this time also, and he didn’t let the people go. 
 \c 9
 \p
-\v 1 Then Yahweh said to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahweh, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
+\v 1 Then Yahuah said to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahuah, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
 \v 2 For if you refuse to let them go, and hold them still, 
-\v 3 behold, Yahweh’s hand is on your livestock which are in the field, on the horses, on the donkeys, on the camels, on the herds, and on the flocks with a very grievous pestilence. 
-\v 4 Yahweh will make a distinction between the livestock of Israel and the livestock of Egypt; and nothing shall die of all that belongs to the children of Israel.” ’ ” 
-\v 5 Yahweh appointed a set time, saying, “Tomorrow Yahweh shall do this thing in the land.” 
-\v 6 Yahweh did that thing on the next day; and all the livestock of Egypt died, but of the livestock of the children of Israel, not one died. 
+\v 3 behold, Yahuah’s hand is on your livestock which are in the field, on the horses, on the donkeys, on the camels, on the herds, and on the flocks with a very grievous pestilence. 
+\v 4 Yahuah will make a distinction between the livestock of Israel and the livestock of Egypt; and nothing shall die of all that belongs to the children of Israel.” ’ ” 
+\v 5 Yahuah appointed a set time, saying, “Tomorrow Yahuah shall do this thing in the land.” 
+\v 6 Yahuah did that thing on the next day; and all the livestock of Egypt died, but of the livestock of the children of Israel, not one died. 
 \v 7 Pharaoh sent, and, behold, there was not so much as one of the livestock of the Israelites dead. But the heart of Pharaoh was stubborn, and he didn’t let the people go. 
 \p
-\v 8 Yahweh said to Moses and to Aaron, “Take handfuls of ashes of the furnace, and let Moses sprinkle it toward the sky in the sight of Pharaoh. 
+\v 8 Yahuah said to Moses and to Aaron, “Take handfuls of ashes of the furnace, and let Moses sprinkle it toward the sky in the sight of Pharaoh. 
 \v 9 It shall become small dust over all the land of Egypt, and shall be boils and blisters breaking out on man and on animal, throughout all the land of Egypt.” 
 \p
 \v 10 They took ashes of the furnace, and stood before Pharaoh; and Moses sprinkled it up toward the sky; and it became boils and blisters breaking out on man and on animal. 
 \v 11 The magicians couldn’t stand before Moses because of the boils; for the boils were on the magicians and on all the Egyptians. 
-\v 12 Yahweh hardened the heart of Pharaoh, and he didn’t listen to them, as Yahweh had spoken to Moses. 
+\v 12 Yahuah hardened the heart of Pharaoh, and he didn’t listen to them, as Yahuah had spoken to Moses. 
 \p
-\v 13 Yahweh said to Moses, “Rise up early in the morning, and stand before Pharaoh, and tell him, ‘This is what Yahweh, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
+\v 13 Yahuah said to Moses, “Rise up early in the morning, and stand before Pharaoh, and tell him, ‘This is what Yahuah, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
 \v 14 For this time I will send all my plagues against your heart, against your officials, and against your people; that you may know that there is no one like me in all the earth. 
 \v 15 For now I would have stretched out my hand, and struck you and your people with pestilence, and you would have been cut off from the earth; 
 \v 16 but indeed for this cause I have made you stand: to show you my power, and that my name may be declared throughout all the earth, 
@@ -333,87 +333,87 @@
 \v 18 Behold, tomorrow about this time I will cause it to rain a very grievous hail, such as has not been in Egypt since the day it was founded even until now. 
 \v 19 Now therefore command that all of your livestock and all that you have in the field be brought into shelter. The hail will come down on every man and animal that is found in the field, and isn’t brought home, and they will die.” ’ ” 
 \p
-\v 20 Those who feared Yahweh’s word among the servants of Pharaoh made their servants and their livestock flee into the houses. 
-\v 21 Whoever didn’t respect Yahweh’s word left his servants and his livestock in the field. 
+\v 20 Those who feared Yahuah’s word among the servants of Pharaoh made their servants and their livestock flee into the houses. 
+\v 21 Whoever didn’t respect Yahuah’s word left his servants and his livestock in the field. 
 \p
-\v 22 Yahweh said to Moses, “Stretch out your hand toward the sky, that there may be hail in all the land of Egypt, on man, and on animal, and on every herb of the field, throughout the land of Egypt.” 
+\v 22 Yahuah said to Moses, “Stretch out your hand toward the sky, that there may be hail in all the land of Egypt, on man, and on animal, and on every herb of the field, throughout the land of Egypt.” 
 \p
-\v 23 Moses stretched out his rod toward the heavens, and Yahweh sent thunder and hail; and lightning flashed down to the earth. Yahweh rained hail on the land of Egypt. 
+\v 23 Moses stretched out his rod toward the heavens, and Yahuah sent thunder and hail; and lightning flashed down to the earth. Yahuah rained hail on the land of Egypt. 
 \v 24 So there was very severe hail, and lightning mixed with the hail, such as had not been in all the land of Egypt since it became a nation. 
 \v 25 The hail struck throughout all the land of Egypt all that was in the field, both man and animal; and the hail struck every herb of the field, and broke every tree of the field. 
 \v 26 Only in the land of Goshen, where the children of Israel were, there was no hail. 
 \p
-\v 27 Pharaoh sent and called for Moses and Aaron, and said to them, “I have sinned this time. Yahweh is righteous, and I and my people are wicked. 
-\v 28 Pray to Yahweh; for there has been enough of mighty thunderings and hail. I will let you go, and you shall stay no longer.” 
+\v 27 Pharaoh sent and called for Moses and Aaron, and said to them, “I have sinned this time. Yahuah is righteous, and I and my people are wicked. 
+\v 28 Pray to Yahuah; for there has been enough of mighty thunderings and hail. I will let you go, and you shall stay no longer.” 
 \p
-\v 29 Moses said to him, “As soon as I have gone out of the city, I will spread out my hands to Yahweh. The thunders shall cease, and there will not be any more hail; that you may know that the earth is Yahweh’s. 
-\v 30 But as for you and your servants, I know that you don’t yet fear Yahweh Elohim.” 
+\v 29 Moses said to him, “As soon as I have gone out of the city, I will spread out my hands to Yahuah. The thunders shall cease, and there will not be any more hail; that you may know that the earth is Yahuah’s. 
+\v 30 But as for you and your servants, I know that you don’t yet fear Yahuah Elohim.” 
 \p
 \v 31 The flax and the barley were struck, for the barley had ripened and the flax was blooming. 
 \v 32 But the wheat and the spelt were not struck, for they had not grown up. 
-\v 33 Moses went out of the city from Pharaoh, and spread out his hands to Yahweh; and the thunders and hail ceased, and the rain was not poured on the earth. 
+\v 33 Moses went out of the city from Pharaoh, and spread out his hands to Yahuah; and the thunders and hail ceased, and the rain was not poured on the earth. 
 \v 34 When Pharaoh saw that the rain and the hail and the thunders had ceased, he sinned yet more, and hardened his heart, he and his servants. 
-\v 35 The heart of Pharaoh was hardened, and he didn’t let the children of Israel go, just as Yahweh had spoken through Moses. 
+\v 35 The heart of Pharaoh was hardened, and he didn’t let the children of Israel go, just as Yahuah had spoken through Moses. 
 \c 10
 \p
-\v 1 Yahweh said to Moses, “Go in to Pharaoh, for I have hardened his heart and the heart of his servants, that I may show these my signs among them; 
-\v 2 and that you may tell in the hearing of your son, and of your son’s son, what things I have done to Egypt, and my signs which I have done among them; that you may know that I am Yahweh.” 
+\v 1 Yahuah said to Moses, “Go in to Pharaoh, for I have hardened his heart and the heart of his servants, that I may show these my signs among them; 
+\v 2 and that you may tell in the hearing of your son, and of your son’s son, what things I have done to Egypt, and my signs which I have done among them; that you may know that I am Yahuah.” 
 \p
-\v 3 Moses and Aaron went in to Pharaoh, and said to him, “This is what Yahweh, the Elohim of the Hebrews, says: ‘How long will you refuse to humble yourself before me? Let my people go, that they may serve me. 
+\v 3 Moses and Aaron went in to Pharaoh, and said to him, “This is what Yahuah, the Elohim of the Hebrews, says: ‘How long will you refuse to humble yourself before me? Let my people go, that they may serve me. 
 \v 4 Or else, if you refuse to let my people go, behold, tomorrow I will bring locusts into your country, 
 \v 5 and they shall cover the surface of the earth, so that one won’t be able to see the earth. They shall eat the residue of that which has escaped, which remains to you from the hail, and shall eat every tree which grows for you out of the field. 
 \v 6 Your houses shall be filled, and the houses of all your servants, and the houses of all the Egyptians, as neither your fathers nor your fathers’ fathers have seen, since the day that they were on the earth to this day.’ ” He turned, and went out from Pharaoh. 
 \p
-\v 7 Pharaoh’s servants said to him, “How long will this man be a snare to us? Let the men go, that they may serve Yahweh, their Elohim. Don’t you yet know that Egypt is destroyed?” 
+\v 7 Pharaoh’s servants said to him, “How long will this man be a snare to us? Let the men go, that they may serve Yahuah, their Elohim. Don’t you yet know that Egypt is destroyed?” 
 \p
-\v 8 Moses and Aaron were brought again to Pharaoh, and he said to them, “Go, serve Yahweh your Elohim; but who are those who will go?” 
+\v 8 Moses and Aaron were brought again to Pharaoh, and he said to them, “Go, serve Yahuah your Elohim; but who are those who will go?” 
 \p
-\v 9 Moses said, “We will go with our young and with our old. We will go with our sons and with our daughters, with our flocks and with our herds; for we must hold a feast to Yahweh.” 
+\v 9 Moses said, “We will go with our young and with our old. We will go with our sons and with our daughters, with our flocks and with our herds; for we must hold a feast to Yahuah.” 
 \p
-\v 10 He said to them, “Yahweh be with you if I let you go with your little ones! See, evil is clearly before your faces. 
-\v 11 Not so! Go now you who are men, and serve Yahweh; for that is what you desire!” Then they were driven out from Pharaoh’s presence. 
+\v 10 He said to them, “Yahuah be with you if I let you go with your little ones! See, evil is clearly before your faces. 
+\v 11 Not so! Go now you who are men, and serve Yahuah; for that is what you desire!” Then they were driven out from Pharaoh’s presence. 
 \p
-\v 12 Yahweh said to Moses, “Stretch out your hand over the land of Egypt for the locusts, that they may come up on the land of Egypt, and eat every herb of the land, even all that the hail has left.” 
-\v 13 Moses stretched out his rod over the land of Egypt, and Yahweh brought an east wind on the land all that day, and all night; and when it was morning, the east wind brought the locusts. 
+\v 12 Yahuah said to Moses, “Stretch out your hand over the land of Egypt for the locusts, that they may come up on the land of Egypt, and eat every herb of the land, even all that the hail has left.” 
+\v 13 Moses stretched out his rod over the land of Egypt, and Yahuah brought an east wind on the land all that day, and all night; and when it was morning, the east wind brought the locusts. 
 \v 14 The locusts went up over all the land of Egypt, and rested in all the borders of Egypt. They were very grievous. Before them there were no such locusts as they, nor will there ever be again. 
 \v 15 For they covered the surface of the whole earth, so that the land was darkened, and they ate every herb of the land, and all the fruit of the trees which the hail had left. There remained nothing green, either tree or herb of the field, through all the land of Egypt. 
-\v 16 Then Pharaoh called for Moses and Aaron in haste, and he said, “I have sinned against Yahweh your Elohim, and against you. 
-\v 17 Now therefore please forgive my sin again, and pray to Yahweh your Elohim, that he may also take away from me this death.” 
+\v 16 Then Pharaoh called for Moses and Aaron in haste, and he said, “I have sinned against Yahuah your Elohim, and against you. 
+\v 17 Now therefore please forgive my sin again, and pray to Yahuah your Elohim, that he may also take away from me this death.” 
 \p
-\v 18 Moses went out from Pharaoh, and prayed to Yahweh. 
-\v 19 Yahweh sent an exceedingly strong west wind, which took up the locusts, and drove them into the Red Sea. There remained not one locust in all the borders of Egypt. 
-\v 20 But Yahweh hardened Pharaoh’s heart, and he didn’t let the children of Israel go. 
+\v 18 Moses went out from Pharaoh, and prayed to Yahuah. 
+\v 19 Yahuah sent an exceedingly strong west wind, which took up the locusts, and drove them into the Red Sea. There remained not one locust in all the borders of Egypt. 
+\v 20 But Yahuah hardened Pharaoh’s heart, and he didn’t let the children of Israel go. 
 \p
-\v 21 Yahweh said to Moses, “Stretch out your hand toward the sky, that there may be darkness over the land of Egypt, even darkness which may be felt.” 
+\v 21 Yahuah said to Moses, “Stretch out your hand toward the sky, that there may be darkness over the land of Egypt, even darkness which may be felt.” 
 \v 22 Moses stretched out his hand toward the sky, and there was a thick darkness in all the land of Egypt for three days. 
 \v 23 They didn’t see one another, and nobody rose from his place for three days; but all the children of Israel had light in their dwellings. 
 \p
-\v 24 Pharaoh called to Moses, and said, “Go, serve Yahweh. Only let your flocks and your herds stay behind. Let your little ones also go with you.” 
+\v 24 Pharaoh called to Moses, and said, “Go, serve Yahuah. Only let your flocks and your herds stay behind. Let your little ones also go with you.” 
 \p
-\v 25 Moses said, “You must also give into our hand sacrifices and burnt offerings, that we may sacrifice to Yahweh our Elohim. 
-\v 26 Our livestock also shall go with us. Not a hoof shall be left behind, for of it we must take to serve Yahweh our Elohim; and we don’t know with what we must serve Yahweh, until we come there.” 
+\v 25 Moses said, “You must also give into our hand sacrifices and burnt offerings, that we may sacrifice to Yahuah our Elohim. 
+\v 26 Our livestock also shall go with us. Not a hoof shall be left behind, for of it we must take to serve Yahuah our Elohim; and we don’t know with what we must serve Yahuah, until we come there.” 
 \p
-\v 27 But Yahweh hardened Pharaoh’s heart, and he wouldn’t let them go. 
+\v 27 But Yahuah hardened Pharaoh’s heart, and he wouldn’t let them go. 
 \v 28 Pharaoh said to him, “Get away from me! Be careful to see my face no more; for in the day you see my face you shall die!” 
 \p
 \v 29 Moses said, “You have spoken well. I will see your face again no more.” 
 \c 11
 \p
-\v 1 Yahweh said to Moses, “I will bring yet one more plague on Pharaoh, and on Egypt; afterwards he will let you go. When he lets you go, he will surely thrust you out altogether. 
+\v 1 Yahuah said to Moses, “I will bring yet one more plague on Pharaoh, and on Egypt; afterwards he will let you go. When he lets you go, he will surely thrust you out altogether. 
 \v 2 Speak now in the ears of the people, and let every man ask of his neighbor, and every woman of her neighbor, jewels of silver, and jewels of gold.” 
-\v 3 Yahweh gave the people favor in the sight of the Egyptians. Moreover, the man Moses was very great in the land of Egypt, in the sight of Pharaoh’s servants, and in the sight of the people. 
+\v 3 Yahuah gave the people favor in the sight of the Egyptians. Moreover, the man Moses was very great in the land of Egypt, in the sight of Pharaoh’s servants, and in the sight of the people. 
 \p
-\v 4 Moses said, “This is what Yahweh says: ‘About midnight I will go out into the middle of Egypt, 
+\v 4 Moses said, “This is what Yahuah says: ‘About midnight I will go out into the middle of Egypt, 
 \v 5 and all the firstborn in the land of Egypt shall die, from the firstborn of Pharaoh who sits on his throne, even to the firstborn of the female servant who is behind the mill, and all the firstborn of livestock. 
 \v 6 There will be a great cry throughout all the land of Egypt, such as there has not been, nor will be any more. 
-\v 7 But against any of the children of Israel a dog won’t even bark or move its tongue, against man or animal, that you may know that Yahweh makes a distinction between the Egyptians and Israel. 
+\v 7 But against any of the children of Israel a dog won’t even bark or move its tongue, against man or animal, that you may know that Yahuah makes a distinction between the Egyptians and Israel. 
 \v 8 All these servants of yours will come down to me, and bow down themselves to me, saying, “Get out, with all the people who follow you;” and after that I will go out.’ ” He went out from Pharaoh in hot anger. 
 \p
-\v 9 Yahweh said to Moses, “Pharaoh won’t listen to you, that my wonders may be multiplied in the land of Egypt.” 
-\v 10 Moses and Aaron did all these wonders before Pharaoh, but Yahweh hardened Pharaoh’s heart, and he didn’t let the children of Israel go out of his land. 
+\v 9 Yahuah said to Moses, “Pharaoh won’t listen to you, that my wonders may be multiplied in the land of Egypt.” 
+\v 10 Moses and Aaron did all these wonders before Pharaoh, but Yahuah hardened Pharaoh’s heart, and he didn’t let the children of Israel go out of his land. 
 \c 12
 \p
-\v 1 Yahweh spoke to Moses and Aaron in the land of Egypt, saying, 
+\v 1 Yahuah spoke to Moses and Aaron in the land of Egypt, saying, 
 \v 2 “This month shall be to you the beginning of months. It shall be the first month of the year to you. 
 \v 3 Speak to all the congregation of Israel, saying, ‘On the tenth day of this month, they shall take to them every man a lamb, according to their fathers’ houses, a lamb for a household; 
 \v 4 and if the household is too little for a lamb, then he and his neighbor next to his house shall take one according to the number of the souls. You shall make your count for the lamb according to what everyone can eat. 
@@ -423,10 +423,10 @@
 \v 8 They shall eat the meat in that night, roasted with fire, with unleavened bread. They shall eat it with bitter herbs. 
 \v 9 Don’t eat it raw, nor boiled at all with water, but roasted with fire; with its head, its legs and its inner parts. 
 \v 10 You shall let nothing of it remain until the morning; but that which remains of it until the morning you shall burn with fire. 
-\v 11 This is how you shall eat it: with your belt on your waist, your sandals on your feet, and your staff in your hand; and you shall eat it in haste: it is Yahweh’s Passover. 
-\v 12 For I will go through the land of Egypt in that night, and will strike all the firstborn in the land of Egypt, both man and animal. I will execute judgments against all the elohims of Egypt. I am Yahweh. 
+\v 11 This is how you shall eat it: with your belt on your waist, your sandals on your feet, and your staff in your hand; and you shall eat it in haste: it is Yahuah’s Passover. 
+\v 12 For I will go through the land of Egypt in that night, and will strike all the firstborn in the land of Egypt, both man and animal. I will execute judgments against all the elohims of Egypt. I am Yahuah. 
 \v 13 The blood shall be to you for a token on the houses where you are. When I see the blood, I will pass over you, and no plague will be on you to destroy you when I strike the land of Egypt. 
-\v 14 This day shall be a memorial for you. You shall keep it as a feast to Yahweh. You shall keep it as a feast throughout your generations by an ordinance forever. 
+\v 14 This day shall be a memorial for you. You shall keep it as a feast to Yahuah. You shall keep it as a feast throughout your generations by an ordinance forever. 
 \p
 \v 15 “ ‘Seven days you shall eat unleavened bread; even the first day you shall put away yeast out of your houses, for whoever eats leavened bread from the first day until the seventh day, that soul shall be cut off from Israel. 
 \v 16 In the first day there shall be to you a set-apart convocation, and in the seventh day a set-apart convocation; no kind of work shall be done in them, except that which every man must eat, only that may be done by you. 
@@ -437,110 +437,110 @@
 \p
 \v 21 Then Moses called for all the elders of Israel, and said to them, “Draw out, and take lambs according to your families, and kill the Passover. 
 \v 22 You shall take a bunch of hyssop, and dip it in the blood that is in the basin, and strike the lintel and the two door posts with the blood that is in the basin. None of you shall go out of the door of his house until the morning. 
-\v 23 For Yahweh will pass through to strike the Egyptians; and when he sees the blood on the lintel, and on the two door posts, Yahweh will pass over the door, and will not allow the destroyer to come in to your houses to strike you. 
+\v 23 For Yahuah will pass through to strike the Egyptians; and when he sees the blood on the lintel, and on the two door posts, Yahuah will pass over the door, and will not allow the destroyer to come in to your houses to strike you. 
 \v 24 You shall observe this thing for an ordinance to you and to your sons forever. 
-\v 25 It shall happen when you have come to the land which Yahweh will give you, as he has promised, that you shall keep this service. 
+\v 25 It shall happen when you have come to the land which Yahuah will give you, as he has promised, that you shall keep this service. 
 \v 26 It will happen, when your children ask you, ‘What do you mean by this service?’ 
-\v 27 that you shall say, ‘It is the sacrifice of Yahweh’s Passover, who passed over the houses of the children of Israel in Egypt, when he struck the Egyptians, and spared our houses.’ ” 
+\v 27 that you shall say, ‘It is the sacrifice of Yahuah’s Passover, who passed over the houses of the children of Israel in Egypt, when he struck the Egyptians, and spared our houses.’ ” 
 \p The people bowed their heads and worshiped. 
-\v 28 The children of Israel went and did so; as Yahweh had commanded Moses and Aaron, so they did. 
+\v 28 The children of Israel went and did so; as Yahuah had commanded Moses and Aaron, so they did. 
 \p
-\v 29 At midnight, Yahweh struck all the firstborn in the land of Egypt, from the firstborn of Pharaoh who sat on his throne to the firstborn of the captive who was in the dungeon, and all the firstborn of livestock. 
+\v 29 At midnight, Yahuah struck all the firstborn in the land of Egypt, from the firstborn of Pharaoh who sat on his throne to the firstborn of the captive who was in the dungeon, and all the firstborn of livestock. 
 \v 30 Pharaoh rose up in the night, he, and all his servants, and all the Egyptians; and there was a great cry in Egypt, for there was not a house where there was not one dead. 
-\v 31 He called for Moses and Aaron by night, and said, “Rise up, get out from among my people, both you and the children of Israel; and go, serve Yahweh, as you have said! 
+\v 31 He called for Moses and Aaron by night, and said, “Rise up, get out from among my people, both you and the children of Israel; and go, serve Yahuah, as you have said! 
 \v 32 Take both your flocks and your herds, as you have said, and be gone; and bless me also!” 
 \p
 \v 33 The Egyptians were urgent with the people, to send them out of the land in haste, for they said, “We are all dead men.” 
 \v 34 The people took their dough before it was leavened, their kneading troughs being bound up in their clothes on their shoulders. 
 \v 35 The children of Israel did according to the word of Moses; and they asked of the Egyptians jewels of silver, and jewels of gold, and clothing. 
-\v 36 Yahweh gave the people favor in the sight of the Egyptians, so that they let them have what they asked. They plundered the Egyptians. 
+\v 36 Yahuah gave the people favor in the sight of the Egyptians, so that they let them have what they asked. They plundered the Egyptians. 
 \p
 \v 37 The children of Israel traveled from Rameses to Succoth, about six hundred thousand on foot who were men, in addition to children. 
 \v 38 A mixed multitude went up also with them, with flocks, herds, and even very much livestock. 
 \v 39 They baked unleavened cakes of the dough which they brought out of Egypt; for it wasn’t leavened, because they were thrust out of Egypt, and couldn’t wait, and they had not prepared any food for themselves. 
 \v 40 Now the time that the children of Israel lived in Egypt was four hundred thirty years. 
-\v 41 At the end of four hundred thirty years, to the day, all of Yahweh’s armies went out from the land of Egypt. 
-\v 42 It is a night to be much observed to Yahweh for bringing them out from the land of Egypt. This is that night of Yahweh, to be much observed by all the children of Israel throughout their generations. 
+\v 41 At the end of four hundred thirty years, to the day, all of Yahuah’s armies went out from the land of Egypt. 
+\v 42 It is a night to be much observed to Yahuah for bringing them out from the land of Egypt. This is that night of Yahuah, to be much observed by all the children of Israel throughout their generations. 
 \p
-\v 43 Yahweh said to Moses and Aaron, “This is the ordinance of the Passover. No foreigner shall eat of it, 
+\v 43 Yahuah said to Moses and Aaron, “This is the ordinance of the Passover. No foreigner shall eat of it, 
 \v 44 but every man’s servant who is bought for money, when you have circumcised him, then shall he eat of it. 
 \v 45 A foreigner and a hired servant shall not eat of it. 
 \v 46 It must be eaten in one house. You shall not carry any of the meat outside of the house. Do not break any of its bones. 
 \v 47 All the congregation of Israel shall keep it. 
-\v 48 When a stranger lives as a foreigner with you, and would like to keep the Passover to Yahweh, let all his males be circumcised, and then let him come near and keep it. He shall be as one who is born in the land; but no uncircumcised person shall eat of it. 
+\v 48 When a stranger lives as a foreigner with you, and would like to keep the Passover to Yahuah, let all his males be circumcised, and then let him come near and keep it. He shall be as one who is born in the land; but no uncircumcised person shall eat of it. 
 \v 49 One law shall be to him who is born at home, and to the stranger who lives as a foreigner among you.” 
-\v 50 All the children of Israel did so. As Yahweh commanded Moses and Aaron, so they did. 
-\v 51 That same day, Yahweh brought the children of Israel out of the land of Egypt by their armies. 
+\v 50 All the children of Israel did so. As Yahuah commanded Moses and Aaron, so they did. 
+\v 51 That same day, Yahuah brought the children of Israel out of the land of Egypt by their armies. 
 \c 13
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Sanctify to me all the firstborn, whatever opens the womb among the children of Israel, both of man and of animal. It is mine.” 
 \p
-\v 3 Moses said to the people, “Remember this day, in which you came out of Egypt, out of the house of bondage; for by strength of hand Yahweh brought you out from this place. No leavened bread shall be eaten. 
+\v 3 Moses said to the people, “Remember this day, in which you came out of Egypt, out of the house of bondage; for by strength of hand Yahuah brought you out from this place. No leavened bread shall be eaten. 
 \v 4 Today you go out in the month Abib. 
-\v 5 It shall be, when Yahweh brings you into the land of the Canaanite, and the Hittite, and the Amorite, and the Hivite, and the Jebusite, which he swore to your fathers to give you, a land flowing with milk and honey, that you shall keep this service in this month. 
-\v 6 Seven days you shall eat unleavened bread, and in the seventh day shall be a feast to Yahweh. 
+\v 5 It shall be, when Yahuah brings you into the land of the Canaanite, and the Hittite, and the Amorite, and the Hivite, and the Jebusite, which he swore to your fathers to give you, a land flowing with milk and honey, that you shall keep this service in this month. 
+\v 6 Seven days you shall eat unleavened bread, and in the seventh day shall be a feast to Yahuah. 
 \v 7 Unleavened bread shall be eaten throughout the seven days; and no leavened bread shall be seen with you. No yeast shall be seen with you, within all your borders. 
-\v 8 You shall tell your son in that day, saying, ‘It is because of that which Yahweh did for me when I came out of Egypt.’ 
-\v 9 It shall be for a sign to you on your hand, and for a memorial between your eyes, that Yahweh’s law may be in your mouth; for with a strong hand Yahweh has brought you out of Egypt. 
+\v 8 You shall tell your son in that day, saying, ‘It is because of that which Yahuah did for me when I came out of Egypt.’ 
+\v 9 It shall be for a sign to you on your hand, and for a memorial between your eyes, that Yahuah’s law may be in your mouth; for with a strong hand Yahuah has brought you out of Egypt. 
 \v 10 You shall therefore keep this ordinance in its season from year to year. 
 \p
-\v 11 “It shall be, when Yahweh brings you into the land of the Canaanite, as he swore to you and to your fathers, and will give it to you, 
-\v 12 that you shall set apart to Yahweh all that opens the womb, and every firstborn that comes from an animal which you have. The males shall be Yahweh’s. 
+\v 11 “It shall be, when Yahuah brings you into the land of the Canaanite, as he swore to you and to your fathers, and will give it to you, 
+\v 12 that you shall set apart to Yahuah all that opens the womb, and every firstborn that comes from an animal which you have. The males shall be Yahuah’s. 
 \v 13 Every firstborn of a donkey you shall redeem with a lamb; and if you will not redeem it, then you shall break its neck; and you shall redeem all the firstborn of man among your sons. 
-\v 14 It shall be, when your son asks you in time to come, saying, ‘What is this?’ that you shall tell him, ‘By strength of hand Yahweh brought us out from Egypt, from the house of bondage. 
-\v 15 When Pharaoh stubbornly refused to let us go, Yahweh killed all the firstborn in the land of Egypt, both the firstborn of man, and the firstborn of livestock. Therefore I sacrifice to Yahweh all that opens the womb, being males; but all the firstborn of my sons I redeem.’ 
-\v 16 It shall be for a sign on your hand, and for symbols between your eyes; for by strength of hand Yahweh brought us out of Egypt.” 
+\v 14 It shall be, when your son asks you in time to come, saying, ‘What is this?’ that you shall tell him, ‘By strength of hand Yahuah brought us out from Egypt, from the house of bondage. 
+\v 15 When Pharaoh stubbornly refused to let us go, Yahuah killed all the firstborn in the land of Egypt, both the firstborn of man, and the firstborn of livestock. Therefore I sacrifice to Yahuah all that opens the womb, being males; but all the firstborn of my sons I redeem.’ 
+\v 16 It shall be for a sign on your hand, and for symbols between your eyes; for by strength of hand Yahuah brought us out of Egypt.” 
 \p
 \v 17 When Pharaoh had let the people go, Elohim didn’t lead them by the way of the land of the Philistines, although that was near; for Elohim said, “Lest perhaps the people change their minds when they see war, and they return to Egypt”; 
 \v 18 but Elohim led the people around by the way of the wilderness by the Red Sea; and the children of Israel went up armed out of the land of Egypt. 
 \v 19 Moses took the bones of Joseph with him, for he had made the children of Israel swear, saying, “Elohim will surely visit you, and you shall carry up my bones away from here with you.” 
 \v 20 They took their journey from Succoth, and encamped in Etham, in the edge of the wilderness. 
-\v 21 Yahweh went before them by day in a pillar of cloud, to lead them on their way, and by night in a pillar of fire, to give them light, that they might go by day and by night: 
+\v 21 Yahuah went before them by day in a pillar of cloud, to lead them on their way, and by night in a pillar of fire, to give them light, that they might go by day and by night: 
 \v 22 the pillar of cloud by day, and the pillar of fire by night, didn’t depart from before the people. 
 \c 14
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Speak to the children of Israel, that they turn back and encamp before Pihahiroth, between Migdol and the sea, before Baal Zephon. You shall encamp opposite it by the sea. 
 \v 3 Pharaoh will say of the children of Israel, ‘They are entangled in the land. The wilderness has shut them in.’ 
-\v 4 I will harden Pharaoh’s heart, and he will follow after them; and I will get honor over Pharaoh, and over all his armies; and the Egyptians shall know that I am Yahweh.” They did so. 
+\v 4 I will harden Pharaoh’s heart, and he will follow after them; and I will get honor over Pharaoh, and over all his armies; and the Egyptians shall know that I am Yahuah.” They did so. 
 \p
 \v 5 The king of Egypt was told that the people had fled; and the heart of Pharaoh and of his servants was changed toward the people, and they said, “What is this we have done, that we have let Israel go from serving us?” 
 \v 6 He prepared his chariot, and took his army with him; 
 \v 7 and he took six hundred chosen chariots, and all the chariots of Egypt, with captains over all of them. 
-\v 8 Yahweh hardened the heart of Pharaoh king of Egypt, and he pursued the children of Israel; for the children of Israel went out with a high hand. 
+\v 8 Yahuah hardened the heart of Pharaoh king of Egypt, and he pursued the children of Israel; for the children of Israel went out with a high hand. 
 \v 9 The Egyptians pursued them. All the horses and chariots of Pharaoh, his horsemen, and his army overtook them encamping by the sea, beside Pihahiroth, before Baal Zephon. 
 \p
-\v 10 When Pharaoh came near, the children of Israel lifted up their eyes, and behold, the Egyptians were marching after them; and they were very afraid. The children of Israel cried out to Yahweh. 
+\v 10 When Pharaoh came near, the children of Israel lifted up their eyes, and behold, the Egyptians were marching after them; and they were very afraid. The children of Israel cried out to Yahuah. 
 \v 11 They said to Moses, “Because there were no graves in Egypt, have you taken us away to die in the wilderness? Why have you treated us this way, to bring us out of Egypt? 
 \v 12 Isn’t this the word that we spoke to you in Egypt, saying, ‘Leave us alone, that we may serve the Egyptians’? For it would have been better for us to serve the Egyptians than to die in the wilderness.” 
 \p
-\v 13 Moses said to the people, “Don’t be afraid. Stand still, and see the salvation of Yahweh, which he will work for you today; for you will never again see the Egyptians whom you have seen today. 
-\v 14 Yahweh will fight for you, and you shall be still.” 
+\v 13 Moses said to the people, “Don’t be afraid. Stand still, and see the salvation of Yahuah, which he will work for you today; for you will never again see the Egyptians whom you have seen today. 
+\v 14 Yahuah will fight for you, and you shall be still.” 
 \p
-\v 15 Yahweh said to Moses, “Why do you cry to me? Speak to the children of Israel, that they go forward. 
+\v 15 Yahuah said to Moses, “Why do you cry to me? Speak to the children of Israel, that they go forward. 
 \v 16 Lift up your rod, and stretch out your hand over the sea and divide it. Then the children of Israel shall go into the middle of the sea on dry ground. 
 \v 17 Behold, I myself will harden the hearts of the Egyptians, and they will go in after them. I will get myself honor over Pharaoh, and over all his armies, over his chariots, and over his horsemen. 
-\v 18 The Egyptians shall know that I am Yahweh when I have gotten myself honor over Pharaoh, over his chariots, and over his horsemen.” 
+\v 18 The Egyptians shall know that I am Yahuah when I have gotten myself honor over Pharaoh, over his chariots, and over his horsemen.” 
 \v 19 The angel of Elohim, who went before the camp of Israel, moved and went behind them; and the pillar of cloud moved from before them, and stood behind them. 
 \v 20 It came between the camp of Egypt and the camp of Israel. There was the cloud and the darkness, yet it gave light by night. One didn’t come near the other all night. 
 \p
-\v 21 Moses stretched out his hand over the sea, and Yahweh caused the sea to go back by a strong east wind all night, and made the sea dry land, and the waters were divided. 
+\v 21 Moses stretched out his hand over the sea, and Yahuah caused the sea to go back by a strong east wind all night, and made the sea dry land, and the waters were divided. 
 \v 22 The children of Israel went into the middle of the sea on the dry ground; and the waters were a wall to them on their right hand and on their left. 
 \v 23 The Egyptians pursued, and went in after them into the middle of the sea: all of Pharaoh’s horses, his chariots, and his horsemen. 
-\v 24 In the morning watch, Yahweh looked out on the Egyptian army through the pillar of fire and of cloud, and confused the Egyptian army. 
-\v 25 He took off their chariot wheels, and they drove them heavily; so that the Egyptians said, “Let’s flee from the face of Israel, for Yahweh fights for them against the Egyptians!” 
+\v 24 In the morning watch, Yahuah looked out on the Egyptian army through the pillar of fire and of cloud, and confused the Egyptian army. 
+\v 25 He took off their chariot wheels, and they drove them heavily; so that the Egyptians said, “Let’s flee from the face of Israel, for Yahuah fights for them against the Egyptians!” 
 \p
-\v 26 Yahweh said to Moses, “Stretch out your hand over the sea, that the waters may come again on the Egyptians, on their chariots, and on their horsemen.” 
-\v 27 Moses stretched out his hand over the sea, and the sea returned to its strength when the morning appeared; and the Egyptians fled against it. Yahweh overthrew the Egyptians in the middle of the sea. 
+\v 26 Yahuah said to Moses, “Stretch out your hand over the sea, that the waters may come again on the Egyptians, on their chariots, and on their horsemen.” 
+\v 27 Moses stretched out his hand over the sea, and the sea returned to its strength when the morning appeared; and the Egyptians fled against it. Yahuah overthrew the Egyptians in the middle of the sea. 
 \v 28 The waters returned, and covered the chariots and the horsemen, even all Pharaoh’s army that went in after them into the sea. There remained not so much as one of them. 
 \v 29 But the children of Israel walked on dry land in the middle of the sea, and the waters were a wall to them on their right hand and on their left. 
-\v 30 Thus Yahweh saved Israel that day out of the hand of the Egyptians; and Israel saw the Egyptians dead on the seashore. 
-\v 31 Israel saw the great work which Yahweh did to the Egyptians, and the people feared Yahweh; and they believed in Yahweh and in his servant Moses. 
+\v 30 Thus Yahuah saved Israel that day out of the hand of the Egyptians; and Israel saw the Egyptians dead on the seashore. 
+\v 31 Israel saw the great work which Yahuah did to the Egyptians, and the people feared Yahuah; and they believed in Yahuah and in his servant Moses. 
 \c 15
 \p
-\v 1 Then Moses and the children of Israel sang this song to Yahweh, and said, 
-\q1 “I will sing to Yahweh, for he has triumphed gloriously. 
+\v 1 Then Moses and the children of Israel sang this song to Yahuah, and said, 
+\q1 “I will sing to Yahuah, for he has triumphed gloriously. 
 \q2 He has thrown the horse and his rider into the sea. 
 \q1
 \v 2 Yah is my strength and song. 
@@ -548,8 +548,8 @@
 \q1 This is my Elohim, and I will praise him; 
 \q2 my father’s Elohim, and I will exalt him. 
 \q1
-\v 3 Yahweh is a man of war. 
-\q2 Yahweh is his name. 
+\v 3 Yahuah is a man of war. 
+\q2 Yahuah is his name. 
 \q1
 \v 4 He has cast Pharaoh’s chariots and his army into the sea. 
 \q2 His chosen captains are sunk in the Red Sea. 
@@ -557,8 +557,8 @@
 \v 5 The deeps cover them. 
 \q2 They went down into the depths like a stone. 
 \q1
-\v 6 Your right hand, Yahweh, is glorious in power. 
-\q2 Your right hand, Yahweh, dashes the enemy in pieces. 
+\v 6 Your right hand, Yahuah, is glorious in power. 
+\q2 Your right hand, Yahuah, dashes the enemy in pieces. 
 \q1
 \v 7 In the greatness of your excellency, you overthrow those who rise up against you. 
 \q2 You send out your wrath. It consumes them as stubble. 
@@ -575,7 +575,7 @@
 \q2 The sea covered them. 
 \q2 They sank like lead in the mighty waters. 
 \q1
-\v 11 Who is like you, Yahweh, among the elohims? 
+\v 11 Who is like you, Yahuah, among the elohims? 
 \q2 Who is like you, glorious in set-apartness, 
 \q2 fearful in praises, doing wonders? 
 \q1
@@ -595,83 +595,83 @@
 \q1
 \v 16 Terror and dread falls on them. 
 \q2 By the greatness of your arm they are as still as a stone, 
-\q2 until your people pass over, Yahweh, 
+\q2 until your people pass over, Yahuah, 
 \q2 until the people you have purchased pass over. 
 \q2
 \v 17 You will bring them in, and plant them in the mountain of your inheritance, 
-\q2 the place, Yahweh, which you have made for yourself to dwell in: 
+\q2 the place, Yahuah, which you have made for yourself to dwell in: 
 \q2 the sanctuary, Lord, which your hands have established. 
 \q1
-\v 18 Yahweh will reign forever and ever.” 
+\v 18 Yahuah will reign forever and ever.” 
 \p
-\v 19 For the horses of Pharaoh went in with his chariots and with his horsemen into the sea, and Yahweh brought back the waters of the sea on them; but the children of Israel walked on dry land in the middle of the sea. 
+\v 19 For the horses of Pharaoh went in with his chariots and with his horsemen into the sea, and Yahuah brought back the waters of the sea on them; but the children of Israel walked on dry land in the middle of the sea. 
 \v 20 Miriam the prophetess, the sister of Aaron, took a tambourine in her hand; and all the women went out after her with tambourines and with dances. 
 \v 21 Miriam answered them, 
-\q1 “Sing to Yahweh, for he has triumphed gloriously. 
+\q1 “Sing to Yahuah, for he has triumphed gloriously. 
 \q1 He has thrown the horse and his rider into the sea.” 
 \p
 \v 22 Moses led Israel onward from the Red Sea, and they went out into the wilderness of Shur; and they went three days in the wilderness, and found no water. 
 \v 23 When they came to Marah, they couldn’t drink from the waters of Marah, for they were bitter. Therefore its name was called Marah. 
 \v 24 The people murmured against Moses, saying, “What shall we drink?” 
-\v 25 Then he cried to Yahweh. Yahweh showed him a tree, and he threw it into the waters, and the waters were made sweet. There he made a statute and an ordinance for them, and there he tested them. 
-\v 26 He said, “If you will diligently listen to Yahweh your Elohim’s voice, and will do that which is right in his eyes, and will pay attention to his commandments, and keep all his statutes, I will put none of the diseases on you which I have put on the Egyptians; for I am Yahweh who heals you.” 
+\v 25 Then he cried to Yahuah. Yahuah showed him a tree, and he threw it into the waters, and the waters were made sweet. There he made a statute and an ordinance for them, and there he tested them. 
+\v 26 He said, “If you will diligently listen to Yahuah your Elohim’s voice, and will do that which is right in his eyes, and will pay attention to his commandments, and keep all his statutes, I will put none of the diseases on you which I have put on the Egyptians; for I am Yahuah who heals you.” 
 \p
 \v 27 They came to Elim, where there were twelve springs of water and seventy palm trees. They encamped there by the waters. 
 \c 16
 \p
 \v 1 They took their journey from Elim, and all the congregation of the children of Israel came to the wilderness of Sin, which is between Elim and Sinai, on the fifteenth day of the second month after their departing out of the land of Egypt. 
 \v 2 The whole congregation of the children of Israel murmured against Moses and against Aaron in the wilderness; 
-\v 3 and the children of Israel said to them, “We wish that we had died by Yahweh’s hand in the land of Egypt, when we sat by the meat pots, when we ate our fill of bread, for you have brought us out into this wilderness to kill this whole assembly with hunger.” 
+\v 3 and the children of Israel said to them, “We wish that we had died by Yahuah’s hand in the land of Egypt, when we sat by the meat pots, when we ate our fill of bread, for you have brought us out into this wilderness to kill this whole assembly with hunger.” 
 \p
-\v 4 Then Yahweh said to Moses, “Behold, I will rain bread from the sky for you, and the people shall go out and gather a day’s portion every day, that I may test them, whether they will walk in my law or not. 
+\v 4 Then Yahuah said to Moses, “Behold, I will rain bread from the sky for you, and the people shall go out and gather a day’s portion every day, that I may test them, whether they will walk in my law or not. 
 \v 5 It shall come to pass on the sixth day, that they shall prepare that which they bring in, and it shall be twice as much as they gather daily.” 
 \p
-\v 6 Moses and Aaron said to all the children of Israel, “At evening, you shall know that Yahweh has brought you out from the land of Egypt. 
-\v 7 In the morning, you shall see Yahweh’s glory; because he hears your murmurings against Yahweh. Who are we, that you murmur against us?” 
-\v 8 Moses said, “Now Yahweh will give you meat to eat in the evening, and in the morning bread to satisfy you, because Yahweh hears your murmurings which you murmur against him. And who are we? Your murmurings are not against us, but against Yahweh.” 
-\v 9 Moses said to Aaron, “Tell all the congregation of the children of Israel, ‘Come close to Yahweh, for he has heard your murmurings.’ ” 
-\v 10 As Aaron spoke to the whole congregation of the children of Israel, they looked toward the wilderness, and behold, Yahweh’s glory appeared in the cloud. 
-\v 11 Yahweh spoke to Moses, saying, 
-\v 12 “I have heard the murmurings of the children of Israel. Speak to them, saying, ‘At evening you shall eat meat, and in the morning you shall be filled with bread. Then you will know that I am Yahweh your Elohim.’ ” 
+\v 6 Moses and Aaron said to all the children of Israel, “At evening, you shall know that Yahuah has brought you out from the land of Egypt. 
+\v 7 In the morning, you shall see Yahuah’s glory; because he hears your murmurings against Yahuah. Who are we, that you murmur against us?” 
+\v 8 Moses said, “Now Yahuah will give you meat to eat in the evening, and in the morning bread to satisfy you, because Yahuah hears your murmurings which you murmur against him. And who are we? Your murmurings are not against us, but against Yahuah.” 
+\v 9 Moses said to Aaron, “Tell all the congregation of the children of Israel, ‘Come close to Yahuah, for he has heard your murmurings.’ ” 
+\v 10 As Aaron spoke to the whole congregation of the children of Israel, they looked toward the wilderness, and behold, Yahuah’s glory appeared in the cloud. 
+\v 11 Yahuah spoke to Moses, saying, 
+\v 12 “I have heard the murmurings of the children of Israel. Speak to them, saying, ‘At evening you shall eat meat, and in the morning you shall be filled with bread. Then you will know that I am Yahuah your Elohim.’ ” 
 \p
 \v 13 In the evening, quail came up and covered the camp; and in the morning the dew lay around the camp. 
 \v 14 When the dew that lay had gone, behold, on the surface of the wilderness was a small round thing, small as the frost on the ground. 
-\v 15 When the children of Israel saw it, they said to one another, “What is it?” For they didn’t know what it was. Moses said to them, “It is the bread which Yahweh has given you to eat. 
-\v 16 This is the thing which Yahweh has commanded: ‘Gather of it everyone according to his eating; an omer a head, according to the number of your persons, you shall take it, every man for those who are in his tent.’ ” 
+\v 15 When the children of Israel saw it, they said to one another, “What is it?” For they didn’t know what it was. Moses said to them, “It is the bread which Yahuah has given you to eat. 
+\v 16 This is the thing which Yahuah has commanded: ‘Gather of it everyone according to his eating; an omer a head, according to the number of your persons, you shall take it, every man for those who are in his tent.’ ” 
 \v 17 The children of Israel did so, and some gathered more, some less. 
 \v 18 When they measured it with an omer, he who gathered much had nothing over, and he who gathered little had no lack. They each gathered according to his eating. 
 \v 19 Moses said to them, “Let no one leave of it until the morning.” 
 \v 20 Notwithstanding they didn’t listen to Moses, but some of them left of it until the morning, so it bred worms and became foul; and Moses was angry with them. 
 \v 21 They gathered it morning by morning, everyone according to his eating. When the sun grew hot, it melted. 
 \v 22 On the sixth day, they gathered twice as much bread, two omers for each one; and all the rulers of the congregation came and told Moses. 
-\v 23 He said to them, “This is that which Yahweh has spoken, ‘Tomorrow is a solemn rest, a set-apart Sabbath to Yahweh. Bake that which you want to bake, and boil that which you want to boil; and all that remains over lay up for yourselves to be kept until the morning.’ ” 
+\v 23 He said to them, “This is that which Yahuah has spoken, ‘Tomorrow is a solemn rest, a set-apart Sabbath to Yahuah. Bake that which you want to bake, and boil that which you want to boil; and all that remains over lay up for yourselves to be kept until the morning.’ ” 
 \v 24 They laid it up until the morning, as Moses ordered, and it didn’t become foul, and there were no worms in it. 
-\v 25 Moses said, “Eat that today, for today is a Sabbath to Yahweh. Today you shall not find it in the field. 
+\v 25 Moses said, “Eat that today, for today is a Sabbath to Yahuah. Today you shall not find it in the field. 
 \v 26 Six days you shall gather it, but on the seventh day is the Sabbath. In it there shall be none.” 
 \v 27 On the seventh day, some of the people went out to gather, and they found none. 
-\v 28 Yahweh said to Moses, “How long do you refuse to keep my commandments and my laws? 
-\v 29 Behold, because Yahweh has given you the Sabbath, therefore he gives you on the sixth day the bread of two days. Everyone stay in his place. Let no one go out of his place on the seventh day.” 
+\v 28 Yahuah said to Moses, “How long do you refuse to keep my commandments and my laws? 
+\v 29 Behold, because Yahuah has given you the Sabbath, therefore he gives you on the sixth day the bread of two days. Everyone stay in his place. Let no one go out of his place on the seventh day.” 
 \v 30 So the people rested on the seventh day. 
 \p
 \v 31 The house of Israel called its name “Manna”, and it was like coriander seed, white; and its taste was like wafers with honey. 
-\v 32 Moses said, “This is the thing which Yahweh has commanded, ‘Let an omer-full of it be kept throughout your generations, that they may see the bread with which I fed you in the wilderness, when I brought you out of the land of Egypt.’ ” 
-\v 33 Moses said to Aaron, “Take a pot, and put an omer-full of manna in it, and lay it up before Yahweh, to be kept throughout your generations.” 
-\v 34 As Yahweh commanded Moses, so Aaron laid it up before the Testimony, to be kept. 
+\v 32 Moses said, “This is the thing which Yahuah has commanded, ‘Let an omer-full of it be kept throughout your generations, that they may see the bread with which I fed you in the wilderness, when I brought you out of the land of Egypt.’ ” 
+\v 33 Moses said to Aaron, “Take a pot, and put an omer-full of manna in it, and lay it up before Yahuah, to be kept throughout your generations.” 
+\v 34 As Yahuah commanded Moses, so Aaron laid it up before the Testimony, to be kept. 
 \v 35 The children of Israel ate the manna forty years, until they came to an inhabited land. They ate the manna until they came to the borders of the land of Canaan. 
 \v 36 Now an omer is one tenth of an ephah. 
 \c 17
 \p
-\v 1 All the congregation of the children of Israel traveled from the wilderness of Sin, starting according to Yahweh’s commandment, and encamped in Rephidim; but there was no water for the people to drink. 
+\v 1 All the congregation of the children of Israel traveled from the wilderness of Sin, starting according to Yahuah’s commandment, and encamped in Rephidim; but there was no water for the people to drink. 
 \v 2 Therefore the people quarreled with Moses, and said, “Give us water to drink.” 
-\p Moses said to them, “Why do you quarrel with me? Why do you test Yahweh?” 
+\p Moses said to them, “Why do you quarrel with me? Why do you test Yahuah?” 
 \p
 \v 3 The people were thirsty for water there; so the people murmured against Moses, and said, “Why have you brought us up out of Egypt, to kill us, our children, and our livestock with thirst?” 
 \p
-\v 4 Moses cried to Yahweh, saying, “What shall I do with these people? They are almost ready to stone me.” 
+\v 4 Moses cried to Yahuah, saying, “What shall I do with these people? They are almost ready to stone me.” 
 \p
-\v 5 Yahweh said to Moses, “Walk on before the people, and take the elders of Israel with you, and take the rod in your hand with which you struck the Nile, and go. 
+\v 5 Yahuah said to Moses, “Walk on before the people, and take the elders of Israel with you, and take the rod in your hand with which you struck the Nile, and go. 
 \v 6 Behold, I will stand before you there on the rock in Horeb. You shall strike the rock, and water will come out of it, that the people may drink.” Moses did so in the sight of the elders of Israel. 
-\v 7 He called the name of the place Massah, and Meribah, because the children of Israel quarreled, and because they tested Yahweh, saying, “Is Yahweh among us, or not?” 
+\v 7 He called the name of the place Massah, and Meribah, because the children of Israel quarreled, and because they tested Yahuah, saying, “Is Yahuah among us, or not?” 
 \p
 \v 8 Then Amalek came and fought with Israel in Rephidim. 
 \v 9 Moses said to Joshua, “Choose men for us, and go out to fight with Amalek. Tomorrow I will stand on the top of the hill with Elohim’s rod in my hand.” 
@@ -679,12 +679,12 @@
 \v 11 When Moses held up his hand, Israel prevailed. When he let down his hand, Amalek prevailed. 
 \v 12 But Moses’ hands were heavy; so they took a stone, and put it under him, and he sat on it. Aaron and Hur held up his hands, the one on the one side, and the other on the other side. His hands were steady until sunset. 
 \v 13 Joshua defeated Amalek and his people with the edge of the sword. 
-\v 14 Yahweh said to Moses, “Write this for a memorial in a book, and rehearse it in the ears of Joshua: that I will utterly blot out the memory of Amalek from under the sky.” 
-\v 15 Moses built an altar, and called its name “Yahweh our Banner”. 
-\v 16 He said, “Yah has sworn: ‘Yahweh will have war with Amalek from generation to generation.’ ” 
+\v 14 Yahuah said to Moses, “Write this for a memorial in a book, and rehearse it in the ears of Joshua: that I will utterly blot out the memory of Amalek from under the sky.” 
+\v 15 Moses built an altar, and called its name “Yahuah our Banner”. 
+\v 16 He said, “Yah has sworn: ‘Yahuah will have war with Amalek from generation to generation.’ ” 
 \c 18
 \p
-\v 1 Now Jethro, the priest of Midian, Moses’ father-in-law, heard of all that Elohim had done for Moses and for Israel his people, how Yahweh had brought Israel out of Egypt. 
+\v 1 Now Jethro, the priest of Midian, Moses’ father-in-law, heard of all that Elohim had done for Moses and for Israel his people, how Yahuah had brought Israel out of Egypt. 
 \v 2 Jethro, Moses’ father-in-law, received Zipporah, Moses’ woman, after he had sent her away, 
 \v 3 and her two sons. The name of one son was Gershom, for Moses said, “I have lived as a foreigner in a foreign land”. 
 \v 4 The name of the other was Eliezer, for he said, “My father’s Elohim was my help and delivered me from Pharaoh’s sword.” 
@@ -692,10 +692,10 @@
 \v 6 He said to Moses, “I, your father-in-law Jethro, have come to you with your woman, and her two sons with her.” 
 \p
 \v 7 Moses went out to meet his father-in-law, and bowed and kissed him. They asked each other of their welfare, and they came into the tent. 
-\v 8 Moses told his father-in-law all that Yahweh had done to Pharaoh and to the Egyptians for Israel’s sake, all the hardships that had come on them on the way, and how Yahweh delivered them. 
-\v 9 Jethro rejoiced for all the goodness which Yahweh had done to Israel, in that he had delivered them out of the hand of the Egyptians. 
-\v 10 Jethro said, “Blessed be Yahweh, who has delivered you out of the hand of the Egyptians, and out of the hand of Pharaoh; who has delivered the people from under the hand of the Egyptians. 
-\v 11 Now I know that Yahweh is greater than all elohims because of the way that they treated people arrogantly.” 
+\v 8 Moses told his father-in-law all that Yahuah had done to Pharaoh and to the Egyptians for Israel’s sake, all the hardships that had come on them on the way, and how Yahuah delivered them. 
+\v 9 Jethro rejoiced for all the goodness which Yahuah had done to Israel, in that he had delivered them out of the hand of the Egyptians. 
+\v 10 Jethro said, “Blessed be Yahuah, who has delivered you out of the hand of the Egyptians, and out of the hand of Pharaoh; who has delivered the people from under the hand of the Egyptians. 
+\v 11 Now I know that Yahuah is greater than all elohims because of the way that they treated people arrogantly.” 
 \v 12 Jethro, Moses’ father-in-law, took a burnt offering and sacrifices for Elohim. Aaron came with all the elders of Israel, to eat bread with Moses’ father-in-law before Elohim. 
 \p
 \v 13 On the next day, Moses sat to judge the people, and the people stood around Moses from the morning to the evening. 
@@ -719,17 +719,17 @@
 \p
 \v 1 In the third month after the children of Israel had gone out of the land of Egypt, on that same day they came into the wilderness of Sinai. 
 \v 2 When they had departed from Rephidim, and had come to the wilderness of Sinai, they encamped in the wilderness; and there Israel encamped before the mountain. 
-\v 3 Moses went up to Elohim, and Yahweh called to him out of the mountain, saying, “This is what you shall tell the house of Jacob, and tell the children of Israel: 
+\v 3 Moses went up to Elohim, and Yahuah called to him out of the mountain, saying, “This is what you shall tell the house of Jacob, and tell the children of Israel: 
 \v 4 ‘You have seen what I did to the Egyptians, and how I bore you on eagles’ wings, and brought you to myself. 
 \v 5 Now therefore, if you will indeed obey my voice and keep my covenant, then you shall be my own possession from among all peoples; for all the earth is mine; 
 \v 6 and you shall be to me a kingdom of priests and a set-apart nation.’ These are the words which you shall speak to the children of Israel.” 
 \p
-\v 7 Moses came and called for the elders of the people, and set before them all these words which Yahweh commanded him. 
-\v 8 All the people answered together, and said, “All that Yahweh has spoken we will do.” 
-\p Moses reported the words of the people to Yahweh. 
-\v 9 Yahweh said to Moses, “Behold, I come to you in a thick cloud, that the people may hear when I speak with you, and may also believe you forever.” Moses told the words of the people to Yahweh. 
-\v 10 Yahweh said to Moses, “Go to the people, and sanctify them today and tomorrow, and let them wash their garments, 
-\v 11 and be ready for the third day; for on the third day Yahweh will come down in the sight of all the people on Mount Sinai. 
+\v 7 Moses came and called for the elders of the people, and set before them all these words which Yahuah commanded him. 
+\v 8 All the people answered together, and said, “All that Yahuah has spoken we will do.” 
+\p Moses reported the words of the people to Yahuah. 
+\v 9 Yahuah said to Moses, “Behold, I come to you in a thick cloud, that the people may hear when I speak with you, and may also believe you forever.” Moses told the words of the people to Yahuah. 
+\v 10 Yahuah said to Moses, “Go to the people, and sanctify them today and tomorrow, and let them wash their garments, 
+\v 11 and be ready for the third day; for on the third day Yahuah will come down in the sight of all the people on Mount Sinai. 
 \v 12 You shall set bounds to the people all around, saying, ‘Be careful that you don’t go up onto the mountain, or touch its border. Whoever touches the mountain shall be surely put to death. 
 \v 13 No hand shall touch him, but he shall surely be stoned or shot through; whether it is animal or man, he shall not live.’ When the trumpet sounds long, they shall come up to the mountain.” 
 \p
@@ -738,37 +738,37 @@
 \p
 \v 16 On the third day, when it was morning, there were thunders and lightnings, and a thick cloud on the mountain, and the sound of an exceedingly loud trumpet; and all the people who were in the camp trembled. 
 \v 17 Moses led the people out of the camp to meet Elohim; and they stood at the lower part of the mountain. 
-\v 18 All of Mount Sinai smoked, because Yahweh descended on it in fire; and its smoke ascended like the smoke of a furnace, and the whole mountain quaked greatly. 
+\v 18 All of Mount Sinai smoked, because Yahuah descended on it in fire; and its smoke ascended like the smoke of a furnace, and the whole mountain quaked greatly. 
 \v 19 When the sound of the trumpet grew louder and louder, Moses spoke, and Elohim answered him by a voice. 
-\v 20 Yahweh came down on Mount Sinai, to the top of the mountain. Yahweh called Moses to the top of the mountain, and Moses went up. 
+\v 20 Yahuah came down on Mount Sinai, to the top of the mountain. Yahuah called Moses to the top of the mountain, and Moses went up. 
 \p
-\v 21 Yahweh said to Moses, “Go down, warn the people, lest they break through to Yahweh to gaze, and many of them perish. 
-\v 22 Let the priests also, who come near to Yahweh, sanctify themselves, lest Yahweh break out on them.” 
+\v 21 Yahuah said to Moses, “Go down, warn the people, lest they break through to Yahuah to gaze, and many of them perish. 
+\v 22 Let the priests also, who come near to Yahuah, sanctify themselves, lest Yahuah break out on them.” 
 \p
-\v 23 Moses said to Yahweh, “The people can’t come up to Mount Sinai, for you warned us, saying, ‘Set bounds around the mountain, and sanctify it.’ ” 
+\v 23 Moses said to Yahuah, “The people can’t come up to Mount Sinai, for you warned us, saying, ‘Set bounds around the mountain, and sanctify it.’ ” 
 \p
-\v 24 Yahweh said to him, “Go down! You shall bring Aaron up with you, but don’t let the priests and the people break through to come up to Yahweh, lest he break out against them.” 
+\v 24 Yahuah said to him, “Go down! You shall bring Aaron up with you, but don’t let the priests and the people break through to come up to Yahuah, lest he break out against them.” 
 \p
 \v 25 So Moses went down to the people, and told them. 
 \c 20
 \p
 \v 1 Elohim spoke all these words, saying, 
-\v 2 “I am Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
+\v 2 “I am Yahuah your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
 \p
 \v 3 “You shall have no other elohims before me. 
 \p
 \v 4 “You shall not make for yourselves an idol, nor any image of anything that is in the heavens above, or that is in the earth beneath, or that is in the water under the earth: 
-\v 5 you shall not bow yourself down to them, nor serve them, for I, Yahweh your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children, on the third and on the fourth generation of those who hate me, 
+\v 5 you shall not bow yourself down to them, nor serve them, for I, Yahuah your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children, on the third and on the fourth generation of those who hate me, 
 \v 6 and showing loving kindness to thousands of those who love me and keep my commandments. 
 \p
-\v 7 “You shall not misuse the name of Yahweh your Elohim, for Yahweh will not hold him guiltless who misuses his name. 
+\v 7 “You shall not misuse the name of Yahuah your Elohim, for Yahuah will not hold him guiltless who misuses his name. 
 \p
 \v 8 “Remember the Sabbath day, to keep it set-apart. 
 \v 9 You shall labor six days, and do all your work, 
-\v 10 but the seventh day is a Sabbath to Yahweh your Elohim. You shall not do any work in it, you, nor your son, nor your daughter, your male servant, nor your female servant, nor your livestock, nor your stranger who is within your gates; 
-\v 11 for in six days Yahweh made heaven and earth, the sea, and all that is in them, and rested the seventh day; therefore Yahweh blessed the Sabbath day, and made it set-apart. 
+\v 10 but the seventh day is a Sabbath to Yahuah your Elohim. You shall not do any work in it, you, nor your son, nor your daughter, your male servant, nor your female servant, nor your livestock, nor your stranger who is within your gates; 
+\v 11 for in six days Yahuah made heaven and earth, the sea, and all that is in them, and rested the seventh day; therefore Yahuah blessed the Sabbath day, and made it set-apart. 
 \p
-\v 12 “Honor your father and your mother, that your days may be long in the land which Yahweh your Elohim gives you. 
+\v 12 “Honor your father and your mother, that your days may be long in the land which Yahuah your Elohim gives you. 
 \p
 \v 13 “You shall not murder. 
 \p
@@ -786,7 +786,7 @@
 \v 20 Moses said to the people, “Don’t be afraid, for Elohim has come to test you, and that his fear may be before you, that you won’t sin.” 
 \v 21 The people stayed at a distance, and Moses came near to the thick darkness where Elohim was. 
 \p
-\v 22 Yahweh said to Moses, “This is what you shall tell the children of Israel: ‘You yourselves have seen that I have talked with you from heaven. 
+\v 22 Yahuah said to Moses, “This is what you shall tell the children of Israel: ‘You yourselves have seen that I have talked with you from heaven. 
 \v 23 You shall most certainly not make elohims of silver or elohims of gold for yourselves to be alongside me. 
 \v 24 You shall make an altar of earth for me, and shall sacrifice on it your burnt offerings and your peace offerings, your sheep and your cattle. In every place where I record my name I will come to you and I will bless you. 
 \v 25 If you make me an altar of stone, you shall not build it of cut stones; for if you lift up your tool on it, you have polluted it. 
@@ -858,7 +858,7 @@
 \v 9 For every matter of trespass, whether it is for ox, for donkey, for sheep, for clothing, or for any kind of lost thing, about which one says, ‘This is mine,’ the cause of both parties shall come before Elohim. He whom Elohim condemns shall pay double to his neighbor. 
 \p
 \v 10 “If a man delivers to his neighbor a donkey, an ox, a sheep, or any animal to keep, and it dies or is injured, or driven away, no man seeing it; 
-\v 11 the oath of Yahweh shall be between them both, he has not put his hand on his neighbor’s goods; and its owner shall accept it, and he shall not make restitution. 
+\v 11 the oath of Yahuah shall be between them both, he has not put his hand on his neighbor’s goods; and its owner shall accept it, and he shall not make restitution. 
 \v 12 But if it is stolen from him, the one who stole shall make restitution to its owner. 
 \v 13 If it is torn in pieces, let him bring it for evidence. He shall not make good that which was torn. 
 \p
@@ -872,7 +872,7 @@
 \p
 \v 19 “Whoever has sex with an animal shall surely be put to death. 
 \p
-\v 20 “He who sacrifices to any elohim, except to Yahweh only, shall be utterly destroyed. 
+\v 20 “He who sacrifices to any elohim, except to Yahuah only, shall be utterly destroyed. 
 \p
 \v 21 “You shall not wrong an alien or oppress him, for you were aliens in the land of Egypt. 
 \p
@@ -919,11 +919,11 @@
 \v 14 “You shall observe a feast to me three times a year. 
 \v 15 You shall observe the feast of unleavened bread. Seven days you shall eat unleavened bread, as I commanded you, at the time appointed in the month Abib (for in it you came out of Egypt), and no one shall appear before me empty. 
 \v 16 And the feast of harvest, the first fruits of your labors, which you sow in the field; and the feast of ingathering, at the end of the year, when you gather in your labors out of the field. 
-\v 17 Three times in the year all your males shall appear before the Lord Yahweh. 
+\v 17 Three times in the year all your males shall appear before the Lord Yahuah. 
 \p
 \v 18 “You shall not offer the blood of my sacrifice with leavened bread. The fat of my feast shall not remain all night until the morning. 
 \p
-\v 19 You shall bring the first of the first fruits of your ground into the house of Yahweh your Elohim. 
+\v 19 You shall bring the first of the first fruits of your ground into the house of Yahuah your Elohim. 
 \p “You shall not boil a young goat in its mother’s milk. 
 \p
 \v 20 “Behold, I send an angel before you, to keep you by the way, and to bring you into the place which I have prepared. 
@@ -931,7 +931,7 @@
 \v 22 But if you indeed listen to his voice, and do all that I speak, then I will be an enemy to your enemies, and an adversary to your adversaries. 
 \v 23 For my angel shall go before you, and bring you in to the Amorite, the Hittite, the Perizzite, the Canaanite, the Hivite, and the Jebusite; and I will cut them off. 
 \v 24 You shall not bow down to their elohims, nor serve them, nor follow their practices, but you shall utterly overthrow them and demolish their pillars. 
-\v 25 You shall serve Yahweh your Elohim, and he will bless your bread and your water, and I will take sickness away from among you. 
+\v 25 You shall serve Yahuah your Elohim, and he will bless your bread and your water, and I will take sickness away from among you. 
 \v 26 No one will miscarry or be barren in your land. I will fulfill the number of your days. 
 \v 27 I will send my terror before you, and will confuse all the people to whom you come, and I will make all your enemies turn their backs to you. 
 \v 28 I will send the hornet before you, which will drive out the Hivite, the Canaanite, and the Hittite, from before you. 
@@ -942,34 +942,34 @@
 \v 33 They shall not dwell in your land, lest they make you sin against me, for if you serve their elohims, it will surely be a snare to you.” 
 \c 24
 \p
-\v 1 He said to Moses, “Come up to Yahweh, you, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel; and worship from a distance. 
-\v 2 Moses alone shall come near to Yahweh, but they shall not come near. The people shall not go up with him.” 
+\v 1 He said to Moses, “Come up to Yahuah, you, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel; and worship from a distance. 
+\v 2 Moses alone shall come near to Yahuah, but they shall not come near. The people shall not go up with him.” 
 \p
-\v 3 Moses came and told the people all Yahweh’s words, and all the ordinances; and all the people answered with one voice, and said, “All the words which Yahweh has spoken will we do.” 
+\v 3 Moses came and told the people all Yahuah’s words, and all the ordinances; and all the people answered with one voice, and said, “All the words which Yahuah has spoken will we do.” 
 \p
-\v 4 Moses wrote all Yahweh’s words, then rose up early in the morning and built an altar at the base of the mountain, with twelve pillars for the twelve tribes of Israel. 
-\v 5 He sent young men of the children of Israel, who offered burnt offerings and sacrificed peace offerings of cattle to Yahweh. 
+\v 4 Moses wrote all Yahuah’s words, then rose up early in the morning and built an altar at the base of the mountain, with twelve pillars for the twelve tribes of Israel. 
+\v 5 He sent young men of the children of Israel, who offered burnt offerings and sacrificed peace offerings of cattle to Yahuah. 
 \v 6 Moses took half of the blood and put it in basins, and half of the blood he sprinkled on the altar. 
-\v 7 He took the book of the covenant and read it in the hearing of the people, and they said, “We will do all that Yahweh has said, and be obedient.” 
+\v 7 He took the book of the covenant and read it in the hearing of the people, and they said, “We will do all that Yahuah has said, and be obedient.” 
 \p
-\v 8 Moses took the blood, and sprinkled it on the people, and said, “Look, this is the blood of the covenant, which Yahweh has made with you concerning all these words.” 
+\v 8 Moses took the blood, and sprinkled it on the people, and said, “Look, this is the blood of the covenant, which Yahuah has made with you concerning all these words.” 
 \p
 \v 9 Then Moses, Aaron, Nadab, Abihu, and seventy of the elders of Israel went up. 
 \v 10 They saw the Elohim of Israel. Under his feet was like a paved work of sapphire stone, like the skies for clearness. 
 \v 11 He didn’t lay his hand on the nobles of the children of Israel. They saw Elohim, and ate and drank. 
 \p
-\v 12 Yahweh said to Moses, “Come up to me on the mountain, and stay here, and I will give you the stone tablets with the law and the commands that I have written, that you may teach them.” 
+\v 12 Yahuah said to Moses, “Come up to me on the mountain, and stay here, and I will give you the stone tablets with the law and the commands that I have written, that you may teach them.” 
 \p
 \v 13 Moses rose up with Joshua, his servant, and Moses went up onto Elohim’s Mountain. 
 \v 14 He said to the elders, “Wait here for us, until we come again to you. Behold, Aaron and Hur are with you. Whoever is involved in a dispute can go to them.” 
 \p
 \v 15 Moses went up on the mountain, and the cloud covered the mountain. 
-\v 16 Yahweh’s glory settled on Mount Sinai, and the cloud covered it six days. The seventh day he called to Moses out of the middle of the cloud. 
-\v 17 The appearance of Yahweh’s glory was like devouring fire on the top of the mountain in the eyes of the children of Israel. 
+\v 16 Yahuah’s glory settled on Mount Sinai, and the cloud covered it six days. The seventh day he called to Moses out of the middle of the cloud. 
+\v 17 The appearance of Yahuah’s glory was like devouring fire on the top of the mountain in the eyes of the children of Israel. 
 \v 18 Moses entered into the middle of the cloud, and went up on the mountain; and Moses was on the mountain forty days and forty nights. 
 \c 25
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Speak to the children of Israel, that they take an offering for me. From everyone whose heart makes him willing you shall take my offering. 
 \v 3 This is the offering which you shall take from them: gold, silver, bronze, 
 \v 4 blue, purple, scarlet, fine linen, goats’ hair, 
@@ -1080,7 +1080,7 @@
 \v 19 All the instruments of the tabernacle in all its service, and all its pins, and all the pins of the court, shall be of bronze. 
 \p
 \v 20 “You shall command the children of Israel, that they bring to you pure olive oil beaten for the light, to cause a lamp to burn continually. 
-\v 21 In the Tent of Meeting, outside the veil which is before the covenant, Aaron and his sons shall keep it in order from evening to morning before Yahweh: it shall be a statute forever throughout their generations on the behalf of the children of Israel. 
+\v 21 In the Tent of Meeting, outside the veil which is before the covenant, Aaron and his sons shall keep it in order from evening to morning before Yahuah: it shall be a statute forever throughout their generations on the behalf of the children of Israel. 
 \c 28
 \p
 \v 1 “Bring Aaron your brother, and his sons with him, near to you from among the children of Israel, that he may minister to me in the priest’s office: Aaron, with Nadab, Abihu, Eleazar, and Ithamar, Aaron’s sons. 
@@ -1095,7 +1095,7 @@
 \v 9 You shall take two onyx stones, and engrave on them the names of the children of Israel. 
 \v 10 Six of their names on the one stone, and the names of the six that remain on the other stone, in the order of their birth. 
 \v 11 With the work of an engraver in stone, like the engravings of a signet, you shall engrave the two stones, according to the names of the children of Israel. You shall make them to be enclosed in settings of gold. 
-\v 12 You shall put the two stones on the shoulder straps of the ephod, to be stones of memorial for the children of Israel. Aaron shall bear their names before Yahweh on his two shoulders for a memorial. 
+\v 12 You shall put the two stones on the shoulder straps of the ephod, to be stones of memorial for the children of Israel. Aaron shall bear their names before Yahuah on his two shoulders for a memorial. 
 \v 13 You shall make settings of gold, 
 \v 14 and two chains of pure gold; you shall make them like cords of braided work. You shall put the braided chains on the settings. 
 \p
@@ -1113,18 +1113,18 @@
 \v 26 You shall make two rings of gold, and you shall put them on the two ends of the breastplate, on its edge, which is toward the side of the ephod inward. 
 \v 27 You shall make two rings of gold, and shall put them on the two shoulder straps of the ephod underneath, in its forepart, close by its coupling, above the skillfully woven band of the ephod. 
 \v 28 They shall bind the breastplate by its rings to the rings of the ephod with a lace of blue, that it may be on the skillfully woven band of the ephod, and that the breastplate may not swing out from the ephod. 
-\v 29 Aaron shall bear the names of the children of Israel in the breastplate of judgment on his heart, when he goes in to the set-apart place, for a memorial before Yahweh continually. 
-\v 30 You shall put in the breastplate of judgment the Urim and the Thummim; and they shall be on Aaron’s heart, when he goes in before Yahweh. Aaron shall bear the judgment of the children of Israel on his heart before Yahweh continually. 
+\v 29 Aaron shall bear the names of the children of Israel in the breastplate of judgment on his heart, when he goes in to the set-apart place, for a memorial before Yahuah continually. 
+\v 30 You shall put in the breastplate of judgment the Urim and the Thummim; and they shall be on Aaron’s heart, when he goes in before Yahuah. Aaron shall bear the judgment of the children of Israel on his heart before Yahuah continually. 
 \p
 \v 31 “You shall make the robe of the ephod all of blue. 
 \v 32 It shall have a hole for the head in the middle of it. It shall have a binding of woven work around its hole, as it were the hole of a coat of mail, that it not be torn. 
 \v 33 On its hem you shall make pomegranates of blue, and of purple, and of scarlet, all around its hem; with bells of gold between and around them: 
 \v 34 a golden bell and a pomegranate, a golden bell and a pomegranate, around the hem of the robe. 
-\v 35 It shall be on Aaron to minister: and its sound shall be heard when he goes in to the set-apart place before Yahweh, and when he comes out, that he not die. 
+\v 35 It shall be on Aaron to minister: and its sound shall be heard when he goes in to the set-apart place before Yahuah, and when he comes out, that he not die. 
 \p
-\v 36 “You shall make a plate of pure gold, and engrave on it, like the engravings of a signet, ‘SET-APART TO YAHWEH.’ 
+\v 36 “You shall make a plate of pure gold, and engrave on it, like the engravings of a signet, ‘SET-APART TO YAHUAH.’ 
 \v 37 You shall put it on a lace of blue, and it shall be on the sash. It shall be on the front of the sash. 
-\v 38 It shall be on Aaron’s forehead, and Aaron shall bear the iniquity of the set-apart things, which the children of Israel shall make set-apart in all their set-apart gifts; and it shall be always on his forehead, that they may be accepted before Yahweh. 
+\v 38 It shall be on Aaron’s forehead, and Aaron shall bear the iniquity of the set-apart things, which the children of Israel shall make set-apart in all their set-apart gifts; and it shall be always on his forehead, that they may be accepted before Yahuah. 
 \v 39 You shall weave the tunic with fine linen. You shall make a turban of fine linen. You shall make a sash, the work of the embroiderer. 
 \p
 \v 40 “You shall make tunics for Aaron’s sons. You shall make sashes for them. You shall make headbands for them, for glory and for beauty. 
@@ -1144,7 +1144,7 @@
 \v 9 You shall clothe them with belts, Aaron and his sons, and bind headbands on them. They shall have the priesthood by a perpetual statute. You shall consecrate Aaron and his sons. 
 \p
 \v 10 “You shall bring the bull before the Tent of Meeting; and Aaron and his sons shall lay their hands on the head of the bull. 
-\v 11 You shall kill the bull before Yahweh at the door of the Tent of Meeting. 
+\v 11 You shall kill the bull before Yahuah at the door of the Tent of Meeting. 
 \v 12 You shall take of the blood of the bull, and put it on the horns of the altar with your finger; and you shall pour out all the blood at the base of the altar. 
 \v 13 You shall take all the fat that covers the innards, the cover of the liver, the two kidneys, and the fat that is on them, and burn them on the altar. 
 \v 14 But the meat of the bull, and its skin, and its dung, you shall burn with fire outside of the camp. It is a sin offering. 
@@ -1152,19 +1152,19 @@
 \v 15 “You shall also take the one ram, and Aaron and his sons shall lay their hands on the head of the ram. 
 \v 16 You shall kill the ram, and you shall take its blood, and sprinkle it around on the altar. 
 \v 17 You shall cut the ram into its pieces, and wash its innards, and its legs, and put them with its pieces, and with its head. 
-\v 18 You shall burn the whole ram on the altar: it is a burnt offering to Yahweh; it is a pleasant aroma, an offering made by fire to Yahweh. 
+\v 18 You shall burn the whole ram on the altar: it is a burnt offering to Yahuah; it is a pleasant aroma, an offering made by fire to Yahuah. 
 \p
 \v 19 “You shall take the other ram, and Aaron and his sons shall lay their hands on the head of the ram. 
 \v 20 Then you shall kill the ram, and take some of its blood, and put it on the tip of the right ear of Aaron, and on the tip of the right ear of his sons, and on the thumb of their right hand, and on the big toe of their right foot; and sprinkle the blood around on the altar. 
 \v 21 You shall take of the blood that is on the altar, and of the anointing oil, and sprinkle it on Aaron, and on his garments, and on his sons, and on the garments of his sons with him: and he shall be made set-apart, and his garments, and his sons, and his sons’ garments with him. 
 \v 22 Also you shall take some of the ram’s fat, the fat tail, the fat that covers the innards, the cover of the liver, the two kidneys, the fat that is on them, and the right thigh (for it is a ram of consecration), 
-\v 23 and one loaf of bread, one cake of oiled bread, and one wafer out of the basket of unleavened bread that is before Yahweh. 
-\v 24 You shall put all of this in Aaron’s hands, and in his sons’ hands, and shall wave them for a wave offering before Yahweh. 
-\v 25 You shall take them from their hands, and burn them on the altar on the burnt offering, for a pleasant aroma before Yahweh: it is an offering made by fire to Yahweh. 
+\v 23 and one loaf of bread, one cake of oiled bread, and one wafer out of the basket of unleavened bread that is before Yahuah. 
+\v 24 You shall put all of this in Aaron’s hands, and in his sons’ hands, and shall wave them for a wave offering before Yahuah. 
+\v 25 You shall take them from their hands, and burn them on the altar on the burnt offering, for a pleasant aroma before Yahuah: it is an offering made by fire to Yahuah. 
 \p
-\v 26 “You shall take the breast of Aaron’s ram of consecration, and wave it for a wave offering before Yahweh. It shall be your portion. 
+\v 26 “You shall take the breast of Aaron’s ram of consecration, and wave it for a wave offering before Yahuah. It shall be your portion. 
 \v 27 You shall sanctify the breast of the wave offering and the thigh of the wave offering, which is waved, and which is raised up, of the ram of consecration, even of that which is for Aaron, and of that which is for his sons. 
-\v 28 It shall be for Aaron and his sons as their portion forever from the children of Israel; for it is a wave offering. It shall be a wave offering from the children of Israel of the sacrifices of their peace offerings, even their wave offering to Yahweh. 
+\v 28 It shall be for Aaron and his sons as their portion forever from the children of Israel; for it is a wave offering. It shall be a wave offering from the children of Israel of the sacrifices of their peace offerings, even their wave offering to Yahuah. 
 \p
 \v 29 “The set-apart garments of Aaron shall be for his sons after him, to be anointed in them, and to be consecrated in them. 
 \v 30 Seven days shall the son who is priest in his place put them on, when he comes into the Tent of Meeting to minister in the set-apart place. 
@@ -1181,12 +1181,12 @@
 \v 38 “Now this is that which you shall offer on the altar: two lambs a year old day by day continually. 
 \v 39 The one lamb you shall offer in the morning; and the other lamb you shall offer at evening; 
 \v 40 and with the one lamb a tenth part of an ephah of fine flour mixed with the fourth part of a hin of beaten oil, and the fourth part of a hin of wine for a drink offering. 
-\v 41 The other lamb you shall offer at evening, and shall do to it according to the meal offering of the morning and according to its drink offering, for a pleasant aroma, an offering made by fire to Yahweh. 
-\v 42 It shall be a continual burnt offering throughout your generations at the door of the Tent of Meeting before Yahweh, where I will meet with you, to speak there to you. 
+\v 41 The other lamb you shall offer at evening, and shall do to it according to the meal offering of the morning and according to its drink offering, for a pleasant aroma, an offering made by fire to Yahuah. 
+\v 42 It shall be a continual burnt offering throughout your generations at the door of the Tent of Meeting before Yahuah, where I will meet with you, to speak there to you. 
 \v 43 There I will meet with the children of Israel; and the place shall be sanctified by my glory. 
 \v 44 I will sanctify the Tent of Meeting and the altar. I will also sanctify Aaron and his sons to minister to me in the priest’s office. 
 \v 45 I will dwell among the children of Israel, and will be their Elohim. 
-\v 46 They shall know that I am Yahweh their Elohim, who brought them out of the land of Egypt, that I might dwell among them: I am Yahweh their Elohim. 
+\v 46 They shall know that I am Yahuah their Elohim, who brought them out of the land of Egypt, that I might dwell among them: I am Yahuah their Elohim. 
 \c 30
 \p
 \v 1 “You shall make an altar to burn incense on. You shall make it of acacia wood. 
@@ -1196,24 +1196,24 @@
 \v 5 You shall make the poles of acacia wood, and overlay them with gold. 
 \v 6 You shall put it before the veil that is by the ark of the covenant, before the mercy seat that is over the covenant, where I will meet with you. 
 \v 7 Aaron shall burn incense of sweet spices on it every morning. When he tends the lamps, he shall burn it. 
-\v 8 When Aaron lights the lamps at evening, he shall burn it, a perpetual incense before Yahweh throughout your generations. 
+\v 8 When Aaron lights the lamps at evening, he shall burn it, a perpetual incense before Yahuah throughout your generations. 
 \v 9 You shall offer no strange incense on it, nor burnt offering, nor meal offering; and you shall pour no drink offering on it. 
-\v 10 Aaron shall make atonement on its horns once in the year; with the blood of the sin offering of atonement once in the year he shall make atonement for it throughout your generations. It is most set-apart to Yahweh.” 
+\v 10 Aaron shall make atonement on its horns once in the year; with the blood of the sin offering of atonement once in the year he shall make atonement for it throughout your generations. It is most set-apart to Yahuah.” 
 \p
-\v 11 Yahweh spoke to Moses, saying, 
-\v 12 “When you take a census of the children of Israel, according to those who are counted among them, then each man shall give a ransom for his soul to Yahweh when you count them, that there be no plague among them when you count them. 
-\v 13 They shall give this, everyone who passes over to those who are counted, half a shekel according to the shekel of the sanctuary (the shekel is twenty gerahs); half a shekel for an offering to Yahweh. 
-\v 14 Everyone who passes over to those who are counted, from twenty years old and upward, shall give the offering to Yahweh. 
-\v 15 The rich shall not give more, and the poor shall not give less, than the half shekel, when they give the offering of Yahweh, to make atonement for your souls. 
-\v 16 You shall take the atonement money from the children of Israel, and shall appoint it for the service of the Tent of Meeting; that it may be a memorial for the children of Israel before Yahweh, to make atonement for your souls.” 
+\v 11 Yahuah spoke to Moses, saying, 
+\v 12 “When you take a census of the children of Israel, according to those who are counted among them, then each man shall give a ransom for his soul to Yahuah when you count them, that there be no plague among them when you count them. 
+\v 13 They shall give this, everyone who passes over to those who are counted, half a shekel according to the shekel of the sanctuary (the shekel is twenty gerahs); half a shekel for an offering to Yahuah. 
+\v 14 Everyone who passes over to those who are counted, from twenty years old and upward, shall give the offering to Yahuah. 
+\v 15 The rich shall not give more, and the poor shall not give less, than the half shekel, when they give the offering of Yahuah, to make atonement for your souls. 
+\v 16 You shall take the atonement money from the children of Israel, and shall appoint it for the service of the Tent of Meeting; that it may be a memorial for the children of Israel before Yahuah, to make atonement for your souls.” 
 \p
-\v 17 Yahweh spoke to Moses, saying, 
+\v 17 Yahuah spoke to Moses, saying, 
 \v 18 “You shall also make a basin of bronze, and its base of bronze, in which to wash. You shall put it between the Tent of Meeting and the altar, and you shall put water in it. 
 \v 19 Aaron and his sons shall wash their hands and their feet in it. 
-\v 20 When they go into the Tent of Meeting, they shall wash with water, that they not die; or when they come near to the altar to minister, to burn an offering made by fire to Yahweh. 
+\v 20 When they go into the Tent of Meeting, they shall wash with water, that they not die; or when they come near to the altar to minister, to burn an offering made by fire to Yahuah. 
 \v 21 So they shall wash their hands and their feet, that they not die. This shall be a statute forever to them, even to him and to his descendants throughout their generations.” 
 \p
-\v 22 Moreover Yahweh spoke to Moses, saying, 
+\v 22 Moreover Yahuah spoke to Moses, saying, 
 \v 23 “Also take fine spices: of liquid myrrh, five hundred shekels; and of fragrant cinnamon half as much, even two hundred and fifty; and of fragrant cane, two hundred and fifty; 
 \v 24 and of cassia five hundred, according to the shekel of the sanctuary; and a hin of olive oil. 
 \v 25 You shall make it into a set-apart anointing oil, a perfume compounded after the art of the perfumer: it shall be a set-apart anointing oil. 
@@ -1226,14 +1226,14 @@
 \v 32 It shall not be poured on man’s flesh, and do not make any like it, according to its composition. It is set-apart. It shall be set-apart to you. 
 \v 33 Whoever compounds any like it, or whoever puts any of it on a stranger, he shall be cut off from his people.’ ” 
 \p
-\v 34 Yahweh said to Moses, “Take to yourself sweet spices, gum resin, onycha, and galbanum: sweet spices with pure frankincense. There shall be an equal weight of each. 
+\v 34 Yahuah said to Moses, “Take to yourself sweet spices, gum resin, onycha, and galbanum: sweet spices with pure frankincense. There shall be an equal weight of each. 
 \v 35 You shall make incense of it, a perfume after the art of the perfumer, seasoned with salt, pure and set-apart. 
 \v 36 You shall beat some of it very small, and put some of it before the covenant in the Tent of Meeting, where I will meet with you. It shall be to you most set-apart. 
-\v 37 You shall not make this incense, according to its composition, for yourselves: it shall be to you set-apart for Yahweh. 
+\v 37 You shall not make this incense, according to its composition, for yourselves: it shall be to you set-apart for Yahuah. 
 \v 38 Whoever shall make any like that, to smell of it, he shall be cut off from his people.” 
 \c 31
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Behold, I have called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah. 
 \v 3 I have filled him with the Spirit of Elohim, in wisdom, and in understanding, and in knowledge, and in all kinds of workmanship, 
 \v 4 to devise skillful works, to work in gold, and in silver, and in bronze, 
@@ -1244,12 +1244,12 @@
 \v 9 the altar of burnt offering with all its vessels, the basin and its base, 
 \v 10 the finely worked garments—the set-apart garments for Aaron the priest, the garments of his sons to minister in the priest’s office—\v 11 the anointing oil, and the incense of sweet spices for the set-apart place: according to all that I have commanded you they shall do.” 
 \p
-\v 12 Yahweh spoke to Moses, saying, 
-\v 13 “Speak also to the children of Israel, saying, ‘Most certainly you shall keep my Sabbaths; for it is a sign between me and you throughout your generations, that you may know that I am Yahweh who sanctifies you. 
+\v 12 Yahuah spoke to Moses, saying, 
+\v 13 “Speak also to the children of Israel, saying, ‘Most certainly you shall keep my Sabbaths; for it is a sign between me and you throughout your generations, that you may know that I am Yahuah who sanctifies you. 
 \v 14 You shall keep the Sabbath therefore, for it is set-apart to you. Everyone who profanes it shall surely be put to death; for whoever does any work therein, that soul shall be cut off from among his people. 
-\v 15 Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, set-apart to Yahweh. Whoever does any work on the Sabbath day shall surely be put to death. 
+\v 15 Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, set-apart to Yahuah. Whoever does any work on the Sabbath day shall surely be put to death. 
 \v 16 Therefore the children of Israel shall keep the Sabbath, to observe the Sabbath throughout their generations, for a perpetual covenant. 
-\v 17 It is a sign between me and the children of Israel forever; for in six days Yahweh made heaven and earth, and on the seventh day he rested, and was refreshed.’ ” 
+\v 17 It is a sign between me and the children of Israel forever; for in six days Yahuah made heaven and earth, and on the seventh day he rested, and was refreshed.’ ” 
 \p
 \v 18 When he finished speaking with him on Mount Sinai, he gave Moses the two tablets of the covenant, stone tablets, written with Elohim’s finger. 
 \c 32
@@ -1261,21 +1261,21 @@
 \v 3 All the people took off the golden rings which were in their ears, and brought them to Aaron. 
 \v 4 He received what they handed him, fashioned it with an engraving tool, and made it a molded calf. Then they said, “These are your elohims, Israel, which brought you up out of the land of Egypt.” 
 \p
-\v 5 When Aaron saw this, he built an altar before it; and Aaron made a proclamation, and said, “Tomorrow shall be a feast to Yahweh.” 
+\v 5 When Aaron saw this, he built an altar before it; and Aaron made a proclamation, and said, “Tomorrow shall be a feast to Yahuah.” 
 \p
 \v 6 They rose up early on the next day, and offered burnt offerings, and brought peace offerings; and the people sat down to eat and to drink, and rose up to play. 
 \p
-\v 7 Yahweh spoke to Moses, “Go, get down; for your people, whom you brought up out of the land of Egypt, have corrupted themselves! 
+\v 7 Yahuah spoke to Moses, “Go, get down; for your people, whom you brought up out of the land of Egypt, have corrupted themselves! 
 \v 8 They have turned away quickly out of the way which I commanded them. They have made themselves a molded calf, and have worshiped it, and have sacrificed to it, and said, ‘These are your elohims, Israel, which brought you up out of the land of Egypt.’ ” 
 \p
-\v 9 Yahweh said to Moses, “I have seen these people, and behold, they are a stiff-necked people. 
+\v 9 Yahuah said to Moses, “I have seen these people, and behold, they are a stiff-necked people. 
 \v 10 Now therefore leave me alone, that my wrath may burn hot against them, and that I may consume them; and I will make of you a great nation.” 
 \p
-\v 11 Moses begged Yahweh his Elohim, and said, “Yahweh, why does your wrath burn hot against your people, that you have brought out of the land of Egypt with great power and with a mighty hand? 
+\v 11 Moses begged Yahuah his Elohim, and said, “Yahuah, why does your wrath burn hot against your people, that you have brought out of the land of Egypt with great power and with a mighty hand? 
 \v 12 Why should the Egyptians talk, saying, ‘He brought them out for evil, to kill them in the mountains, and to consume them from the surface of the earth’? Turn from your fierce wrath, and turn away from this evil against your people. 
 \v 13 Remember Abraham, Isaac, and Israel, your servants, to whom you swore by your own self, and said to them, ‘I will multiply your offspring as the stars of the sky, and all this land that I have spoken of I will give to your offspring, and they shall inherit it forever.’ ” 
 \p
-\v 14 So Yahweh turned away from the evil which he said he would do to his people. 
+\v 14 So Yahuah turned away from the evil which he said he would do to his people. 
 \p
 \v 15 Moses turned, and went down from the mountain, with the two tablets of the covenant in his hand; tablets that were written on both their sides. They were written on one side and on the other. 
 \v 16 The tablets were the work of Elohim, and the writing was the writing of Elohim, engraved on the tablets. 
@@ -1293,39 +1293,39 @@
 \v 24 I said to them, ‘Whoever has any gold, let them take it off.’ So they gave it to me; and I threw it into the fire, and out came this calf.” 
 \p
 \v 25 When Moses saw that the people were out of control, (for Aaron had let them lose control, causing derision among their enemies), 
-\v 26 then Moses stood in the gate of the camp, and said, “Whoever is on Yahweh’s side, come to me!” 
+\v 26 then Moses stood in the gate of the camp, and said, “Whoever is on Yahuah’s side, come to me!” 
 \p All the sons of Levi gathered themselves together to him. 
-\v 27 He said to them, “Yahweh, the Elohim of Israel, says, ‘Every man put his sword on his thigh, and go back and forth from gate to gate throughout the camp, and every man kill his brother, and every man his companion, and every man his neighbor.’ ” 
+\v 27 He said to them, “Yahuah, the Elohim of Israel, says, ‘Every man put his sword on his thigh, and go back and forth from gate to gate throughout the camp, and every man kill his brother, and every man his companion, and every man his neighbor.’ ” 
 \v 28 The sons of Levi did according to the word of Moses. About three thousand men fell of the people that day. 
-\v 29 Moses said, “Consecrate yourselves today to Yahweh, for every man was against his son and against his brother, that he may give you a blessing today.” 
+\v 29 Moses said, “Consecrate yourselves today to Yahuah, for every man was against his son and against his brother, that he may give you a blessing today.” 
 \p
-\v 30 On the next day, Moses said to the people, “You have sinned a great sin. Now I will go up to Yahweh. Perhaps I shall make atonement for your sin.” 
+\v 30 On the next day, Moses said to the people, “You have sinned a great sin. Now I will go up to Yahuah. Perhaps I shall make atonement for your sin.” 
 \p
-\v 31 Moses returned to Yahweh, and said, “Oh, this people have sinned a great sin, and have made themselves elohims of gold. 
+\v 31 Moses returned to Yahuah, and said, “Oh, this people have sinned a great sin, and have made themselves elohims of gold. 
 \v 32 Yet now, if you will, forgive their sin—and if not, please blot me out of your book which you have written.” 
 \p
-\v 33 Yahweh said to Moses, “Whoever has sinned against me, I will blot him out of my book. 
+\v 33 Yahuah said to Moses, “Whoever has sinned against me, I will blot him out of my book. 
 \v 34 Now go, lead the people to the place of which I have spoken to you. Behold, my angel shall go before you. Nevertheless, in the day when I punish, I will punish them for their sin.” 
-\v 35 Yahweh struck the people, because of what they did with the calf, which Aaron made. 
+\v 35 Yahuah struck the people, because of what they did with the calf, which Aaron made. 
 \c 33
 \p
-\v 1 Yahweh spoke to Moses, “Depart, go up from here, you and the people that you have brought up out of the land of Egypt, to the land of which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ 
+\v 1 Yahuah spoke to Moses, “Depart, go up from here, you and the people that you have brought up out of the land of Egypt, to the land of which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ 
 \v 2 I will send an angel before you; and I will drive out the Canaanite, the Amorite, and the Hittite, and the Perizzite, the Hivite, and the Jebusite. 
 \v 3 Go to a land flowing with milk and honey; but I will not go up among you, for you are a stiff-necked people, lest I consume you on the way.” 
 \p
 \v 4 When the people heard this evil news, they mourned; and no one put on his jewelry. 
 \p
-\v 5 Yahweh had said to Moses, “Tell the children of Israel, ‘You are a stiff-necked people. If I were to go up among you for one moment, I would consume you. Therefore now take off your jewelry from you, that I may know what to do to you.’ ” 
+\v 5 Yahuah had said to Moses, “Tell the children of Israel, ‘You are a stiff-necked people. If I were to go up among you for one moment, I would consume you. Therefore now take off your jewelry from you, that I may know what to do to you.’ ” 
 \p
 \v 6 The children of Israel stripped themselves of their jewelry from Mount Horeb onward. 
 \p
-\v 7 Now Moses used to take the tent and pitch it outside the camp, far away from the camp, and he called it “The Tent of Meeting.” Everyone who sought Yahweh went out to the Tent of Meeting, which was outside the camp. 
+\v 7 Now Moses used to take the tent and pitch it outside the camp, far away from the camp, and he called it “The Tent of Meeting.” Everyone who sought Yahuah went out to the Tent of Meeting, which was outside the camp. 
 \v 8 When Moses went out to the Tent, all the people rose up, and stood, everyone at their tent door, and watched Moses, until he had gone into the Tent. 
-\v 9 When Moses entered into the Tent, the pillar of cloud descended, stood at the door of the Tent, and Yahweh spoke with Moses. 
+\v 9 When Moses entered into the Tent, the pillar of cloud descended, stood at the door of the Tent, and Yahuah spoke with Moses. 
 \v 10 All the people saw the pillar of cloud stand at the door of the Tent, and all the people rose up and worshiped, everyone at their tent door. 
-\v 11 Yahweh spoke to Moses face to face, as a man speaks to his friend. He turned again into the camp, but his servant Joshua, the son of Nun, a young man, didn’t depart from the Tent. 
+\v 11 Yahuah spoke to Moses face to face, as a man speaks to his friend. He turned again into the camp, but his servant Joshua, the son of Nun, a young man, didn’t depart from the Tent. 
 \p
-\v 12 Moses said to Yahweh, “Behold, you tell me, ‘Bring up this people;’ and you haven’t let me know whom you will send with me. Yet you have said, ‘I know you by name, and you have also found favor in my sight.’ 
+\v 12 Moses said to Yahuah, “Behold, you tell me, ‘Bring up this people;’ and you haven’t let me know whom you will send with me. Yet you have said, ‘I know you by name, and you have also found favor in my sight.’ 
 \v 13 Now therefore, if I have found favor in your sight, please show me your way, now, that I may know you, so that I may find favor in your sight; and consider that this nation is your people.” 
 \p
 \v 14 He said, “My presence will go with you, and I will give you rest.” 
@@ -1333,34 +1333,34 @@
 \v 15 Moses said to him, “If your presence doesn’t go with me, don’t carry us up from here. 
 \v 16 For how would people know that I have found favor in your sight, I and your people? Isn’t it that you go with us, so that we are separated, I and your people, from all the people who are on the surface of the earth?” 
 \p
-\v 17 Yahweh said to Moses, “I will do this thing also that you have spoken; for you have found favor in my sight, and I know you by name.” 
+\v 17 Yahuah said to Moses, “I will do this thing also that you have spoken; for you have found favor in my sight, and I know you by name.” 
 \p
 \v 18 Moses said, “Please show me your glory.” 
 \p
-\v 19 He said, “I will make all my goodness pass before you, and will proclaim Yahweh’s name before you. I will be gracious to whom I will be gracious, and will show mercy on whom I will show mercy.” 
+\v 19 He said, “I will make all my goodness pass before you, and will proclaim Yahuah’s name before you. I will be gracious to whom I will be gracious, and will show mercy on whom I will show mercy.” 
 \v 20 He said, “You cannot see my face, for man may not see me and live.” 
-\v 21 Yahweh also said, “Behold, there is a place by me, and you shall stand on the rock. 
+\v 21 Yahuah also said, “Behold, there is a place by me, and you shall stand on the rock. 
 \v 22 It will happen, while my glory passes by, that I will put you in a cleft of the rock, and will cover you with my hand until I have passed by; 
 \v 23 then I will take away my hand, and you will see my back; but my face shall not be seen.” 
 \c 34
 \p
-\v 1 Yahweh said to Moses, “Chisel two stone tablets like the first. I will write on the tablets the words that were on the first tablets, which you broke. 
+\v 1 Yahuah said to Moses, “Chisel two stone tablets like the first. I will write on the tablets the words that were on the first tablets, which you broke. 
 \v 2 Be ready by the morning, and come up in the morning to Mount Sinai, and present yourself there to me on the top of the mountain. 
 \v 3 No one shall come up with you or be seen anywhere on the mountain. Do not let the flocks or herds graze in front of that mountain.” 
 \p
-\v 4 He chiseled two tablets of stone like the first; then Moses rose up early in the morning, and went up to Mount Sinai, as Yahweh had commanded him, and took in his hand two stone tablets. 
-\v 5 Yahweh descended in the cloud, and stood with him there, and proclaimed Yahweh’s name. 
-\v 6 Yahweh passed by before him, and proclaimed, “Yahweh! Yahweh, a merciful and gracious Elohim, slow to anger, and abundant in loving kindness and truth, 
+\v 4 He chiseled two tablets of stone like the first; then Moses rose up early in the morning, and went up to Mount Sinai, as Yahuah had commanded him, and took in his hand two stone tablets. 
+\v 5 Yahuah descended in the cloud, and stood with him there, and proclaimed Yahuah’s name. 
+\v 6 Yahuah passed by before him, and proclaimed, “Yahuah! Yahuah, a merciful and gracious Elohim, slow to anger, and abundant in loving kindness and truth, 
 \v 7 keeping loving kindness for thousands, forgiving iniquity and disobedience and sin; and who will by no means clear the guilty, visiting the iniquity of the fathers on the children, and on the children’s children, on the third and on the fourth generation.” 
 \p
 \v 8 Moses hurried and bowed his head toward the earth, and worshiped. 
 \v 9 He said, “If now I have found favor in your sight, Lord, please let the Lord go among us, even though this is a stiff-necked people; pardon our iniquity and our sin, and take us for your inheritance.” 
 \p
-\v 10 He said, “Behold, I make a covenant: before all your people I will do marvels, such as have not been worked in all the earth, nor in any nation; and all the people among whom you are shall see the work of Yahweh; for it is an awesome thing that I do with you. 
+\v 10 He said, “Behold, I make a covenant: before all your people I will do marvels, such as have not been worked in all the earth, nor in any nation; and all the people among whom you are shall see the work of Yahuah; for it is an awesome thing that I do with you. 
 \v 11 Observe that which I command you today. Behold, I will drive out before you the Amorite, the Canaanite, the Hittite, the Perizzite, the Hivite, and the Jebusite. 
 \v 12 Be careful, lest you make a covenant with the inhabitants of the land where you are going, lest it be for a snare among you; 
 \v 13 but you shall break down their altars, and dash in pieces their pillars, and you shall cut down their Asherah poles; 
-\v 14 for you shall worship no other elohim; for Yahweh, whose name is Jealous, is a jealous Elohim. 
+\v 14 for you shall worship no other elohim; for Yahuah, whose name is Jealous, is a jealous Elohim. 
 \p
 \v 15 “Don’t make a covenant with the inhabitants of the land, lest they play the prostitute after their elohims, and sacrifice to their elohims, and one call you and you eat of his sacrifice; 
 \v 16 and you take of their daughters to your sons, and their daughters play the prostitute after their elohims, and make your sons play the prostitute after their elohims. 
@@ -1375,39 +1375,39 @@
 \v 21 “Six days you shall work, but on the seventh day you shall rest: in plowing time and in harvest you shall rest. 
 \p
 \v 22 “You shall observe the feast of weeks with the first fruits of wheat harvest, and the feast of harvest at the year’s end. 
-\v 23 Three times in the year all your males shall appear before the Lord Yahweh, the Elohim of Israel. 
-\v 24 For I will drive out nations before you and enlarge your borders; neither shall any man desire your land when you go up to appear before Yahweh, your Elohim, three times in the year. 
+\v 23 Three times in the year all your males shall appear before the Lord Yahuah, the Elohim of Israel. 
+\v 24 For I will drive out nations before you and enlarge your borders; neither shall any man desire your land when you go up to appear before Yahuah, your Elohim, three times in the year. 
 \p
 \v 25 “You shall not offer the blood of my sacrifice with leavened bread. The sacrifice of the feast of the Passover shall not be left to the morning. 
 \p
-\v 26 “You shall bring the first of the first fruits of your ground to the house of Yahweh your Elohim. 
+\v 26 “You shall bring the first of the first fruits of your ground to the house of Yahuah your Elohim. 
 \p “You shall not boil a young goat in its mother’s milk.” 
 \p
-\v 27 Yahweh said to Moses, “Write these words; for in accordance with these words I have made a covenant with you and with Israel.” 
+\v 27 Yahuah said to Moses, “Write these words; for in accordance with these words I have made a covenant with you and with Israel.” 
 \p
-\v 28 He was there with Yahweh forty days and forty nights; he neither ate bread, nor drank water. He wrote on the tablets the words of the covenant, the ten commandments. 
+\v 28 He was there with Yahuah forty days and forty nights; he neither ate bread, nor drank water. He wrote on the tablets the words of the covenant, the ten commandments. 
 \p
 \v 29 When Moses came down from Mount Sinai with the two tablets of the covenant in Moses’ hand, when he came down from the mountain, Moses didn’t know that the skin of his face shone by reason of his speaking with him. 
 \v 30 When Aaron and all the children of Israel saw Moses, behold, the skin of his face shone; and they were afraid to come near him. 
 \v 31 Moses called to them, and Aaron and all the rulers of the congregation returned to him; and Moses spoke to them. 
-\v 32 Afterward all the children of Israel came near, and he gave them all the commandments that Yahweh had spoken with him on Mount Sinai. 
+\v 32 Afterward all the children of Israel came near, and he gave them all the commandments that Yahuah had spoken with him on Mount Sinai. 
 \v 33 When Moses was done speaking with them, he put a veil on his face. 
-\v 34 But when Moses went in before Yahweh to speak with him, he took the veil off, until he came out; and he came out, and spoke to the children of Israel that which he was commanded. 
+\v 34 But when Moses went in before Yahuah to speak with him, he took the veil off, until he came out; and he came out, and spoke to the children of Israel that which he was commanded. 
 \v 35 The children of Israel saw Moses’ face, that the skin of Moses’ face shone; so Moses put the veil on his face again, until he went in to speak with him. 
 \c 35
 \p
-\v 1 Moses assembled all the congregation of the children of Israel, and said to them, “These are the words which Yahweh has commanded, that you should do them. 
-\v 2 ‘Six days shall work be done, but on the seventh day there shall be a set-apart day for you, a Sabbath of solemn rest to Yahweh: whoever does any work in it shall be put to death. 
+\v 1 Moses assembled all the congregation of the children of Israel, and said to them, “These are the words which Yahuah has commanded, that you should do them. 
+\v 2 ‘Six days shall work be done, but on the seventh day there shall be a set-apart day for you, a Sabbath of solemn rest to Yahuah: whoever does any work in it shall be put to death. 
 \v 3 You shall kindle no fire throughout your habitations on the Sabbath day.’ ” 
 \p
-\v 4 Moses spoke to all the congregation of the children of Israel, saying, “This is the thing which Yahweh commanded, saying, 
-\v 5 ‘Take from among you an offering to Yahweh. Whoever is of a willing heart, let him bring it as Yahweh’s offering: gold, silver, bronze, 
+\v 4 Moses spoke to all the congregation of the children of Israel, saying, “This is the thing which Yahuah commanded, saying, 
+\v 5 ‘Take from among you an offering to Yahuah. Whoever is of a willing heart, let him bring it as Yahuah’s offering: gold, silver, bronze, 
 \v 6 blue, purple, scarlet, fine linen, goats’ hair, 
 \v 7 rams’ skins dyed red, sea cow hides, acacia wood, 
 \v 8 oil for the light, spices for the anointing oil and for the sweet incense, 
 \v 9 onyx stones, and stones to be set for the ephod and for the breastplate. 
 \p
-\v 10 “ ‘Let every wise-hearted man among you come, and make all that Yahweh has commanded: 
+\v 10 “ ‘Let every wise-hearted man among you come, and make all that Yahuah has commanded: 
 \v 11 the tabernacle, its outer covering, its roof, its clasps, its boards, its bars, its pillars, and its sockets; 
 \v 12 the ark, and its poles, the mercy seat, the veil of the screen; 
 \v 13 the table with its poles and all its vessels, and the show bread; 
@@ -1419,17 +1419,17 @@
 \v 19 the finely worked garments for ministering in the set-apart place—the set-apart garments for Aaron the priest, and the garments of his sons—to minister in the priest’s office.’ ” 
 \p
 \v 20 All the congregation of the children of Israel departed from the presence of Moses. 
-\v 21 They came, everyone whose heart stirred him up, and everyone whom his spirit made willing, and brought Yahweh’s offering for the work of the Tent of Meeting, and for all of its service, and for the set-apart garments. 
-\v 22 They came, both men and women, as many as were willing-hearted, and brought brooches, earrings, signet rings, and armlets, all jewels of gold; even every man who offered an offering of gold to Yahweh. 
+\v 21 They came, everyone whose heart stirred him up, and everyone whom his spirit made willing, and brought Yahuah’s offering for the work of the Tent of Meeting, and for all of its service, and for the set-apart garments. 
+\v 22 They came, both men and women, as many as were willing-hearted, and brought brooches, earrings, signet rings, and armlets, all jewels of gold; even every man who offered an offering of gold to Yahuah. 
 \v 23 Everyone with whom was found blue, purple, scarlet, fine linen, goats’ hair, rams’ skins dyed red, and sea cow hides, brought them. 
-\v 24 Everyone who offered an offering of silver and bronze brought Yahweh’s offering; and everyone with whom was found acacia wood for any work of the service, brought it. 
+\v 24 Everyone who offered an offering of silver and bronze brought Yahuah’s offering; and everyone with whom was found acacia wood for any work of the service, brought it. 
 \v 25 All the women who were wise-hearted spun with their hands, and brought that which they had spun: the blue, the purple, the scarlet, and the fine linen. 
 \v 26 All the women whose heart stirred them up in wisdom spun the goats’ hair. 
 \v 27 The rulers brought the onyx stones and the stones to be set for the ephod and for the breastplate; 
 \v 28 with the spice and the oil for the light, for the anointing oil, and for the sweet incense. 
-\v 29 The children of Israel brought a free will offering to Yahweh; every man and woman whose heart made them willing to bring for all the work, which Yahweh had commanded to be made by Moses. 
+\v 29 The children of Israel brought a free will offering to Yahuah; every man and woman whose heart made them willing to bring for all the work, which Yahuah had commanded to be made by Moses. 
 \p
-\v 30 Moses said to the children of Israel, “Behold, Yahweh has called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah. 
+\v 30 Moses said to the children of Israel, “Behold, Yahuah has called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah. 
 \v 31 He has filled him with the Spirit of Elohim, in wisdom, in understanding, in knowledge, and in all kinds of workmanship; 
 \v 32 and to make skillful works, to work in gold, in silver, in bronze, 
 \v 33 in cutting of stones for setting, and in carving of wood, to work in all kinds of skillful workmanship. 
@@ -1437,12 +1437,12 @@
 \v 35 He has filled them with wisdom of heart to work all kinds of workmanship, of the engraver, of the skillful workman, and of the embroiderer, in blue, in purple, in scarlet, and in fine linen, and of the weaver, even of those who do any workmanship, and of those who make skillful works. 
 \c 36
 \p
-\v 1 “Bezalel and Oholiab shall work with every wise-hearted man, in whom Yahweh has put wisdom and understanding to know how to do all the work for the service of the sanctuary, according to all that Yahweh has commanded.” 
+\v 1 “Bezalel and Oholiab shall work with every wise-hearted man, in whom Yahuah has put wisdom and understanding to know how to do all the work for the service of the sanctuary, according to all that Yahuah has commanded.” 
 \p
-\v 2 Moses called Bezalel and Oholiab, and every wise-hearted man, in whose heart Yahweh had put wisdom, even everyone whose heart stirred him up to come to the work to do it. 
+\v 2 Moses called Bezalel and Oholiab, and every wise-hearted man, in whose heart Yahuah had put wisdom, even everyone whose heart stirred him up to come to the work to do it. 
 \v 3 They received from Moses all the offering which the children of Israel had brought for the work of the service of the sanctuary, with which to make it. They kept bringing free will offerings to him every morning. 
 \v 4 All the wise men, who performed all the work of the sanctuary, each came from his work which he did. 
-\v 5 They spoke to Moses, saying, “The people have brought much more than enough for the service of the work which Yahweh commanded to make.” 
+\v 5 They spoke to Moses, saying, “The people have brought much more than enough for the service of the work which Yahuah commanded to make.” 
 \p
 \v 6 Moses gave a commandment, and they caused it to be proclaimed throughout the camp, saying, “Let neither man nor woman make anything else for the offering for the sanctuary.” So the people were restrained from bringing. 
 \v 7 For the stuff they had was sufficient to do all the work, and too much. 
@@ -1542,7 +1542,7 @@
 \v 20 All the pins of the tabernacle, and around the court, were of bronze. 
 \p
 \v 21 These are the amounts of materials used for the tabernacle, even the Tabernacle of the Testimony, as they were counted, according to the commandment of Moses, for the service of the Levites, by the hand of Ithamar, the son of Aaron the priest. 
-\v 22 Bezalel the son of Uri, the son of Hur, of the tribe of Judah, made all that Yahweh commanded Moses. 
+\v 22 Bezalel the son of Uri, the son of Hur, of the tribe of Judah, made all that Yahuah commanded Moses. 
 \v 23 With him was Oholiab, the son of Ahisamach, of the tribe of Dan, an engraver, and a skillful workman, and an embroiderer in blue, in purple, in scarlet, and in fine linen. 
 \p
 \v 24 All the gold that was used for the work in all the work of the sanctuary, even the gold of the offering, was twenty-nine talents and seven hundred thirty shekels, according to the shekel of the sanctuary. 
@@ -1555,15 +1555,15 @@
 \v 31 the sockets around the court, the sockets of the gate of the court, all the pins of the tabernacle, and all the pins around the court. 
 \c 39
 \p
-\v 1 Of the blue, purple, and scarlet, they made finely worked garments for ministering in the set-apart place, and made the set-apart garments for Aaron, as Yahweh commanded Moses. 
+\v 1 Of the blue, purple, and scarlet, they made finely worked garments for ministering in the set-apart place, and made the set-apart garments for Aaron, as Yahuah commanded Moses. 
 \p
 \v 2 He made the ephod of gold, blue, purple, scarlet, and fine twined linen. 
 \v 3 They beat the gold into thin plates, and cut it into wires, to work it in with the blue, the purple, the scarlet, and the fine linen, the work of the skillful workman. 
 \v 4 They made shoulder straps for it, joined together. It was joined together at the two ends. 
-\v 5 The skillfully woven band that was on it, with which to fasten it on, was of the same piece, like its work: of gold, of blue, purple, scarlet, and fine twined linen, as Yahweh commanded Moses. 
+\v 5 The skillfully woven band that was on it, with which to fasten it on, was of the same piece, like its work: of gold, of blue, purple, scarlet, and fine twined linen, as Yahuah commanded Moses. 
 \p
 \v 6 They worked the onyx stones, enclosed in settings of gold, engraved with the engravings of a signet, according to the names of the children of Israel. 
-\v 7 He put them on the shoulder straps of the ephod, to be stones of memorial for the children of Israel, as Yahweh commanded Moses. 
+\v 7 He put them on the shoulder straps of the ephod, to be stones of memorial for the children of Israel, as Yahuah commanded Moses. 
 \p
 \v 8 He made the breastplate, the work of a skillful workman, like the work of the ephod: of gold, of blue, purple, scarlet, and fine twined linen. 
 \v 9 It was square. They made the breastplate double. Its length was a span, and its width a span, being double. 
@@ -1578,22 +1578,22 @@
 \v 18 The other two ends of the two braided chains they put on the two settings, and put them on the shoulder straps of the ephod, in its front. 
 \v 19 They made two rings of gold, and put them on the two ends of the breastplate, on its edge, which was toward the side of the ephod inward. 
 \v 20 They made two more rings of gold, and put them on the two shoulder straps of the ephod underneath, in its front, close by its coupling, above the skillfully woven band of the ephod. 
-\v 21 They bound the breastplate by its rings to the rings of the ephod with a lace of blue, that it might be on the skillfully woven band of the ephod, and that the breastplate might not come loose from the ephod, as Yahweh commanded Moses. 
+\v 21 They bound the breastplate by its rings to the rings of the ephod with a lace of blue, that it might be on the skillfully woven band of the ephod, and that the breastplate might not come loose from the ephod, as Yahuah commanded Moses. 
 \p
 \v 22 He made the robe of the ephod of woven work, all of blue. 
 \v 23 The opening of the robe in the middle of it was like the opening of a coat of mail, with a binding around its opening, that it should not be torn. 
 \v 24 They made on the skirts of the robe pomegranates of blue, purple, scarlet, and twined linen. 
 \v 25 They made bells of pure gold, and put the bells between the pomegranates around the skirts of the robe, between the pomegranates; 
-\v 26 a bell and a pomegranate, a bell and a pomegranate, around the skirts of the robe, to minister in, as Yahweh commanded Moses. 
+\v 26 a bell and a pomegranate, a bell and a pomegranate, around the skirts of the robe, to minister in, as Yahuah commanded Moses. 
 \p
 \v 27 They made the tunics of fine linen of woven work for Aaron and for his sons, 
 \v 28 the turban of fine linen, the linen headbands of fine linen, the linen trousers of fine twined linen, 
-\v 29 the sash of fine twined linen, blue, purple, and scarlet, the work of the embroiderer, as Yahweh commanded Moses. 
+\v 29 the sash of fine twined linen, blue, purple, and scarlet, the work of the embroiderer, as Yahuah commanded Moses. 
 \p
-\v 30 They made the plate of the set-apart crown of pure gold, and wrote on it an inscription, like the engravings of a signet: “SET-APART TO YAHWEH”. 
-\v 31 They tied to it a lace of blue, to fasten it on the turban above, as Yahweh commanded Moses. 
+\v 30 They made the plate of the set-apart crown of pure gold, and wrote on it an inscription, like the engravings of a signet: “SET-APART TO YAHUAH”. 
+\v 31 They tied to it a lace of blue, to fasten it on the turban above, as Yahuah commanded Moses. 
 \p
-\v 32 Thus all the work of the tabernacle of the Tent of Meeting was finished. The children of Israel did according to all that Yahweh commanded Moses; so they did. 
+\v 32 Thus all the work of the tabernacle of the Tent of Meeting was finished. The children of Israel did according to all that Yahuah commanded Moses; so they did. 
 \v 33 They brought the tabernacle to Moses: the tent, with all its furniture, its clasps, its boards, its bars, its pillars, its sockets, 
 \v 34 the covering of rams’ skins dyed red, the covering of sea cow hides, the veil of the screen, 
 \v 35 the ark of the covenant with its poles, the mercy seat, 
@@ -1603,11 +1603,11 @@
 \v 39 the bronze altar, its grating of bronze, its poles, all of its vessels, the basin and its base, 
 \v 40 the hangings of the court, its pillars, its sockets, the screen for the gate of the court, its cords, its pins, and all the instruments of the service of the tabernacle, for the Tent of Meeting, 
 \v 41 the finely worked garments for ministering in the set-apart place, the set-apart garments for Aaron the priest, and the garments of his sons, to minister in the priest’s office. 
-\v 42 According to all that Yahweh commanded Moses, so the children of Israel did all the work. 
-\v 43 Moses saw all the work, and behold, they had done it as Yahweh had commanded. They had done so; and Moses blessed them. 
+\v 42 According to all that Yahuah commanded Moses, so the children of Israel did all the work. 
+\v 43 Moses saw all the work, and behold, they had done it as Yahuah had commanded. They had done so; and Moses blessed them. 
 \c 40
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “On the first day of the first month you shall raise up the tabernacle of the Tent of Meeting. 
 \v 3 You shall put the ark of the covenant in it, and you shall screen the ark with the veil. 
 \v 4 You shall bring in the table, and set in order the things that are on it. You shall bring in the lamp stand, and light its lamps. 
@@ -1625,28 +1625,28 @@
 \v 13 You shall put on Aaron the set-apart garments; and you shall anoint him, and sanctify him, that he may minister to me in the priest’s office. 
 \v 14 You shall bring his sons, and put tunics on them. 
 \v 15 You shall anoint them, as you anointed their father, that they may minister to me in the priest’s office. Their anointing shall be to them for an everlasting priesthood throughout their generations.” 
-\v 16 Moses did so. According to all that Yahweh commanded him, so he did. 
+\v 16 Moses did so. According to all that Yahuah commanded him, so he did. 
 \p
 \v 17 In the first month in the second year, on the first day of the month, the tabernacle was raised up. 
 \v 18 Moses raised up the tabernacle, and laid its sockets, and set up its boards, and put in its bars, and raised up its pillars. 
-\v 19 He spread the covering over the tent, and put the roof of the tabernacle above on it, as Yahweh commanded Moses. 
+\v 19 He spread the covering over the tent, and put the roof of the tabernacle above on it, as Yahuah commanded Moses. 
 \v 20 He took and put the covenant into the ark, and set the poles on the ark, and put the mercy seat above on the ark. 
-\v 21 He brought the ark into the tabernacle, and set up the veil of the screen, and screened the ark of the covenant, as Yahweh commanded Moses. 
+\v 21 He brought the ark into the tabernacle, and set up the veil of the screen, and screened the ark of the covenant, as Yahuah commanded Moses. 
 \v 22 He put the table in the Tent of Meeting, on the north side of the tabernacle, outside of the veil. 
-\v 23 He set the bread in order on it before Yahweh, as Yahweh commanded Moses. 
+\v 23 He set the bread in order on it before Yahuah, as Yahuah commanded Moses. 
 \v 24 He put the lamp stand in the Tent of Meeting, opposite the table, on the south side of the tabernacle. 
-\v 25 He lit the lamps before Yahweh, as Yahweh commanded Moses. 
+\v 25 He lit the lamps before Yahuah, as Yahuah commanded Moses. 
 \v 26 He put the golden altar in the Tent of Meeting before the veil; 
-\v 27 and he burned incense of sweet spices on it, as Yahweh commanded Moses. 
+\v 27 and he burned incense of sweet spices on it, as Yahuah commanded Moses. 
 \v 28 He put up the screen of the door to the tabernacle. 
-\v 29 He set the altar of burnt offering at the door of the tabernacle of the Tent of Meeting, and offered on it the burnt offering and the meal offering, as Yahweh commanded Moses. 
+\v 29 He set the altar of burnt offering at the door of the tabernacle of the Tent of Meeting, and offered on it the burnt offering and the meal offering, as Yahuah commanded Moses. 
 \v 30 He set the basin between the Tent of Meeting and the altar, and put water therein, with which to wash. 
 \v 31 Moses, Aaron, and his sons washed their hands and their feet there. 
-\v 32 When they went into the Tent of Meeting, and when they came near to the altar, they washed, as Yahweh commanded Moses. 
+\v 32 When they went into the Tent of Meeting, and when they came near to the altar, they washed, as Yahuah commanded Moses. 
 \v 33 He raised up the court around the tabernacle and the altar, and set up the screen of the gate of the court. So Moses finished the work. 
 \p
-\v 34 Then the cloud covered the Tent of Meeting, and Yahweh’s glory filled the tabernacle. 
-\v 35 Moses wasn’t able to enter into the Tent of Meeting, because the cloud stayed on it, and Yahweh’s glory filled the tabernacle. 
+\v 34 Then the cloud covered the Tent of Meeting, and Yahuah’s glory filled the tabernacle. 
+\v 35 Moses wasn’t able to enter into the Tent of Meeting, because the cloud stayed on it, and Yahuah’s glory filled the tabernacle. 
 \v 36 When the cloud was taken up from over the tabernacle, the children of Israel went onward, throughout all their journeys; 
 \v 37 but if the cloud wasn’t taken up, then they didn’t travel until the day that it was taken up. 
-\v 38 For the cloud of Yahweh was on the tabernacle by day, and there was fire in the cloud by night, in the sight of all the house of Israel, throughout all their journeys. 
+\v 38 For the cloud of Yahuah was on the tabernacle by day, and there was fire in the cloud by night, in the sight of all the house of Israel, throughout all their journeys. 

--- a/usfm/ezekiel.usfm
+++ b/usfm/ezekiel.usfm
@@ -6,7 +6,7 @@
 \v 1 Now in the thirtieth year, in the fourth month, in the fifth day of the month, as I was among the captives by the river Chebar, the heavens were opened, and I saw visions of Elohim. 
 \p
 \v 2 In the fifth of the month, which was the fifth year of King Jehoiachin’s captivity, 
-\v 3 Yahweh’s word came to Ezekiel the priest, the son of Buzi, in the land of the Chaldeans by the river Chebar; and Yahweh’s hand was there on him. 
+\v 3 Yahuah’s word came to Ezekiel the priest, the son of Buzi, in the land of the Chaldeans by the river Chebar; and Yahuah’s hand was there on him. 
 \p
 \v 4 I looked, and behold, a stormy wind came out of the north: a great cloud, with flashing lightning, and a brightness around it, and out of the middle of it as it were glowing metal, out of the middle of the fire. 
 \v 5 Out of its center came the likeness of four living creatures. This was their appearance: They had the likeness of a man. 
@@ -38,14 +38,14 @@
 \v 26 Above the expanse that was over their heads was the likeness of a throne, as the appearance of a sapphire stone. On the likeness of the throne was a likeness as the appearance of a man on it above. 
 \v 27 I saw as it were glowing metal, as the appearance of fire within it all around, from the appearance of his waist and upward; and from the appearance of his waist and downward I saw as it were the appearance of fire, and there was brightness around him. 
 \v 28 As the appearance of the rainbow that is in the cloud in the day of rain, so was the appearance of the brightness all around. 
-\p This was the appearance of the likeness of Yahweh’s glory. When I saw it, I fell on my face, and I heard a voice of one that spoke. 
+\p This was the appearance of the likeness of Yahuah’s glory. When I saw it, I fell on my face, and I heard a voice of one that spoke. 
 \c 2
 \p
 \v 1 He said to me, “Son of man, stand on your feet, and I will speak with you.” 
 \v 2 The Spirit entered into me when he spoke to me, and set me on my feet; and I heard him who spoke to me. 
 \p
 \v 3 He said to me, “Son of man, I send you to the children of Israel, to a nation of rebels who have rebelled against me. They and their fathers have transgressed against me even to this very day. 
-\v 4 The children are impudent and stiff-hearted. I am sending you to them, and you shall tell them, ‘This is what the Lord Yahweh says.’ 
+\v 4 The children are impudent and stiff-hearted. I am sending you to them, and you shall tell them, ‘This is what the Lord Yahuah says.’ 
 \v 5 They, whether they will hear, or whether they will refuse—for they are a rebellious house—yet they will know that there has been a prophet among them. 
 \v 6 You, son of man, don’t be afraid of them, neither be afraid of their words, though briers and thorns are with you, and you dwell among scorpions. Don’t be afraid of their words, nor be dismayed at their looks, though they are a rebellious house. 
 \v 7 You shall speak my words to them, whether they will hear or whether they will refuse; for they are most rebellious. 
@@ -69,14 +69,14 @@
 \v 9 I have made your forehead as a diamond, harder than flint. Don’t be afraid of them, neither be dismayed at their looks, though they are a rebellious house.” 
 \p
 \v 10 Moreover he said to me, “Son of man, receive in your heart and hear with your ears all my words that I speak to you. 
-\v 11 Go to them of the captivity, to the children of your people, and speak to them, and tell them, ‘This is what the Lord Yahweh says,’ whether they will hear, or whether they will refuse.” 
+\v 11 Go to them of the captivity, to the children of your people, and speak to them, and tell them, ‘This is what the Lord Yahuah says,’ whether they will hear, or whether they will refuse.” 
 \p
-\v 12 Then the Spirit lifted me up, and I heard behind me the voice of a great rushing, saying, “Blessed be Yahweh’s glory from his place.” 
+\v 12 Then the Spirit lifted me up, and I heard behind me the voice of a great rushing, saying, “Blessed be Yahuah’s glory from his place.” 
 \v 13 I heard the noise of the wings of the living creatures as they touched one another, and the noise of the wheels beside them, even the noise of a great rushing. 
-\v 14 So the Spirit lifted me up, and took me away; and I went in bitterness, in the heat of my spirit; and Yahweh’s hand was strong on me. 
+\v 14 So the Spirit lifted me up, and took me away; and I went in bitterness, in the heat of my spirit; and Yahuah’s hand was strong on me. 
 \v 15 Then I came to them of the captivity at Tel Aviv who lived by the river Chebar, and to where they lived; and I sat there overwhelmed among them seven days. 
 \p
-\v 16 At the end of seven days, Yahweh’s word came to me, saying, 
+\v 16 At the end of seven days, Yahuah’s word came to me, saying, 
 \v 17 “Son of man, I have made you a watchman to the house of Israel. Therefore hear the word from my mouth, and warn them from me. 
 \v 18 When I tell the wicked, ‘You will surely die;’ and you give him no warning, nor speak to warn the wicked from his wicked way, to save his life, that wicked man will die in his iniquity; but I will require his blood at your hand. 
 \v 19 Yet if you warn the wicked, and he doesn’t turn from his wickedness, nor from his wicked way, he will die in his iniquity; but you have delivered your soul.” 
@@ -84,14 +84,14 @@
 \v 20 “Again, when a righteous man turns from his righteousness and commits iniquity, and I lay a stumbling block before him, he will die. Because you have not given him warning, he will die in his sin, and his righteous deeds which he has done will not be remembered; but I will require his blood at your hand. 
 \v 21 Nevertheless if you warn the righteous man, that the righteous not sin, and he does not sin, he will surely live, because he took warning; and you have delivered your soul.” 
 \p
-\v 22 Yahweh’s hand was there on me; and he said to me, “Arise, go out into the plain, and I will talk with you there.” 
+\v 22 Yahuah’s hand was there on me; and he said to me, “Arise, go out into the plain, and I will talk with you there.” 
 \p
-\v 23 Then I arose, and went out into the plain, and behold, Yahweh’s glory stood there, like the glory which I saw by the river Chebar. Then I fell on my face. 
+\v 23 Then I arose, and went out into the plain, and behold, Yahuah’s glory stood there, like the glory which I saw by the river Chebar. Then I fell on my face. 
 \p
 \v 24 Then the Spirit entered into me and set me on my feet. He spoke with me, and said to me, “Go, shut yourself inside your house. 
 \v 25 But you, son of man, behold, they will put ropes on you, and will bind you with them, and you will not go out among them. 
 \v 26 I will make your tongue stick to the roof of your mouth so that you will be mute and will not be able to correct them, for they are a rebellious house. 
-\v 27 But when I speak with you, I will open your mouth, and you shall tell them, ‘This is what the Lord Yahweh says.’ He who hears, let him hear; and he who refuses, let him refuse; for they are a rebellious house.” 
+\v 27 But when I speak with you, I will open your mouth, and you shall tell them, ‘This is what the Lord Yahuah says.’ He who hears, let him hear; and he who refuses, let him refuse; for they are a rebellious house.” 
 \c 4
 \p
 \v 1 “You also, son of man, take a tile, and lay it before yourself, and portray on it a city, even Jerusalem. 
@@ -109,9 +109,9 @@
 \v 10 Your food which you shall eat shall be by weight, twenty shekels a day. From time to time you shall eat it. 
 \v 11 You shall drink water by measure, the sixth part of a hin. From time to time you shall drink. 
 \v 12 You shall eat it as barley cakes, and you shall bake it in their sight with dung that comes out of man.” 
-\v 13 Yahweh said, “Even thus will the children of Israel eat their bread unclean, among the nations where I will drive them.” 
+\v 13 Yahuah said, “Even thus will the children of Israel eat their bread unclean, among the nations where I will drive them.” 
 \p
-\v 14 Then I said, “Ah Lord Yahweh! Behold, my soul has not been polluted; for from my youth up even until now I have not eaten of that which dies of itself, or is torn of animals. No abominable meat has come into my mouth!” 
+\v 14 Then I said, “Ah Lord Yahuah! Behold, my soul has not been polluted; for from my youth up even until now I have not eaten of that which dies of itself, or is torn of animals. No abominable meat has come into my mouth!” 
 \p
 \v 15 Then he said to me, “Behold, I have given you cow’s dung for man’s dung, and you shall prepare your bread on it.” 
 \p
@@ -124,52 +124,52 @@
 \v 3 You shall take a small number of these and bind them in the folds of your robe. 
 \v 4 Of these again you shall take, and cast them into the middle of the fire, and burn them in the fire. From it a fire will come out into all the house of Israel. 
 \p
-\v 5 “The Lord Yahweh says: ‘This is Jerusalem. I have set her in the middle of the nations, and countries are around her. 
+\v 5 “The Lord Yahuah says: ‘This is Jerusalem. I have set her in the middle of the nations, and countries are around her. 
 \v 6 She has rebelled against my ordinances in doing wickedness more than the nations, and against my statutes more than the countries that are around her; for they have rejected my ordinances, and as for my statutes, they have not walked in them.’ 
 \p
-\v 7 “Therefore the Lord Yahweh says: ‘Because you are more turbulent than the nations that are around you, and have not walked in my statutes, neither have kept my ordinances, neither have followed the ordinances of the nations that are around you; 
-\v 8 therefore the Lord Yahweh says: ‘Behold, I, even I, am against you; and I will execute judgments among you in the sight of the nations. 
+\v 7 “Therefore the Lord Yahuah says: ‘Because you are more turbulent than the nations that are around you, and have not walked in my statutes, neither have kept my ordinances, neither have followed the ordinances of the nations that are around you; 
+\v 8 therefore the Lord Yahuah says: ‘Behold, I, even I, am against you; and I will execute judgments among you in the sight of the nations. 
 \v 9 I will do in you that which I have not done, and which I will not do anything like it any more, because of all your abominations. 
 \v 10 Therefore the fathers will eat the sons within you, and the sons will eat their fathers. I will execute judgments on you; and I will scatter the whole remnant of you to all the winds. 
-\v 11 Therefore as I live,’ says the Lord Yahweh, ‘surely, because you have defiled my sanctuary with all your detestable things, and with all your abominations, therefore I will also diminish you. My eye won’t spare, and I will have no pity. 
+\v 11 Therefore as I live,’ says the Lord Yahuah, ‘surely, because you have defiled my sanctuary with all your detestable things, and with all your abominations, therefore I will also diminish you. My eye won’t spare, and I will have no pity. 
 \v 12 A third part of you will die with the pestilence, and they will be consumed with famine within you. A third part will fall by the sword around you. A third part I will scatter to all the winds, and will draw out a sword after them. 
 \p
-\v 13 “ ‘Thus my anger will be accomplished, and I will cause my wrath toward them to rest, and I will be comforted. They will know that I, Yahweh, have spoken in my zeal, when I have accomplished my wrath on them. 
+\v 13 “ ‘Thus my anger will be accomplished, and I will cause my wrath toward them to rest, and I will be comforted. They will know that I, Yahuah, have spoken in my zeal, when I have accomplished my wrath on them. 
 \p
 \v 14 “ ‘Moreover I will make you a desolation and a reproach among the nations that are around you, in the sight of all that pass by. 
-\v 15 So it will be a reproach and a taunt, an instruction and an astonishment, to the nations that are around you, when I execute judgments on you in anger and in wrath, and in wrathful rebukes—I, Yahweh, have spoken it—\v 16 when I send on them the evil arrows of famine that are for destruction, which I will send to destroy you. I will increase the famine on you and will break your staff of bread. 
-\v 17 I will send on you famine and evil animals, and they will bereave you. Pestilence and blood will pass through you. I will bring the sword on you. I, Yahweh, have spoken it.’ ” 
+\v 15 So it will be a reproach and a taunt, an instruction and an astonishment, to the nations that are around you, when I execute judgments on you in anger and in wrath, and in wrathful rebukes—I, Yahuah, have spoken it—\v 16 when I send on them the evil arrows of famine that are for destruction, which I will send to destroy you. I will increase the famine on you and will break your staff of bread. 
+\v 17 I will send on you famine and evil animals, and they will bereave you. Pestilence and blood will pass through you. I will bring the sword on you. I, Yahuah, have spoken it.’ ” 
 \c 6
 \p
-\v 1 Yahweh’s word came to me, saying, 
+\v 1 Yahuah’s word came to me, saying, 
 \v 2 “Son of man, set your face toward the mountains of Israel, and prophesy to them, 
-\v 3 and say, ‘You mountains of Israel, hear the word of the Lord Yahweh! The Lord Yahweh says to the mountains and to the hills, to the watercourses and to the valleys: “Behold, I, even I, will bring a sword on you, and I will destroy your high places. 
+\v 3 and say, ‘You mountains of Israel, hear the word of the Lord Yahuah! The Lord Yahuah says to the mountains and to the hills, to the watercourses and to the valleys: “Behold, I, even I, will bring a sword on you, and I will destroy your high places. 
 \v 4 Your altars will become desolate, and your incense altars will be broken. I will cast down your slain men before your idols. 
 \v 5 I will lay the dead bodies of the children of Israel before their idols. I will scatter your bones around your altars. 
 \v 6 In all your dwelling places, the cities will be laid waste and the high places will be desolate, so that your altars may be laid waste and made desolate, and your idols may be broken and cease, and your incense altars may be cut down, and your works may be abolished. 
-\v 7 The slain will fall among you, and you will know that I am Yahweh. 
+\v 7 The slain will fall among you, and you will know that I am Yahuah. 
 \p
 \v 8 “ ‘ “Yet I will leave a remnant, in that you will have some that escape the sword among the nations, when you are scattered through the countries. 
 \v 9 Those of you that escape will remember me among the nations where they are carried captive, how I have been broken with their lewd heart, which has departed from me, and with their eyes, which play the prostitute after their idols. Then they will loathe themselves in their own sight for the evils which they have committed in all their abominations. 
-\v 10 They will know that I am Yahweh. I have not said in vain that I would do this evil to them.” ’ 
+\v 10 They will know that I am Yahuah. I have not said in vain that I would do this evil to them.” ’ 
 \p
-\v 11 “The Lord Yahweh says: ‘Strike with your hand, and stamp with your foot, and say, “Alas!”, because of all the evil abominations of the house of Israel; for they will fall by the sword, by the famine, and by the pestilence. 
+\v 11 “The Lord Yahuah says: ‘Strike with your hand, and stamp with your foot, and say, “Alas!”, because of all the evil abominations of the house of Israel; for they will fall by the sword, by the famine, and by the pestilence. 
 \v 12 He who is far off will die of the pestilence. He who is near will fall by the sword. He who remains and is besieged will die by the famine. Thus I will accomplish my wrath on them. 
-\v 13 You will know that I am Yahweh when their slain men are among their idols around their altars, on every high hill, on all the tops of the mountains, under every green tree, and under every thick oak—the places where they offered pleasant aroma to all their idols. 
-\v 14 I will stretch out my hand on them and make the land desolate and waste, from the wilderness toward Diblah, throughout all their habitations. Then they will know that I am Yahweh.’ ” 
+\v 13 You will know that I am Yahuah when their slain men are among their idols around their altars, on every high hill, on all the tops of the mountains, under every green tree, and under every thick oak—the places where they offered pleasant aroma to all their idols. 
+\v 14 I will stretch out my hand on them and make the land desolate and waste, from the wilderness toward Diblah, throughout all their habitations. Then they will know that I am Yahuah.’ ” 
 \b
 \c 7
 \p
-\v 1 Moreover Yahweh’s word came to me, saying, 
-\v 2 “You, son of man, the Lord Yahweh says to the land of Israel, ‘An end! The end has come on the four corners of the land. 
+\v 1 Moreover Yahuah’s word came to me, saying, 
+\v 2 “You, son of man, the Lord Yahuah says to the land of Israel, ‘An end! The end has come on the four corners of the land. 
 \v 3 Now the end is on you, and I will send my anger on you, and will judge you according to your ways. I will bring on you all your abominations. 
-\v 4 My eye will not spare you, neither will I have pity; but I will bring your ways on you, and your abominations will be among you. Then you will know that I am Yahweh.’ 
+\v 4 My eye will not spare you, neither will I have pity; but I will bring your ways on you, and your abominations will be among you. Then you will know that I am Yahuah.’ 
 \p
-\v 5 “The Lord Yahweh says: ‘A disaster! A unique disaster! Behold, it comes. 
+\v 5 “The Lord Yahuah says: ‘A disaster! A unique disaster! Behold, it comes. 
 \v 6 An end has come. The end has come! It awakes against you. Behold, it comes. 
 \v 7 Your doom has come to you, inhabitant of the land! The time has come! The day is near, a day of tumult, and not of joyful shouting, on the mountains. 
 \v 8 Now I will shortly pour out my wrath on you, and accomplish my anger against you, and will judge you according to your ways. I will bring on you all your abominations. 
-\v 9 My eye won’t spare, neither will I have pity. I will punish you according to your ways. Your abominations will be among you. Then you will know that I, Yahweh, strike. 
+\v 9 My eye won’t spare, neither will I have pity. I will punish you according to your ways. Your abominations will be among you. Then you will know that I, Yahuah, strike. 
 \p
 \v 10 “ ‘Behold, the day! Behold, it comes! Your doom has gone out. The rod has blossomed. Pride has budded. 
 \v 11 Violence has risen up into a rod of wickedness. None of them will remain, nor of their multitude, nor of their wealth. There will be nothing of value among them. 
@@ -181,7 +181,7 @@
 \v 16 But of those who escape, they will escape and will be on the mountains like doves of the valleys, all of them moaning, everyone in his iniquity. 
 \v 17 All hands will be feeble, and all knees will be weak as water. 
 \v 18 They will also clothe themselves with sackcloth, and horror will cover them. Shame will be on all faces, and baldness on all their heads. 
-\v 19 They will cast their silver in the streets, and their gold will be as an unclean thing. Their silver and their gold won’t be able to deliver them in the day of Yahweh’s wrath. They won’t satisfy their souls or fill their bellies; because it has been the stumbling block of their iniquity. 
+\v 19 They will cast their silver in the streets, and their gold will be as an unclean thing. Their silver and their gold won’t be able to deliver them in the day of Yahuah’s wrath. They won’t satisfy their souls or fill their bellies; because it has been the stumbling block of their iniquity. 
 \v 20 As for the beauty of his ornament, he set it in majesty; but they made the images of their abominations and their detestable things therein. Therefore I have made it to them as an unclean thing. 
 \v 21 I will give it into the hands of the strangers for a prey, and to the wicked of the earth for a plunder; and they will profane it. 
 \v 22 I will also turn my face from them, and they will profane my secret place. Robbers will enter into it, and profane it. 
@@ -190,10 +190,10 @@
 \v 24 Therefore I will bring the worst of the nations, and they will possess their houses. I will also make the pride of the strong to cease. Their set-apart places will be profaned. 
 \v 25 Destruction comes! They will seek peace, and there will be none. 
 \v 26 Mischief will come on mischief, and rumor will be on rumor. They will seek a vision of the prophet; but the law will perish from the priest, and counsel from the elders. 
-\v 27 The king will mourn, and the prince will be clothed with desolation. The hands of the people of the land will be troubled. I will do to them after their way, and according to their own judgments I will judge them. Then they will know that I am Yahweh.’ ” 
+\v 27 The king will mourn, and the prince will be clothed with desolation. The hands of the people of the land will be troubled. I will do to them after their way, and according to their own judgments I will judge them. Then they will know that I am Yahuah.’ ” 
 \c 8
 \p
-\v 1 In the sixth year, in the sixth month, in the fifth day of the month, as I sat in my house, and the elders of Judah sat before me, the Lord Yahweh’s hand fell on me there. 
+\v 1 In the sixth year, in the sixth month, in the fifth day of the month, as I sat in my house, and the elders of Judah sat before me, the Lord Yahuah’s hand fell on me there. 
 \v 2 Then I saw, and behold, a likeness as the appearance of fire—from the appearance of his waist and downward, fire, and from his waist and upward, as the appearance of brightness, as it were glowing metal. 
 \v 3 He stretched out the form of a hand, and took me by a lock of my head; and the Spirit lifted me up between earth and the sky, and brought me in the visions of Elohim to Jerusalem, to the door of the gate of the inner court that looks toward the north, where there was the seat of the image of jealousy, which provokes to jealousy. 
 \v 4 Behold, the glory of the Elohim of Israel was there, according to the appearance that I saw in the plain. 
@@ -212,13 +212,13 @@
 \v 10 So I went in and looked, and saw every form of creeping things, abominable animals, and all the idols of the house of Israel, portrayed around on the wall. 
 \v 11 Seventy men of the elders of the house of Israel stood before them. In the middle of them Jaazaniah the son of Shaphan stood, every man with his censer in his hand; and the smell of the cloud of incense went up. 
 \p
-\v 12 Then he said to me, “Son of man, have you seen what the elders of the house of Israel do in the dark, every man in his rooms of imagery? For they say, ‘Yahweh doesn’t see us. Yahweh has forsaken the land.’ ” 
+\v 12 Then he said to me, “Son of man, have you seen what the elders of the house of Israel do in the dark, every man in his rooms of imagery? For they say, ‘Yahuah doesn’t see us. Yahuah has forsaken the land.’ ” 
 \v 13 He said also to me, “You will again see more of the great abominations which they do.” 
 \p
-\v 14 Then he brought me to the door of the gate of Yahweh’s house which was toward the north; and I saw the women sit there weeping for Tammuz. 
+\v 14 Then he brought me to the door of the gate of Yahuah’s house which was toward the north; and I saw the women sit there weeping for Tammuz. 
 \v 15 Then he said to me, “Have you seen this, son of man? You will again see yet greater abominations than these.” 
 \p
-\v 16 He brought me into the inner court of Yahweh’s house; and I saw at the door of Yahweh’s temple, between the porch and the altar, there were about twenty-five men with their backs toward Yahweh’s temple and their faces toward the east. They were worshiping the sun toward the east. 
+\v 16 He brought me into the inner court of Yahuah’s house; and I saw at the door of Yahuah’s temple, between the porch and the altar, there were about twenty-five men with their backs toward Yahuah’s temple and their faces toward the east. They were worshiping the sun toward the east. 
 \p
 \v 17 Then he said to me, “Have you seen this, son of man? Is it a light thing to the house of Judah that they commit the abominations which they commit here? For they have filled the land with violence, and have turned again to provoke me to anger. Behold, they put the branch to their nose. 
 \v 18 Therefore I will also deal in wrath. My eye won’t spare, neither will I have pity. Though they cry in my ears with a loud voice, yet I will not hear them.” 
@@ -228,7 +228,7 @@
 \v 2 Behold, six men came from the way of the upper gate, which lies toward the north, every man with his slaughter weapon in his hand. One man in the middle of them was clothed in linen, with a writer’s inkhorn by his side. They went in, and stood beside the bronze altar. 
 \p
 \v 3 The glory of the Elohim of Israel went up from the cherub, whereupon it was, to the threshold of the house; and he called to the man clothed in linen, who had the writer’s inkhorn by his side. 
-\v 4 Yahweh said to him, “Go through the middle of the city, through the middle of Jerusalem, and set a mark on the foreheads of the men that sigh and that cry over all the abominations that are done within it.” 
+\v 4 Yahuah said to him, “Go through the middle of the city, through the middle of Jerusalem, and set a mark on the foreheads of the men that sigh and that cry over all the abominations that are done within it.” 
 \p
 \v 5 To the others he said in my hearing, “Go through the city after him, and strike. Don’t let your eye spare, neither have pity. 
 \v 6 Kill utterly the old man, the young man, the virgin, little children and women; but don’t come near any man on whom is the mark. Begin at my sanctuary.” 
@@ -237,9 +237,9 @@
 \v 7 He said to them, “Defile the house, and fill the courts with the slain. Go out!” 
 \p They went out, and struck in the city. 
 \p
-\v 8 While they were killing, and I was left, I fell on my face, and cried, and said, “Ah Lord Yahweh! Will you destroy all the residue of Israel in your pouring out of your wrath on Jerusalem?” 
+\v 8 While they were killing, and I was left, I fell on my face, and cried, and said, “Ah Lord Yahuah! Will you destroy all the residue of Israel in your pouring out of your wrath on Jerusalem?” 
 \p
-\v 9 Then he said to me, “The iniquity of the house of Israel and Judah is exceedingly great, and the land is full of blood, and the city full of perversion; for they say, ‘Yahweh has forsaken the land, and Yahweh doesn’t see.’ 
+\v 9 Then he said to me, “The iniquity of the house of Israel and Judah is exceedingly great, and the land is full of blood, and the city full of perversion; for they say, ‘Yahuah has forsaken the land, and Yahuah doesn’t see.’ 
 \v 10 As for me also, my eye won’t spare, neither will I have pity, but I will bring their way on their head.” 
 \p
 \v 11 Behold, the man clothed in linen, who had the inkhorn by his side, reported the matter, saying, “I have done as you have commanded me.” 
@@ -249,7 +249,7 @@
 \v 2 He spoke to the man clothed in linen, and said, “Go in between the whirling wheels, even under the cherub, and fill both your hands with coals of fire from between the cherubim, and scatter them over the city.” 
 \p He went in as I watched. 
 \v 3 Now the cherubim stood on the right side of the house when the man went in; and the cloud filled the inner court. 
-\v 4 Yahweh’s glory mounted up from the cherub, and stood over the threshold of the house; and the house was filled with the cloud, and the court was full of the brightness of Yahweh’s glory. 
+\v 4 Yahuah’s glory mounted up from the cherub, and stood over the threshold of the house; and the house was filled with the cloud, and the court was full of the brightness of Yahuah’s glory. 
 \v 5 The sound of the wings of the cherubim was heard even to the outer court, as the voice of Elohim Almighty when he speaks. 
 \p
 \v 6 It came to pass, when he commanded the man clothed in linen, saying, “Take fire from between the whirling wheels, from between the cherubim,” that he went in and stood beside a wheel. 
@@ -267,51 +267,51 @@
 \v 16 When the cherubim went, the wheels went beside them; and when the cherubim lifted up their wings to mount up from the earth, the wheels also didn’t turn from beside them. 
 \v 17 When they stood, these stood. When they mounted up, these mounted up with them; for the spirit of the living creature was in them. 
 \p
-\v 18 Yahweh’s glory went out from over the threshold of the house and stood over the cherubim. 
-\v 19 The cherubim lifted up their wings and mounted up from the earth in my sight when they went out, with the wheels beside them. Then they stood at the door of the east gate of Yahweh’s house; and the glory of the Elohim of Israel was over them above. 
+\v 18 Yahuah’s glory went out from over the threshold of the house and stood over the cherubim. 
+\v 19 The cherubim lifted up their wings and mounted up from the earth in my sight when they went out, with the wheels beside them. Then they stood at the door of the east gate of Yahuah’s house; and the glory of the Elohim of Israel was over them above. 
 \p
 \v 20 This is the living creature that I saw under the Elohim of Israel by the river Chebar; and I knew that they were cherubim. 
 \v 21 Every one had four faces, and every one four wings. The likeness of the hands of a man was under their wings. 
 \v 22 As for the likeness of their faces, they were the faces which I saw by the river Chebar, their appearances and themselves. They each went straight forward. 
 \c 11
 \p
-\v 1 Moreover the Spirit lifted me up and brought me to the east gate of Yahweh’s house, which looks eastward. Behold, twenty-five men were at the door of the gate; and I saw among them Jaazaniah the son of Azzur, and Pelatiah the son of Benaiah, princes of the people. 
+\v 1 Moreover the Spirit lifted me up and brought me to the east gate of Yahuah’s house, which looks eastward. Behold, twenty-five men were at the door of the gate; and I saw among them Jaazaniah the son of Azzur, and Pelatiah the son of Benaiah, princes of the people. 
 \v 2 He said to me, “Son of man, these are the men who devise iniquity, and who give wicked counsel in this city; 
 \v 3 who say, ‘The time is not near to build houses. This is the cauldron, and we are the meat.’ 
 \v 4 Therefore prophesy against them. Prophesy, son of man.” 
 \p
-\v 5 Yahweh’s Spirit fell on me, and he said to me, “Speak, ‘Yahweh says: “Thus you have said, house of Israel; for I know the things that come into your mind. 
+\v 5 Yahuah’s Spirit fell on me, and he said to me, “Speak, ‘Yahuah says: “Thus you have said, house of Israel; for I know the things that come into your mind. 
 \v 6 You have multiplied your slain in this city, and you have filled its streets with the slain.” 
 \p
-\v 7 “ ‘Therefore the Lord Yahweh says: “Your slain whom you have laid in the middle of it, they are the meat, and this is the cauldron; but you will be brought out of the middle of it. 
-\v 8 You have feared the sword; and I will bring the sword on you,” says the Lord Yahweh. 
+\v 7 “ ‘Therefore the Lord Yahuah says: “Your slain whom you have laid in the middle of it, they are the meat, and this is the cauldron; but you will be brought out of the middle of it. 
+\v 8 You have feared the sword; and I will bring the sword on you,” says the Lord Yahuah. 
 \v 9 “I will bring you out of the middle of it, and deliver you into the hands of strangers, and will execute judgments among you. 
-\v 10 You will fall by the sword. I will judge you in the border of Israel. Then you will know that I am Yahweh. 
+\v 10 You will fall by the sword. I will judge you in the border of Israel. Then you will know that I am Yahuah. 
 \v 11 This will not be your cauldron, neither will you be the meat in the middle of it. I will judge you in the border of Israel. 
-\v 12 You will know that I am Yahweh, for you have not walked in my statutes. You have not executed my ordinances, but have done after the ordinances of the nations that are around you.” ’ ” 
+\v 12 You will know that I am Yahuah, for you have not walked in my statutes. You have not executed my ordinances, but have done after the ordinances of the nations that are around you.” ’ ” 
 \p
-\v 13 When I prophesied, Pelatiah the son of Benaiah died. Then I fell down on my face, and cried with a loud voice, and said, “Ah Lord Yahweh! Will you make a full end of the remnant of Israel?” 
+\v 13 When I prophesied, Pelatiah the son of Benaiah died. Then I fell down on my face, and cried with a loud voice, and said, “Ah Lord Yahuah! Will you make a full end of the remnant of Israel?” 
 \p
-\v 14 Yahweh’s word came to me, saying, 
-\v 15 “Son of man, your brothers, even your brothers, the men of your relatives, and all the house of Israel, all of them, are the ones to whom the inhabitants of Jerusalem have said, ‘Go far away from Yahweh. This land has been given to us for a possession.’ 
+\v 14 Yahuah’s word came to me, saying, 
+\v 15 “Son of man, your brothers, even your brothers, the men of your relatives, and all the house of Israel, all of them, are the ones to whom the inhabitants of Jerusalem have said, ‘Go far away from Yahuah. This land has been given to us for a possession.’ 
 \p
-\v 16 “Therefore say, ‘The Lord Yahweh says: “Whereas I have removed them far off among the nations, and whereas I have scattered them among the countries, yet I will be to them a sanctuary for a little while in the countries where they have come.” ’ 
+\v 16 “Therefore say, ‘The Lord Yahuah says: “Whereas I have removed them far off among the nations, and whereas I have scattered them among the countries, yet I will be to them a sanctuary for a little while in the countries where they have come.” ’ 
 \p
-\v 17 “Therefore say, ‘The Lord Yahweh says: “I will gather you from the peoples, and assemble you out of the countries where you have been scattered, and I will give you the land of Israel.” 
+\v 17 “Therefore say, ‘The Lord Yahuah says: “I will gather you from the peoples, and assemble you out of the countries where you have been scattered, and I will give you the land of Israel.” 
 \p
 \v 18 “ ‘They will come there, and they will take away all its detestable things and all its abominations from there. 
 \v 19 I will give them one heart, and I will put a new spirit within them. I will take the stony heart out of their flesh, and will give them a heart of flesh, 
 \v 20 that they may walk in my statutes, and keep my ordinances, and do them. They will be my people, and I will be their Elohim. 
-\v 21 But as for them whose heart walks after the heart of their detestable things and their abominations, I will bring their way on their own heads,’ says the Lord Yahweh.” 
+\v 21 But as for them whose heart walks after the heart of their detestable things and their abominations, I will bring their way on their own heads,’ says the Lord Yahuah.” 
 \p
 \v 22 Then the cherubim lifted up their wings, and the wheels were beside them. The glory of the Elohim of Israel was over them above. 
-\v 23 Yahweh’s glory went up from the middle of the city, and stood on the mountain which is on the east side of the city. 
+\v 23 Yahuah’s glory went up from the middle of the city, and stood on the mountain which is on the east side of the city. 
 \v 24 The Spirit lifted me up, and brought me in the vision by the Spirit of Elohim into Chaldea, to the captives. 
 \p So the vision that I had seen went up from me. 
-\v 25 Then I spoke to the captives all the things that Yahweh had shown me. 
+\v 25 Then I spoke to the captives all the things that Yahuah had shown me. 
 \c 12
 \p
-\v 1 Yahweh’s word also came to me, saying, 
+\v 1 Yahuah’s word also came to me, saying, 
 \v 2 “Son of man, you dwell in the middle of the rebellious house, who have eyes to see, and don’t see, who have ears to hear, and don’t hear; for they are a rebellious house. 
 \p
 \v 3 “Therefore, you son of man, prepare your baggage for moving, and move by day in their sight. You shall move from your place to another place in their sight. It may be they will consider, though they are a rebellious house. 
@@ -321,10 +321,10 @@
 \p
 \v 7 I did so as I was commanded. I brought out my baggage by day, as baggage for moving, and in the evening I dug through the wall with my hand. I brought it out in the dark, and bore it on my shoulder in their sight. 
 \p
-\v 8 In the morning, Yahweh’s word came to me, saying, 
+\v 8 In the morning, Yahuah’s word came to me, saying, 
 \v 9 “Son of man, hasn’t the house of Israel, the rebellious house, said to you, ‘What are you doing?’ 
 \p
-\v 10 “Say to them, ‘The Lord Yahweh says: “This burden concerns the prince in Jerusalem, and all the house of Israel among whom they are.” ’ 
+\v 10 “Say to them, ‘The Lord Yahuah says: “This burden concerns the prince in Jerusalem, and all the house of Israel among whom they are.” ’ 
 \p
 \v 11 “Say, ‘I am your sign. As I have done, so will it be done to them. They will go into exile, into captivity. 
 \p
@@ -332,139 +332,139 @@
 \v 13 I will also spread my net on him, and he will be taken in my snare. I will bring him to Babylon to the land of the Chaldeans; yet he will not see it, though he will die there. 
 \v 14 I will scatter toward every wind all who are around him to help him, and all his bands. I will draw out the sword after them. 
 \p
-\v 15 “ ‘They will know that I am Yahweh when I disperse them among the nations and scatter them through the countries. 
-\v 16 But I will leave a few men of them from the sword, from the famine, and from the pestilence, that they may declare all their abominations among the nations where they come. Then they will know that I am Yahweh.’ ” 
+\v 15 “ ‘They will know that I am Yahuah when I disperse them among the nations and scatter them through the countries. 
+\v 16 But I will leave a few men of them from the sword, from the famine, and from the pestilence, that they may declare all their abominations among the nations where they come. Then they will know that I am Yahuah.’ ” 
 \p
-\v 17 Moreover Yahweh’s word came to me, saying, 
+\v 17 Moreover Yahuah’s word came to me, saying, 
 \v 18 “Son of man, eat your bread with quaking, and drink your water with trembling and with fearfulness. 
-\v 19 Tell the people of the land, ‘The Lord Yahweh says concerning the inhabitants of Jerusalem and the land of Israel: “They will eat their bread with fearfulness and drink their water in dismay, that her land may be desolate, and all that is therein, because of the violence of all those who dwell therein. 
-\v 20 The cities that are inhabited will be laid waste, and the land will be a desolation. Then you will know that I am Yahweh.” ’ ” 
+\v 19 Tell the people of the land, ‘The Lord Yahuah says concerning the inhabitants of Jerusalem and the land of Israel: “They will eat their bread with fearfulness and drink their water in dismay, that her land may be desolate, and all that is therein, because of the violence of all those who dwell therein. 
+\v 20 The cities that are inhabited will be laid waste, and the land will be a desolation. Then you will know that I am Yahuah.” ’ ” 
 \p
-\v 21 Yahweh’s word came to me, saying, 
+\v 21 Yahuah’s word came to me, saying, 
 \v 22 “Son of man, what is this proverb that you have in the land of Israel, saying, ‘The days are prolonged, and every vision fails’? 
-\v 23 Tell them therefore, ‘The Lord Yahweh says: “I will make this proverb to cease, and they will no more use it as a proverb in Israel;” ’ but tell them, ‘ “The days are at hand, and the fulfillment of every vision. 
+\v 23 Tell them therefore, ‘The Lord Yahuah says: “I will make this proverb to cease, and they will no more use it as a proverb in Israel;” ’ but tell them, ‘ “The days are at hand, and the fulfillment of every vision. 
 \v 24 For there will be no more any false vision nor flattering divination within the house of Israel. 
-\v 25 For I am Yahweh. I will speak, and the word that I speak will be performed. It will be no more deferred; for in your days, rebellious house, I will speak the word and will perform it,” says the Lord Yahweh.’ ” 
+\v 25 For I am Yahuah. I will speak, and the word that I speak will be performed. It will be no more deferred; for in your days, rebellious house, I will speak the word and will perform it,” says the Lord Yahuah.’ ” 
 \p
-\v 26 Again Yahweh’s word came to me, saying, 
+\v 26 Again Yahuah’s word came to me, saying, 
 \v 27 “Son of man, behold, they of the house of Israel say, ‘The vision that he sees is for many days to come, and he prophesies of times that are far off.’ 
 \p
-\v 28 “Therefore tell them, ‘The Lord Yahweh says: “None of my words will be deferred any more, but the word which I speak will be performed,” says the Lord Yahweh.’ ” 
+\v 28 “Therefore tell them, ‘The Lord Yahuah says: “None of my words will be deferred any more, but the word which I speak will be performed,” says the Lord Yahuah.’ ” 
 \c 13
 \p
-\v 1 Yahweh’s word came to me, saying, 
-\v 2 “Son of man, prophesy against the prophets of Israel who prophesy, and say to those who prophesy out of their own heart, ‘Hear Yahweh’s word: 
-\v 3 The Lord Yahweh says, “Woe to the foolish prophets, who follow their own spirit, and have seen nothing! 
+\v 1 Yahuah’s word came to me, saying, 
+\v 2 “Son of man, prophesy against the prophets of Israel who prophesy, and say to those who prophesy out of their own heart, ‘Hear Yahuah’s word: 
+\v 3 The Lord Yahuah says, “Woe to the foolish prophets, who follow their own spirit, and have seen nothing! 
 \v 4 Israel, your prophets have been like foxes in the waste places. 
-\v 5 You have not gone up into the gaps or built up the wall for the house of Israel, to stand in the battle in Yahweh’s day. 
-\v 6 They have seen falsehood and lying divination, who say, ‘Yahweh says;’ but Yahweh has not sent them. They have made men to hope that the word would be confirmed. 
-\v 7 Haven’t you seen a false vision, and haven’t you spoken a lying divination, in that you say, ‘Yahweh says;’ but I have not spoken?” 
+\v 5 You have not gone up into the gaps or built up the wall for the house of Israel, to stand in the battle in Yahuah’s day. 
+\v 6 They have seen falsehood and lying divination, who say, ‘Yahuah says;’ but Yahuah has not sent them. They have made men to hope that the word would be confirmed. 
+\v 7 Haven’t you seen a false vision, and haven’t you spoken a lying divination, in that you say, ‘Yahuah says;’ but I have not spoken?” 
 \p
-\v 8 “ ‘Therefore the Lord Yahweh says: “Because you have spoken falsehood and seen lies, therefore, behold, I am against you,” says the Lord Yahweh. 
-\v 9 “My hand will be against the prophets who see false visions and who utter lying divinations. They will not be in the council of my people, neither will they be written in the writing of the house of Israel, neither will they enter into the land of Israel. Then you will know that I am the Lord Yahweh.” 
+\v 8 “ ‘Therefore the Lord Yahuah says: “Because you have spoken falsehood and seen lies, therefore, behold, I am against you,” says the Lord Yahuah. 
+\v 9 “My hand will be against the prophets who see false visions and who utter lying divinations. They will not be in the council of my people, neither will they be written in the writing of the house of Israel, neither will they enter into the land of Israel. Then you will know that I am the Lord Yahuah.” 
 \p
 \v 10 “ ‘Because, even because they have seduced my people, saying, “Peace;” and there is no peace. When one builds up a wall, behold, they plaster it with whitewash. 
 \v 11 Tell those who plaster it with whitewash that it will fall. There will be an overflowing shower; and you, great hailstones, will fall. A stormy wind will tear it. 
 \v 12 Behold, when the wall has fallen, won’t it be said to you, “Where is the plaster with which you have plastered it?” 
 \p
-\v 13 “ ‘Therefore the Lord Yahweh says: “I will even tear it with a stormy wind in my wrath. There will be an overflowing shower in my anger, and great hailstones in wrath to consume it. 
-\v 14 So I will break down the wall that you have plastered with whitewash, and bring it down to the ground, so that its foundation will be uncovered. It will fall, and you will be consumed in the middle of it. Then you will know that I am Yahweh. 
-\v 15 Thus I will accomplish my wrath on the wall, and on those who have plastered it with whitewash. I will tell you, ‘The wall is no more, nor those who plastered it—\v 16 to wit, the prophets of Israel who prophesy concerning Jerusalem, and who see visions of peace for her, and there is no peace,’ ” says the Lord Yahweh.’ ” 
+\v 13 “ ‘Therefore the Lord Yahuah says: “I will even tear it with a stormy wind in my wrath. There will be an overflowing shower in my anger, and great hailstones in wrath to consume it. 
+\v 14 So I will break down the wall that you have plastered with whitewash, and bring it down to the ground, so that its foundation will be uncovered. It will fall, and you will be consumed in the middle of it. Then you will know that I am Yahuah. 
+\v 15 Thus I will accomplish my wrath on the wall, and on those who have plastered it with whitewash. I will tell you, ‘The wall is no more, nor those who plastered it—\v 16 to wit, the prophets of Israel who prophesy concerning Jerusalem, and who see visions of peace for her, and there is no peace,’ ” says the Lord Yahuah.’ ” 
 \p
 \v 17 You, son of man, set your face against the daughters of your people, who prophesy out of their own heart; and prophesy against them, 
-\v 18 and say, “The Lord Yahweh says: ‘Woe to the women who sew magic bands on all elbows and make veils for the head of persons of every stature to hunt souls! Will you hunt the souls of my people and save souls alive for yourselves? 
+\v 18 and say, “The Lord Yahuah says: ‘Woe to the women who sew magic bands on all elbows and make veils for the head of persons of every stature to hunt souls! Will you hunt the souls of my people and save souls alive for yourselves? 
 \v 19 You have profaned me among my people for handfuls of barley and for pieces of bread, to kill the souls who should not die and to save the souls alive who should not live, by your lying to my people who listen to lies.’ 
 \p
-\v 20 “Therefore the Lord Yahweh says: ‘Behold, I am against your magic bands, with which you hunt the souls to make them fly, and I will tear them from your arms. I will let the souls fly free, even the souls whom you ensnare like birds. 
-\v 21 I will also tear your veils and deliver my people out of your hand; and they will no longer be in your hand to be ensnared. Then you will know that I am Yahweh. 
+\v 20 “Therefore the Lord Yahuah says: ‘Behold, I am against your magic bands, with which you hunt the souls to make them fly, and I will tear them from your arms. I will let the souls fly free, even the souls whom you ensnare like birds. 
+\v 21 I will also tear your veils and deliver my people out of your hand; and they will no longer be in your hand to be ensnared. Then you will know that I am Yahuah. 
 \v 22 Because with lies you have grieved the heart of the righteous, whom I have not made sad; and strengthened the hands of the wicked, that he should not return from his wicked way, and be saved alive. 
-\v 23 Therefore you shall no more see false visions nor practice divination. I will deliver my people out of your hand. Then you will know that I am Yahweh.’ ” 
+\v 23 Therefore you shall no more see false visions nor practice divination. I will deliver my people out of your hand. Then you will know that I am Yahuah.’ ” 
 \c 14
 \p
 \v 1 Then some of the elders of Israel came to me and sat before me. 
-\v 2 Yahweh’s word came to me, saying, 
+\v 2 Yahuah’s word came to me, saying, 
 \v 3 “Son of man, these men have taken their idols into their heart, and put the stumbling block of their iniquity before their face. Should I be inquired of at all by them? 
-\v 4 Therefore speak to them and tell them, ‘The Lord Yahweh says: “Every man of the house of Israel who takes his idols into his heart and puts the stumbling block of his iniquity before his face then comes to the prophet, I Yahweh will answer him there according to the multitude of his idols, 
+\v 4 Therefore speak to them and tell them, ‘The Lord Yahuah says: “Every man of the house of Israel who takes his idols into his heart and puts the stumbling block of his iniquity before his face then comes to the prophet, I Yahuah will answer him there according to the multitude of his idols, 
 \v 5 that I may take the house of Israel in their own heart, because they are all estranged from me through their idols.” ’ 
 \p
-\v 6 “Therefore tell the house of Israel, ‘The Lord Yahweh says: “Return, and turn yourselves from your idols! Turn away your faces from all your abominations. 
+\v 6 “Therefore tell the house of Israel, ‘The Lord Yahuah says: “Return, and turn yourselves from your idols! Turn away your faces from all your abominations. 
 \p
-\v 7 “ ‘ “For everyone of the house of Israel, or of the strangers who live in Israel, who separates himself from me and takes his idols into his heart, and puts the stumbling block of his iniquity before his face, and comes to the prophet to inquire for himself of me, I Yahweh will answer him by myself. 
-\v 8 I will set my face against that man and will make him an astonishment, for a sign and a proverb, and I will cut him off from among my people. Then you will know that I am Yahweh. 
+\v 7 “ ‘ “For everyone of the house of Israel, or of the strangers who live in Israel, who separates himself from me and takes his idols into his heart, and puts the stumbling block of his iniquity before his face, and comes to the prophet to inquire for himself of me, I Yahuah will answer him by myself. 
+\v 8 I will set my face against that man and will make him an astonishment, for a sign and a proverb, and I will cut him off from among my people. Then you will know that I am Yahuah. 
 \p
-\v 9 “ ‘ “If the prophet is deceived and speaks a word, I, Yahweh, have deceived that prophet, and I will stretch out my hand on him, and will destroy him from among my people Israel. 
+\v 9 “ ‘ “If the prophet is deceived and speaks a word, I, Yahuah, have deceived that prophet, and I will stretch out my hand on him, and will destroy him from among my people Israel. 
 \v 10 They will bear their iniquity. The iniquity of the prophet will be even as the iniquity of him who seeks him, 
-\v 11 that the house of Israel may no more go astray from me, neither defile themselves any more with all their transgressions; but that they may be my people, and I may be their Elohim,” says the Lord Yahweh.’ ” 
+\v 11 that the house of Israel may no more go astray from me, neither defile themselves any more with all their transgressions; but that they may be my people, and I may be their Elohim,” says the Lord Yahuah.’ ” 
 \p
-\v 12 Yahweh’s word came to me, saying, 
-\v 13 “Son of man, when a land sins against me by committing a trespass, and I stretch out my hand on it, and break the staff of its bread and send famine on it, and cut off from it man and animal—\v 14 though these three men, Noah, Daniel, and Job, were in it, they would deliver only their own souls by their righteousness,” says the Lord Yahweh. 
+\v 12 Yahuah’s word came to me, saying, 
+\v 13 “Son of man, when a land sins against me by committing a trespass, and I stretch out my hand on it, and break the staff of its bread and send famine on it, and cut off from it man and animal—\v 14 though these three men, Noah, Daniel, and Job, were in it, they would deliver only their own souls by their righteousness,” says the Lord Yahuah. 
 \p
-\v 15 “If I cause evil animals to pass through the land, and they ravage it and it is made desolate, so that no man may pass through because of the animals—\v 16 though these three men were in it, as I live,” says the Lord Yahweh, “they would deliver neither sons nor daughters. They only would be delivered, but the land would be desolate. 
+\v 15 “If I cause evil animals to pass through the land, and they ravage it and it is made desolate, so that no man may pass through because of the animals—\v 16 though these three men were in it, as I live,” says the Lord Yahuah, “they would deliver neither sons nor daughters. They only would be delivered, but the land would be desolate. 
 \p
-\v 17 “Or if I bring a sword on that land, and say, ‘Sword, go through the land, so that I cut off from it man and animal’—\v 18 though these three men were in it, as I live,” says the Lord Yahweh, “they would deliver neither sons nor daughters, but they only would be delivered themselves. 
+\v 17 “Or if I bring a sword on that land, and say, ‘Sword, go through the land, so that I cut off from it man and animal’—\v 18 though these three men were in it, as I live,” says the Lord Yahuah, “they would deliver neither sons nor daughters, but they only would be delivered themselves. 
 \p
-\v 19 “Or if I send a pestilence into that land, and pour out my wrath on it in blood, to cut off from it man and animal—\v 20 though Noah, Daniel, and Job, were in it, as I live,” says the Lord Yahweh, “they would deliver neither son nor daughter; they would deliver only their own souls by their righteousness.” 
+\v 19 “Or if I send a pestilence into that land, and pour out my wrath on it in blood, to cut off from it man and animal—\v 20 though Noah, Daniel, and Job, were in it, as I live,” says the Lord Yahuah, “they would deliver neither son nor daughter; they would deliver only their own souls by their righteousness.” 
 \p
-\v 21 For the Lord Yahweh says: “How much more when I send my four severe judgments on Jerusalem—the sword, the famine, the evil animals, and the pestilence—to cut off from it man and animal! 
+\v 21 For the Lord Yahuah says: “How much more when I send my four severe judgments on Jerusalem—the sword, the famine, the evil animals, and the pestilence—to cut off from it man and animal! 
 \v 22 Yet, behold, there will be left a remnant in it that will be carried out, both sons and daughters. Behold, they will come out to you, and you will see their way and their doings. Then you will be comforted concerning the evil that I have brought on Jerusalem, even concerning all that I have brought on it. 
-\v 23 They will comfort you, when you see their way and their doings; then you will know that I have not done all that I have done in it without cause,” says the Lord Yahweh. 
+\v 23 They will comfort you, when you see their way and their doings; then you will know that I have not done all that I have done in it without cause,” says the Lord Yahuah. 
 \c 15
 \p
-\v 1 Yahweh’s word came to me, saying, 
+\v 1 Yahuah’s word came to me, saying, 
 \v 2 “Son of man, what is the vine tree more than any tree, the vine branch which is among the trees of the forest? 
 \v 3 Will wood be taken of it to make anything? Will men take a pin of it to hang any vessel on it? 
 \v 4 Behold, it is cast into the fire for fuel; the fire has devoured both its ends, and the middle of it is burned. Is it profitable for any work? 
 \v 5 Behold, when it was whole, it was suitable for no work. How much less, when the fire has devoured it, and it has been burned, will it yet be suitable for any work?” 
 \p
-\v 6 Therefore the Lord Yahweh says: “As the vine wood among the trees of the forest, which I have given to the fire for fuel, so I will give the inhabitants of Jerusalem. 
-\v 7 I will set my face against them. They will go out from the fire, but the fire will still devour them. Then you will know that I am Yahweh, when I set my face against them. 
-\v 8 I will make the land desolate, because they have acted unfaithfully,” says the Lord Yahweh. 
+\v 6 Therefore the Lord Yahuah says: “As the vine wood among the trees of the forest, which I have given to the fire for fuel, so I will give the inhabitants of Jerusalem. 
+\v 7 I will set my face against them. They will go out from the fire, but the fire will still devour them. Then you will know that I am Yahuah, when I set my face against them. 
+\v 8 I will make the land desolate, because they have acted unfaithfully,” says the Lord Yahuah. 
 \c 16
 \p
-\v 1 Again Yahweh’s word came to me, saying, 
+\v 1 Again Yahuah’s word came to me, saying, 
 \v 2 “Son of man, cause Jerusalem to know her abominations; 
-\v 3 and say, ‘The Lord Yahweh says to Jerusalem: “Your origin and your birth is of the land of the Canaanite. An Amorite was your father, and your mother was a Hittite. 
+\v 3 and say, ‘The Lord Yahuah says to Jerusalem: “Your origin and your birth is of the land of the Canaanite. An Amorite was your father, and your mother was a Hittite. 
 \v 4 As for your birth, in the day you were born your navel was not cut. You weren’t washed in water to cleanse you. You weren’t salted at all, nor wrapped in blankets at all. 
 \v 5 No eye pitied you, to do any of these things to you, to have compassion on you; but you were cast out in the open field, because you were abhorred in the day that you were born. 
 \p
 \v 6 “ ‘ “When I passed by you, and saw you wallowing in your blood, I said to you, ‘Though you are in your blood, live!’ Yes, I said to you, ‘Though you are in your blood, live!’ 
 \v 7 I caused you to multiply as that which grows in the field, and you increased and grew great, and you attained to excellent beauty. Your breasts were formed, and your hair grew; yet you were naked and bare. 
 \p
-\v 8 “ ‘ “Now when I passed by you, and looked at you, behold, your time was the time of love; and I spread my garment over you and covered your nakedness. Yes, I pledged myself to you and entered into a covenant with you,” says the Lord Yahweh, “and you became mine. 
+\v 8 “ ‘ “Now when I passed by you, and looked at you, behold, your time was the time of love; and I spread my garment over you and covered your nakedness. Yes, I pledged myself to you and entered into a covenant with you,” says the Lord Yahuah, “and you became mine. 
 \p
 \v 9 “ ‘ “Then I washed you with water. Yes, I thoroughly washed away your blood from you, and I anointed you with oil. 
 \v 10 I clothed you also with embroidered work and put leather sandals on you. I dressed you with fine linen and covered you with silk. 
 \v 11 I decked you with ornaments, put bracelets on your hands, and put a chain on your neck. 
 \v 12 I put a ring on your nose, earrings in your ears, and a beautiful crown on your head. 
 \v 13 Thus you were decked with gold and silver. Your clothing was of fine linen, silk, and embroidered work. You ate fine flour, honey, and oil. You were exceedingly beautiful, and you prospered to royal estate. 
-\v 14 Your renown went out among the nations for your beauty; for it was perfect, through my majesty which I had put on you,” says the Lord Yahweh. 
+\v 14 Your renown went out among the nations for your beauty; for it was perfect, through my majesty which I had put on you,” says the Lord Yahuah. 
 \p
 \v 15 “ ‘ “But you trusted in your beauty, and played the prostitute because of your renown, and poured out your prostitution on everyone who passed by. It was his. 
 \v 16 You took some of your garments, and made for yourselves high places decked with various colors, and played the prostitute on them. This shouldn’t happen, neither shall it be. 
 \v 17 You also took your beautiful jewels of my gold and of my silver, which I had given you, and made for yourself images of men, and played the prostitute with them. 
 \v 18 You took your embroidered garments, covered them, and set my oil and my incense before them. 
-\v 19 My bread also which I gave you, fine flour, oil, and honey, with which I fed you, you even set it before them for a pleasant aroma; and so it was,” says the Lord Yahweh. 
+\v 19 My bread also which I gave you, fine flour, oil, and honey, with which I fed you, you even set it before them for a pleasant aroma; and so it was,” says the Lord Yahuah. 
 \p
 \v 20 “ ‘ “Moreover you have taken your sons and your daughters, whom you have borne to me, and you have sacrificed these to them to be devoured. Was your prostitution a small matter, 
 \v 21 that you have slain my children and delivered them up, in causing them to pass through the fire to them? 
 \v 22 In all your abominations and your prostitution you have not remembered the days of your youth, when you were naked and bare, and were wallowing in your blood. 
 \p
-\v 23 “ ‘ “It has happened after all your wickedness—woe, woe to you!” says the Lord Yahweh—\v 24 “that you have built for yourselves a vaulted place, and have made yourselves a lofty place in every street. 
+\v 23 “ ‘ “It has happened after all your wickedness—woe, woe to you!” says the Lord Yahuah—\v 24 “that you have built for yourselves a vaulted place, and have made yourselves a lofty place in every street. 
 \v 25 You have built your lofty place at the head of every way, and have made your beauty an abomination, and have opened your feet to everyone who passed by, and multiplied your prostitution. 
 \v 26 You have also committed sexual immorality with the Egyptians, your neighbors, great of flesh; and have multiplied your prostitution, to provoke me to anger. 
 \v 27 See therefore, I have stretched out my hand over you, and have diminished your portion, and delivered you to the will of those who hate you, the daughters of the Philistines, who are ashamed of your lewd way. 
 \v 28 You have played the prostitute also with the Assyrians, because you were insatiable; yes, you have played the prostitute with them, and yet you weren’t satisfied. 
 \v 29 You have moreover multiplied your prostitution to the land of merchants, to Chaldea; and yet you weren’t satisfied with this. 
 \p
-\v 30 “ ‘ “How weak is your heart,” says the Lord Yahweh, “since you do all these things, the work of an impudent prostitute; 
+\v 30 “ ‘ “How weak is your heart,” says the Lord Yahuah, “since you do all these things, the work of an impudent prostitute; 
 \v 31 in that you build your vaulted place at the head of every way, and make your lofty place in every street, and have not been as a prostitute, in that you scorn pay. 
 \p
 \v 32 “ ‘ “Adulterous woman, who takes strangers instead of her man! 
 \v 33 People give gifts to all prostitutes; but you give your gifts to all your lovers, and bribe them, that they may come to you on every side for your prostitution. 
 \v 34 You are different from other women in your prostitution, in that no one follows you to play the prostitute; and whereas you give hire, and no hire is given to you, therefore you are different.” ’ 
 \p
-\v 35 “Therefore, prostitute, hear Yahweh’s word: 
-\v 36 ‘The Lord Yahweh says, “Because your filthiness was poured out, and your nakedness uncovered through your prostitution with your lovers; and because of all the idols of your abominations, and for the blood of your children, that you gave to them; 
+\v 35 “Therefore, prostitute, hear Yahuah’s word: 
+\v 36 ‘The Lord Yahuah says, “Because your filthiness was poured out, and your nakedness uncovered through your prostitution with your lovers; and because of all the idols of your abominations, and for the blood of your children, that you gave to them; 
 \v 37 therefore see, I will gather all your lovers, with whom you have taken pleasure, and all those whom you have loved, with all those whom you have hated. I will even gather them against you on every side, and will uncover your nakedness to them, that they may see all your nakedness. 
 \v 38 I will judge you as women who break wedlock and shed blood are judged; and I will bring on you the blood of wrath and jealousy. 
 \v 39 I will also give you into their hand, and they will throw down your vaulted place, and break down your lofty places. They will strip you of your clothes and take your beautiful jewels. They will leave you naked and bare. 
@@ -472,13 +472,13 @@
 \v 41 They will burn your houses with fire, and execute judgments on you in the sight of many women. I will cause you to cease from playing the prostitute, and you will also give no hire any more. 
 \v 42 So I will cause my wrath toward you to rest, and my jealousy will depart from you. I will be quiet, and will not be angry any more. 
 \p
-\v 43 “ ‘ “Because you have not remembered the days of your youth, but have raged against me in all these things; therefore, behold, I also will bring your way on your head,” says the Lord Yahweh: “and you shall not commit this lewdness with all your abominations. 
+\v 43 “ ‘ “Because you have not remembered the days of your youth, but have raged against me in all these things; therefore, behold, I also will bring your way on your head,” says the Lord Yahuah: “and you shall not commit this lewdness with all your abominations. 
 \p
 \v 44 “ ‘ “Behold, everyone who uses proverbs will use this proverb against you, saying, ‘As is the mother, so is her daughter.’ 
 \v 45 You are the daughter of your mother, who loathes her man and her children; and you are the sister of your sisters, who loathed their men and their children. Your mother was a Hittite, and your father an Amorite. 
 \v 46 Your elder sister is Samaria, who dwells at your left hand, she and her daughters; and your younger sister, who dwells at your right hand, is Sodom with her daughters. 
 \v 47 Yet you have not walked in their ways, nor done their abominations; but soon you were more corrupt than they in all your ways. 
-\v 48 As I live,” says the Lord Yahweh, “Sodom your sister has not done, she nor her daughters, as you have done, you and your daughters. 
+\v 48 As I live,” says the Lord Yahuah, “Sodom your sister has not done, she nor her daughters, as you have done, you and your daughters. 
 \p
 \v 49 “ ‘ “Behold, this was the iniquity of your sister Sodom: pride, fullness of bread, and prosperous ease was in her and in her daughters. She also didn’t strengthen the hand of the poor and needy. 
 \v 50 They were arrogant and committed abomination before me. Therefore I took them away when I saw it. 
@@ -490,18 +490,18 @@
 \v 55 Your sisters, Sodom and her daughters, will return to their former estate; and Samaria and her daughters will return to their former estate; and you and your daughters will return to your former estate. 
 \v 56 For your sister Sodom was not mentioned by your mouth in the day of your pride, 
 \v 57 before your wickedness was uncovered, as at the time of the reproach of the daughters of Syria, and of all who are around her, the daughters of the Philistines, who despise you all around. 
-\v 58 You have borne your lewdness and your abominations,” says Yahweh. 
+\v 58 You have borne your lewdness and your abominations,” says Yahuah. 
 \p
-\v 59 “ ‘For the Lord Yahweh says: “I will also deal with you as you have done, who have despised the oath in breaking the covenant. 
+\v 59 “ ‘For the Lord Yahuah says: “I will also deal with you as you have done, who have despised the oath in breaking the covenant. 
 \v 60 Nevertheless I will remember my covenant with you in the days of your youth, and I will establish an everlasting covenant with you. 
 \v 61 Then you will remember your ways and be ashamed when you receive your sisters, your elder sisters and your younger; and I will give them to you for daughters, but not by your covenant. 
-\v 62 I will establish my covenant with you. Then you will know that I am Yahweh; 
-\v 63 that you may remember, and be confounded, and never open your mouth any more because of your shame, when I have forgiven you all that you have done,” says the Lord Yahweh.’ ” 
+\v 62 I will establish my covenant with you. Then you will know that I am Yahuah; 
+\v 63 that you may remember, and be confounded, and never open your mouth any more because of your shame, when I have forgiven you all that you have done,” says the Lord Yahuah.’ ” 
 \c 17
 \p
-\v 1 Yahweh’s word came to me, saying, 
+\v 1 Yahuah’s word came to me, saying, 
 \v 2 “Son of man, tell a riddle, and speak a parable to the house of Israel; 
-\v 3 and say, ‘The Lord Yahweh says: “A great eagle with great wings and long feathers, full of feathers which had various colors, came to Lebanon and took the top of the cedar. 
+\v 3 and say, ‘The Lord Yahuah says: “A great eagle with great wings and long feathers, full of feathers which had various colors, came to Lebanon and took the top of the cedar. 
 \v 4 He cropped off the topmost of its young twigs, and carried it to a land of traffic. He planted it in a city of merchants. 
 \p
 \v 5 “ ‘ “He also took some of the seed of the land and planted it in fruitful soil. He placed it beside many waters. He set it as a willow tree. 
@@ -510,35 +510,35 @@
 \v 7 “ ‘ “There was also another great eagle with great wings and many feathers. Behold, this vine bent its roots toward him, and shot out its branches toward him, from the ground where it was planted, that he might water it. 
 \v 8 It was planted in a good soil by many waters, that it might produce branches and that it might bear fruit, that it might be a good vine.” ’ 
 \p
-\v 9 “Say, ‘The Lord Yahweh says: “Will it prosper? Won’t he pull up its roots and cut off its fruit, that it may wither, that all its fresh springing leaves may wither? It can’t be raised from its roots by a strong arm or many people. 
+\v 9 “Say, ‘The Lord Yahuah says: “Will it prosper? Won’t he pull up its roots and cut off its fruit, that it may wither, that all its fresh springing leaves may wither? It can’t be raised from its roots by a strong arm or many people. 
 \v 10 Yes, behold, being planted, will it prosper? Won’t it utterly wither when the east wind touches it? It will wither in the ground where it grew.” ’ ” 
 \p
-\v 11 Moreover Yahweh’s word came to me, saying, 
+\v 11 Moreover Yahuah’s word came to me, saying, 
 \v 12 “Say now to the rebellious house, ‘Don’t you know what these things mean?’ Tell them, ‘Behold, the king of Babylon came to Jerusalem, and took its king, and its princes, and brought them to him to Babylon. 
 \v 13 He took one of the royal offspring, and made a covenant with him. He also brought him under an oath, and took away the mighty of the land, 
 \v 14 that the kingdom might be brought low, that it might not lift itself up, but that by keeping his covenant it might stand. 
 \v 15 But he rebelled against him in sending his ambassadors into Egypt, that they might give him horses and many people. Will he prosper? Will he who does such things escape? Will he break the covenant, and still escape? 
 \p
-\v 16 “ ‘As I live,’ says the Lord Yahweh, ‘surely in the place where the king dwells who made him king, whose oath he despised, and whose covenant he broke, even with him in the middle of Babylon he will die. 
+\v 16 “ ‘As I live,’ says the Lord Yahuah, ‘surely in the place where the king dwells who made him king, whose oath he despised, and whose covenant he broke, even with him in the middle of Babylon he will die. 
 \v 17 Pharaoh with his mighty army and great company won’t help him in the war, when they cast up mounds and build forts to cut off many persons. 
 \v 18 For he has despised the oath by breaking the covenant; and behold, he had given his hand, and yet has done all these things. He won’t escape. 
 \p
-\v 19 “Therefore the Lord Yahweh says: ‘As I live, I will surely bring on his own head my oath that he has despised and my covenant that he has broken. 
+\v 19 “Therefore the Lord Yahuah says: ‘As I live, I will surely bring on his own head my oath that he has despised and my covenant that he has broken. 
 \v 20 I will spread my net on him, and he will be taken in my snare. I will bring him to Babylon, and will enter into judgment with him there for his trespass that he has trespassed against me. 
-\v 21 All his fugitives in all his bands will fall by the sword, and those who remain will be scattered toward every wind. Then you will know that I, Yahweh, have spoken it.’ 
+\v 21 All his fugitives in all his bands will fall by the sword, and those who remain will be scattered toward every wind. Then you will know that I, Yahuah, have spoken it.’ 
 \p
-\v 22 “The Lord Yahweh says: ‘I will also take some of the lofty top of the cedar, and will plant it. I will crop off from the topmost of its young twigs a tender one, and I will plant it on a high and lofty mountain. 
+\v 22 “The Lord Yahuah says: ‘I will also take some of the lofty top of the cedar, and will plant it. I will crop off from the topmost of its young twigs a tender one, and I will plant it on a high and lofty mountain. 
 \v 23 I will plant it in the mountain of the height of Israel; and it will produce boughs, and bear fruit, and be a good cedar. Birds of every kind will dwell in the shade of its branches. 
-\v 24 All the trees of the field will know that I, Yahweh, have brought down the high tree, have exalted the low tree, have dried up the green tree, and have made the dry tree flourish. 
-\p “ ‘I, Yahweh, have spoken and have done it.’ ” 
+\v 24 All the trees of the field will know that I, Yahuah, have brought down the high tree, have exalted the low tree, have dried up the green tree, and have made the dry tree flourish. 
+\p “ ‘I, Yahuah, have spoken and have done it.’ ” 
 \c 18
 \p
-\v 1 Yahweh’s word came to me again, saying, 
+\v 1 Yahuah’s word came to me again, saying, 
 \v 2 “What do you mean, that you use this proverb concerning the land of Israel, saying, 
 \q1 ‘The fathers have eaten sour grapes, 
 \q2 and the children’s teeth are set on edge’? 
 \p
-\v 3 “As I live,” says the Lord Yahweh, “you shall not use this proverb any more in Israel. 
+\v 3 “As I live,” says the Lord Yahuah, “you shall not use this proverb any more in Israel. 
 \v 4 Behold, all souls are mine; as the soul of the father, so also the soul of the son is mine. The soul who sins, he shall die. 
 \b
 \q1
@@ -565,7 +565,7 @@
 \q2 and has kept my ordinances, 
 \q2 to deal truly; 
 \q1 he is just, 
-\q2 he shall surely live,” says the Lord Yahweh. 
+\q2 he shall surely live,” says the Lord Yahuah. 
 \b
 \p
 \v 10 “If he fathers a son who is a robber who sheds blood, and who does any one of these things, 
@@ -607,7 +607,7 @@
 \p
 \v 21 “But if the wicked turns from all his sins that he has committed, and keeps all my statutes, and does that which is lawful and right, he shall surely live. He shall not die. 
 \v 22 None of his transgressions that he has committed will be remembered against him. In his righteousness that he has done, he shall live. 
-\v 23 Have I any pleasure in the death of the wicked?” says the Lord Yahweh, “and not rather that he should return from his way, and live? 
+\v 23 Have I any pleasure in the death of the wicked?” says the Lord Yahuah, “and not rather that he should return from his way, and live? 
 \p
 \v 24 “But when the righteous turns away from his righteousness, and commits iniquity, and does according to all the abominations that the wicked man does, should he live? None of his righteous deeds that he has done will be remembered. In his trespass that he has trespassed, and in his sin that he has sinned, in them he shall die. 
 \p
@@ -617,9 +617,9 @@
 \v 28 Because he considers, and turns away from all his transgressions that he has committed, he shall surely live. He shall not die. 
 \v 29 Yet the house of Israel says, ‘The way of the Lord is not fair.’ House of Israel, aren’t my ways fair? Aren’t your ways unfair? 
 \p
-\v 30 “Therefore I will judge you, house of Israel, everyone according to his ways,” says the Lord Yahweh. “Return, and turn yourselves from all your transgressions, so iniquity will not be your ruin. 
+\v 30 “Therefore I will judge you, house of Israel, everyone according to his ways,” says the Lord Yahuah. “Return, and turn yourselves from all your transgressions, so iniquity will not be your ruin. 
 \v 31 Cast away from you all your transgressions in which you have transgressed; and make yourself a new heart and a new spirit. For why will you die, house of Israel? 
-\v 32 For I have no pleasure in the death of him who dies,” says the Lord Yahweh. “Therefore turn yourselves, and live! 
+\v 32 For I have no pleasure in the death of him who dies,” says the Lord Yahuah. “Therefore turn yourselves, and live! 
 \c 19
 \p
 \v 1 “Moreover, take up a lamentation for the princes of Israel, 
@@ -687,21 +687,21 @@
 \m This is a lamentation, and shall be for a lamentation.” 
 \c 20
 \p
-\v 1 In the seventh year, in the fifth month, the tenth day of the month, some of the elders of Israel came to inquire of Yahweh, and sat before me. 
+\v 1 In the seventh year, in the fifth month, the tenth day of the month, some of the elders of Israel came to inquire of Yahuah, and sat before me. 
 \p
-\v 2 Yahweh’s word came to me, saying, 
-\v 3 “Son of man, speak to the elders of Israel, and tell them, ‘The Lord Yahweh says: “Is it to inquire of me that you have come? As I live,” says the Lord Yahweh, “I will not be inquired of by you.” ’ 
+\v 2 Yahuah’s word came to me, saying, 
+\v 3 “Son of man, speak to the elders of Israel, and tell them, ‘The Lord Yahuah says: “Is it to inquire of me that you have come? As I live,” says the Lord Yahuah, “I will not be inquired of by you.” ’ 
 \p
 \v 4 “Will you judge them, son of man? Will you judge them? Cause them to know the abominations of their fathers. 
-\v 5 Tell them, ‘The Lord Yahweh says: “In the day when I chose Israel, and swore to the offspring of the house of Jacob, and made myself known to them in the land of Egypt, when I swore to them, saying, ‘I am Yahweh your Elohim;’ 
+\v 5 Tell them, ‘The Lord Yahuah says: “In the day when I chose Israel, and swore to the offspring of the house of Jacob, and made myself known to them in the land of Egypt, when I swore to them, saying, ‘I am Yahuah your Elohim;’ 
 \v 6 in that day I swore to them to bring them out of the land of Egypt into a land that I had searched out for them, flowing with milk and honey, which is the glory of all lands. 
-\v 7 I said to them, ‘Each of you throw away the abominations of his eyes. Don’t defile yourselves with the idols of Egypt. I am Yahweh your Elohim.’ 
+\v 7 I said to them, ‘Each of you throw away the abominations of his eyes. Don’t defile yourselves with the idols of Egypt. I am Yahuah your Elohim.’ 
 \p
 \v 8 “ ‘ “But they rebelled against me and wouldn’t listen to me. They didn’t all throw away the abominations of their eyes. They also didn’t forsake the idols of Egypt. Then I said I would pour out my wrath on them, to accomplish my anger against them in the middle of the land of Egypt. 
 \v 9 But I worked for my name’s sake, that it should not be profaned in the sight of the nations among which they were, in whose sight I made myself known to them in bringing them out of the land of Egypt. 
 \v 10 So I caused them to go out of the land of Egypt and brought them into the wilderness. 
 \v 11 I gave them my statutes and showed them my ordinances, which if a man does, he will live in them. 
-\v 12 Moreover also I gave them my Sabbaths, to be a sign between me and them, that they might know that I am Yahweh who sanctifies them. 
+\v 12 Moreover also I gave them my Sabbaths, to be a sign between me and them, that they might know that I am Yahuah who sanctifies them. 
 \p
 \v 13 “ ‘ “But the house of Israel rebelled against me in the wilderness. They didn’t walk in my statutes and they rejected my ordinances, which if a man keeps, he shall live in them. They greatly profaned my Sabbaths. Then I said I would pour out my wrath on them in the wilderness, to consume them. 
 \v 14 But I worked for my name’s sake, that it should not be profaned in the sight of the nations, in whose sight I brought them out. 
@@ -709,57 +709,57 @@
 \v 16 because they rejected my ordinances, and didn’t walk in my statutes, and profaned my Sabbaths; for their heart went after their idols. 
 \v 17 Nevertheless my eye spared them, and I didn’t destroy them. I didn’t make a full end of them in the wilderness. 
 \v 18 I said to their children in the wilderness, ‘Don’t walk in the statutes of your fathers. Don’t observe their ordinances or defile yourselves with their idols. 
-\v 19 I am Yahweh your Elohim. Walk in my statutes, keep my ordinances, and do them. 
-\v 20 Make my Sabbaths set-apart. They shall be a sign between me and you, that you may know that I am Yahweh your Elohim.’ 
+\v 19 I am Yahuah your Elohim. Walk in my statutes, keep my ordinances, and do them. 
+\v 20 Make my Sabbaths set-apart. They shall be a sign between me and you, that you may know that I am Yahuah your Elohim.’ 
 \p
 \v 21 “ ‘ “But the children rebelled against me. They didn’t walk in my statutes, and didn’t keep my ordinances to do them, which if a man does, he shall live in them. They profaned my Sabbaths. Then I said I would pour out my wrath on them, to accomplish my anger against them in the wilderness. 
 \v 22 Nevertheless I withdrew my hand and worked for my name’s sake, that it should not be profaned in the sight of the nations, in whose sight I brought them out. 
 \v 23 Moreover I swore to them in the wilderness, that I would scatter them among the nations and disperse them through the countries, 
 \v 24 because they had not executed my ordinances, but had rejected my statutes, and had profaned my Sabbaths, and their eyes were after their fathers’ idols. 
 \v 25 Moreover also I gave them statutes that were not good, and ordinances in which they couldn’t live. 
-\v 26 I polluted them in their own gifts, in that they caused all that opens the womb to pass through the fire, that I might make them desolate, to the end that they might know that I am Yahweh.” ’ 
+\v 26 I polluted them in their own gifts, in that they caused all that opens the womb to pass through the fire, that I might make them desolate, to the end that they might know that I am Yahuah.” ’ 
 \p
-\v 27 “Therefore, son of man, speak to the house of Israel, and tell them, ‘The Lord Yahweh says: “Moreover, in this your fathers have blasphemed me, in that they have committed a trespass against me. 
+\v 27 “Therefore, son of man, speak to the house of Israel, and tell them, ‘The Lord Yahuah says: “Moreover, in this your fathers have blasphemed me, in that they have committed a trespass against me. 
 \v 28 For when I had brought them into the land which I swore to give to them, then they saw every high hill and every thick tree, and they offered there their sacrifices, and there they presented the provocation of their offering. There they also made their pleasant aroma, and there they poured out their drink offerings. 
 \v 29 Then I said to them, ‘What does the high place where you go mean?’ So its name is called Bamah to this day.” ’ 
 \p
-\v 30 “Therefore tell the house of Israel, ‘The Lord Yahweh says: “Do you pollute yourselves in the way of your fathers? Do you play the prostitute after their abominations? 
-\v 31 When you offer your gifts, when you make your sons pass through the fire, do you pollute yourselves with all your idols to this day? Should I be inquired of by you, house of Israel? As I live, says the Lord Yahweh, I will not be inquired of by you! 
+\v 30 “Therefore tell the house of Israel, ‘The Lord Yahuah says: “Do you pollute yourselves in the way of your fathers? Do you play the prostitute after their abominations? 
+\v 31 When you offer your gifts, when you make your sons pass through the fire, do you pollute yourselves with all your idols to this day? Should I be inquired of by you, house of Israel? As I live, says the Lord Yahuah, I will not be inquired of by you! 
 \p
 \v 32 “ ‘ “That which comes into your mind will not be at all, in that you say, ‘We will be as the nations, as the families of the countries, to serve wood and stone.’ 
-\v 33 As I live,” says the Lord Yahweh, “surely with a mighty hand, with an outstretched arm, and with wrath poured out, I will be king over you. 
+\v 33 As I live,” says the Lord Yahuah, “surely with a mighty hand, with an outstretched arm, and with wrath poured out, I will be king over you. 
 \v 34 I will bring you out from the peoples, and will gather you out of the countries in which you are scattered with a mighty hand, with an outstretched arm, and with wrath poured out. 
 \v 35 I will bring you into the wilderness of the peoples, and there I will enter into judgment with you face to face. 
-\v 36 Just as I entered into judgment with your fathers in the wilderness of the land of Egypt, so I will enter into judgment with you,” says the Lord Yahweh. 
+\v 36 Just as I entered into judgment with your fathers in the wilderness of the land of Egypt, so I will enter into judgment with you,” says the Lord Yahuah. 
 \v 37 “I will cause you to pass under the rod, and I will bring you into the bond of the covenant. 
-\v 38 I will purge out from among you the rebels and those who disobey me. I will bring them out of the land where they live, but they shall not enter into the land of Israel. Then you will know that I am Yahweh.” 
+\v 38 I will purge out from among you the rebels and those who disobey me. I will bring them out of the land where they live, but they shall not enter into the land of Israel. Then you will know that I am Yahuah.” 
 \p
-\v 39 “ ‘As for you, house of Israel, the Lord Yahweh says: “Go, everyone serve his idols, and hereafter also, if you will not listen to me; but you shall no more profane my set-apart name with your gifts and with your idols. 
-\v 40 For in my set-apart mountain, in the mountain of the height of Israel,” says the Lord Yahweh, “there all the house of Israel, all of them, shall serve me in the land. There I will accept them, and there I will require your offerings and the first fruits of your offerings, with all your set-apart things. 
+\v 39 “ ‘As for you, house of Israel, the Lord Yahuah says: “Go, everyone serve his idols, and hereafter also, if you will not listen to me; but you shall no more profane my set-apart name with your gifts and with your idols. 
+\v 40 For in my set-apart mountain, in the mountain of the height of Israel,” says the Lord Yahuah, “there all the house of Israel, all of them, shall serve me in the land. There I will accept them, and there I will require your offerings and the first fruits of your offerings, with all your set-apart things. 
 \v 41 I will accept you as a pleasant aroma when I bring you out from the peoples and gather you out of the countries in which you have been scattered. I will be sanctified in you in the sight of the nations. 
-\v 42 You will know that I am Yahweh when I bring you into the land of Israel, into the country which I swore to give to your fathers. 
+\v 42 You will know that I am Yahuah when I bring you into the land of Israel, into the country which I swore to give to your fathers. 
 \v 43 There you will remember your ways, and all your deeds in which you have polluted yourselves. Then you will loathe yourselves in your own sight for all your evils that you have committed. 
-\v 44 You will know that I am Yahweh, when I have dealt with you for my name’s sake, not according to your evil ways, nor according to your corrupt doings, you house of Israel,” says the Lord Yahweh.’ ” 
+\v 44 You will know that I am Yahuah, when I have dealt with you for my name’s sake, not according to your evil ways, nor according to your corrupt doings, you house of Israel,” says the Lord Yahuah.’ ” 
 \p
-\v 45 Yahweh’s word came to me, saying, 
+\v 45 Yahuah’s word came to me, saying, 
 \v 46 “Son of man, set your face toward the south, and preach toward the south, and prophesy against the forest of the field in the south. 
-\v 47 Tell the forest of the south, ‘Hear Yahweh’s word: The Lord Yahweh says, “Behold, I will kindle a fire in you, and it will devour every green tree in you, and every dry tree. The burning flame will not be quenched, and all faces from the south to the north will be burned by it. 
-\v 48 All flesh will see that I, Yahweh, have kindled it. It will not be quenched.” ’ ” 
+\v 47 Tell the forest of the south, ‘Hear Yahuah’s word: The Lord Yahuah says, “Behold, I will kindle a fire in you, and it will devour every green tree in you, and every dry tree. The burning flame will not be quenched, and all faces from the south to the north will be burned by it. 
+\v 48 All flesh will see that I, Yahuah, have kindled it. It will not be quenched.” ’ ” 
 \p
-\v 49 Then I said, “Ah Lord Yahweh! They say of me, ‘Isn’t he a speaker of parables?’ ” 
+\v 49 Then I said, “Ah Lord Yahuah! They say of me, ‘Isn’t he a speaker of parables?’ ” 
 \c 21
 \p
-\v 1 Yahweh’s word came to me, saying, 
+\v 1 Yahuah’s word came to me, saying, 
 \v 2 “Son of man, set your face toward Jerusalem, and preach toward the sanctuaries, and prophesy against the land of Israel. 
-\v 3 Tell the land of Israel, ‘Yahweh says: “Behold, I am against you, and will draw my sword out of its sheath, and will cut off from you the righteous and the wicked. 
+\v 3 Tell the land of Israel, ‘Yahuah says: “Behold, I am against you, and will draw my sword out of its sheath, and will cut off from you the righteous and the wicked. 
 \v 4 Seeing then that I will cut off from you the righteous and the wicked, therefore my sword will go out of its sheath against all flesh from the south to the north. 
-\v 5 All flesh will know that I, Yahweh, have drawn my sword out of its sheath. It will not return any more.” ’ 
+\v 5 All flesh will know that I, Yahuah, have drawn my sword out of its sheath. It will not return any more.” ’ 
 \p
 \v 6 “Therefore sigh, you son of man. You shall sigh before their eyes with a broken heart and with bitterness. 
-\v 7 It shall be, when they ask you, ‘Why do you sigh?’ that you shall say, ‘Because of the news, for it comes! Every heart will melt, all hands will be feeble, every spirit will faint, and all knees will be weak as water. Behold, it comes, and it shall be done, says the Lord Yahweh.’ ” 
+\v 7 It shall be, when they ask you, ‘Why do you sigh?’ that you shall say, ‘Because of the news, for it comes! Every heart will melt, all hands will be feeble, every spirit will faint, and all knees will be weak as water. Behold, it comes, and it shall be done, says the Lord Yahuah.’ ” 
 \p
-\v 8 Yahweh’s word came to me, saying, 
-\v 9 “Son of man, prophesy, and say, ‘Yahweh says: 
+\v 8 Yahuah’s word came to me, saying, 
+\v 9 “Son of man, prophesy, and say, ‘Yahuah says: 
 \q1 “A sword! A sword! 
 \q2 It is sharpened, 
 \q2 and also polished. 
@@ -782,7 +782,7 @@
 \q2 Therefore beat your thigh. 
 \b
 \p
-\v 13 “For there is a trial. What if even the rod that condemns will be no more?” says the Lord Yahweh. 
+\v 13 “For there is a trial. What if even the rod that condemns will be no more?” says the Lord Yahuah. 
 \q1
 \v 14 “You therefore, son of man, prophesy, 
 \q2 and strike your hands together. 
@@ -805,22 +805,22 @@
 \q1
 \v 17 I will also strike my hands together, 
 \q2 and I will cause my wrath to rest. 
-\q2 I, Yahweh, have spoken it.” 
+\q2 I, Yahuah, have spoken it.” 
 \p
-\v 18 Yahweh’s word came to me again, saying, 
+\v 18 Yahuah’s word came to me again, saying, 
 \v 19 “Also, you son of man, appoint two ways, that the sword of the king of Babylon may come. They both will come out of one land, and mark out a place. Mark it out at the head of the way to the city. 
 \v 20 You shall appoint a way for the sword to come to Rabbah of the children of Ammon, and to Judah in Jerusalem the fortified. 
 \v 21 For the king of Babylon stood at the parting of the way, at the head of the two ways, to use divination. He shook the arrows back and forth. He consulted the teraphim. He looked in the liver. 
 \v 22 In his right hand was the lot for Jerusalem, to set battering rams, to open the mouth in the slaughter, to lift up the voice with shouting, to set battering rams against the gates, to cast up mounds, and to build forts. 
 \v 23 It will be to them as a false divination in their sight, who have sworn oaths to them; but he brings iniquity to memory, that they may be taken. 
 \p
-\v 24 “Therefore the Lord Yahweh says: ‘Because you have caused your iniquity to be remembered, in that your transgressions are uncovered, so that in all your doings your sins appear; because you have come to memory, you will be taken with the hand. 
+\v 24 “Therefore the Lord Yahuah says: ‘Because you have caused your iniquity to be remembered, in that your transgressions are uncovered, so that in all your doings your sins appear; because you have come to memory, you will be taken with the hand. 
 \p
 \v 25 “ ‘You, deadly wounded wicked one, the prince of Israel, whose day has come, in the time of the iniquity of the end, 
-\v 26 the Lord Yahweh says: “Remove the turban, and take off the crown. This will not be as it was. Exalt that which is low, and humble that which is high. 
+\v 26 the Lord Yahuah says: “Remove the turban, and take off the crown. This will not be as it was. Exalt that which is low, and humble that which is high. 
 \v 27 I will overturn, overturn, overturn it. This also will be no more, until he comes whose right it is; and I will give it.” ’ 
 \p
-\v 28 “You, son of man, prophesy and say, ‘The Lord Yahweh says this concerning the children of Ammon, and concerning their reproach: 
+\v 28 “You, son of man, prophesy and say, ‘The Lord Yahuah says this concerning the children of Ammon, and concerning their reproach: 
 \q1 “A sword! A sword is drawn! 
 \q2 It is polished for the slaughter, 
 \q1 to cause it to devour, 
@@ -843,12 +843,12 @@
 \v 32 You will be for fuel to the fire. 
 \q2 Your blood will be in the middle of the land. 
 \q1 You will be remembered no more; 
-\q2 for I, Yahweh, have spoken it.” ’ ” 
+\q2 for I, Yahuah, have spoken it.” ’ ” 
 \c 22
 \p
-\v 1 Moreover Yahweh’s word came to me, saying, 
+\v 1 Moreover Yahuah’s word came to me, saying, 
 \v 2 “You, son of man, will you judge? Will you judge the bloody city? Then cause her to know all her abominations. 
-\v 3 You shall say, ‘The Lord Yahweh says: “A city that sheds blood within herself, that her time may come, and that makes idols against herself to defile her! 
+\v 3 You shall say, ‘The Lord Yahuah says: “A city that sheds blood within herself, that her time may come, and that makes idols against herself to defile her! 
 \v 4 You have become guilty in your blood that you have shed, and are defiled in your idols which you have made! You have caused your days to draw near, and have come to the end of your years. Therefore I have made you a reproach to the nations, and a mocking to all the countries. 
 \v 5 Those who are near and those who are far from you will mock you, you infamous one, full of tumult. 
 \p
@@ -858,33 +858,33 @@
 \v 9 Slanderous men have been in you to shed blood. In you they have eaten on the mountains. They have committed lewdness among you. 
 \v 10 In you have they uncovered their fathers’ nakedness. In you have they humbled her who was unclean in her impurity. 
 \v 11 One has committed abomination with his neighbor’s woman, and another has lewdly defiled his daughter-in-law. Another in you has humbled his sister, his father’s daughter. 
-\v 12 In you have they taken bribes to shed blood. You have taken interest and increase, and you have greedily gained of your neighbors by oppression, and have forgotten me,” says the Lord Yahweh. 
+\v 12 In you have they taken bribes to shed blood. You have taken interest and increase, and you have greedily gained of your neighbors by oppression, and have forgotten me,” says the Lord Yahuah. 
 \p
 \v 13 “ ‘ “Behold, therefore I have struck my hand at your dishonest gain which you have made, and at the blood which has been shed within you. 
-\v 14 Can your heart endure, or can your hands be strong, in the days that I will deal with you? I, Yahweh, have spoken it, and will do it. 
+\v 14 Can your heart endure, or can your hands be strong, in the days that I will deal with you? I, Yahuah, have spoken it, and will do it. 
 \v 15 I will scatter you among the nations, and disperse you through the countries. I will purge your filthiness out of you. 
-\v 16 You will be profaned in yourself in the sight of the nations. Then you will know that I am Yahweh.” ’ ” 
+\v 16 You will be profaned in yourself in the sight of the nations. Then you will know that I am Yahuah.” ’ ” 
 \p
-\v 17 Yahweh’s word came to me, saying, 
+\v 17 Yahuah’s word came to me, saying, 
 \v 18 “Son of man, the house of Israel has become dross to me. All of them are bronze, tin, iron, and lead in the middle of the furnace. They are the dross of silver. 
-\v 19 Therefore the Lord Yahweh says: ‘Because you have all become dross, therefore, behold, I will gather you into the middle of Jerusalem. 
+\v 19 Therefore the Lord Yahuah says: ‘Because you have all become dross, therefore, behold, I will gather you into the middle of Jerusalem. 
 \v 20 As they gather silver, bronze, iron, lead, and tin into the middle of the furnace, to blow the fire on it, to melt it, so I will gather you in my anger and in my wrath, and I will lay you there and melt you. 
 \v 21 Yes, I will gather you, and blow on you with the fire of my wrath, and you will be melted in the middle of it. 
-\v 22 As silver is melted in the middle of the furnace, so you will be melted in the middle of it; and you will know that I, Yahweh, have poured out my wrath on you.’ ” 
+\v 22 As silver is melted in the middle of the furnace, so you will be melted in the middle of it; and you will know that I, Yahuah, have poured out my wrath on you.’ ” 
 \p
-\v 23 Yahweh’s word came to me, saying, 
+\v 23 Yahuah’s word came to me, saying, 
 \v 24 “Son of man, tell her, ‘You are a land that is not cleansed nor rained on in the day of indignation.’ 
 \v 25 There is a conspiracy of her prophets within it, like a roaring lion ravening the prey. They have devoured souls. They take treasure and precious things. They have made many widows within it. 
 \v 26 Her priests have done violence to my law and have profaned my set-apart things. They have made no distinction between the set-apart and the common, neither have they caused men to discern between the unclean and the clean, and have hidden their eyes from my Sabbaths. So I am profaned among them. 
 \v 27 Her princes within it are like wolves ravening the prey, to shed blood and to destroy souls, that they may get dishonest gain. 
-\v 28 Her prophets have plastered for them with whitewash, seeing false visions, and divining lies to them, saying, ‘The Lord Yahweh says,’ when Yahweh has not spoken. 
+\v 28 Her prophets have plastered for them with whitewash, seeing false visions, and divining lies to them, saying, ‘The Lord Yahuah says,’ when Yahuah has not spoken. 
 \v 29 The people of the land have used oppression and exercised robbery. Yes, they have troubled the poor and needy, and have oppressed the foreigner wrongfully. 
 \p
 \v 30 “I sought for a man among them who would build up the wall and stand in the gap before me for the land, that I would not destroy it; but I found no one. 
-\v 31 Therefore I have poured out my indignation on them. I have consumed them with the fire of my wrath. I have brought their own way on their heads,” says the Lord Yahweh. 
+\v 31 Therefore I have poured out my indignation on them. I have consumed them with the fire of my wrath. I have brought their own way on their heads,” says the Lord Yahuah. 
 \c 23
 \p
-\v 1 Yahweh’s word came again to me, saying, 
+\v 1 Yahuah’s word came again to me, saying, 
 \v 2 “Son of man, there were two women, the daughters of one mother. 
 \v 3 They played the prostitute in Egypt. They played the prostitute in their youth. Their breasts were fondled there, and their youthful nipples were caressed there. 
 \v 4 Their names were Oholah the elder, and Oholibah her sister. They became mine, and they bore sons and daughters. As for their names, Samaria is Oholah, and Jerusalem Oholibah. 
@@ -910,19 +910,19 @@
 \v 20 She lusted after their lovers, whose flesh is as the flesh of donkeys, and whose issue is like the issue of horses. 
 \v 21 Thus you called to memory the lewdness of your youth, in the caressing of your nipples by the Egyptians because of your youthful breasts. 
 \p
-\v 22 “Therefore, Oholibah, the Lord Yahweh says: ‘Behold, I will raise up your lovers against you, from whom your soul is alienated, and I will bring them against you on every side: 
+\v 22 “Therefore, Oholibah, the Lord Yahuah says: ‘Behold, I will raise up your lovers against you, from whom your soul is alienated, and I will bring them against you on every side: 
 \v 23 the Babylonians and all the Chaldeans, Pekod, Shoa, Koa, and all the Assyrians with them; all of them desirable young men, governors and rulers, princes and men of renown, all of them riding on horses. 
 \v 24 They will come against you with weapons, chariots, and wagons, and with a company of peoples. They will set themselves against you with buckler, shield, and helmet all around. I will commit the judgment to them, and they will judge you according to their judgments. 
 \v 25 I will set my jealousy against you, and they will deal with you in fury. They will take away your nose and your ears. Your remnant will fall by the sword. They will take your sons and your daughters; and the rest of you will be devoured by the fire. 
 \v 26 They will also strip you of your clothes and take away your beautiful jewels. 
 \v 27 Thus I will make your lewdness to cease from you, and remove your prostitution from the land of Egypt, so that you will not lift up your eyes to them, nor remember Egypt any more.’ 
 \p
-\v 28 “For the Lord Yahweh says: ‘Behold, I will deliver you into the hand of them whom you hate, into the hand of them from whom your soul is alienated. 
+\v 28 “For the Lord Yahuah says: ‘Behold, I will deliver you into the hand of them whom you hate, into the hand of them from whom your soul is alienated. 
 \v 29 They will deal with you in hatred, and will take away all your labor, and will leave you naked and bare. The nakedness of your prostitution will be uncovered, both your lewdness and your prostitution. 
 \v 30 These things will be done to you because you have played the prostitute after the nations, and because you are polluted with their idols. 
 \v 31 You have walked in the way of your sister; therefore I will give her cup into your hand.’ 
 \p
-\v 32 “The Lord Yahweh says: 
+\v 32 “The Lord Yahuah says: 
 \q1 ‘You will drink of your sister’s cup, 
 \q2 which is deep and large. 
 \q1 You will be ridiculed and held in derision. 
@@ -935,11 +935,11 @@
 \v 34 You will even drink it and drain it out. 
 \q2 You will gnaw the broken pieces of it, 
 \q2 and will tear your breasts; 
-\m for I have spoken it,’ says the Lord Yahweh. 
+\m for I have spoken it,’ says the Lord Yahuah. 
 \p
-\v 35 “Therefore the Lord Yahweh says: ‘Because you have forgotten me and cast me behind your back, therefore you also bear your lewdness and your prostitution.’ ” 
+\v 35 “Therefore the Lord Yahuah says: ‘Because you have forgotten me and cast me behind your back, therefore you also bear your lewdness and your prostitution.’ ” 
 \p
-\v 36 Yahweh said moreover to me: “Son of man, will you judge Oholah and Oholibah? Then declare to them their abominations. 
+\v 36 Yahuah said moreover to me: “Son of man, will you judge Oholah and Oholibah? Then declare to them their abominations. 
 \v 37 For they have committed adultery, and blood is in their hands. They have committed adultery with their idols. They have also caused their sons, whom they bore to me, to pass through the fire to them to be devoured. 
 \v 38 Moreover this they have done to me: they have defiled my sanctuary in the same day, and have profaned my Sabbaths. 
 \v 39 For when they had slain their children to their idols, then they came the same day into my sanctuary to profane it; and behold, they have done this in the middle of my house. 
@@ -952,16 +952,16 @@
 \v 44 They went in to her, as they go in to a prostitute. So they went in to Oholah and to Oholibah, the lewd women. 
 \v 45 Righteous men will judge them with the judgment of adulteresses and with the judgment of women who shed blood, because they are adulteresses, and blood is in their hands. 
 \p
-\v 46 “For the Lord Yahweh says: ‘I will bring up a mob against them, and will give them to be tossed back and forth and robbed. 
+\v 46 “For the Lord Yahuah says: ‘I will bring up a mob against them, and will give them to be tossed back and forth and robbed. 
 \v 47 The company will stone them with stones and dispatch them with their swords. They will kill their sons and their daughters, and burn up their houses with fire. 
 \p
 \v 48 “ ‘Thus I will cause lewdness to cease out of the land, that all women may be taught not to be lewd like you. 
-\v 49 They will recompense your lewdness on you, and you will bear the sins of your idols. Then you will know that I am the Lord Yahweh.’ ” 
+\v 49 They will recompense your lewdness on you, and you will bear the sins of your idols. Then you will know that I am the Lord Yahuah.’ ” 
 \c 24
 \p
-\v 1 Again, in the ninth year, in the tenth month, in the tenth day of the month, Yahweh’s word came to me, saying, 
+\v 1 Again, in the ninth year, in the tenth month, in the tenth day of the month, Yahuah’s word came to me, saying, 
 \v 2 “Son of man, write the name of the day, this same day. The king of Babylon drew close to Jerusalem this same day. 
-\v 3 Utter a parable to the rebellious house, and tell them, ‘The Lord Yahweh says, 
+\v 3 Utter a parable to the rebellious house, and tell them, ‘The Lord Yahuah says, 
 \q1 “Put the cauldron on the fire. 
 \q2 Put it on, 
 \q2 and also pour water into it. 
@@ -976,7 +976,7 @@
 \q1 Make it boil well. 
 \q2 Yes, let its bones be boiled within it.” 
 \m
-\v 6 “ ‘Therefore the Lord Yahweh says: 
+\v 6 “ ‘Therefore the Lord Yahuah says: 
 \q1 “Woe to the bloody city, 
 \q2 to the cauldron whose rust is in it, 
 \q2 and whose rust hasn’t gone out of it! 
@@ -993,7 +993,7 @@
 \q2 I have set her blood on the bare rock, 
 \q2 that it should not be covered.” 
 \m
-\v 9 “ ‘Therefore the Lord Yahweh says: 
+\v 9 “ ‘Therefore the Lord Yahuah says: 
 \q1 “Woe to the bloody city! 
 \q2 I also will make the pile great. 
 \q1
@@ -1015,9 +1015,9 @@
 \p
 \v 13 “ ‘ “In your filthiness is lewdness. Because I have cleansed you and you weren’t cleansed, you won’t be cleansed from your filthiness any more, until I have caused my wrath toward you to rest. 
 \p
-\v 14 “ ‘ “I, Yahweh, have spoken it. It will happen, and I will do it. I won’t go back. I won’t spare. I won’t repent. According to your ways and according to your doings, they will judge you,” says the Lord Yahweh.’ ” 
+\v 14 “ ‘ “I, Yahuah, have spoken it. It will happen, and I will do it. I won’t go back. I won’t spare. I won’t repent. According to your ways and according to your doings, they will judge you,” says the Lord Yahuah.’ ” 
 \p
-\v 15 Also Yahweh’s word came to me, saying, 
+\v 15 Also Yahuah’s word came to me, saying, 
 \v 16 “Son of man, behold, I will take away from you the desire of your eyes with one stroke; yet you shall neither mourn nor weep, neither shall your tears run down. 
 \v 17 Sigh, but not aloud. Make no mourning for the dead. Bind your headdress on you, and put your sandals on your feet. Don’t cover your lips, and don’t eat mourner’s bread.” 
 \p
@@ -1025,55 +1025,55 @@
 \p
 \v 19 The people asked me, “Won’t you tell us what these things mean to us, that you act like this?” 
 \p
-\v 20 Then I said to them, “Yahweh’s word came to me, saying, 
-\v 21 ‘Speak to the house of Israel, “The Lord Yahweh says: ‘Behold, I will profane my sanctuary, the pride of your power, the desire of your eyes, and that which your soul pities; and your sons and your daughters whom you have left behind will fall by the sword. 
+\v 20 Then I said to them, “Yahuah’s word came to me, saying, 
+\v 21 ‘Speak to the house of Israel, “The Lord Yahuah says: ‘Behold, I will profane my sanctuary, the pride of your power, the desire of your eyes, and that which your soul pities; and your sons and your daughters whom you have left behind will fall by the sword. 
 \v 22 You will do as I have done. You won’t cover your lips or eat mourner’s bread. 
 \v 23 Your turbans will be on your heads, and your sandals on your feet. You won’t mourn or weep; but you will pine away in your iniquities, and moan one toward another. 
-\v 24 Thus Ezekiel will be a sign to you; according to all that he has done, you will do. When this comes, then you will know that I am the Lord Yahweh.’ ” ’ ” 
+\v 24 Thus Ezekiel will be a sign to you; according to all that he has done, you will do. When this comes, then you will know that I am the Lord Yahuah.’ ” ’ ” 
 \p
 \v 25 “You, son of man, shouldn’t it be in the day when I take from them their strength, the joy of their glory, the desire of their eyes, and that whereupon they set their heart—their sons and their daughters—\v 26 that in that day he who escapes will come to you, to cause you to hear it with your ears? 
-\v 27 In that day your mouth will be opened to him who has escaped, and you will speak and be no more mute. So you will be a sign to them. Then they will know that I am Yahweh.” 
+\v 27 In that day your mouth will be opened to him who has escaped, and you will speak and be no more mute. So you will be a sign to them. Then they will know that I am Yahuah.” 
 \c 25
 \p
-\v 1 Yahweh’s word came to me, saying, 
+\v 1 Yahuah’s word came to me, saying, 
 \v 2 “Son of man, set your face toward the children of Ammon, and prophesy against them. 
-\v 3 Tell the children of Ammon, ‘Hear the word of the Lord Yahweh! The Lord Yahweh says, “Because you said, ‘Aha!’ against my sanctuary when it was profaned, and against the land of Israel when it was made desolate, and against the house of Judah when they went into captivity, 
+\v 3 Tell the children of Ammon, ‘Hear the word of the Lord Yahuah! The Lord Yahuah says, “Because you said, ‘Aha!’ against my sanctuary when it was profaned, and against the land of Israel when it was made desolate, and against the house of Judah when they went into captivity, 
 \v 4 therefore, behold, I will deliver you to the children of the east for a possession. They will set their encampments in you and make their dwellings in you. They will eat your fruit and they will drink your milk. 
-\v 5 I will make Rabbah a stable for camels and the children of Ammon a resting place for flocks. Then you will know that I am Yahweh.” 
-\v 6 For the Lord Yahweh says: “Because you have clapped your hands, stamped with the feet, and rejoiced with all the contempt of your soul against the land of Israel, 
-\v 7 therefore, behold, I have stretched out my hand on you, and will deliver you for a plunder to the nations. I will cut you off from the peoples, and I will cause you to perish out of the countries. I will destroy you. Then you will know that I am Yahweh.” 
+\v 5 I will make Rabbah a stable for camels and the children of Ammon a resting place for flocks. Then you will know that I am Yahuah.” 
+\v 6 For the Lord Yahuah says: “Because you have clapped your hands, stamped with the feet, and rejoiced with all the contempt of your soul against the land of Israel, 
+\v 7 therefore, behold, I have stretched out my hand on you, and will deliver you for a plunder to the nations. I will cut you off from the peoples, and I will cause you to perish out of the countries. I will destroy you. Then you will know that I am Yahuah.” 
 \p
-\v 8 “ ‘The Lord Yahweh says: “Because Moab and Seir say, ‘Behold, the house of Judah is like all the nations,’ 
+\v 8 “ ‘The Lord Yahuah says: “Because Moab and Seir say, ‘Behold, the house of Judah is like all the nations,’ 
 \v 9 therefore, behold, I will open the side of Moab from the cities, from his cities which are on its frontiers, the glory of the country, Beth Jeshimoth, Baal Meon, and Kiriathaim, 
 \v 10 to the children of the east, to go against the children of Ammon; and I will give them for a possession, that the children of Ammon may not be remembered among the nations. 
-\v 11 I will execute judgments on Moab. Then they will know that I am Yahweh.” 
+\v 11 I will execute judgments on Moab. Then they will know that I am Yahuah.” 
 \p
-\v 12 “ ‘The Lord Yahweh says: “Because Edom has dealt against the house of Judah by taking vengeance, and has greatly offended, and taken revenge on them,” 
-\v 13 therefore the Lord Yahweh says, “I will stretch out my hand on Edom, and will cut off man and animal from it; and I will make it desolate from Teman. They will fall by the sword even to Dedan. 
-\v 14 I will lay my vengeance on Edom by the hand of my people Israel. They will do in Edom according to my anger and according to my wrath. Then they will know my vengeance,” says the Lord Yahweh. 
+\v 12 “ ‘The Lord Yahuah says: “Because Edom has dealt against the house of Judah by taking vengeance, and has greatly offended, and taken revenge on them,” 
+\v 13 therefore the Lord Yahuah says, “I will stretch out my hand on Edom, and will cut off man and animal from it; and I will make it desolate from Teman. They will fall by the sword even to Dedan. 
+\v 14 I will lay my vengeance on Edom by the hand of my people Israel. They will do in Edom according to my anger and according to my wrath. Then they will know my vengeance,” says the Lord Yahuah. 
 \p
-\v 15 “ ‘The Lord Yahweh says: “Because the Philistines have taken revenge, and have taken vengeance with contempt of soul to destroy with perpetual hostility,” 
-\v 16 therefore the Lord Yahweh says, “Behold, I will stretch out my hand on the Philistines, and I will cut off the Cherethites, and destroy the remnant of the sea coast. 
-\v 17 I will execute great vengeance on them with wrathful rebukes. Then they will know that I am Yahweh, when I lay my vengeance on them.” ’ ” 
+\v 15 “ ‘The Lord Yahuah says: “Because the Philistines have taken revenge, and have taken vengeance with contempt of soul to destroy with perpetual hostility,” 
+\v 16 therefore the Lord Yahuah says, “Behold, I will stretch out my hand on the Philistines, and I will cut off the Cherethites, and destroy the remnant of the sea coast. 
+\v 17 I will execute great vengeance on them with wrathful rebukes. Then they will know that I am Yahuah, when I lay my vengeance on them.” ’ ” 
 \c 26
 \p
-\v 1 In the eleventh year, in the first of the month, Yahweh’s word came to me, saying, 
+\v 1 In the eleventh year, in the first of the month, Yahuah’s word came to me, saying, 
 \v 2 “Son of man, because Tyre has said against Jerusalem, ‘Aha! She is broken! She who was the gateway of the peoples has been returned to me. I will be replenished, now that she is laid waste;’ 
-\v 3 therefore the Lord Yahweh says, ‘Behold, I am against you, Tyre, and will cause many nations to come up against you, as the sea causes its waves to come up. 
+\v 3 therefore the Lord Yahuah says, ‘Behold, I am against you, Tyre, and will cause many nations to come up against you, as the sea causes its waves to come up. 
 \v 4 They will destroy the walls of Tyre, and break down her towers. I will also scrape her dust from her, and make her a bare rock. 
-\v 5 She will be a place for the spreading of nets in the middle of the sea; for I have spoken it,’ says the Lord Yahweh. ‘She will become plunder for the nations. 
-\v 6 Her daughters who are in the field will be slain with the sword. Then they will know that I am Yahweh.’ 
+\v 5 She will be a place for the spreading of nets in the middle of the sea; for I have spoken it,’ says the Lord Yahuah. ‘She will become plunder for the nations. 
+\v 6 Her daughters who are in the field will be slain with the sword. Then they will know that I am Yahuah.’ 
 \p
-\v 7 “For the Lord Yahweh says: ‘Behold, I will bring on Tyre Nebuchadnezzar king of Babylon, king of kings, from the north, with horses, with chariots, with horsemen, and an army with many people. 
+\v 7 “For the Lord Yahuah says: ‘Behold, I will bring on Tyre Nebuchadnezzar king of Babylon, king of kings, from the north, with horses, with chariots, with horsemen, and an army with many people. 
 \v 8 He will kill your daughters in the field with the sword. He will make forts against you, cast up a mound against you, and raise up the buckler against you. 
 \v 9 He will set his battering engines against your walls, and with his axes he will break down your towers. 
 \v 10 By reason of the abundance of his horses, their dust will cover you. Your walls will shake at the noise of the horsemen, of the wagons, and of the chariots, when he enters into your gates, as men enter into a city which is broken open. 
 \v 11 He will tread down all your streets with the hoofs of his horses. He will kill your people with the sword. The pillars of your strength will go down to the ground. 
 \v 12 They will make a plunder of your riches and make a prey of your merchandise. They will break down your walls and destroy your pleasant houses. They will lay your stones, your timber, and your dust in the middle of the waters. 
 \v 13 I will cause the noise of your songs to cease. The sound of your harps won’t be heard any more. 
-\v 14 I will make you a bare rock. You will be a place for the spreading of nets. You will be built no more; for I Yahweh have spoken it,’ says the Lord Yahweh. 
+\v 14 I will make you a bare rock. You will be a place for the spreading of nets. You will be built no more; for I Yahuah have spoken it,’ says the Lord Yahuah. 
 \p
-\v 15 “The Lord Yahweh says to Tyre: ‘Won’t the islands shake at the sound of your fall, when the wounded groan, when the slaughter is made within you? 
+\v 15 “The Lord Yahuah says to Tyre: ‘Won’t the islands shake at the sound of your fall, when the wounded groan, when the slaughter is made within you? 
 \v 16 Then all the princes of the sea will come down from their thrones, and lay aside their robes, and strip off their embroidered garments. They will clothe themselves with trembling. They will sit on the ground, and will tremble every moment, and be astonished at you. 
 \v 17 They will take up a lamentation over you, and tell you, 
 \q1 “How you are destroyed, 
@@ -1086,14 +1086,14 @@
 \v 18 Now the islands will tremble in the day of your fall. 
 \q2 Yes, the islands that are in the sea will be dismayed at your departure.’ 
 \p
-\v 19 “For the Lord Yahweh says: ‘When I make you a desolate city, like the cities that are not inhabited, when I bring up the deep on you, and the great waters cover you, 
+\v 19 “For the Lord Yahuah says: ‘When I make you a desolate city, like the cities that are not inhabited, when I bring up the deep on you, and the great waters cover you, 
 \v 20 then I will bring you down with those who descend into the pit, to the people of old time, and will make you dwell in the lower parts of the earth, in the places that are desolate of old, with those who go down to the pit, that you be not inhabited; and I will set glory in the land of the living. 
-\v 21 I will make you a terror, and you will no more have any being. Though you are sought for, yet you will never be found again,’ says the Lord Yahweh.” 
+\v 21 I will make you a terror, and you will no more have any being. Though you are sought for, yet you will never be found again,’ says the Lord Yahuah.” 
 \c 27
 \p
-\v 1 Yahweh’s word came again to me, saying, 
+\v 1 Yahuah’s word came again to me, saying, 
 \v 2 “You, son of man, take up a lamentation over Tyre; 
-\v 3 and tell Tyre, ‘You who dwell at the entry of the sea, who are the merchant of the peoples to many islands, the Lord Yahweh says: 
+\v 3 and tell Tyre, ‘You who dwell at the entry of the sea, who are the merchant of the peoples to many islands, the Lord Yahuah says: 
 \q1 “You, Tyre, have said, 
 \q2 ‘I am perfect in beauty.’ 
 \q1
@@ -1210,8 +1210,8 @@
 \q2 and you will be no more.” ’ ” 
 \c 28
 \p
-\v 1 Yahweh’s word came again to me, saying, 
-\v 2 “Son of man, tell the prince of Tyre, ‘The Lord Yahweh says: 
+\v 1 Yahuah’s word came again to me, saying, 
+\v 2 “Son of man, tell the prince of Tyre, ‘The Lord Yahuah says: 
 \q1 “Because your heart is lifted up, 
 \q2 and you have said, ‘I am an elohim, 
 \q1 I sit in the seat of Elohim, 
@@ -1229,7 +1229,7 @@
 \q2 and by your trading you have increased your riches, 
 \q2 and your heart is lifted up because of your riches—” 
 \p
-\v 6 “ ‘therefore the Lord Yahweh says: 
+\v 6 “ ‘therefore the Lord Yahuah says: 
 \q1 “Because you have set your heart as the heart of Elohim, 
 \q2
 \v 7 therefore, behold, I will bring strangers on you, 
@@ -1247,11 +1247,11 @@
 \q1
 \v 10 You will die the death of the uncircumcised 
 \q2 by the hand of strangers; 
-\q2 for I have spoken it,” says the Lord Yahweh.’ ” 
+\q2 for I have spoken it,” says the Lord Yahuah.’ ” 
 \b
 \p
-\v 11 Moreover Yahweh’s word came to me, saying, 
-\v 12 “Son of man, take up a lamentation over the king of Tyre, and tell him, ‘The Lord Yahweh says: 
+\v 11 Moreover Yahuah’s word came to me, saying, 
+\v 12 “Son of man, take up a lamentation over the king of Tyre, and tell him, ‘The Lord Yahuah says: 
 \q1 “You were the seal of full measure, 
 \q2 full of wisdom, 
 \q2 and perfect in beauty. 
@@ -1298,12 +1298,12 @@
 \q2 and you will exist no more.” ’ ” 
 \b
 \p
-\v 20 Yahweh’s word came to me, saying, 
+\v 20 Yahuah’s word came to me, saying, 
 \v 21 “Son of man, set your face toward Sidon, and prophesy against it, 
-\v 22 and say, ‘The Lord Yahweh says: 
+\v 22 and say, ‘The Lord Yahuah says: 
 \q1 “Behold, I am against you, Sidon. 
 \q2 I will be glorified among you. 
-\q1 Then they will know that I am Yahweh, 
+\q1 Then they will know that I am Yahuah, 
 \q2 when I have executed judgments in her, 
 \q2 and am sanctified in her. 
 \q1
@@ -1311,17 +1311,17 @@
 \q2 and blood into her streets. 
 \q1 The wounded will fall within her, 
 \q2 with the sword on her on every side. 
-\q2 Then they will know that I am Yahweh. 
+\q2 Then they will know that I am Yahuah. 
 \p
-\v 24 “ ‘ “There will no longer be a pricking brier to the house of Israel, nor a hurting thorn of any that are around them that scorned them. Then they will know that I am the Lord Yahweh.” 
+\v 24 “ ‘ “There will no longer be a pricking brier to the house of Israel, nor a hurting thorn of any that are around them that scorned them. Then they will know that I am the Lord Yahuah.” 
 \p
-\v 25 “ ‘The Lord Yahweh says: “When I have gathered the house of Israel from the peoples among whom they are scattered, and am shown as set-apart among them in the sight of the nations, then they will dwell in their own land which I gave to my servant Jacob. 
-\v 26 They will dwell in it securely. Yes, they will build houses, plant vineyards, and will dwell securely when I have executed judgments on all those around them who have treated them with contempt. Then they will know that I am Yahweh their Elohim.” ’ ” 
+\v 25 “ ‘The Lord Yahuah says: “When I have gathered the house of Israel from the peoples among whom they are scattered, and am shown as set-apart among them in the sight of the nations, then they will dwell in their own land which I gave to my servant Jacob. 
+\v 26 They will dwell in it securely. Yes, they will build houses, plant vineyards, and will dwell securely when I have executed judgments on all those around them who have treated them with contempt. Then they will know that I am Yahuah their Elohim.” ’ ” 
 \c 29
 \p
-\v 1 In the tenth year, in the tenth month, on the twelfth day of the month, Yahweh’s word came to me, saying, 
+\v 1 In the tenth year, in the tenth month, on the twelfth day of the month, Yahuah’s word came to me, saying, 
 \v 2 “Son of man, set your face against Pharaoh king of Egypt, and prophesy against him and against all Egypt. 
-\v 3 Speak and say, ‘The Lord Yahweh says: 
+\v 3 Speak and say, ‘The Lord Yahuah says: 
 \q1 “Behold, I am against you, Pharaoh king of Egypt, 
 \q2 the great monster that lies in the middle of his rivers, 
 \q1 that has said, ‘My river is my own, 
@@ -1339,36 +1339,36 @@
 \q1 I have given you for food to the animals of the earth 
 \q2 and to the birds of the sky. 
 \p
-\v 6 “ ‘ “All the inhabitants of Egypt will know that I am Yahweh, because they have been a staff of reed to the house of Israel. 
+\v 6 “ ‘ “All the inhabitants of Egypt will know that I am Yahuah, because they have been a staff of reed to the house of Israel. 
 \v 7 When they took hold of you by your hand, you broke and tore all their shoulders. When they leaned on you, you broke and paralyzed all of their thighs.” 
 \p
-\v 8 “ ‘Therefore the Lord Yahweh says: “Behold, I will bring a sword on you, and will cut off man and animal from you. 
-\v 9 The land of Egypt will be a desolation and a waste. Then they will know that I am Yahweh. 
+\v 8 “ ‘Therefore the Lord Yahuah says: “Behold, I will bring a sword on you, and will cut off man and animal from you. 
+\v 9 The land of Egypt will be a desolation and a waste. Then they will know that I am Yahuah. 
 \p “ ‘ “Because he has said, ‘The river is mine, and I have made it,’ 
 \v 10 therefore, behold, I am against you and against your rivers. I will make the land of Egypt an utter waste and desolation, from the tower of Seveneh even to the border of Ethiopia. 
 \v 11 No foot of man will pass through it, nor will any animal foot pass through it. It won’t be inhabited for forty years. 
 \v 12 I will make the land of Egypt a desolation in the middle of the countries that are desolate. Her cities among the cities that are laid waste will be a desolation forty years. I will scatter the Egyptians among the nations, and will disperse them through the countries.” 
 \p
-\v 13 “ ‘For the Lord Yahweh says: “At the end of forty years I will gather the Egyptians from the peoples where they were scattered. 
+\v 13 “ ‘For the Lord Yahuah says: “At the end of forty years I will gather the Egyptians from the peoples where they were scattered. 
 \v 14 I will reverse the captivity of Egypt, and will cause them to return into the land of Pathros, into the land of their birth. There they will be a lowly kingdom. 
 \v 15 It will be the lowest of the kingdoms. It won’t lift itself up above the nations any more. I will diminish them so that they will no longer rule over the nations. 
-\v 16 It will no longer be the confidence of the house of Israel, bringing iniquity to memory, when they turn to look after them. Then they will know that I am the Lord Yahweh.” ’ ” 
+\v 16 It will no longer be the confidence of the house of Israel, bringing iniquity to memory, when they turn to look after them. Then they will know that I am the Lord Yahuah.” ’ ” 
 \b
 \p
-\v 17 It came to pass in the twenty-seventh year, in the first month, in the first day of the month, Yahweh’s word came to me, saying, 
+\v 17 It came to pass in the twenty-seventh year, in the first month, in the first day of the month, Yahuah’s word came to me, saying, 
 \v 18 “Son of man, Nebuchadnezzar king of Babylon caused his army to serve a great service against Tyre. Every head was made bald, and every shoulder was worn; yet he had no wages, nor did his army, from Tyre, for the service that he had served against it. 
-\v 19 Therefore the Lord Yahweh says: ‘Behold, I will give the land of Egypt to Nebuchadnezzar king of Babylon. He will carry off her multitude, take her plunder, and take her prey. That will be the wages for his army. 
-\v 20 I have given him the land of Egypt as his payment for which he served, because they worked for me,’ says the Lord Yahweh. 
+\v 19 Therefore the Lord Yahuah says: ‘Behold, I will give the land of Egypt to Nebuchadnezzar king of Babylon. He will carry off her multitude, take her plunder, and take her prey. That will be the wages for his army. 
+\v 20 I have given him the land of Egypt as his payment for which he served, because they worked for me,’ says the Lord Yahuah. 
 \p
-\v 21 “In that day I will cause a horn to sprout for the house of Israel, and I will open your mouth among them. Then they will know that I am Yahweh.” 
+\v 21 “In that day I will cause a horn to sprout for the house of Israel, and I will open your mouth among them. Then they will know that I am Yahuah.” 
 \c 30
 \p
-\v 1 Yahweh’s word came again to me, saying, 
-\v 2 “Son of man, prophesy, and say, ‘The Lord Yahweh says: 
+\v 1 Yahuah’s word came again to me, saying, 
+\v 2 “Son of man, prophesy, and say, ‘The Lord Yahuah says: 
 \q1 “Wail, ‘Alas for the day!’ 
 \q2
 \v 3 For the day is near, 
-\q2 even Yahweh’s day is near. 
+\q2 even Yahuah’s day is near. 
 \q1 It will be a day of clouds, 
 \q2 a time of the nations. 
 \q1
@@ -1380,22 +1380,22 @@
 \p
 \v 5 “ ‘ “Ethiopia, Put, Lud, all the mixed people, Cub, and the children of the land that is allied with them, will fall with them by the sword.” 
 \p
-\v 6 “ ‘Yahweh says: 
+\v 6 “ ‘Yahuah says: 
 \q1 “They also who uphold Egypt will fall. 
 \q2 The pride of her power will come down. 
 \q1 They will fall by the sword in it from the tower of Seveneh,” 
-\q2 says the Lord Yahweh. 
+\q2 says the Lord Yahuah. 
 \q1
 \v 7 “They will be desolate in the middle of the countries that are desolate. 
 \q2 Her cities will be among the cities that are wasted. 
 \q1
-\v 8 They will know that I am Yahweh 
+\v 8 They will know that I am Yahuah 
 \q2 when I have set a fire in Egypt, 
 \q2 and all her helpers are destroyed. 
 \p
 \v 9 “ ‘ “In that day messengers will go out from before me in ships to make the careless Ethiopians afraid. There will be anguish on them, as in the day of Egypt; for, behold, it comes.” 
 \p
-\v 10 “ ‘The Lord Yahweh says: 
+\v 10 “ ‘The Lord Yahuah says: 
 \q1 “I will also make the multitude of Egypt to cease, 
 \q2 by the hand of Nebuchadnezzar king of Babylon. 
 \q1
@@ -1410,9 +1410,9 @@
 \q1 I will make the land desolate, 
 \q2 and all that is therein, 
 \q2 by the hand of foreigners. 
-\q2 I, Yahweh, have spoken it.” 
+\q2 I, Yahuah, have spoken it.” 
 \p
-\v 13 “ ‘The Lord Yahweh says: 
+\v 13 “ ‘The Lord Yahuah says: 
 \q1 “I will also destroy the idols, 
 \q2 and I will cause the images to cease from Memphis. 
 \q1 There will be no more a prince from the land of Egypt. 
@@ -1441,19 +1441,19 @@
 \q2 and her daughters will go into captivity. 
 \q1
 \v 19 Thus I will execute judgments on Egypt. 
-\q2 Then they will know that I am Yahweh.” ’ ” 
+\q2 Then they will know that I am Yahuah.” ’ ” 
 \b
 \p
-\v 20 In the eleventh year, in the first month, in the seventh day of the month, Yahweh’s word came to me, saying, 
+\v 20 In the eleventh year, in the first month, in the seventh day of the month, Yahuah’s word came to me, saying, 
 \v 21 “Son of man, I have broken the arm of Pharaoh king of Egypt. Behold, it has not been bound up, to apply medicines, to put a bandage to bind it, that it may become strong to hold the sword. 
-\v 22 Therefore the Lord Yahweh says: ‘Behold, I am against Pharaoh king of Egypt, and will break his arms, the strong arm, and that which was broken. I will cause the sword to fall out of his hand. 
+\v 22 Therefore the Lord Yahuah says: ‘Behold, I am against Pharaoh king of Egypt, and will break his arms, the strong arm, and that which was broken. I will cause the sword to fall out of his hand. 
 \v 23 I will scatter the Egyptians among the nations, and will disperse them through the countries. 
 \v 24 I will strengthen the arms of the king of Babylon, and put my sword in his hand; but I will break the arms of Pharaoh, and he will groan before the king of Babylon with the groaning of a mortally wounded man. 
-\v 25 I will hold up the arms of the king of Babylon, but the arms of Pharaoh will fall down. Then they will know that I am Yahweh when I put my sword into the hand of the king of Babylon, and he stretches it out on the land of Egypt. 
-\v 26 I will scatter the Egyptians among the nations and disperse them through the countries. Then they will know that I am Yahweh.’ ” 
+\v 25 I will hold up the arms of the king of Babylon, but the arms of Pharaoh will fall down. Then they will know that I am Yahuah when I put my sword into the hand of the king of Babylon, and he stretches it out on the land of Egypt. 
+\v 26 I will scatter the Egyptians among the nations and disperse them through the countries. Then they will know that I am Yahuah.’ ” 
 \c 31
 \p
-\v 1 In the eleventh year, in the third month, in the first day of the month, Yahweh’s word came to me, saying, 
+\v 1 In the eleventh year, in the third month, in the first day of the month, Yahuah’s word came to me, saying, 
 \v 2 “Son of man, tell Pharaoh king of Egypt and his multitude: 
 \q1 ‘Whom are you like in your greatness? 
 \q1
@@ -1490,21 +1490,21 @@
 \q2 so that all the trees of Eden, 
 \q2 that were in the garden of Elohim, envied it.’ 
 \p
-\v 10 “Therefore thus said the Lord Yahweh: ‘Because he is exalted in stature, and he has set his top among the thick branches, and his heart is lifted up in his height, 
+\v 10 “Therefore thus said the Lord Yahuah: ‘Because he is exalted in stature, and he has set his top among the thick branches, and his heart is lifted up in his height, 
 \v 11 I will deliver him into the hand of the mighty one of the nations. He will surely deal with him. I have driven him out for his wickedness. 
 \v 12 Foreigners, the tyrants of the nations, have cut him off and have left him. His branches have fallen on the mountains and in all the valleys, and his boughs are broken by all the watercourses of the land. All the peoples of the earth have gone down from his shadow and have left him. 
 \v 13 All the birds of the sky will dwell on his ruin, and all the animals of the field will be on his branches, 
 \v 14 to the end that none of all the trees by the waters exalt themselves in their stature, and don’t set their top among the thick boughs. Their mighty ones don’t stand up on their height, even all who drink water; for they are all delivered to death, to the lower parts of the earth, among the children of men, with those who go down to the pit.’ 
 \p
-\v 15 “The Lord Yahweh says: ‘In the day when he went down to Sheol, I caused a mourning. I covered the deep for him, and I restrained its rivers. The great waters were stopped. I caused Lebanon to mourn for him, and all the trees of the field fainted for him. 
+\v 15 “The Lord Yahuah says: ‘In the day when he went down to Sheol, I caused a mourning. I covered the deep for him, and I restrained its rivers. The great waters were stopped. I caused Lebanon to mourn for him, and all the trees of the field fainted for him. 
 \v 16 I made the nations to shake at the sound of his fall, when I cast him down to Sheol with those who descend into the pit. All the trees of Eden, the choice and best of Lebanon, all that drink water, were comforted in the lower parts of the earth. 
 \v 17 They also went down into Sheol with him to those who are slain by the sword; yes, those who were his arm, who lived under his shadow in the middle of the nations. 
 \p
 \v 18 “ ‘To whom are you thus like in glory and in greatness among the trees of Eden? Yet you will be brought down with the trees of Eden to the lower parts of the earth. You will lie in the middle of the uncircumcised, with those who are slain by the sword. 
-\p “ ‘This is Pharaoh and all his multitude,’ says the Lord Yahweh.” 
+\p “ ‘This is Pharaoh and all his multitude,’ says the Lord Yahuah.” 
 \c 32
 \p
-\v 1 In the twelfth year, in the twelfth month, in the first day of the month, “Yahweh’s word came to me, saying, 
+\v 1 In the twelfth year, in the twelfth month, in the first day of the month, “Yahuah’s word came to me, saying, 
 \v 2 ‘Son of man, take up a lamentation over Pharaoh king of Egypt, and tell him, 
 \q1 “You were likened to a young lion of the nations; 
 \q2 yet you are as a monster in the seas. 
@@ -1512,7 +1512,7 @@
 \q2 and troubled the waters with your feet, 
 \q2 and fouled their rivers.” 
 \q1
-\v 3 The Lord Yahweh says: 
+\v 3 The Lord Yahuah says: 
 \q2 “I will spread out my net on you with a company of many peoples. 
 \q2 They will bring you up in my net. 
 \q1
@@ -1534,7 +1534,7 @@
 \q2 and the moon won’t give its light. 
 \q1
 \v 8 I will make all the bright lights of the sky dark over you, 
-\q2 and set darkness on your land,” says the Lord Yahweh. 
+\q2 and set darkness on your land,” says the Lord Yahuah. 
 \q1
 \v 9 “I will also trouble the hearts of many peoples, 
 \q2 when I bring your destruction among the nations, 
@@ -1547,7 +1547,7 @@
 \q1 every man for his own life, 
 \q2 in the day of your fall.” 
 \q1
-\v 11 For the Lord Yahweh says: 
+\v 11 For the Lord Yahuah says: 
 \q2 “The sword of the king of Babylon will come on you. 
 \q1
 \v 12 I will cause your multitude to fall by the swords of the mighty. 
@@ -1561,17 +1561,17 @@
 \q1
 \v 14 Then I will make their waters clear, 
 \q2 and cause their rivers to run like oil,” 
-\q2 says the Lord Yahweh. 
+\q2 says the Lord Yahuah. 
 \q1
 \v 15 “When I make the land of Egypt desolate and waste, 
 \q2 a land destitute of that of which it was full, 
 \q1 when I strike all those who dwell therein, 
-\q2 then they will know that I am Yahweh. 
+\q2 then they will know that I am Yahuah. 
 \p
-\v 16 “ ‘ “This is the lamentation with which they will lament. The daughters of the nations will lament with this. They will lament with it over Egypt, and over all her multitude,” says the Lord Yahweh.’ ” 
+\v 16 “ ‘ “This is the lamentation with which they will lament. The daughters of the nations will lament with this. They will lament with it over Egypt, and over all her multitude,” says the Lord Yahuah.’ ” 
 \b
 \p
-\v 17 Also in the twelfth year, in the fifteenth day of the month, Yahweh’s word came to me, saying, 
+\v 17 Also in the twelfth year, in the fifteenth day of the month, Yahuah’s word came to me, saying, 
 \v 18 “Son of man, wail for the multitude of Egypt, and cast them down, even her and the daughters of the famous nations, to the lower parts of the earth, with those who go down into the pit. 
 \v 19 Whom do you pass in beauty? Go down, and be laid with the uncircumcised. 
 \v 20 They will fall among those who are slain by the sword. She is delivered to the sword. Draw her away with all her multitudes. 
@@ -1592,11 +1592,11 @@
 \p
 \v 30 “There are the princes of the north, all of them, and all the Sidonians, who have gone down with the slain. They are put to shame in the terror which they caused by their might. They lie uncircumcised with those who are slain by the sword, and bear their shame with those who go down to the pit. 
 \p
-\v 31 “Pharaoh will see them and will be comforted over all his multitude, even Pharaoh and all his army, slain by the sword,” says the Lord Yahweh. 
-\v 32 “For I have put his terror in the land of the living. He will be laid among the uncircumcised, with those who are slain by the sword, even Pharaoh and all his multitude,” says the Lord Yahweh. 
+\v 31 “Pharaoh will see them and will be comforted over all his multitude, even Pharaoh and all his army, slain by the sword,” says the Lord Yahuah. 
+\v 32 “For I have put his terror in the land of the living. He will be laid among the uncircumcised, with those who are slain by the sword, even Pharaoh and all his multitude,” says the Lord Yahuah. 
 \c 33
 \p
-\v 1 Yahweh’s word came to me, saying, 
+\v 1 Yahuah’s word came to me, saying, 
 \v 2 “Son of man, speak to the children of your people, and tell them, ‘When I bring the sword on a land, and the people of the land take a man from among them, and set him for their watchman, 
 \v 3 if, when he sees the sword come on the land, he blows the trumpet and warns the people, 
 \v 4 then whoever hears the sound of the trumpet and doesn’t heed the warning, if the sword comes and takes him away, his blood will be on his own head. 
@@ -1608,7 +1608,7 @@
 \v 9 Nevertheless, if you warn the wicked of his way to turn from it, and he doesn’t turn from his way; he will die in his iniquity, but you have delivered your soul. 
 \p
 \v 10 “You, son of man, tell the house of Israel: ‘You say this, “Our transgressions and our sins are on us, and we pine away in them. How then can we live?” ’ 
-\v 11 Tell them, ‘ “As I live,” says the Lord Yahweh, “I have no pleasure in the death of the wicked, but that the wicked turn from his way and live. Turn, turn from your evil ways! For why will you die, house of Israel?” ’ 
+\v 11 Tell them, ‘ “As I live,” says the Lord Yahuah, “I have no pleasure in the death of the wicked, but that the wicked turn from his way and live. Turn, turn from your evil ways! For why will you die, house of Israel?” ’ 
 \p
 \v 12 “You, son of man, tell the children of your people, ‘The righteousness of the righteous will not deliver him in the day of his disobedience. And as for the wickedness of the wicked, he will not fall by it in the day that he turns from his wickedness; neither will he who is righteous be able to live by it in the day that he sins. 
 \v 13 When I tell the righteous that he will surely live, if he trusts in his righteousness and commits iniquity, none of his righteous deeds will be remembered; but he will die in his iniquity that he has committed. 
@@ -1623,108 +1623,108 @@
 \b
 \p
 \v 21 In the twelfth year of our captivity, in the tenth month, in the fifth day of the month, one who had escaped out of Jerusalem came to me, saying, “The city has been defeated!” 
-\v 22 Now Yahweh’s hand had been on me in the evening, before he who had escaped came; and he had opened my mouth until he came to me in the morning; and my mouth was opened, and I was no longer mute. 
+\v 22 Now Yahuah’s hand had been on me in the evening, before he who had escaped came; and he had opened my mouth until he came to me in the morning; and my mouth was opened, and I was no longer mute. 
 \p
-\v 23 Yahweh’s word came to me, saying, 
+\v 23 Yahuah’s word came to me, saying, 
 \v 24 “Son of man, those who inhabit the waste places in the land of Israel speak, saying, ‘Abraham was one, and he inherited the land; but we are many. The land is given us for inheritance.’ 
-\v 25 Therefore tell them, ‘The Lord Yahweh says: “You eat with the blood, and lift up your eyes to your idols, and shed blood. So should you possess the land? 
+\v 25 Therefore tell them, ‘The Lord Yahuah says: “You eat with the blood, and lift up your eyes to your idols, and shed blood. So should you possess the land? 
 \v 26 You stand on your sword, you work abomination, and every one of you defiles his neighbor’s woman. So should you possess the land?” ’ 
 \p
-\v 27 “You shall tell them, ‘The Lord Yahweh says: “As I live, surely those who are in the waste places will fall by the sword. I will give whoever is in the open field to the animals to be devoured, and those who are in the strongholds and in the caves will die of the pestilence. 
+\v 27 “You shall tell them, ‘The Lord Yahuah says: “As I live, surely those who are in the waste places will fall by the sword. I will give whoever is in the open field to the animals to be devoured, and those who are in the strongholds and in the caves will die of the pestilence. 
 \v 28 I will make the land a desolation and an astonishment. The pride of her power will cease. The mountains of Israel will be desolate, so that no one will pass through. 
-\v 29 Then they will know that I am Yahweh, when I have made the land a desolation and an astonishment because of all their abominations which they have committed.” ’ 
+\v 29 Then they will know that I am Yahuah, when I have made the land a desolation and an astonishment because of all their abominations which they have committed.” ’ 
 \p
-\v 30 “As for you, son of man, the children of your people talk about you by the walls and in the doors of the houses, and speak to one another, everyone to his brother, saying, ‘Please come and hear what the word is that comes out from Yahweh.’ 
+\v 30 “As for you, son of man, the children of your people talk about you by the walls and in the doors of the houses, and speak to one another, everyone to his brother, saying, ‘Please come and hear what the word is that comes out from Yahuah.’ 
 \v 31 They come to you as the people come, and they sit before you as my people, and they hear your words, but don’t do them; for with their mouth they show much love, but their heart goes after their gain. 
 \v 32 Behold, you are to them as a very lovely song of one who has a pleasant voice, and can play well on an instrument; for they hear your words, but they don’t do them. 
 \p
 \v 33 “When this comes to pass—behold, it comes—then they will know that a prophet has been among them.” 
 \c 34
 \p
-\v 1 Yahweh’s word came to me, saying, 
-\v 2 “Son of man, prophesy against the shepherds of Israel. Prophesy, and tell them, even the shepherds, ‘The Lord Yahweh says: “Woe to the shepherds of Israel who feed themselves! Shouldn’t the shepherds feed the sheep? 
+\v 1 Yahuah’s word came to me, saying, 
+\v 2 “Son of man, prophesy against the shepherds of Israel. Prophesy, and tell them, even the shepherds, ‘The Lord Yahuah says: “Woe to the shepherds of Israel who feed themselves! Shouldn’t the shepherds feed the sheep? 
 \v 3 You eat the fat. You clothe yourself with the wool. You kill the fatlings, but you don’t feed the sheep. 
 \v 4 You haven’t strengthened the diseased. You haven’t healed that which was sick. You haven’t bound up that which was broken. You haven’t brought back that which was driven away. You haven’t sought that which was lost, but you have ruled over them with force and with rigor. 
 \v 5 They were scattered, because there was no shepherd. They became food to all the animals of the field, and were scattered. 
 \v 6 My sheep wandered through all the mountains and on every high hill. Yes, my sheep were scattered on all the surface of the earth. There was no one who searched or sought.” 
 \p
-\v 7 “ ‘Therefore, you shepherds, hear Yahweh’s word: 
-\v 8 “As I live,” says the Lord Yahweh, “surely because my sheep became a prey, and my sheep became food to all the animals of the field, because there was no shepherd, and my shepherds didn’t search for my sheep, but the shepherds fed themselves, and didn’t feed my sheep, 
-\v 9 therefore, you shepherds, hear Yahweh’s word!” 
-\v 10 The Lord Yahweh says: “Behold, I am against the shepherds. I will require my sheep at their hand, and cause them to cease from feeding the sheep. The shepherds won’t feed themselves any more. I will deliver my sheep from their mouth, that they may not be food for them.” 
+\v 7 “ ‘Therefore, you shepherds, hear Yahuah’s word: 
+\v 8 “As I live,” says the Lord Yahuah, “surely because my sheep became a prey, and my sheep became food to all the animals of the field, because there was no shepherd, and my shepherds didn’t search for my sheep, but the shepherds fed themselves, and didn’t feed my sheep, 
+\v 9 therefore, you shepherds, hear Yahuah’s word!” 
+\v 10 The Lord Yahuah says: “Behold, I am against the shepherds. I will require my sheep at their hand, and cause them to cease from feeding the sheep. The shepherds won’t feed themselves any more. I will deliver my sheep from their mouth, that they may not be food for them.” 
 \p
-\v 11 “ ‘For the Lord Yahweh says: “Behold, I myself, even I, will search for my sheep, and will seek them out. 
+\v 11 “ ‘For the Lord Yahuah says: “Behold, I myself, even I, will search for my sheep, and will seek them out. 
 \v 12 As a shepherd seeks out his flock in the day that he is among his sheep that are scattered abroad, so I will seek out my sheep. I will deliver them out of all places where they have been scattered in the cloudy and dark day. 
 \v 13 I will bring them out from the peoples, and gather them from the countries, and will bring them into their own land. I will feed them on the mountains of Israel, by the watercourses, and in all the inhabited places of the country. 
 \v 14 I will feed them with good pasture, and their fold will be on the mountains of the height of Israel. There they will lie down in a good fold. They will feed on rich pasture on the mountains of Israel. 
-\v 15 I myself will be the shepherd of my sheep, and I will cause them to lie down,” says the Lord Yahweh. 
+\v 15 I myself will be the shepherd of my sheep, and I will cause them to lie down,” says the Lord Yahuah. 
 \v 16 “I will seek that which was lost, and will bring back that which was driven away, and will bind up that which was broken, and will strengthen that which was sick; but I will destroy the fat and the strong. I will feed them in justice.” ’ 
 \p
-\v 17 “As for you, O my flock, the Lord Yahweh says: ‘Behold, I judge between sheep and sheep, the rams and the male goats. 
+\v 17 “As for you, O my flock, the Lord Yahuah says: ‘Behold, I judge between sheep and sheep, the rams and the male goats. 
 \v 18 Does it seem a small thing to you to have fed on the good pasture, but you must tread down with your feet the residue of your pasture? And to have drunk of the clear waters, but must you foul the residue with your feet? 
 \v 19 As for my sheep, they eat that which you have trodden with your feet, and they drink that which you have fouled with your feet.’ 
 \p
-\v 20 “Therefore the Lord Yahweh says to them: ‘Behold, I, even I, will judge between the fat sheep and the lean sheep. 
+\v 20 “Therefore the Lord Yahuah says to them: ‘Behold, I, even I, will judge between the fat sheep and the lean sheep. 
 \v 21 Because you thrust with side and with shoulder, and push all the diseased with your horns, until you have scattered them abroad, 
 \v 22 therefore I will save my flock, and they will no more be a prey. I will judge between sheep and sheep. 
 \v 23 I will set up one shepherd over them, and he will feed them, even my servant David. He will feed them, and he will be their shepherd. 
-\v 24 I, Yahweh, will be their Elohim, and my servant David prince among them. I, Yahweh, have spoken it. 
+\v 24 I, Yahuah, will be their Elohim, and my servant David prince among them. I, Yahuah, have spoken it. 
 \p
 \v 25 “ ‘I will make with them a covenant of peace, and will cause evil animals to cease out of the land. They will dwell securely in the wilderness and sleep in the woods. 
 \v 26 I will make them and the places around my hill a blessing. I will cause the shower to come down in its season. There will be showers of blessing. 
-\v 27 The tree of the field will yield its fruit, and the earth will yield its increase, and they will be secure in their land. Then they will know that I am Yahweh, when I have broken the bars of their yoke, and have delivered them out of the hand of those who made slaves of them. 
+\v 27 The tree of the field will yield its fruit, and the earth will yield its increase, and they will be secure in their land. Then they will know that I am Yahuah, when I have broken the bars of their yoke, and have delivered them out of the hand of those who made slaves of them. 
 \v 28 They will no more be a prey to the nations, neither will the animals of the earth devour them; but they will dwell securely, and no one will make them afraid. 
 \v 29 I will raise up to them a plantation for renown, and they will no more be consumed with famine in the land, and not bear the shame of the nations any more. 
-\v 30 They will know that I, Yahweh, their Elohim am with them, and that they, the house of Israel, are my people, says the Lord Yahweh. 
-\v 31 You my sheep, the sheep of my pasture, are men, and I am your Elohim,’ says the Lord Yahweh.” 
+\v 30 They will know that I, Yahuah, their Elohim am with them, and that they, the house of Israel, are my people, says the Lord Yahuah. 
+\v 31 You my sheep, the sheep of my pasture, are men, and I am your Elohim,’ says the Lord Yahuah.” 
 \c 35
 \p
-\v 1 Moreover Yahweh’s word came to me, saying, 
+\v 1 Moreover Yahuah’s word came to me, saying, 
 \v 2 “Son of man, set your face against Mount Seir, and prophesy against it, 
-\v 3 and tell it, ‘The Lord Yahweh says: “Behold, I am against you, Mount Seir, and I will stretch out my hand against you. I will make you a desolation and an astonishment. 
-\v 4 I will lay your cities waste, and you will be desolate. Then you will know that I am Yahweh. 
+\v 3 and tell it, ‘The Lord Yahuah says: “Behold, I am against you, Mount Seir, and I will stretch out my hand against you. I will make you a desolation and an astonishment. 
+\v 4 I will lay your cities waste, and you will be desolate. Then you will know that I am Yahuah. 
 \p
 \v 5 “ ‘ “Because you have had a perpetual hostility, and have given over the children of Israel to the power of the sword in the time of their calamity, in the time of the iniquity of the end, 
-\v 6 therefore, as I live,” says the Lord Yahweh, “I will prepare you for blood, and blood will pursue you. Since you have not hated blood, therefore blood will pursue you. 
+\v 6 therefore, as I live,” says the Lord Yahuah, “I will prepare you for blood, and blood will pursue you. Since you have not hated blood, therefore blood will pursue you. 
 \v 7 Thus I will make Mount Seir an astonishment and a desolation. I will cut off from it him who passes through and him who returns. 
 \v 8 I will fill its mountains with its slain. The slain with the sword will fall in your hills and in your valleys and in all your watercourses. 
-\v 9 I will make you a perpetual desolation, and your cities will not be inhabited. Then you will know that I am Yahweh. 
+\v 9 I will make you a perpetual desolation, and your cities will not be inhabited. Then you will know that I am Yahuah. 
 \p
-\v 10 “ ‘ “Because you have said, ‘These two nations and these two countries will be mine, and we will possess it,’ although Yahweh was there, 
-\v 11 therefore, as I live,” says the Lord Yahweh, “I will do according to your anger, and according to your envy which you have shown out of your hatred against them; and I will make myself known among them when I judge you. 
-\v 12 You will know that I, Yahweh, have heard all your insults which you have spoken against the mountains of Israel, saying, ‘They have been laid desolate. They have been given to us to devour.’ 
+\v 10 “ ‘ “Because you have said, ‘These two nations and these two countries will be mine, and we will possess it,’ although Yahuah was there, 
+\v 11 therefore, as I live,” says the Lord Yahuah, “I will do according to your anger, and according to your envy which you have shown out of your hatred against them; and I will make myself known among them when I judge you. 
+\v 12 You will know that I, Yahuah, have heard all your insults which you have spoken against the mountains of Israel, saying, ‘They have been laid desolate. They have been given to us to devour.’ 
 \v 13 You have magnified yourselves against me with your mouth, and have multiplied your words against me. I have heard it.” 
-\v 14 The Lord Yahweh says: “When the whole earth rejoices, I will make you desolate. 
-\v 15 As you rejoiced over the inheritance of the house of Israel because it was desolate, so I will do to you. You will be desolate, Mount Seir, and all Edom, even all of it. Then they will know that I am Yahweh.’ ” 
+\v 14 The Lord Yahuah says: “When the whole earth rejoices, I will make you desolate. 
+\v 15 As you rejoiced over the inheritance of the house of Israel because it was desolate, so I will do to you. You will be desolate, Mount Seir, and all Edom, even all of it. Then they will know that I am Yahuah.’ ” 
 \c 36
 \p
-\v 1 You, son of man, prophesy to the mountains of Israel, and say, “You mountains of Israel, hear Yahweh’s word. 
-\v 2 The Lord Yahweh says: ‘Because the enemy has said against you, “Aha!” and, “The ancient high places are ours in possession!” ’ 
-\v 3 therefore prophesy, and say, ‘The Lord Yahweh says: “Because, even because they have made you desolate, and swallowed you up on every side, that you might be a possession to the residue of the nations, and you are taken up in the lips of talkers, and the evil report of the people;” 
-\v 4 therefore, you mountains of Israel, hear the word of the Lord Yahweh: The Lord Yahweh says to the mountains and to the hills, to the watercourses and to the valleys, to the desolate wastes and to the cities that are forsaken, which have become a prey and derision to the residue of the nations that are all around; 
-\v 5 therefore the Lord Yahweh says: “Surely in the fire of my jealousy I have spoken against the residue of the nations, and against all Edom, that have appointed my land to themselves for a possession with the joy of all their heart, with despite of soul, to cast it out for a prey.” ’ 
-\v 6 Therefore prophesy concerning the land of Israel, and tell the mountains, the hills, the watercourses and the valleys, ‘The Lord Yahweh says: “Behold, I have spoken in my jealousy and in my wrath, because you have borne the shame of the nations.” 
-\v 7 Therefore the Lord Yahweh says: “I have sworn, ‘Surely the nations that are around you will bear their shame.’ 
+\v 1 You, son of man, prophesy to the mountains of Israel, and say, “You mountains of Israel, hear Yahuah’s word. 
+\v 2 The Lord Yahuah says: ‘Because the enemy has said against you, “Aha!” and, “The ancient high places are ours in possession!” ’ 
+\v 3 therefore prophesy, and say, ‘The Lord Yahuah says: “Because, even because they have made you desolate, and swallowed you up on every side, that you might be a possession to the residue of the nations, and you are taken up in the lips of talkers, and the evil report of the people;” 
+\v 4 therefore, you mountains of Israel, hear the word of the Lord Yahuah: The Lord Yahuah says to the mountains and to the hills, to the watercourses and to the valleys, to the desolate wastes and to the cities that are forsaken, which have become a prey and derision to the residue of the nations that are all around; 
+\v 5 therefore the Lord Yahuah says: “Surely in the fire of my jealousy I have spoken against the residue of the nations, and against all Edom, that have appointed my land to themselves for a possession with the joy of all their heart, with despite of soul, to cast it out for a prey.” ’ 
+\v 6 Therefore prophesy concerning the land of Israel, and tell the mountains, the hills, the watercourses and the valleys, ‘The Lord Yahuah says: “Behold, I have spoken in my jealousy and in my wrath, because you have borne the shame of the nations.” 
+\v 7 Therefore the Lord Yahuah says: “I have sworn, ‘Surely the nations that are around you will bear their shame.’ 
 \p
 \v 8 “ ‘ “But you, mountains of Israel, you shall shoot out your branches and yield your fruit to my people Israel; for they are at hand to come. 
 \v 9 For, behold, I am for you, and I will come to you, and you will be tilled and sown. 
 \v 10 I will multiply men on you, all the house of Israel, even all of it. The cities will be inhabited and the waste places will be built. 
-\v 11 I will multiply man and animal on you. They will increase and be fruitful. I will cause you to be inhabited as you were before, and you will do better than at your beginnings. Then you will know that I am Yahweh. 
+\v 11 I will multiply man and animal on you. They will increase and be fruitful. I will cause you to be inhabited as you were before, and you will do better than at your beginnings. Then you will know that I am Yahuah. 
 \v 12 Yes, I will cause men to walk on you, even my people Israel. They will possess you, and you will be their inheritance, and you will never again bereave them of their children.” 
 \p
-\v 13 “ ‘The Lord Yahweh says: “Because they say to you, ‘You are a devourer of men, and have been a bereaver of your nation;’ 
-\v 14 therefore you shall devour men no more, and not bereave your nation any more,” says the Lord Yahweh. 
-\v 15 “I won’t let you hear the shame of the nations any more. You won’t bear the reproach of the peoples any more, and you won’t cause your nation to stumble any more,” says the Lord Yahweh.’ ” 
+\v 13 “ ‘The Lord Yahuah says: “Because they say to you, ‘You are a devourer of men, and have been a bereaver of your nation;’ 
+\v 14 therefore you shall devour men no more, and not bereave your nation any more,” says the Lord Yahuah. 
+\v 15 “I won’t let you hear the shame of the nations any more. You won’t bear the reproach of the peoples any more, and you won’t cause your nation to stumble any more,” says the Lord Yahuah.’ ” 
 \p
-\v 16 Moreover Yahweh’s word came to me, saying, 
+\v 16 Moreover Yahuah’s word came to me, saying, 
 \v 17 “Son of man, when the house of Israel lived in their own land, they defiled it by their ways and by their deeds. Their way before me was as the uncleanness of a woman in her impurity. 
 \v 18 Therefore I poured out my wrath on them for the blood which they had poured out on the land, and because they had defiled it with their idols. 
 \v 19 I scattered them among the nations, and they were dispersed through the countries. I judged them according to their way and according to their deeds. 
-\v 20 When they came to the nations where they went, they profaned my set-apart name, in that men said of them, ‘These are Yahweh’s people, and have left his land.’ 
+\v 20 When they came to the nations where they went, they profaned my set-apart name, in that men said of them, ‘These are Yahuah’s people, and have left his land.’ 
 \v 21 But I had respect for my set-apart name, which the house of Israel had profaned among the nations where they went. 
 \p
-\v 22 “Therefore tell the house of Israel, ‘The Lord Yahweh says: “I don’t do this for your sake, house of Israel, but for my set-apart name, which you have profaned among the nations where you went. 
-\v 23 I will sanctify my great name, which has been profaned among the nations, which you have profaned among them. Then the nations will know that I am Yahweh,” says the Lord Yahweh, “when I am proven set-apart in you before their eyes. 
+\v 22 “Therefore tell the house of Israel, ‘The Lord Yahuah says: “I don’t do this for your sake, house of Israel, but for my set-apart name, which you have profaned among the nations where you went. 
+\v 23 I will sanctify my great name, which has been profaned among the nations, which you have profaned among them. Then the nations will know that I am Yahuah,” says the Lord Yahuah, “when I am proven set-apart in you before their eyes. 
 \p
 \v 24 “ ‘ “For I will take you from among the nations and gather you out of all the countries, and will bring you into your own land. 
 \v 25 I will sprinkle clean water on you, and you will be clean. I will cleanse you from all your filthiness and from all your idols. 
@@ -1735,47 +1735,47 @@
 \v 30 I will multiply the fruit of the tree and the increase of the field, that you may receive no more the reproach of famine among the nations. 
 \p
 \v 31 “ ‘ “Then you will remember your evil ways, and your deeds that were not good; and you will loathe yourselves in your own sight for your iniquities and for your abominations. 
-\v 32 I don’t do this for your sake,” says the Lord Yahweh. “Let it be known to you. Be ashamed and confounded for your ways, house of Israel.” 
+\v 32 I don’t do this for your sake,” says the Lord Yahuah. “Let it be known to you. Be ashamed and confounded for your ways, house of Israel.” 
 \p
-\v 33 “ ‘The Lord Yahweh says: “In the day that I cleanse you from all your iniquities, I will cause the cities to be inhabited and the waste places will be built. 
+\v 33 “ ‘The Lord Yahuah says: “In the day that I cleanse you from all your iniquities, I will cause the cities to be inhabited and the waste places will be built. 
 \v 34 The land that was desolate will be tilled instead of being a desolation in the sight of all who passed by. 
 \v 35 They will say, ‘This land that was desolate has become like the garden of Eden. The waste, desolate, and ruined cities are fortified and inhabited.’ 
-\v 36 Then the nations that are left around you will know that I, Yahweh, have built the ruined places and planted that which was desolate. I, Yahweh, have spoken it, and I will do it.” 
+\v 36 Then the nations that are left around you will know that I, Yahuah, have built the ruined places and planted that which was desolate. I, Yahuah, have spoken it, and I will do it.” 
 \p
-\v 37 “ ‘The Lord Yahweh says: “For this, moreover, I will be inquired of by the house of Israel, to do it for them: I will increase them with men like a flock. 
-\v 38 As the flock for sacrifice, as the flock of Jerusalem in her appointed feasts, so the waste cities will be filled with flocks of men. Then they will know that I am Yahweh.’ ” 
+\v 37 “ ‘The Lord Yahuah says: “For this, moreover, I will be inquired of by the house of Israel, to do it for them: I will increase them with men like a flock. 
+\v 38 As the flock for sacrifice, as the flock of Jerusalem in her appointed feasts, so the waste cities will be filled with flocks of men. Then they will know that I am Yahuah.’ ” 
 \c 37
 \p
-\v 1 Yahweh’s hand was on me, and he brought me out in Yahweh’s Spirit, and set me down in the middle of the valley; and it was full of bones. 
+\v 1 Yahuah’s hand was on me, and he brought me out in Yahuah’s Spirit, and set me down in the middle of the valley; and it was full of bones. 
 \v 2 He caused me to pass by them all around; and behold, there were very many in the open valley, and behold, they were very dry. 
 \v 3 He said to me, “Son of man, can these bones live?” 
-\p I answered, “Lord Yahweh, you know.” 
+\p I answered, “Lord Yahuah, you know.” 
 \p
-\v 4 Again he said to me, “Prophesy over these bones, and tell them, ‘You dry bones, hear Yahweh’s word. 
-\v 5 The Lord Yahweh says to these bones: “Behold, I will cause breath to enter into you, and you will live. 
-\v 6 I will lay sinews on you, and will bring up flesh on you, and cover you with skin, and put breath in you, and you will live. Then you will know that I am Yahweh.” ’ ” 
+\v 4 Again he said to me, “Prophesy over these bones, and tell them, ‘You dry bones, hear Yahuah’s word. 
+\v 5 The Lord Yahuah says to these bones: “Behold, I will cause breath to enter into you, and you will live. 
+\v 6 I will lay sinews on you, and will bring up flesh on you, and cover you with skin, and put breath in you, and you will live. Then you will know that I am Yahuah.” ’ ” 
 \p
 \v 7 So I prophesied as I was commanded. As I prophesied, there was a noise, and behold, there was an earthquake. Then the bones came together, bone to its bone. 
 \v 8 I saw, and, behold, there were sinews on them, and flesh came up, and skin covered them above; but there was no breath in them. 
 \p
-\v 9 Then he said to me, “Prophesy to the wind, prophesy, son of man, and tell the wind, ‘The Lord Yahweh says: “Come from the four winds, breath, and breathe on these slain, that they may live.” ’ ” 
+\v 9 Then he said to me, “Prophesy to the wind, prophesy, son of man, and tell the wind, ‘The Lord Yahuah says: “Come from the four winds, breath, and breathe on these slain, that they may live.” ’ ” 
 \p
 \v 10 So I prophesied as he commanded me, and the breath came into them, and they lived, and stood up on their feet, an exceedingly great army. 
 \p
 \v 11 Then he said to me, “Son of man, these bones are the whole house of Israel. Behold, they say, ‘Our bones are dried up, and our hope is lost. We are completely cut off.’ 
-\v 12 Therefore prophesy, and tell them, ‘The Lord Yahweh says: “Behold, I will open your graves, and cause you to come up out of your graves, my people; and I will bring you into the land of Israel. 
-\v 13 You will know that I am Yahweh, when I have opened your graves and caused you to come up out of your graves, my people. 
-\v 14 I will put my Spirit in you, and you will live. Then I will place you in your own land; and you will know that I, Yahweh, have spoken it and performed it,” says Yahweh.’ ” 
+\v 12 Therefore prophesy, and tell them, ‘The Lord Yahuah says: “Behold, I will open your graves, and cause you to come up out of your graves, my people; and I will bring you into the land of Israel. 
+\v 13 You will know that I am Yahuah, when I have opened your graves and caused you to come up out of your graves, my people. 
+\v 14 I will put my Spirit in you, and you will live. Then I will place you in your own land; and you will know that I, Yahuah, have spoken it and performed it,” says Yahuah.’ ” 
 \b
 \p
-\v 15 Yahweh’s word came again to me, saying, 
+\v 15 Yahuah’s word came again to me, saying, 
 \v 16 “You, son of man, take one stick and write on it, ‘For Judah, and for the children of Israel his companions.’ Then take another stick, and write on it, ‘For Joseph, the stick of Ephraim, and for all the house of Israel his companions.’ 
 \v 17 Then join them for yourself to one another into one stick, that they may become one in your hand. 
 \p
 \v 18 “When the children of your people speak to you, saying, ‘Won’t you show us what you mean by these?’ 
-\v 19 tell them, ‘The Lord Yahweh says: “Behold, I will take the stick of Joseph, which is in the hand of Ephraim, and the tribes of Israel his companions; and I will put them with it, with the stick of Judah, and make them one stick, and they will be one in my hand. 
+\v 19 tell them, ‘The Lord Yahuah says: “Behold, I will take the stick of Joseph, which is in the hand of Ephraim, and the tribes of Israel his companions; and I will put them with it, with the stick of Judah, and make them one stick, and they will be one in my hand. 
 \v 20 The sticks on which you write will be in your hand before their eyes.” ’ 
-\v 21 Say to them, ‘The Lord Yahweh says: “Behold, I will take the children of Israel from among the nations where they have gone, and will gather them on every side, and bring them into their own land. 
+\v 21 Say to them, ‘The Lord Yahuah says: “Behold, I will take the children of Israel from among the nations where they have gone, and will gather them on every side, and bring them into their own land. 
 \v 22 I will make them one nation in the land, on the mountains of Israel. One king will be king to them all. They will no longer be two nations. They won’t be divided into two kingdoms any more at all. 
 \v 23 They won’t defile themselves any more with their idols, nor with their detestable things, nor with any of their transgressions; but I will save them out of all their dwelling places in which they have sinned, and will cleanse them. So they will be my people, and I will be their Elohim. 
 \p
@@ -1783,12 +1783,12 @@
 \v 25 They will dwell in the land that I have given to Jacob my servant, in which your fathers lived. They will dwell therein, they, and their children, and their children’s children, forever. David my servant will be their prince forever. 
 \v 26 Moreover I will make a covenant of peace with them. It will be an everlasting covenant with them. I will place them, multiply them, and will set my sanctuary among them forever more. 
 \v 27 My tent also will be with them. I will be their Elohim, and they will be my people. 
-\v 28 The nations will know that I am Yahweh who sanctifies Israel, when my sanctuary is among them forever more.” ’ ” 
+\v 28 The nations will know that I am Yahuah who sanctifies Israel, when my sanctuary is among them forever more.” ’ ” 
 \c 38
 \p
-\v 1 Yahweh’s word came to me, saying, 
+\v 1 Yahuah’s word came to me, saying, 
 \v 2 “Son of man, set your face toward Gog, of the land of Magog, the prince of Rosh, Meshech, and Tubal, and prophesy against him, 
-\v 3 and say, ‘The Lord Yahweh says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
+\v 3 and say, ‘The Lord Yahuah says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
 \v 4 I will turn you around, and put hooks into your jaws, and I will bring you out, with all your army, horses and horsemen, all of them clothed in full armor, a great company with buckler and shield, all of them handling swords; 
 \v 5 Persia, Cush, and Put with them, all of them with shield and helmet; 
 \v 6 Gomer, and all his hordes; the house of Togarmah in the uttermost parts of the north, and all his hordes—even many peoples with you. 
@@ -1797,64 +1797,64 @@
 \v 8 After many days you will be visited. In the latter years you will come into the land that is brought back from the sword, that is gathered out of many peoples, on the mountains of Israel, which have been a continual waste; but it is brought out of the peoples and they will dwell securely, all of them. 
 \v 9 You will ascend. You will come like a storm. You will be like a cloud to cover the land, you and all your hordes, and many peoples with you.” 
 \p
-\v 10 “ ‘The Lord Yahweh says: “It will happen in that day that things will come into your mind, and you will devise an evil plan. 
+\v 10 “ ‘The Lord Yahuah says: “It will happen in that day that things will come into your mind, and you will devise an evil plan. 
 \v 11 You will say, ‘I will go up to the land of unwalled villages. I will go to those who are at rest, who dwell securely, all of them dwelling without walls, and having neither bars nor gates, 
 \v 12 to take the plunder and to take prey; to turn your hand against the waste places that are inhabited, and against the people who are gathered out of the nations, who have gotten livestock and goods, who dwell in the middle of the earth.’ 
 \v 13 Sheba, Dedan, and the merchants of Tarshish, with all its young lions, will ask you, ‘Have you come to take the plunder? Have you assembled your company to take the prey, to carry away silver and gold, to take away livestock and goods, to take great plunder?’ ” ’ 
 \p
-\v 14 “Therefore, son of man, prophesy, and tell Gog, ‘The Lord Yahweh says: “In that day when my people Israel dwells securely, will you not know it? 
+\v 14 “Therefore, son of man, prophesy, and tell Gog, ‘The Lord Yahuah says: “In that day when my people Israel dwells securely, will you not know it? 
 \v 15 You will come from your place out of the uttermost parts of the north, you, and many peoples with you, all of them riding on horses, a great company and a mighty army. 
 \v 16 You will come up against my people Israel as a cloud to cover the land. It will happen in the latter days that I will bring you against my land, that the nations may know me when I am sanctified in you, Gog, before their eyes.” 
 \p
-\v 17 “ ‘The Lord Yahweh says: “Are you he of whom I spoke in old time by my servants the prophets of Israel, who prophesied in those days for years that I would bring you against them? 
-\v 18 It will happen in that day, when Gog comes against the land of Israel,” says the Lord Yahweh, “that my wrath will come up into my nostrils. 
+\v 17 “ ‘The Lord Yahuah says: “Are you he of whom I spoke in old time by my servants the prophets of Israel, who prophesied in those days for years that I would bring you against them? 
+\v 18 It will happen in that day, when Gog comes against the land of Israel,” says the Lord Yahuah, “that my wrath will come up into my nostrils. 
 \v 19 For in my jealousy and in the fire of my wrath I have spoken. Surely in that day there will be a great shaking in the land of Israel, 
 \v 20 so that the fish of the sea, the birds of the sky, the animals of the field, all creeping things who creep on the earth, and all the men who are on the surface of the earth will shake at my presence. Then the mountains will be thrown down, the steep places will fall, and every wall will fall to the ground. 
-\v 21 I will call for a sword against him to all my mountains,” says the Lord Yahweh. “Every man’s sword will be against his brother. 
+\v 21 I will call for a sword against him to all my mountains,” says the Lord Yahuah. “Every man’s sword will be against his brother. 
 \v 22 I will enter into judgment with him with pestilence and with blood. I will rain on him, on his hordes, and on the many peoples who are with him, torrential rains with great hailstones, fire, and sulfur. 
-\v 23 I will magnify myself and sanctify myself, and I will make myself known in the eyes of many nations. Then they will know that I am Yahweh.” ’ 
+\v 23 I will magnify myself and sanctify myself, and I will make myself known in the eyes of many nations. Then they will know that I am Yahuah.” ’ 
 \c 39
 \p
-\v 1 “You, son of man, prophesy against Gog, and say, ‘The Lord Yahweh says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
+\v 1 “You, son of man, prophesy against Gog, and say, ‘The Lord Yahuah says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
 \v 2 I will turn you around, will lead you on, and will cause you to come up from the uttermost parts of the north; and I will bring you onto the mountains of Israel. 
 \v 3 I will strike your bow out of your left hand, and will cause your arrows to fall out of your right hand. 
 \v 4 You will fall on the mountains of Israel, you, and all your hordes, and the peoples who are with you. I will give you to the ravenous birds of every sort and to the animals of the field to be devoured. 
-\v 5 You will fall on the open field, for I have spoken it,” says the Lord Yahweh. 
-\v 6 “I will send a fire on Magog and on those who dwell securely in the islands. Then they will know that I am Yahweh. 
+\v 5 You will fall on the open field, for I have spoken it,” says the Lord Yahuah. 
+\v 6 “I will send a fire on Magog and on those who dwell securely in the islands. Then they will know that I am Yahuah. 
 \p
-\v 7 “ ‘ “I will make my set-apart name known among my people Israel. I won’t allow my set-apart name to be profaned any more. Then the nations will know that I am Yahweh, the Set-Apart One in Israel. 
-\v 8 Behold, it comes, and it will be done,” says the Lord Yahweh. “This is the day about which I have spoken. 
+\v 7 “ ‘ “I will make my set-apart name known among my people Israel. I won’t allow my set-apart name to be profaned any more. Then the nations will know that I am Yahuah, the Set-Apart One in Israel. 
+\v 8 Behold, it comes, and it will be done,” says the Lord Yahuah. “This is the day about which I have spoken. 
 \p
 \v 9 “ ‘ “Those who dwell in the cities of Israel will go out and will make fires of the weapons and burn them, both the shields and the bucklers, the bows and the arrows, and the war clubs and the spears, and they will make fires with them for seven years; 
-\v 10 so that they will take no wood out of the field, and not cut down any out of the forests; for they will make fires with the weapons. They will plunder those who plundered them, and rob those who robbed them,” says the Lord Yahweh. 
+\v 10 so that they will take no wood out of the field, and not cut down any out of the forests; for they will make fires with the weapons. They will plunder those who plundered them, and rob those who robbed them,” says the Lord Yahuah. 
 \p
 \v 11 “ ‘ “It will happen in that day, that I will give to Gog a place for burial in Israel, the valley of those who pass through on the east of the sea; and it will stop those who pass through. They will bury Gog and all his multitude there, and they will call it ‘The valley of Hamon Gog’. 
 \p
 \v 12 “ ‘ “The house of Israel will be burying them for seven months, that they may cleanse the land. 
-\v 13 Yes, all the people of the land will bury them; and they will become famous in the day that I will be glorified,” says the Lord Yahweh. 
+\v 13 Yes, all the people of the land will bury them; and they will become famous in the day that I will be glorified,” says the Lord Yahuah. 
 \p
 \v 14 “ ‘ “They will set apart men of continual employment who will pass through the land. Those who pass through will go with those who bury those who remain on the surface of the land, to cleanse it. After the end of seven months they will search. 
 \v 15 Those who search through the land will pass through; and when anyone sees a man’s bone, then he will set up a sign by it, until the undertakers have buried it in the valley of Hamon Gog. 
 \v 16 Hamonah will also be the name of a city. Thus they will cleanse the land.” ’ 
 \p
-\v 17 “You, son of man, the Lord Yahweh says: ‘Speak to the birds of every sort, and to every animal of the field, “Assemble yourselves, and come; gather yourselves on every side to my sacrifice that I sacrifice for you, even a great sacrifice on the mountains of Israel, that you may eat meat and drink blood. 
+\v 17 “You, son of man, the Lord Yahuah says: ‘Speak to the birds of every sort, and to every animal of the field, “Assemble yourselves, and come; gather yourselves on every side to my sacrifice that I sacrifice for you, even a great sacrifice on the mountains of Israel, that you may eat meat and drink blood. 
 \v 18 You shall eat the flesh of the mighty, and drink the blood of the princes of the earth, of rams, of lambs, and of goats, of bulls, all of them fatlings of Bashan. 
 \v 19 You shall eat fat until you are full, and drink blood until you are drunk, of my sacrifice which I have sacrificed for you. 
-\v 20 You shall be filled at my table with horses and charioteers, with mighty men, and with all men of war,” says the Lord Yahweh.’ 
+\v 20 You shall be filled at my table with horses and charioteers, with mighty men, and with all men of war,” says the Lord Yahuah.’ 
 \p
 \v 21 “I will set my glory among the nations. Then all the nations will see my judgment that I have executed, and my hand that I have laid on them. 
-\v 22 So the house of Israel will know that I am Yahweh their Elohim, from that day and forward. 
+\v 22 So the house of Israel will know that I am Yahuah their Elohim, from that day and forward. 
 \v 23 The nations will know that the house of Israel went into captivity for their iniquity, because they trespassed against me, and I hid my face from them; so I gave them into the hand of their adversaries, and they all fell by the sword. 
 \v 24 I did to them according to their uncleanness and according to their transgressions. I hid my face from them. 
 \p
-\v 25 “Therefore the Lord Yahweh says: ‘Now I will reverse the captivity of Jacob and have mercy on the whole house of Israel. I will be jealous for my set-apart name. 
+\v 25 “Therefore the Lord Yahuah says: ‘Now I will reverse the captivity of Jacob and have mercy on the whole house of Israel. I will be jealous for my set-apart name. 
 \v 26 They will forget their shame and all their trespasses by which they have trespassed against me, when they dwell securely in their land. No one will make them afraid 
 \v 27 when I have brought them back from the peoples, gathered them out of their enemies’ lands, and am shown set-apart among them in the sight of many nations. 
-\v 28 They will know that I am Yahweh their Elohim, in that I caused them to go into captivity among the nations, and have gathered them to their own land. Then I will leave none of them captive any more. 
-\v 29 I won’t hide my face from them any more, for I have poured out my Spirit on the house of Israel,’ says the Lord Yahweh.” 
+\v 28 They will know that I am Yahuah their Elohim, in that I caused them to go into captivity among the nations, and have gathered them to their own land. Then I will leave none of them captive any more. 
+\v 29 I won’t hide my face from them any more, for I have poured out my Spirit on the house of Israel,’ says the Lord Yahuah.” 
 \c 40
 \p
-\v 1 In the twenty-fifth year of our captivity, in the beginning of the year, in the tenth day of the month, in the fourteenth year after the city was struck, in the same day, Yahweh’s hand was on me, and he brought me there. 
+\v 1 In the twenty-fifth year of our captivity, in the beginning of the year, in the tenth day of the month, in the fourteenth year after the city was struck, in the same day, Yahuah’s hand was on me, and he brought me there. 
 \v 2 In the visions of Elohim he brought me into the land of Israel, and set me down on a very high mountain, on which was something like the frame of a city to the south. 
 \v 3 He brought me there; and, behold, there was a man whose appearance was like the appearance of bronze, with a line of flax in his hand and a measuring reed; and he stood in the gate. 
 \v 4 The man said to me, “Son of man, see with your eyes, and hear with your ears, and set your heart on all that I will show you; for you have been brought here so that I may show them to you. Declare all that you see to the house of Israel.” 
@@ -1910,7 +1910,7 @@
 \p
 \v 44 Outside of the inner gate were rooms for the singers in the inner court, which was at the side of the north gate. They faced toward the south. One at the side of the east gate faced toward the north. 
 \v 45 He said to me, “This room, which faces toward the south, is for the priests who perform the duty of the house. 
-\v 46 The room which faces toward the north is for the priests who perform the duty of the altar. These are the sons of Zadok, who from among the sons of Levi come near to Yahweh to minister to him.” 
+\v 46 The room which faces toward the north is for the priests who perform the duty of the altar. These are the sons of Zadok, who from among the sons of Levi come near to Yahuah to minister to him.” 
 \v 47 He measured the court, one hundred cubits long and one hundred cubits wide, square. The altar was before the house. 
 \p
 \v 48 Then he brought me to the porch of the house, and measured each post of the porch, five cubits on this side, and five cubits on that side. The width of the gate was three cubits on this side and three cubits on that side. 
@@ -1945,7 +1945,7 @@
 \v 20 Cherubim and palm trees were made from the ground to above the door. The wall of the temple was like this. 
 \p
 \v 21 The door posts of the nave were squared. As for the face of the nave, its appearance was as the appearance of the temple. 
-\v 22 The altar was of wood, three cubits high, and its length two cubits. Its corners, its base, and its walls were of wood. He said to me, “This is the table that is before Yahweh.” 
+\v 22 The altar was of wood, three cubits high, and its length two cubits. Its corners, its base, and its walls were of wood. He said to me, “This is the table that is before Yahuah.” 
 \v 23 The temple and the sanctuary had two doors. 
 \v 24 The doors had two leaves each, two turning leaves: two for the one door, and two leaves for the other. 
 \v 25 There were made on them, on the doors of the nave, cherubim and palm trees, like those made on the walls. There was a threshold of wood on the face of the porch outside. 
@@ -1966,7 +1966,7 @@
 \v 11 The way before them was like the appearance of the rooms which were toward the north. Their length and width were the same. All their exits had the same arrangement and doors. 
 \v 12 Like the doors of the rooms that were toward the south was a door at the head of the way, even the way directly before the wall toward the east, as one enters into them. 
 \p
-\v 13 Then he said to me, “The north rooms and the south rooms, which are opposite the separate place, are the set-apart rooms, where the priests who are near to Yahweh shall eat the most set-apart things. There they shall lay the most set-apart things, with the meal offering, the sin offering, and the trespass offering; for the place is set-apart. 
+\v 13 Then he said to me, “The north rooms and the south rooms, which are opposite the separate place, are the set-apart rooms, where the priests who are near to Yahuah shall eat the most set-apart things. There they shall lay the most set-apart things, with the meal offering, the sin offering, and the trespass offering; for the place is set-apart. 
 \v 14 When the priests enter in, then they shall not go out of the set-apart place into the outer court until they lay their garments in which they minister there; for they are set-apart. Then they shall put on other garments, and shall approach that which is for the people.” 
 \p
 \v 15 Now when he had finished measuring the inner house, he brought me out by the way of the gate which faces toward the east, and measured it all around. 
@@ -1980,8 +1980,8 @@
 \v 1 Afterward he brought me to the gate, even the gate that looks toward the east. 
 \v 2 Behold, the glory of the Elohim of Israel came from the way of the east. His voice was like the sound of many waters; and the earth was illuminated with his glory. 
 \v 3 It was like the appearance of the vision which I saw, even according to the vision that I saw when I came to destroy the city; and the visions were like the vision that I saw by the river Chebar; and I fell on my face. 
-\v 4 Yahweh’s glory came into the house by the way of the gate which faces toward the east. 
-\v 5 The Spirit took me up and brought me into the inner court; and behold, Yahweh’s glory filled the house. 
+\v 4 Yahuah’s glory came into the house by the way of the gate which faces toward the east. 
+\v 5 The Spirit took me up and brought me into the inner court; and behold, Yahuah’s glory filled the house. 
 \p
 \v 6 I heard one speaking to me out of the house, and a man stood by me. 
 \v 7 He said to me, “Son of man, this is the place of my throne and the place of the soles of my feet, where I will dwell among the children of Israel forever. The house of Israel will no more defile my set-apart name, neither they nor their kings, by their prostitution and by the dead bodies of their kings in their high places; 
@@ -1999,39 +1999,39 @@
 \v 16 The altar hearth shall be twelve cubits long by twelve wide, square in its four sides. 
 \v 17 The ledge shall be fourteen cubits long by fourteen wide in its four sides; and the border about it shall be half a cubit; and its bottom shall be a cubit around; and its steps shall look toward the east.” 
 \p
-\v 18 He said to me, “Son of man, the Lord Yahweh says: ‘These are the ordinances of the altar in the day when they make it, to offer burnt offerings on it, and to sprinkle blood on it. 
-\v 19 You shall give to the Levitical priests who are of the offspring of Zadok, who are near to me, to minister to me,’ says the Lord Yahweh, ‘a young bull for a sin offering. 
+\v 18 He said to me, “Son of man, the Lord Yahuah says: ‘These are the ordinances of the altar in the day when they make it, to offer burnt offerings on it, and to sprinkle blood on it. 
+\v 19 You shall give to the Levitical priests who are of the offspring of Zadok, who are near to me, to minister to me,’ says the Lord Yahuah, ‘a young bull for a sin offering. 
 \v 20 You shall take of its blood and put it on its four horns, and on the four corners of the ledge, and on the border all around. You shall cleanse it and make atonement for it that way. 
 \v 21 You shall also take the bull of the sin offering, and it shall be burned in the appointed place of the house, outside of the sanctuary. 
 \p
 \v 22 “On the second day you shall offer a male goat without defect for a sin offering; and they shall cleanse the altar, as they cleansed it with the bull. 
 \v 23 When you have finished cleansing it, you shall offer a young bull without defect and a ram out of the flock without defect. 
-\v 24 You shall bring them near to Yahweh, and the priests shall cast salt on them, and they shall offer them up for a burnt offering to Yahweh. 
+\v 24 You shall bring them near to Yahuah, and the priests shall cast salt on them, and they shall offer them up for a burnt offering to Yahuah. 
 \p
 \v 25 “Seven days you shall prepare every day a goat for a sin offering. They shall also prepare a young bull and a ram out of the flock, without defect. 
 \v 26 Seven days shall they make atonement for the altar and purify it. So shall they consecrate it. 
-\v 27 When they have accomplished the days, it shall be that on the eighth day and onward, the priests shall make your burnt offerings on the altar and your peace offerings. Then I will accept you,’ says the Lord Yahweh.” 
+\v 27 When they have accomplished the days, it shall be that on the eighth day and onward, the priests shall make your burnt offerings on the altar and your peace offerings. Then I will accept you,’ says the Lord Yahuah.” 
 \c 44
 \p
 \v 1 Then he brought me back by the way of the outer gate of the sanctuary, which looks toward the east; and it was shut. 
-\v 2 Yahweh said to me, “This gate shall be shut. It shall not be opened, no man shall enter in by it; for Yahweh, the Elohim of Israel, has entered in by it. Therefore it shall be shut. 
-\v 3 As for the prince, he shall sit in it as prince to eat bread before Yahweh. He shall enter by the way of the porch of the gate, and shall go out the same way.” 
+\v 2 Yahuah said to me, “This gate shall be shut. It shall not be opened, no man shall enter in by it; for Yahuah, the Elohim of Israel, has entered in by it. Therefore it shall be shut. 
+\v 3 As for the prince, he shall sit in it as prince to eat bread before Yahuah. He shall enter by the way of the porch of the gate, and shall go out the same way.” 
 \p
-\v 4 Then he brought me by the way of the north gate before the house; and I looked, and behold, Yahweh’s glory filled Yahweh’s house; so I fell on my face. 
+\v 4 Then he brought me by the way of the north gate before the house; and I looked, and behold, Yahuah’s glory filled Yahuah’s house; so I fell on my face. 
 \p
-\v 5 Yahweh said to me, “Son of man, mark well, and see with your eyes, and hear with your ears all that I tell you concerning all the ordinances of Yahweh’s house and all its laws; and mark well the entrance of the house, with every exit of the sanctuary. 
-\v 6 You shall tell the rebellious, even the house of Israel, ‘The Lord Yahweh says: “You house of Israel, let that be enough of all your abominations, 
+\v 5 Yahuah said to me, “Son of man, mark well, and see with your eyes, and hear with your ears all that I tell you concerning all the ordinances of Yahuah’s house and all its laws; and mark well the entrance of the house, with every exit of the sanctuary. 
+\v 6 You shall tell the rebellious, even the house of Israel, ‘The Lord Yahuah says: “You house of Israel, let that be enough of all your abominations, 
 \v 7 in that you have brought in foreigners, uncircumcised in heart and uncircumcised in flesh, to be in my sanctuary, to profane it, even my house, when you offer my bread, the fat and the blood; and they have broken my covenant, to add to all your abominations. 
 \v 8 You have not performed the duty of my set-apart things; but you have set performers of my duty in my sanctuary for yourselves.” 
-\v 9 The Lord Yahweh says, “No foreigner, uncircumcised in heart and uncircumcised in flesh, shall enter into my sanctuary, of any foreigners who are among the children of Israel. 
+\v 9 The Lord Yahuah says, “No foreigner, uncircumcised in heart and uncircumcised in flesh, shall enter into my sanctuary, of any foreigners who are among the children of Israel. 
 \p
 \v 10 “ ‘ “But the Levites who went far from me when Israel went astray, who went astray from me after their idols, they will bear their iniquity. 
 \v 11 Yet they shall be ministers in my sanctuary, having oversight at the gates of the house, and ministering in the house. They shall kill the burnt offering and the sacrifice for the people, and they shall stand before them to minister to them. 
-\v 12 Because they ministered to them before their idols, and became a stumbling block of iniquity to the house of Israel, therefore I have lifted up my hand against them,” says the Lord Yahweh, “and they will bear their iniquity. 
+\v 12 Because they ministered to them before their idols, and became a stumbling block of iniquity to the house of Israel, therefore I have lifted up my hand against them,” says the Lord Yahuah, “and they will bear their iniquity. 
 \v 13 They shall not come near to me, to execute the office of priest to me, nor to come near to any of my set-apart things, to the things that are most set-apart; but they will bear their shame and their abominations which they have committed. 
 \v 14 Yet I will make them performers of the duty of the house, for all its service and for all that will be done therein. 
 \p
-\v 15 “ ‘ “But the Levitical priests, the sons of Zadok, who performed the duty of my sanctuary when the children of Israel went astray from me, shall come near to me to minister to me. They shall stand before me to offer to me the fat and the blood,” says the Lord Yahweh. 
+\v 15 “ ‘ “But the Levitical priests, the sons of Zadok, who performed the duty of my sanctuary when the children of Israel went astray from me, shall come near to me to minister to me. They shall stand before me to offer to me the fat and the blood,” says the Lord Yahuah. 
 \v 16 “They shall enter into my sanctuary, and they shall come near to my table, to minister to me, and they shall keep my instruction. 
 \p
 \v 17 “ ‘ “It will be that when they enter in at the gates of the inner court, they shall be clothed with linen garments. No wool shall come on them while they minister in the gates of the inner court, and within. 
@@ -2047,7 +2047,7 @@
 \p
 \v 25 “ ‘ “They shall go in to no dead person to defile themselves; but for father, or for mother, or for son, or for daughter, for brother, or for sister who has had no man, they may defile themselves. 
 \v 26 After he is cleansed, they shall reckon to him seven days. 
-\v 27 In the day that he goes into the sanctuary, into the inner court, to minister in the sanctuary, he shall offer his sin offering,” says the Lord Yahweh. 
+\v 27 In the day that he goes into the sanctuary, into the inner court, to minister in the sanctuary, he shall offer his sin offering,” says the Lord Yahuah. 
 \p
 \v 28 “ ‘They shall have an inheritance: I am their inheritance; and you shall give them no possession in Israel. I am their possession. 
 \v 29 They shall eat the meal offering, and the sin offering, and the trespass offering; and every devoted thing in Israel shall be theirs. 
@@ -2055,10 +2055,10 @@
 \v 31 The priests shall not eat of anything that dies of itself or is torn, whether it is bird or animal. 
 \c 45
 \p
-\v 1 “ ‘ “Moreover, when you divide by lot the land for inheritance, you shall offer an offering to Yahweh, a set-apart portion of the land. The length shall be the length of twenty-five thousand reeds, and the width shall be ten thousand. It shall be set-apart in all its border all around. 
+\v 1 “ ‘ “Moreover, when you divide by lot the land for inheritance, you shall offer an offering to Yahuah, a set-apart portion of the land. The length shall be the length of twenty-five thousand reeds, and the width shall be ten thousand. It shall be set-apart in all its border all around. 
 \v 2 Of this there shall be a five hundred by five hundred square for the set-apart place, and fifty cubits for its pasture lands all around. 
 \v 3 Of this measure you shall measure a length of twenty-five thousand, and a width of ten thousand. In it shall be the sanctuary, which is most set-apart. 
-\v 4 It is a set-apart portion of the land; it shall be for the priests, the ministers of the sanctuary, who come near to minister to Yahweh. It shall be a place for their houses and a set-apart place for the sanctuary. 
+\v 4 It is a set-apart portion of the land; it shall be for the priests, the ministers of the sanctuary, who come near to minister to Yahuah. It shall be a place for their houses and a set-apart place for the sanctuary. 
 \v 5 Twenty-five thousand cubits in length and ten thousand in width shall be for the Levites, the ministers of the house, as a possession for themselves, for twenty rooms. 
 \p
 \v 6 “ ‘ “You shall appoint the possession of the city five thousand cubits wide and twenty-five thousand long, side by side with the offering of the set-apart portion. It shall be for the whole house of Israel. 
@@ -2066,49 +2066,49 @@
 \v 7 “ ‘ “What is for the prince shall be on the one side and on the other side of the set-apart allotment and of the possession of the city, in front of the set-apart allotment and in front of the possession of the city, on the west side westward, and on the east side eastward, and in length corresponding to one of the portions, from the west border to the east border. 
 \v 8 In the land it shall be to him for a possession in Israel. My princes shall no more oppress my people, but they shall give the land to the house of Israel according to their tribes.” 
 \p
-\v 9 “ ‘The Lord Yahweh says: “Enough you, princes of Israel! Remove violence and plunder, and execute justice and righteousness! Stop dispossessing my people!” says the Lord Yahweh. 
+\v 9 “ ‘The Lord Yahuah says: “Enough you, princes of Israel! Remove violence and plunder, and execute justice and righteousness! Stop dispossessing my people!” says the Lord Yahuah. 
 \v 10 “You shall have just balances, a just ephah, and a just bath. 
 \v 11 The ephah and the bath shall be of one measure, that the bath may contain one tenth of a homer, and the ephah one tenth of a homer. Its measure shall be the same as the homer. 
 \v 12 The shekel shall be twenty gerahs. Twenty shekels plus twenty-five shekels plus fifteen shekels shall be your mina. 
 \p
 \v 13 “ ‘ “This is the offering that you shall offer: the sixth part of an ephah from a homer of wheat, and you shall give the sixth part of an ephah from a homer of barley, 
 \v 14 and the set portion of oil, of the bath of oil, one tenth of a bath out of the cor, which is ten baths, even a homer (for ten baths are a homer), 
-\v 15 and one lamb of the flock out of two hundred, from the well-watered pastures of Israel—for a meal offering, for a burnt offering, and for peace offerings, to make atonement for them,” says the Lord Yahweh. 
+\v 15 and one lamb of the flock out of two hundred, from the well-watered pastures of Israel—for a meal offering, for a burnt offering, and for peace offerings, to make atonement for them,” says the Lord Yahuah. 
 \v 16 “All the people of the land shall give to this offering for the prince in Israel. 
 \v 17 It shall be the prince’s part to give the burnt offerings, the meal offerings, and the drink offerings, in the feasts, and on the new moons, and on the Sabbaths, in all the appointed feasts of the house of Israel. He shall prepare the sin offering, the meal offering, the burnt offering, and the peace offerings, to make atonement for the house of Israel.” 
 \p
-\v 18 “ ‘The Lord Yahweh says: “In the first month, on the first day of the month, you shall take a young bull without defect, and you shall cleanse the sanctuary. 
+\v 18 “ ‘The Lord Yahuah says: “In the first month, on the first day of the month, you shall take a young bull without defect, and you shall cleanse the sanctuary. 
 \v 19 The priest shall take of the blood of the sin offering and put it on the door posts of the house, and on the four corners of the ledge of the altar, and on the posts of the gate of the inner court. 
 \v 20 So you shall do on the seventh day of the month for everyone who errs, and for him who is simple. So you shall make atonement for the house. 
 \p
 \v 21 “ ‘ “In the first month, on the fourteenth day of the month, you shall have the Passover, a feast of seven days; unleavened bread shall be eaten. 
 \v 22 On that day the prince shall prepare for himself and for all the people of the land a bull for a sin offering. 
-\v 23 The seven days of the feast he shall prepare a burnt offering to Yahweh, seven bulls and seven rams without defect daily the seven days; and a male goat daily for a sin offering. 
+\v 23 The seven days of the feast he shall prepare a burnt offering to Yahuah, seven bulls and seven rams without defect daily the seven days; and a male goat daily for a sin offering. 
 \v 24 He shall prepare a meal offering, an ephah for a bull, an ephah for a ram, and a hin of oil to an ephah. 
 \p
 \v 25 “ ‘ “In the seventh month, on the fifteenth day of the month, during the feast, he shall do like that for seven days. He shall make the same provision for sin offering, the burnt offering, the meal offering, and the oil.” 
 \c 46
 \p
-\v 1 “ ‘The Lord Yahweh says: “The gate of the inner court that looks toward the east shall be shut the six working days; but on the Sabbath day it shall be opened, and on the day of the new moon it shall be opened. 
+\v 1 “ ‘The Lord Yahuah says: “The gate of the inner court that looks toward the east shall be shut the six working days; but on the Sabbath day it shall be opened, and on the day of the new moon it shall be opened. 
 \v 2 The prince shall enter by the way of the porch of the gate outside, and shall stand by the post of the gate; and the priests shall prepare his burnt offering and his peace offerings, and he shall worship at the threshold of the gate. Then he shall go out, but the gate shall not be shut until the evening. 
-\v 3 The people of the land shall worship at the door of that gate before Yahweh on the Sabbaths and on the new moons. 
-\v 4 The burnt offering that the prince shall offer to Yahweh shall be on the Sabbath day, six lambs without defect and a ram without defect; 
+\v 3 The people of the land shall worship at the door of that gate before Yahuah on the Sabbaths and on the new moons. 
+\v 4 The burnt offering that the prince shall offer to Yahuah shall be on the Sabbath day, six lambs without defect and a ram without defect; 
 \v 5 and the meal offering shall be an ephah for the ram, and the meal offering for the lambs as he is able to give, and a hin of oil to an ephah. 
 \v 6 On the day of the new moon it shall be a young bull without defect, six lambs, and a ram. They shall be without defect. 
 \v 7 He shall prepare a meal offering: an ephah for the bull, and an ephah for the ram, and for the lambs according as he is able, and a hin of oil to an ephah. 
 \v 8 When the prince enters, he shall go in by the way of the porch of the gate, and he shall go out by its way. 
 \p
-\v 9 “ ‘ “But when the people of the land come before Yahweh in the appointed feasts, he who enters by the way of the north gate to worship shall go out by the way of the south gate; and he who enters by the way of the south gate shall go out by the way of the north gate. He shall not return by the way of the gate by which he came in, but shall go out straight before him. 
+\v 9 “ ‘ “But when the people of the land come before Yahuah in the appointed feasts, he who enters by the way of the north gate to worship shall go out by the way of the south gate; and he who enters by the way of the south gate shall go out by the way of the north gate. He shall not return by the way of the gate by which he came in, but shall go out straight before him. 
 \v 10 The prince shall go in with them when they go in. When they go out, he shall go out. 
 \p
 \v 11 “ ‘ “In the feasts and in the appointed set-apart days, the meal offering shall be an ephah for a bull, and an ephah for a ram, and for the lambs as he is able to give, and a hin of oil to an ephah. 
-\v 12 When the prince prepares a free will offering, a burnt offering or peace offerings as a free will offering to Yahweh, one shall open for him the gate that looks toward the east; and he shall prepare his burnt offering and his peace offerings, as he does on the Sabbath day. Then he shall go out; and after his going out one shall shut the gate. 
+\v 12 When the prince prepares a free will offering, a burnt offering or peace offerings as a free will offering to Yahuah, one shall open for him the gate that looks toward the east; and he shall prepare his burnt offering and his peace offerings, as he does on the Sabbath day. Then he shall go out; and after his going out one shall shut the gate. 
 \p
-\v 13 “ ‘ “You shall prepare a lamb a year old without defect for a burnt offering to Yahweh daily. Morning by morning you shall prepare it. 
-\v 14 You shall prepare a meal offering with it morning by morning, the sixth part of an ephah, and the third part of a hin of oil to moisten the fine flour; a meal offering to Yahweh continually by a perpetual ordinance. 
+\v 13 “ ‘ “You shall prepare a lamb a year old without defect for a burnt offering to Yahuah daily. Morning by morning you shall prepare it. 
+\v 14 You shall prepare a meal offering with it morning by morning, the sixth part of an ephah, and the third part of a hin of oil to moisten the fine flour; a meal offering to Yahuah continually by a perpetual ordinance. 
 \v 15 Thus they shall prepare the lamb, the meal offering, and the oil, morning by morning, for a continual burnt offering.” 
 \p
-\v 16 “ ‘The Lord Yahweh says: “If the prince gives a gift to any of his sons, it is his inheritance. It shall belong to his sons. It is their possession by inheritance. 
+\v 16 “ ‘The Lord Yahuah says: “If the prince gives a gift to any of his sons, it is his inheritance. It shall belong to his sons. It is their possession by inheritance. 
 \v 17 But if he gives of his inheritance a gift to one of his servants, it shall be his to the year of liberty; then it shall return to the prince; but as for his inheritance, it shall be for his sons. 
 \v 18 Moreover the prince shall not take of the people’s inheritance, to thrust them out of their possession. He shall give inheritance to his sons out of his own possession, that my people not each be scattered from his possession.” ’ ” 
 \p
@@ -2137,7 +2137,7 @@
 \v 11 But its swamps marshes will not be healed. They will be given up to salt. 
 \v 12 By the river banks, on both sides, will grow every tree for food, whose leaf won’t wither, neither will its fruit fail. It will produce new fruit every month, because its waters issue out of the sanctuary. Its fruit will be for food, and its leaf for healing.” 
 \p
-\v 13 The Lord Yahweh says: “This shall be the border by which you shall divide the land for inheritance according to the twelve tribes of Israel. Joseph shall have two portions. 
+\v 13 The Lord Yahuah says: “This shall be the border by which you shall divide the land for inheritance according to the twelve tribes of Israel. Joseph shall have two portions. 
 \v 14 You shall inherit it, one as well as another; for I swore to give it to your fathers. This land will fall to you for inheritance. 
 \p
 \v 15 “This shall be the border of the land: 
@@ -2153,7 +2153,7 @@
 \p
 \v 21 “So you shall divide this land to yourselves according to the tribes of Israel. 
 \v 22 You shall divide it by lot for an inheritance to you and to the aliens who live among you, who will father children among you. Then they shall be to you as the native-born among the children of Israel. They shall have inheritance with you among the tribes of Israel. 
-\v 23 In whatever tribe the stranger lives, there you shall give him his inheritance,” says the Lord Yahweh. 
+\v 23 In whatever tribe the stranger lives, there you shall give him his inheritance,” says the Lord Yahuah. 
 \c 48
 \p
 \v 1 “Now these are the names of the tribes: From the north end, beside the way of Hethlon to the entrance of Hamath, Hazar Enan at the border of Damascus, northward beside Hamath (and they shall have their sides east and west), Dan, one portion. 
@@ -2172,13 +2172,13 @@
 \p
 \v 8 “By the border of Judah, from the east side to the west side, shall be the offering which you shall offer, twenty-five thousand reeds in width, and in length as one of the portions, from the east side to the west side; and the sanctuary shall be in the middle of it. 
 \p
-\v 9 “The offering that you shall offer to Yahweh shall be twenty-five thousand reeds in length, and ten thousand in width. 
-\v 10 For these, even for the priests, shall be the set-apart offering: toward the north twenty-five thousand in length, and toward the west ten thousand in width, and toward the east ten thousand in width, and toward the south twenty-five thousand in length; and the sanctuary of Yahweh shall be in the middle of it. 
+\v 9 “The offering that you shall offer to Yahuah shall be twenty-five thousand reeds in length, and ten thousand in width. 
+\v 10 For these, even for the priests, shall be the set-apart offering: toward the north twenty-five thousand in length, and toward the west ten thousand in width, and toward the east ten thousand in width, and toward the south twenty-five thousand in length; and the sanctuary of Yahuah shall be in the middle of it. 
 \v 11 It shall be for the priests who are sanctified of the sons of Zadok, who have kept my instruction, who didn’t go astray when the children of Israel went astray, as the Levites went astray. 
 \v 12 It shall be to them an offering from the offering of the land, a most set-apart thing, by the border of the Levites. 
 \p
 \v 13 “Alongside the border of the priests, the Levites shall have twenty-five thousand cubits in length and ten thousand in width. All the length shall be twenty-five thousand, and the width ten thousand. 
-\v 14 They shall sell none of it, nor exchange it, nor shall the first fruits of the land be alienated, for it is set-apart to Yahweh. 
+\v 14 They shall sell none of it, nor exchange it, nor shall the first fruits of the land be alienated, for it is set-apart to Yahuah. 
 \p
 \v 15 “The five thousand cubits that are left in the width, in front of the twenty-five thousand, shall be for common use, for the city, for dwelling and for pasture lands; and the city shall be in the middle of it. 
 \v 16 These shall be its measurements: the north side four thousand and five hundred, and the south side four thousand and five hundred, and on the east side four thousand and five hundred, and the west side four thousand and five hundred. 
@@ -2202,7 +2202,7 @@
 \p
 \v 28 “By the border of Gad, at the south side southward, the border shall be even from Tamar to the waters of Meribath Kadesh, to the brook, to the great sea. 
 \p
-\v 29 “This is the land which you shall divide by lot to the tribes of Israel for inheritance, and these are their several portions, says the Lord Yahweh. 
+\v 29 “This is the land which you shall divide by lot to the tribes of Israel for inheritance, and these are their several portions, says the Lord Yahuah. 
 \p
 \v 30 “These are the exits of the city: On the north side four thousand five hundred reeds by measure; 
 \v 31 and the gates of the city shall be named after the tribes of Israel, three gates northward: the gate of Reuben, one; the gate of Judah, one; the gate of Levi, one. 
@@ -2213,4 +2213,4 @@
 \p
 \v 34 “At the west side four thousand five hundred reeds, with their three gates: the gate of Gad, one; the gate of Asher, one; the gate of Naphtali, one. 
 \p
-\v 35 “It shall be eighteen thousand reeds in circumference; and the name of the city from that day shall be, ‘Yahweh is there.’ 
+\v 35 “It shall be eighteen thousand reeds in circumference; and the name of the city from that day shall be, ‘Yahuah is there.’ 

--- a/usfm/ezra.usfm
+++ b/usfm/ezra.usfm
@@ -3,15 +3,15 @@
 \h Ezra
 \c 1
 \p
-\v 1 Now in the first year of Cyrus king of Persia, that Yahweh’s word by Jeremiah’s mouth might be accomplished, Yahweh stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
+\v 1 Now in the first year of Cyrus king of Persia, that Yahuah’s word by Jeremiah’s mouth might be accomplished, Yahuah stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
 \mi
-\v 2 “Cyrus king of Persia says, ‘Yahweh, the Elohim of heaven, has given me all the kingdoms of the earth; and he has commanded me to build him a house in Jerusalem, which is in Judah. 
-\v 3 Whoever there is among you of all his people, may his Elohim be with him, and let him go up to Jerusalem, which is in Judah, and build the house of Yahweh, the Elohim of Israel (he is Elohim), which is in Jerusalem. 
+\v 2 “Cyrus king of Persia says, ‘Yahuah, the Elohim of heaven, has given me all the kingdoms of the earth; and he has commanded me to build him a house in Jerusalem, which is in Judah. 
+\v 3 Whoever there is among you of all his people, may his Elohim be with him, and let him go up to Jerusalem, which is in Judah, and build the house of Yahuah, the Elohim of Israel (he is Elohim), which is in Jerusalem. 
 \v 4 Whoever is left, in any place where he lives, let the men of his place help him with silver, with gold, with goods, and with animals, in addition to the free will offering for Elohim’s house which is in Jerusalem.’ ” 
 \p
-\v 5 Then the heads of fathers’ households of Judah and Benjamin, the priests and the Levites, all whose spirit Elohim had stirred to go up, rose up to build Yahweh’s house which is in Jerusalem. 
+\v 5 Then the heads of fathers’ households of Judah and Benjamin, the priests and the Levites, all whose spirit Elohim had stirred to go up, rose up to build Yahuah’s house which is in Jerusalem. 
 \v 6 All those who were around them strengthened their hands with vessels of silver, with gold, with goods, with animals, and with precious things, in addition to all that was willingly offered. 
-\v 7 Also Cyrus the king brought out the vessels of Yahweh’s house, which Nebuchadnezzar had brought out of Jerusalem, and had put in the house of his elohims; 
+\v 7 Also Cyrus the king brought out the vessels of Yahuah’s house, which Nebuchadnezzar had brought out of Jerusalem, and had put in the house of his elohims; 
 \v 8 even those, Cyrus king of Persia brought out by the hand of Mithredath the treasurer, and counted them out to Sheshbazzar the prince of Judah. 
 \v 9 This is the number of them: thirty platters of gold, one thousand platters of silver, twenty-nine knives, 
 \v 10 thirty bowls of gold, four hundred ten silver bowls of a second kind, and one thousand other vessels. 
@@ -93,7 +93,7 @@
 \v 66 Their horses were seven hundred thirty-six; their mules, two hundred forty-five; 
 \v 67 their camels, four hundred thirty-five; their donkeys, six thousand seven hundred twenty. 
 \p
-\v 68 Some of the heads of fathers’ households, when they came to Yahweh’s house which is in Jerusalem, offered willingly for Elohim’s house to set it up in its place. 
+\v 68 Some of the heads of fathers’ households, when they came to Yahuah’s house which is in Jerusalem, offered willingly for Elohim’s house to set it up in its place. 
 \v 69 They gave according to their ability into the treasury of the work sixty-one thousand darics of gold, five thousand minas of silver, and one hundred priests’ garments. 
 \p
 \v 70 So the priests and the Levites, with some of the people, the singers, the gatekeepers, and the temple servants, lived in their cities, and all Israel in their cities. 
@@ -101,26 +101,26 @@
 \p
 \v 1 When the seventh month had come, and the children of Israel were in the cities, the people gathered themselves together as one man to Jerusalem. 
 \v 2 Then Jeshua the son of Jozadak stood up with his brothers the priests and Zerubbabel the son of Shealtiel and his relatives, and built the altar of the Elohim of Israel, to offer burnt offerings on it, as it is written in the law of Moses the man of Elohim. 
-\v 3 In spite of their fear because of the peoples of the surrounding lands, they set the altar on its base; and they offered burnt offerings on it to Yahweh, even burnt offerings morning and evening. 
+\v 3 In spite of their fear because of the peoples of the surrounding lands, they set the altar on its base; and they offered burnt offerings on it to Yahuah, even burnt offerings morning and evening. 
 \v 4 They kept the feast of booths, as it is written, and offered the daily burnt offerings by number, according to the ordinance, as the duty of every day required; 
-\v 5 and afterward the continual burnt offering, the offerings of the new moons, of all the set feasts of Yahweh that were consecrated, and of everyone who willingly offered a free will offering to Yahweh. 
-\v 6 From the first day of the seventh month, they began to offer burnt offerings to Yahweh; but the foundation of Yahweh’s temple was not yet laid. 
+\v 5 and afterward the continual burnt offering, the offerings of the new moons, of all the set feasts of Yahuah that were consecrated, and of everyone who willingly offered a free will offering to Yahuah. 
+\v 6 From the first day of the seventh month, they began to offer burnt offerings to Yahuah; but the foundation of Yahuah’s temple was not yet laid. 
 \v 7 They also gave money to the masons and to the carpenters. They also gave food, drink, and oil to the people of Sidon and Tyre to bring cedar trees from Lebanon to the sea, to Joppa, according to the grant that they had from Cyrus King of Persia. 
 \p
-\v 8 Now in the second year of their coming to Elohim’s house at Jerusalem, in the second month, Zerubbabel the son of Shealtiel, Jeshua the son of Jozadak, and the rest of their brothers the priests and the Levites, and all those who had come out of the captivity to Jerusalem, began the work and appointed the Levites, from twenty years old and upward, to have the oversight of the work of Yahweh’s house. 
+\v 8 Now in the second year of their coming to Elohim’s house at Jerusalem, in the second month, Zerubbabel the son of Shealtiel, Jeshua the son of Jozadak, and the rest of their brothers the priests and the Levites, and all those who had come out of the captivity to Jerusalem, began the work and appointed the Levites, from twenty years old and upward, to have the oversight of the work of Yahuah’s house. 
 \v 9 Then Jeshua stood with his sons and his brothers, Kadmiel and his sons, the sons of Judah, together to have the oversight of the workmen in Elohim’s house: the sons of Henadad, with their sons and their brothers the Levites. 
 \p
-\v 10 When the builders laid the foundation of Yahweh’s temple, they set the priests in their vestments with trumpets, with the Levites the sons of Asaph with cymbals, to praise Yahweh, according to the directions of David king of Israel. 
-\v 11 They sang to one another in praising and giving thanks to Yahweh, “For he is good, for his loving kindness endures forever toward Israel.” All the people shouted with a great shout, when they praised Yahweh, because the foundation of Yahweh’s house had been laid. 
+\v 10 When the builders laid the foundation of Yahuah’s temple, they set the priests in their vestments with trumpets, with the Levites the sons of Asaph with cymbals, to praise Yahuah, according to the directions of David king of Israel. 
+\v 11 They sang to one another in praising and giving thanks to Yahuah, “For he is good, for his loving kindness endures forever toward Israel.” All the people shouted with a great shout, when they praised Yahuah, because the foundation of Yahuah’s house had been laid. 
 \p
 \v 12 But many of the priests and Levites and heads of fathers’ households, the old men who had seen the first house, when the foundation of this house was laid before their eyes, wept with a loud voice. Many also shouted aloud for joy, 
 \v 13 so that the people could not discern the noise of the shout of joy from the noise of the weeping of the people; for the people shouted with a loud shout, and the noise was heard far away. 
 \c 4
 \p
-\v 1 Now when the adversaries of Judah and Benjamin heard that the children of the captivity were building a temple to Yahweh, the Elohim of Israel, 
+\v 1 Now when the adversaries of Judah and Benjamin heard that the children of the captivity were building a temple to Yahuah, the Elohim of Israel, 
 \v 2 they came near to Zerubbabel, and to the heads of fathers’ households, and said to them, “Let us build with you, for we seek your Elohim as you do; and we have been sacrificing to him since the days of Esar Haddon king of Assyria, who brought us up here.” 
 \p
-\v 3 But Zerubbabel, Jeshua, and the rest of the heads of fathers’ households of Israel said to them, “You have nothing to do with us in building a house to our Elohim; but we ourselves together will build to Yahweh, the Elohim of Israel, as King Cyrus the king of Persia has commanded us.” 
+\v 3 But Zerubbabel, Jeshua, and the rest of the heads of fathers’ households of Israel said to them, “You have nothing to do with us in building a house to our Elohim; but we ourselves together will build to Yahuah, the Elohim of Israel, as King Cyrus the king of Persia has commanded us.” 
 \p
 \v 4 Then the people of the land weakened the hands of the people of Judah, and troubled them in building. 
 \v 5 They hired counselors against them to frustrate their purpose all the days of Cyrus king of Persia, even until the reign of Darius king of Persia. 
@@ -211,21 +211,21 @@
 \p
 \v 19 The children of the captivity kept the Passover on the fourteenth day of the first month. 
 \v 20 Because the priests and the Levites had purified themselves together, all of them were pure. They killed the Passover for all the children of the captivity, for their brothers the priests, and for themselves. 
-\v 21 The children of Israel who had returned out of the captivity, and all who had separated themselves to them from the filthiness of the nations of the land to seek Yahweh, the Elohim of Israel, ate, 
-\v 22 and kept the feast of unleavened bread seven days with joy; because Yahweh had made them joyful, and had turned the heart of the king of Assyria to them, to strengthen their hands in the work of Elohim, the Elohim of Israel’s house. 
+\v 21 The children of Israel who had returned out of the captivity, and all who had separated themselves to them from the filthiness of the nations of the land to seek Yahuah, the Elohim of Israel, ate, 
+\v 22 and kept the feast of unleavened bread seven days with joy; because Yahuah had made them joyful, and had turned the heart of the king of Assyria to them, to strengthen their hands in the work of Elohim, the Elohim of Israel’s house. 
 \c 7
 \p
 \v 1 Now after these things, in the reign of Artaxerxes king of Persia, Ezra the son of Seraiah, the son of Azariah, the son of Hilkiah, 
 \v 2 the son of Shallum, the son of Zadok, the son of Ahitub, 
 \v 3 the son of Amariah, the son of Azariah, the son of Meraioth, 
 \v 4 the son of Zerahiah, the son of Uzzi, the son of Bukki, 
-\v 5 the son of Abishua, the son of Phinehas, the son of Eleazar, the son of Aaron the chief priest—\v 6 this Ezra went up from Babylon. He was a skilled scribe in the law of Moses, which Yahweh, the Elohim of Israel, had given; and the king granted him all his request, according to Yahweh his Elohim’s hand on him. 
+\v 5 the son of Abishua, the son of Phinehas, the son of Eleazar, the son of Aaron the chief priest—\v 6 this Ezra went up from Babylon. He was a skilled scribe in the law of Moses, which Yahuah, the Elohim of Israel, had given; and the king granted him all his request, according to Yahuah his Elohim’s hand on him. 
 \v 7 Some of the children of Israel, including some of the priests, the Levites, the singers, the gatekeepers, and the temple servants went up to Jerusalem in the seventh year of Artaxerxes the king. 
 \v 8 He came to Jerusalem in the fifth month, which was in the seventh year of the king. 
 \v 9 For on the first day of the first month he began to go up from Babylon; and on the first day of the fifth month he came to Jerusalem, according to the good hand of his Elohim on him. 
-\v 10 For Ezra had set his heart to seek Yahweh’s law, and to do it, and to teach statutes and ordinances in Israel. 
+\v 10 For Ezra had set his heart to seek Yahuah’s law, and to do it, and to teach statutes and ordinances in Israel. 
 \p
-\v 11 Now this is the copy of the letter that King Artaxerxes gave to Ezra the priest, the scribe, even the scribe of the words of Yahweh’s commandments, and of his statutes to Israel: 
+\v 11 Now this is the copy of the letter that King Artaxerxes gave to Ezra the priest, the scribe, even the scribe of the words of Yahuah’s commandments, and of his statutes to Israel: 
 \b
 \mi
 \v 12 Artaxerxes, king of kings, 
@@ -250,8 +250,8 @@
 \v 26 Whoever will not do the law of your Elohim and the law of the king, let judgment be executed on him with all diligence, whether it is to death, or to banishment, or to confiscation of goods, or to imprisonment. 
 \b
 \p
-\v 27 Blessed be Yahweh, the Elohim of our fathers, who has put such a thing as this in the king’s heart, to beautify Yahweh’s house which is in Jerusalem; 
-\v 28 and has extended loving kindness to me before the king and his counselors, and before all the king’s mighty princes. I was strengthened according to Yahweh my Elohim’s hand on me, and I gathered together chief men out of Israel to go up with me. 
+\v 27 Blessed be Yahuah, the Elohim of our fathers, who has put such a thing as this in the king’s heart, to beautify Yahuah’s house which is in Jerusalem; 
+\v 28 and has extended loving kindness to me before the king and his counselors, and before all the king’s mighty princes. I was strengthened according to Yahuah my Elohim’s hand on me, and I gathered together chief men out of Israel to go up with me. 
 \c 8
 \p
 \v 1 Now these are the heads of their fathers’ households, and this is the genealogy of those who went up with me from Babylon, in the reign of Artaxerxes the king: 
@@ -299,8 +299,8 @@
 \v 25 and weighed to them the silver, the gold, and the vessels, even the offering for the house of our Elohim, which the king, his counselors, his princes, and all Israel there present, had offered. 
 \v 26 I weighed into their hand six hundred fifty talents of silver, one hundred talents of silver vessels, one hundred talents of gold, 
 \v 27 twenty bowls of gold weighing one thousand darics, and two vessels of fine bright bronze, precious as gold. 
-\v 28 I said to them, “You are set-apart to Yahweh, and the vessels are set-apart. The silver and the gold are a free will offering to Yahweh, the Elohim of your fathers. 
-\v 29 Watch and keep them until you weigh them before the chiefs of the priests, the Levites, and the princes of the fathers’ households of Israel at Jerusalem, in the rooms of Yahweh’s house.” 
+\v 28 I said to them, “You are set-apart to Yahuah, and the vessels are set-apart. The silver and the gold are a free will offering to Yahuah, the Elohim of your fathers. 
+\v 29 Watch and keep them until you weigh them before the chiefs of the priests, the Levites, and the princes of the fathers’ households of Israel at Jerusalem, in the rooms of Yahuah’s house.” 
 \p
 \v 30 So the priests and the Levites received the weight of the silver, the gold, and the vessels, to bring them to Jerusalem to the house of our Elohim. 
 \p
@@ -309,7 +309,7 @@
 \v 33 On the fourth day the silver and the gold and the vessels were weighed in the house of our Elohim into the hand of Meremoth the son of Uriah the priest; and with him was Eleazar the son of Phinehas; and with them were Jozabad the son of Jeshua, and Noadiah the son of Binnui, the Levites. 
 \v 34 Everything was counted and weighed; and all the weight was written at that time. 
 \p
-\v 35 The children of the captivity, who had come out of exile, offered burnt offerings to the Elohim of Israel: twelve bulls for all Israel, ninety-six rams, seventy-seven lambs, and twelve male goats for a sin offering. All this was a burnt offering to Yahweh. 
+\v 35 The children of the captivity, who had come out of exile, offered burnt offerings to the Elohim of Israel: twelve bulls for all Israel, ninety-six rams, seventy-seven lambs, and twelve male goats for a sin offering. All this was a burnt offering to Yahuah. 
 \v 36 They delivered the king’s commissions to the king’s local governors and to the governors beyond the River. So they supported the people and Elohim’s house. 
 \c 9
 \p
@@ -319,10 +319,10 @@
 \v 3 When I heard this thing, I tore my garment and my robe, and pulled the hair out of my head and of my beard, and sat down confounded. 
 \v 4 Then everyone who trembled at the words of the Elohim of Israel were assembled to me because of the trespass of the exiles; and I sat confounded until the evening offering. 
 \p
-\v 5 At the evening offering I rose up from my humiliation, even with my garment and my robe torn; and I fell on my knees, and spread out my hands to Yahweh my Elohim; 
+\v 5 At the evening offering I rose up from my humiliation, even with my garment and my robe torn; and I fell on my knees, and spread out my hands to Yahuah my Elohim; 
 \v 6 and I said, “My Elohim, I am ashamed and blush to lift up my face to you, my Elohim, for our iniquities have increased over our head, and our guiltiness has grown up to the heavens. 
 \v 7 Since the days of our fathers we have been exceedingly guilty to this day; and for our iniquities we, our kings, and our priests have been delivered into the hand of the kings of the lands, to the sword, to captivity, to plunder, and to confusion of face, as it is this day. 
-\v 8 Now for a little moment grace has been shown from Yahweh our Elohim, to leave us a remnant to escape, and to give us a stake in his set-apart place, that our Elohim may lighten our eyes, and revive us a little in our bondage. 
+\v 8 Now for a little moment grace has been shown from Yahuah our Elohim, to leave us a remnant to escape, and to give us a stake in his set-apart place, that our Elohim may lighten our eyes, and revive us a little in our bondage. 
 \v 9 For we are bondservants; yet our Elohim has not forsaken us in our bondage, but has extended loving kindness to us in the sight of the kings of Persia, to revive us, to set up the house of our Elohim, and to repair its ruins, and to give us a wall in Judah and in Jerusalem. 
 \p
 \v 10 “Now, our Elohim, what shall we say after this? For we have forsaken your commandments, 
@@ -331,7 +331,7 @@
 \p
 \v 13 “After all that has come on us for our evil deeds and for our great guilt, since you, our Elohim, have punished us less than our iniquities deserve, and have given us such a remnant, 
 \v 14 shall we again break your commandments, and join ourselves with the peoples that do these abominations? Wouldn’t you be angry with us until you had consumed us, so that there would be no remnant, nor any to escape? 
-\v 15 Yahweh, the Elohim of Israel, you are righteous; for we are left a remnant that has escaped, as it is today. Behold, we are before you in our guiltiness; for no one can stand before you because of this.” 
+\v 15 Yahuah, the Elohim of Israel, you are righteous; for we are left a remnant that has escaped, as it is today. Behold, we are before you in our guiltiness; for no one can stand before you because of this.” 
 \c 10
 \p
 \v 1 Now while Ezra prayed and made confession, weeping and casting himself down before Elohim’s house, there was gathered together to him out of Israel a very great assembly of men and women and children; for the people wept very bitterly. 
@@ -347,7 +347,7 @@
 \v 9 Then all the men of Judah and Benjamin gathered themselves together to Jerusalem within the three days. It was the ninth month, on the twentieth day of the month; and all the people sat in the wide place in front of Elohim’s house, trembling because of this matter, and because of the great rain. 
 \p
 \v 10 Ezra the priest stood up and said to them, “You have trespassed, and have taken foreign women, increasing the guilt of Israel. 
-\v 11 Now therefore make confession to Yahweh, the Elohim of your fathers and do his pleasure. Separate yourselves from the peoples of the land and from the foreign women.” 
+\v 11 Now therefore make confession to Yahuah, the Elohim of your fathers and do his pleasure. Separate yourselves from the peoples of the land and from the foreign women.” 
 \p
 \v 12 Then all the assembly answered with a loud voice, “We must do as you have said concerning us. 
 \v 13 But the people are many, and it is a time of much rain, and we are not able to stand outside. This is not a work of one day or two, for we have greatly transgressed in this matter. 

--- a/usfm/genesis.usfm
+++ b/usfm/genesis.usfm
@@ -48,32 +48,32 @@
 \v 2 On the seventh day Elohim finished his work which he had done; and he rested on the seventh day from all his work which he had done. 
 \v 3 Elohim blessed the seventh day, and made it set-apart, because he rested in it from all his work of creation which he had done. 
 \p
-\v 4 This is the history of the generations of the heavens and of the earth when they were created, in the day that Yahweh Elohim made the earth and the heavens. 
-\v 5 No plant of the field was yet in the earth, and no herb of the field had yet sprung up; for Yahweh Elohim had not caused it to rain on the earth. There was not a man to till the ground, 
+\v 4 This is the history of the generations of the heavens and of the earth when they were created, in the day that Yahuah Elohim made the earth and the heavens. 
+\v 5 No plant of the field was yet in the earth, and no herb of the field had yet sprung up; for Yahuah Elohim had not caused it to rain on the earth. There was not a man to till the ground, 
 \v 6 but a mist went up from the earth, and watered the whole surface of the ground. 
-\v 7 Yahweh Elohim formed man from the dust of the ground, and breathed into his nostrils the breath of life; and man became a living soul. 
-\v 8 Yahweh Elohim planted a garden eastward, in Eden, and there he put the man whom he had formed. 
-\v 9 Out of the ground Yahweh Elohim made every tree to grow that is pleasant to the sight, and good for food, including the tree of life in the middle of the garden and the tree of the knowledge of good and evil. 
+\v 7 Yahuah Elohim formed man from the dust of the ground, and breathed into his nostrils the breath of life; and man became a living soul. 
+\v 8 Yahuah Elohim planted a garden eastward, in Eden, and there he put the man whom he had formed. 
+\v 9 Out of the ground Yahuah Elohim made every tree to grow that is pleasant to the sight, and good for food, including the tree of life in the middle of the garden and the tree of the knowledge of good and evil. 
 \v 10 A river went out of Eden to water the garden; and from there it was parted, and became the source of four rivers. 
 \v 11 The name of the first is Pishon: it flows through the whole land of Havilah, where there is gold; 
 \v 12 and the gold of that land is good. Bdellium and onyx stone are also there. 
 \v 13 The name of the second river is Gihon. It is the same river that flows through the whole land of Cush. 
 \v 14 The name of the third river is Hiddekel. This is the one which flows in front of Assyria. The fourth river is the Euphrates. 
-\v 15 Yahweh Elohim took the man, and put him into the garden of Eden to cultivate and keep it. 
-\v 16 Yahweh Elohim commanded the man, saying, “You may freely eat of every tree of the garden; 
+\v 15 Yahuah Elohim took the man, and put him into the garden of Eden to cultivate and keep it. 
+\v 16 Yahuah Elohim commanded the man, saying, “You may freely eat of every tree of the garden; 
 \v 17 but you shall not eat of the tree of the knowledge of good and evil; for in the day that you eat of it, you will surely die.” 
 \p
-\v 18 Yahweh Elohim said, “It is not good for the man to be alone. I will make him a helper comparable to him.” 
-\v 19 Out of the ground Yahweh Elohim formed every animal of the field, and every bird of the sky, and brought them to the man to see what he would call them. Whatever the man called every living creature became its name. 
+\v 18 Yahuah Elohim said, “It is not good for the man to be alone. I will make him a helper comparable to him.” 
+\v 19 Out of the ground Yahuah Elohim formed every animal of the field, and every bird of the sky, and brought them to the man to see what he would call them. Whatever the man called every living creature became its name. 
 \v 20 The man gave names to all livestock, and to the birds of the sky, and to every animal of the field; but for man there was not found a helper comparable to him. 
-\v 21 Yahweh Elohim caused the man to fall into a deep sleep. As the man slept, he took one of his ribs, and closed up the flesh in its place. 
-\v 22 Yahweh Elohim made a woman from the rib which he had taken from the man, and brought her to the man. 
+\v 21 Yahuah Elohim caused the man to fall into a deep sleep. As the man slept, he took one of his ribs, and closed up the flesh in its place. 
+\v 22 Yahuah Elohim made a woman from the rib which he had taken from the man, and brought her to the man. 
 \v 23 The man said, “This is now bone of my bones, and flesh of my flesh. She will be called ‘woman,’ because she was taken out of Man.” 
 \v 24 Therefore a man will leave his father and his mother, and will join with his woman, and they will be one flesh. 
 \v 25 The man and his woman were both naked, and they were not ashamed. 
 \c 3
 \p
-\v 1 Now the serpent was more subtle than any animal of the field which Yahweh Elohim had made. He said to the woman, “Has Elohim really said, ‘You shall not eat of any tree of the garden’?” 
+\v 1 Now the serpent was more subtle than any animal of the field which Yahuah Elohim had made. He said to the woman, “Has Elohim really said, ‘You shall not eat of any tree of the garden’?” 
 \p
 \v 2 The woman said to the serpent, “We may eat fruit from the trees of the garden, 
 \v 3 but not the fruit of the tree which is in the middle of the garden. Elohim has said, ‘You shall not eat of it. You shall not touch it, lest you die.’ ” 
@@ -83,9 +83,9 @@
 \p
 \v 6 When the woman saw that the tree was good for food, and that it was a delight to the eyes, and that the tree was to be desired to make one wise, she took some of its fruit, and ate. Then she gave some to her man with her, and he ate it, too. 
 \v 7 Their eyes were opened, and they both knew that they were naked. They sewed fig leaves together, and made coverings for themselves. 
-\v 8 They heard Yahweh Elohim’s voice walking in the garden in the cool of the day, and the man and his woman hid themselves from the presence of Yahweh Elohim among the trees of the garden. 
+\v 8 They heard Yahuah Elohim’s voice walking in the garden in the cool of the day, and the man and his woman hid themselves from the presence of Yahuah Elohim among the trees of the garden. 
 \p
-\v 9 Yahweh Elohim called to the man, and said to him, “Where are you?” 
+\v 9 Yahuah Elohim called to the man, and said to him, “Where are you?” 
 \p
 \v 10 The man said, “I heard your voice in the garden, and I was afraid, because I was naked; so I hid myself.” 
 \p
@@ -93,10 +93,10 @@
 \p
 \v 12 The man said, “The woman whom you gave to be with me, she gave me fruit from the tree, and I ate it.” 
 \p
-\v 13 Yahweh Elohim said to the woman, “What have you done?” 
+\v 13 Yahuah Elohim said to the woman, “What have you done?” 
 \p The woman said, “The serpent deceived me, and I ate.” 
 \p
-\v 14 Yahweh Elohim said to the serpent, 
+\v 14 Yahuah Elohim said to the serpent, 
 \q1 “Because you have done this, 
 \q2 you are cursed above all livestock, 
 \q2 and above every animal of the field. 
@@ -130,35 +130,35 @@
 \q2 and you shall return to dust.” 
 \p
 \v 20 The man called his woman Eve because she would be the mother of all the living. 
-\v 21 Yahweh Elohim made garments of animal skins for Adam and for his woman, and clothed them. 
+\v 21 Yahuah Elohim made garments of animal skins for Adam and for his woman, and clothed them. 
 \p
-\v 22 Yahweh Elohim said, “Behold, the man has become like one of us, knowing good and evil. Now, lest he reach out his hand, and also take of the tree of life, and eat, and live forever—” 
-\v 23 Therefore Yahweh Elohim sent him out from the garden of Eden, to till the ground from which he was taken. 
+\v 22 Yahuah Elohim said, “Behold, the man has become like one of us, knowing good and evil. Now, lest he reach out his hand, and also take of the tree of life, and eat, and live forever—” 
+\v 23 Therefore Yahuah Elohim sent him out from the garden of Eden, to till the ground from which he was taken. 
 \v 24 So he drove out the man; and he placed cherubim at the east of the garden of Eden, and a flaming sword which turned every way, to guard the way to the tree of life. 
 \c 4
 \p
-\v 1 The man knew Eve his woman. She conceived, and gave birth to Cain, and said, “I have gotten a man with Yahweh’s help.” 
+\v 1 The man knew Eve his woman. She conceived, and gave birth to Cain, and said, “I have gotten a man with Yahuah’s help.” 
 \v 2 Again she gave birth, to Cain’s brother Abel. Abel was a keeper of sheep, but Cain was a tiller of the ground. 
-\v 3 As time passed, Cain brought an offering to Yahweh from the fruit of the ground. 
-\v 4 Abel also brought some of the firstborn of his flock and of its fat. Yahweh respected Abel and his offering, 
+\v 3 As time passed, Cain brought an offering to Yahuah from the fruit of the ground. 
+\v 4 Abel also brought some of the firstborn of his flock and of its fat. Yahuah respected Abel and his offering, 
 \v 5 but he didn’t respect Cain and his offering. Cain was very angry, and the expression on his face fell. 
-\v 6 Yahweh said to Cain, “Why are you angry? Why has the expression of your face fallen? 
+\v 6 Yahuah said to Cain, “Why are you angry? Why has the expression of your face fallen? 
 \v 7 If you do well, won’t it be lifted up? If you don’t do well, sin crouches at the door. Its desire is for you, but you are to rule over it.” 
 \v 8 Cain said to Abel, his brother, “Let’s go into the field.” While they were in the field, Cain rose up against Abel, his brother, and killed him. 
 \p
-\v 9 Yahweh said to Cain, “Where is Abel, your brother?” 
+\v 9 Yahuah said to Cain, “Where is Abel, your brother?” 
 \p He said, “I don’t know. Am I my brother’s keeper?” 
 \p
-\v 10 Yahweh said, “What have you done? The voice of your brother’s blood cries to me from the ground. 
+\v 10 Yahuah said, “What have you done? The voice of your brother’s blood cries to me from the ground. 
 \v 11 Now you are cursed because of the ground, which has opened its mouth to receive your brother’s blood from your hand. 
 \v 12 From now on, when you till the ground, it won’t yield its strength to you. You will be a fugitive and a wanderer in the earth.” 
 \p
-\v 13 Cain said to Yahweh, “My punishment is greater than I can bear. 
+\v 13 Cain said to Yahuah, “My punishment is greater than I can bear. 
 \v 14 Behold, you have driven me out today from the surface of the ground. I will be hidden from your face, and I will be a fugitive and a wanderer in the earth. Whoever finds me will kill me.” 
 \p
-\v 15 Yahweh said to him, “Therefore whoever slays Cain, vengeance will be taken on him sevenfold.” Yahweh appointed a sign for Cain, so that anyone finding him would not strike him. 
+\v 15 Yahuah said to him, “Therefore whoever slays Cain, vengeance will be taken on him sevenfold.” Yahuah appointed a sign for Cain, so that anyone finding him would not strike him. 
 \p
-\v 16 Cain left Yahweh’s presence, and lived in the land of Nod, east of Eden. 
+\v 16 Cain left Yahuah’s presence, and lived in the land of Nod, east of Eden. 
 \v 17 Cain knew his woman. She conceived, and gave birth to Enoch. He built a city, and named the city after the name of his son, Enoch. 
 \v 18 Irad was born to Enoch. Irad brought forth Mehujael. Mehujael brought forth Methushael. Methushael brought forth Lamech. 
 \v 19 Lamech took two women: the name of the first one was Adah, and the name of the second one was Zillah. 
@@ -175,7 +175,7 @@
 \q2 truly Lamech seventy-seven times.” 
 \p
 \v 25 Adam knew his woman again. She gave birth to a son, and named him Seth, saying, “for Elohim has given me another child instead of Abel, for Cain killed him.” 
-\v 26 A son was also born to Seth, and he named him Enosh. At that time men began to call on Yahweh’s name. 
+\v 26 A son was also born to Seth, and he named him Enosh. At that time men began to call on Yahuah’s name. 
 \c 5
 \p
 \v 1 This is the book of the generations of Adam. In the day that Elohim created man, he made him in Elohim’s likeness. 
@@ -214,7 +214,7 @@
 \v 27 All the days of Methuselah were nine hundred sixty-nine years, then he died. 
 \p
 \v 28 Lamech lived one hundred eighty-two years, then brought forth a son. 
-\v 29 He named him Noah, saying, “This one will comfort us in our work and in the toil of our hands, caused by the ground which Yahweh has cursed.” 
+\v 29 He named him Noah, saying, “This one will comfort us in our work and in the toil of our hands, caused by the ground which Yahuah has cursed.” 
 \v 30 Lamech lived after he brought forth Noah five hundred ninety-five years, and brought forth other sons and daughters. 
 \v 31 All the days of Lamech were seven hundred seventy-seven years, then he died. 
 \p
@@ -223,13 +223,13 @@
 \p
 \v 1 When men began to multiply on the surface of the ground, and daughters were born to them, 
 \v 2 Elohim’s sons saw that men’s daughters were beautiful, and they took any that they wanted for themselves as women. 
-\v 3 Yahweh said, “My Spirit will not strive with man forever, because he also is flesh; so his days will be one hundred twenty years.” 
+\v 3 Yahuah said, “My Spirit will not strive with man forever, because he also is flesh; so his days will be one hundred twenty years.” 
 \v 4 The Nephilim were in the earth in those days, and also after that, when Elohim’s sons came in to men’s daughters and had children with them. Those were the mighty men who were of old, men of renown. 
 \p
-\v 5 Yahweh saw that the wickedness of man was great in the earth, and that every imagination of the thoughts of man’s heart was continually only evil. 
-\v 6 Yahweh was sorry that he had made man on the earth, and it grieved him in his heart. 
-\v 7 Yahweh said, “I will destroy man whom I have created from the surface of the ground—man, along with animals, creeping things, and birds of the sky—for I am sorry that I have made them.” 
-\v 8 But Noah found favor in Yahweh’s eyes. 
+\v 5 Yahuah saw that the wickedness of man was great in the earth, and that every imagination of the thoughts of man’s heart was continually only evil. 
+\v 6 Yahuah was sorry that he had made man on the earth, and it grieved him in his heart. 
+\v 7 Yahuah said, “I will destroy man whom I have created from the surface of the ground—man, along with animals, creeping things, and birds of the sky—for I am sorry that I have made them.” 
+\v 8 But Noah found favor in Yahuah’s eyes. 
 \p
 \v 9 This is the history of the generations of Noah: Noah was a righteous man, blameless among the people of his time. Noah walked with Elohim. 
 \v 10 Noah brought forth three sons: Shem, Ham, and Japheth. 
@@ -248,12 +248,12 @@
 \v 22 Thus Noah did. He did all that Elohim commanded him. 
 \c 7
 \p
-\v 1 Yahweh said to Noah, “Come with all of your household into the ship, for I have seen your righteousness before me in this generation. 
+\v 1 Yahuah said to Noah, “Come with all of your household into the ship, for I have seen your righteousness before me in this generation. 
 \v 2 You shall take seven pairs of every clean animal with you, the male and his female. Of the animals that are not clean, take two, the male and his female. 
 \v 3 Also of the birds of the sky, seven and seven, male and female, to keep seed alive on the surface of all the earth. 
 \v 4 In seven days, I will cause it to rain on the earth for forty days and forty nights. I will destroy every living thing that I have made from the surface of the ground.” 
 \p
-\v 5 Noah did everything that Yahweh commanded him. 
+\v 5 Noah did everything that Yahuah commanded him. 
 \p
 \v 6 Noah was six hundred years old when the flood of waters came on the earth. 
 \v 7 Noah went into the ship with his sons, his woman, and his sons’ women, because of the floodwaters. 
@@ -265,7 +265,7 @@
 \p
 \v 13 In the same day Noah, and Shem, Ham, and Japheth—the sons of Noah—and Noah’s woman and the three women of his sons with them, entered into the ship—\v 14 they, and every animal after its kind, all the livestock after their kind, every creeping thing that creeps on the earth after its kind, and every bird after its kind, every bird of every sort. 
 \v 15 Pairs from all flesh with the breath of life in them went into the ship to Noah. 
-\v 16 Those who went in, went in male and female of all flesh, as Elohim commanded him; then Yahweh shut him in. 
+\v 16 Those who went in, went in male and female of all flesh, as Elohim commanded him; then Yahuah shut him in. 
 \v 17 The flood was forty days on the earth. The waters increased, and lifted up the ship, and it was lifted up above the earth. 
 \v 18 The waters rose, and increased greatly on the earth; and the ship floated on the surface of the waters. 
 \v 19 The waters rose very high on the earth. All the high mountains that were under the whole sky were covered. 
@@ -300,8 +300,8 @@
 \v 18 Noah went out, with his sons, his woman, and his sons’ women with him. 
 \v 19 Every animal, every creeping thing, and every bird, whatever moves on the earth, after their families, went out of the ship. 
 \p
-\v 20 Noah built an altar to Yahweh, and took of every clean animal, and of every clean bird, and offered burnt offerings on the altar. 
-\v 21 Yahweh smelled the pleasant aroma. Yahweh said in his heart, “I will not again curse the ground any more for man’s sake because the imagination of man’s heart is evil from his youth. I will never again strike every living thing, as I have done. 
+\v 20 Noah built an altar to Yahuah, and took of every clean animal, and of every clean bird, and offered burnt offerings on the altar. 
+\v 21 Yahuah smelled the pleasant aroma. Yahuah said in his heart, “I will not again curse the ground any more for man’s sake because the imagination of man’s heart is evil from his youth. I will never again strike every living thing, as I have done. 
 \v 22 While the earth remains, seed time and harvest, and cold and heat, and summer and winter, and day and night will not cease.” 
 \c 9
 \p
@@ -337,7 +337,7 @@
 \q2 He will be a servant of servants to his brothers.” 
 \p
 \v 26 He said, 
-\q1 “Blessed be Yahweh, the Elohim of Shem. 
+\q1 “Blessed be Yahuah, the Elohim of Shem. 
 \q2 Let Canaan be his servant. 
 \q1
 \v 27 May Elohim enlarge Japheth. 
@@ -358,7 +358,7 @@
 \v 6 The sons of Ham were: Cush, Mizraim, Put, and Canaan. 
 \v 7 The sons of Cush were: Seba, Havilah, Sabtah, Raamah, and Sabteca. The sons of Raamah were: Sheba and Dedan. 
 \v 8 Cush brought forth Nimrod. He began to be a mighty one in the earth. 
-\v 9 He was a mighty hunter before Yahweh. Therefore it is said, “like Nimrod, a mighty hunter before Yahweh”. 
+\v 9 He was a mighty hunter before Yahuah. Therefore it is said, “like Nimrod, a mighty hunter before Yahuah”. 
 \v 10 The beginning of his kingdom was Babel, Erech, Accad, and Calneh, in the land of Shinar. 
 \v 11 Out of that land he went into Assyria, and built Nineveh, Rehoboth Ir, Calah, 
 \v 12 and Resen between Nineveh and the great city Calah. 
@@ -392,11 +392,11 @@
 \v 3 They said to one another, “Come, let’s make bricks, and burn them thoroughly.” They had brick for stone, and they used tar for mortar. 
 \v 4 They said, “Come, let’s build ourselves a city, and a tower whose top reaches to the sky, and let’s make a name for ourselves, lest we be scattered abroad on the surface of the whole earth.” 
 \p
-\v 5 Yahweh came down to see the city and the tower, which the children of men built. 
-\v 6 Yahweh said, “Behold, they are one people, and they all have one language, and this is what they begin to do. Now nothing will be withheld from them, which they intend to do. 
+\v 5 Yahuah came down to see the city and the tower, which the children of men built. 
+\v 6 Yahuah said, “Behold, they are one people, and they all have one language, and this is what they begin to do. Now nothing will be withheld from them, which they intend to do. 
 \v 7 Come, let’s go down, and there confuse their language, that they may not understand one another’s speech.” 
-\v 8 So Yahweh scattered them abroad from there on the surface of all the earth. They stopped building the city. 
-\v 9 Therefore its name was called Babel, because there Yahweh confused the language of all the earth. From there, Yahweh scattered them abroad on the surface of all the earth. 
+\v 8 So Yahuah scattered them abroad from there on the surface of all the earth. They stopped building the city. 
+\v 9 Therefore its name was called Babel, because there Yahuah confused the language of all the earth. From there, Yahuah scattered them abroad on the surface of all the earth. 
 \p
 \v 10 This is the history of the generations of Shem: Shem was one hundred years old when he brought forth Arpachshad two years after the flood. 
 \v 11 Shem lived five hundred years after he brought forth Arpachshad, and brought forth more sons and daughters. 
@@ -432,17 +432,17 @@
 \v 32 The days of Terah were two hundred five years. Terah died in Haran. 
 \c 12
 \p
-\v 1 Now Yahweh said to Abram, “Leave your country, and your relatives, and your father’s house, and go to the land that I will show you. 
+\v 1 Now Yahuah said to Abram, “Leave your country, and your relatives, and your father’s house, and go to the land that I will show you. 
 \v 2 I will make of you a great nation. I will bless you and make your name great. You will be a blessing. 
 \v 3 I will bless those who bless you, and I will curse him who treats you with contempt. All the families of the earth will be blessed through you.” 
 \p
-\v 4 So Abram went, as Yahweh had told him. Lot went with him. Abram was seventy-five years old when he departed from Haran. 
+\v 4 So Abram went, as Yahuah had told him. Lot went with him. Abram was seventy-five years old when he departed from Haran. 
 \v 5 Abram took Sarai his woman, Lot his brother’s son, all their possessions that they had gathered, and the people whom they had acquired in Haran, and they went to go into the land of Canaan. They entered into the land of Canaan. 
 \v 6 Abram passed through the land to the place of Shechem, to the oak of Moreh. At that time, Canaanites were in the land. 
 \p
-\v 7 Yahweh appeared to Abram and said, “I will give this land to your offspring.” 
-\p He built an altar there to Yahweh, who had appeared to him. 
-\v 8 He left from there to go to the mountain on the east of Bethel and pitched his tent, having Bethel on the west, and Ai on the east. There he built an altar to Yahweh and called on Yahweh’s name. 
+\v 7 Yahuah appeared to Abram and said, “I will give this land to your offspring.” 
+\p He built an altar there to Yahuah, who had appeared to him. 
+\v 8 He left from there to go to the mountain on the east of Bethel and pitched his tent, having Bethel on the west, and Ai on the east. There he built an altar to Yahuah and called on Yahuah’s name. 
 \v 9 Abram traveled, still going on toward the South. 
 \p
 \v 10 There was a famine in the land. Abram went down into Egypt to live as a foreigner there, for the famine was severe in the land. 
@@ -453,7 +453,7 @@
 \v 14 When Abram had come into Egypt, Egyptians saw that the woman was very beautiful. 
 \v 15 The princes of Pharaoh saw her, and praised her to Pharaoh; and the woman was taken into Pharaoh’s house. 
 \v 16 He dealt well with Abram for her sake. He had sheep, cattle, male donkeys, male servants, female servants, female donkeys, and camels. 
-\v 17 Yahweh afflicted Pharaoh and his house with great plagues because of Sarai, Abram’s woman. 
+\v 17 Yahuah afflicted Pharaoh and his house with great plagues because of Sarai, Abram’s woman. 
 \v 18 Pharaoh called Abram and said, “What is this that you have done to me? Why didn’t you tell me that she was your woman? 
 \v 19 Why did you say, ‘She is my sister,’ so that I took her to be my woman? Now therefore, see your woman, take her, and go your way.” 
 \p
@@ -463,24 +463,24 @@
 \v 1 Abram went up out of Egypt—he, his woman, all that he had, and Lot with him—into the South. 
 \v 2 Abram was very rich in livestock, in silver, and in gold. 
 \v 3 He went on his journeys from the South as far as Bethel, to the place where his tent had been at the beginning, between Bethel and Ai, 
-\v 4 to the place of the altar, which he had made there at the first. There Abram called on Yahweh’s name. 
+\v 4 to the place of the altar, which he had made there at the first. There Abram called on Yahuah’s name. 
 \v 5 Lot also, who went with Abram, had flocks, herds, and tents. 
 \v 6 The land was not able to bear them, that they might live together; for their possessions were so great that they couldn’t live together. 
 \v 7 There was strife between the herdsmen of Abram’s livestock and the herdsmen of Lot’s livestock. The Canaanites and the Perizzites lived in the land at that time. 
 \v 8 Abram said to Lot, “Please, let there be no strife between you and me, and between your herdsmen and my herdsmen; for we are relatives. 
 \v 9 Isn’t the whole land before you? Please separate yourself from me. If you go to the left hand, then I will go to the right. Or if you go to the right hand, then I will go to the left.” 
 \p
-\v 10 Lot lifted up his eyes, and saw all the plain of the Jordan, that it was well-watered everywhere, before Yahweh destroyed Sodom and Gomorrah, like the garden of Yahweh, like the land of Egypt, as you go to Zoar. 
+\v 10 Lot lifted up his eyes, and saw all the plain of the Jordan, that it was well-watered everywhere, before Yahuah destroyed Sodom and Gomorrah, like the garden of Yahuah, like the land of Egypt, as you go to Zoar. 
 \v 11 So Lot chose the Plain of the Jordan for himself. Lot traveled east, and they separated themselves from one other. 
 \v 12 Abram lived in the land of Canaan, and Lot lived in the cities of the plain, and moved his tent as far as Sodom. 
-\v 13 Now the men of Sodom were exceedingly wicked and sinners against Yahweh. 
+\v 13 Now the men of Sodom were exceedingly wicked and sinners against Yahuah. 
 \p
-\v 14 Yahweh said to Abram, after Lot was separated from him, “Now, lift up your eyes, and look from the place where you are, northward and southward and eastward and westward, 
+\v 14 Yahuah said to Abram, after Lot was separated from him, “Now, lift up your eyes, and look from the place where you are, northward and southward and eastward and westward, 
 \v 15 for I will give all the land which you see to you and to your offspring forever. 
 \v 16 I will make your offspring as the dust of the earth, so that if a man can count the dust of the earth, then your offspring may also be counted. 
 \v 17 Arise, walk through the land in its length and in its width; for I will give it to you.” 
 \p
-\v 18 Abram moved his tent, and came and lived by the oaks of Mamre, which are in Hebron, and built an altar there to Yahweh. 
+\v 18 Abram moved his tent, and came and lived by the oaks of Mamre, which are in Hebron, and built an altar there to Yahuah. 
 \c 14
 \p
 \v 1 In the days of Amraphel, king of Shinar; Arioch, king of Ellasar; Chedorlaomer, king of Elam; and Tidal, king of Goiim, 
@@ -509,22 +509,22 @@
 \p
 \v 21 The king of Sodom said to Abram, “Give me the people, and take the goods for yourself.” 
 \p
-\v 22 Abram said to the king of Sodom, “I have lifted up my hand to Yahweh, Elohim Most High, possessor of heaven and earth, 
+\v 22 Abram said to the king of Sodom, “I have lifted up my hand to Yahuah, Elohim Most High, possessor of heaven and earth, 
 \v 23 that I will not take a thread nor a sandal strap nor anything that is yours, lest you should say, ‘I have made Abram rich.’ 
 \v 24 I will accept nothing from you except that which the young men have eaten, and the portion of the men who went with me: Aner, Eshcol, and Mamre. Let them take their portion.” 
 \c 15
 \p
-\v 1 After these things Yahweh’s word came to Abram in a vision, saying, “Don’t be afraid, Abram. I am your shield, your exceedingly great reward.” 
+\v 1 After these things Yahuah’s word came to Abram in a vision, saying, “Don’t be afraid, Abram. I am your shield, your exceedingly great reward.” 
 \p
-\v 2 Abram said, “Lord Yahweh, what will you give me, since I go childless, and he who will inherit my estate is Eliezer of Damascus?” 
+\v 2 Abram said, “Lord Yahuah, what will you give me, since I go childless, and he who will inherit my estate is Eliezer of Damascus?” 
 \v 3 Abram said, “Behold, you have given no children to me: and, behold, one born in my house is my heir.” 
 \p
-\v 4 Behold, Yahweh’s word came to him, saying, “This man will not be your heir, but he who will come out of your own body will be your heir.” 
-\v 5 Yahweh brought him outside, and said, “Look now toward the sky, and count the stars, if you are able to count them.” He said to Abram, “So your offspring will be.” 
-\v 6 He believed in Yahweh, and credited it to him as righteousness. 
-\v 7 He said to Abram, “I am Yahweh who brought you out of Ur of the Chaldees, to give you this land to inherit it.” 
+\v 4 Behold, Yahuah’s word came to him, saying, “This man will not be your heir, but he who will come out of your own body will be your heir.” 
+\v 5 Yahuah brought him outside, and said, “Look now toward the sky, and count the stars, if you are able to count them.” He said to Abram, “So your offspring will be.” 
+\v 6 He believed in Yahuah, and credited it to him as righteousness. 
+\v 7 He said to Abram, “I am Yahuah who brought you out of Ur of the Chaldees, to give you this land to inherit it.” 
 \p
-\v 8 He said, “Lord Yahweh, how will I know that I will inherit it?” 
+\v 8 He said, “Lord Yahuah, how will I know that I will inherit it?” 
 \p
 \v 9 He said to him, “Bring me a heifer three years old, a female goat three years old, a ram three years old, a turtledove, and a young pigeon.” 
 \v 10 He brought him all these, and divided them in the middle, and laid each half opposite the other; but he didn’t divide the birds. 
@@ -536,37 +536,37 @@
 \v 15 but you will go to your fathers in peace. You will be buried at a good old age. 
 \v 16 In the fourth generation they will come here again, for the iniquity of the Amorite is not yet full.” 
 \v 17 It came to pass that, when the sun went down, and it was dark, behold, a smoking furnace and a flaming torch passed between these pieces. 
-\v 18 In that day Yahweh made a covenant with Abram, saying, “I have given this land to your offspring, from the river of Egypt to the great river, the river Euphrates: 
+\v 18 In that day Yahuah made a covenant with Abram, saying, “I have given this land to your offspring, from the river of Egypt to the great river, the river Euphrates: 
 \v 19 the land of the Kenites, the Kenizzites, the Kadmonites, 
 \v 20 the Hittites, the Perizzites, the Rephaim, 
 \v 21 the Amorites, the Canaanites, the Girgashites, and the Jebusites.” 
 \c 16
 \p
 \v 1 Now Sarai, Abram’s woman, bore him no children. She had a servant, an Egyptian, whose name was Hagar. 
-\v 2 Sarai said to Abram, “See now, Yahweh has restrained me from bearing. Please go in to my servant. It may be that I will obtain children by her.” Abram listened to the voice of Sarai. 
+\v 2 Sarai said to Abram, “See now, Yahuah has restrained me from bearing. Please go in to my servant. It may be that I will obtain children by her.” Abram listened to the voice of Sarai. 
 \v 3 Sarai, Abram’s woman, took Hagar the Egyptian, her servant, after Abram had lived ten years in the land of Canaan, and gave her to Abram her man to be his woman. 
 \v 4 He went in to Hagar, and she conceived. When she saw that she had conceived, her mistress was despised in her eyes. 
-\v 5 Sarai said to Abram, “This wrong is your fault. I gave my servant into your bosom, and when she saw that she had conceived, she despised me. May Yahweh judge between me and you.” 
+\v 5 Sarai said to Abram, “This wrong is your fault. I gave my servant into your bosom, and when she saw that she had conceived, she despised me. May Yahuah judge between me and you.” 
 \p
 \v 6 But Abram said to Sarai, “Behold, your maid is in your hand. Do to her whatever is good in your eyes.” Sarai dealt harshly with her, and she fled from her face. 
 \p
-\v 7 Yahweh’s angel found her by a fountain of water in the wilderness, by the fountain on the way to Shur. 
+\v 7 Yahuah’s angel found her by a fountain of water in the wilderness, by the fountain on the way to Shur. 
 \v 8 He said, “Hagar, Sarai’s servant, where did you come from? Where are you going?” 
 \p She said, “I am fleeing from the face of my mistress Sarai.” 
 \p
-\v 9 Yahweh’s angel said to her, “Return to your mistress, and submit yourself under her hands.” 
-\v 10 Yahweh’s angel said to her, “I will greatly multiply your offspring, that they will not be counted for multitude.” 
-\v 11 Yahweh’s angel said to her, “Behold, you are with child, and will bear a son. You shall call his name Ishmael, because Yahweh has heard your affliction. 
+\v 9 Yahuah’s angel said to her, “Return to your mistress, and submit yourself under her hands.” 
+\v 10 Yahuah’s angel said to her, “I will greatly multiply your offspring, that they will not be counted for multitude.” 
+\v 11 Yahuah’s angel said to her, “Behold, you are with child, and will bear a son. You shall call his name Ishmael, because Yahuah has heard your affliction. 
 \v 12 He will be like a wild donkey among men. His hand will be against every man, and every man’s hand against him. He will live opposed to all of his brothers.” 
 \p
-\v 13 She called the name of Yahweh who spoke to her, “You are an Elohim who sees,” for she said, “Have I even stayed alive after seeing him?” 
+\v 13 She called the name of Yahuah who spoke to her, “You are an Elohim who sees,” for she said, “Have I even stayed alive after seeing him?” 
 \v 14 Therefore the well was called Beer Lahai Roi. Behold, it is between Kadesh and Bered. 
 \p
 \v 15 Hagar bore a son for Abram. Abram called the name of his son, whom Hagar bore, Ishmael. 
 \v 16 Abram was eighty-six years old when Hagar bore Ishmael to Abram. 
 \c 17
 \p
-\v 1 When Abram was ninety-nine years old, Yahweh appeared to Abram and said to him, “I am Elohim Almighty. Walk before me and be blameless. 
+\v 1 When Abram was ninety-nine years old, Yahuah appeared to Abram and said to him, “I am Elohim Almighty. Walk before me and be blameless. 
 \v 2 I will make my covenant between me and you, and will multiply you exceedingly.” 
 \p
 \v 3 Abram fell on his face. Elohim talked with him, saying, 
@@ -601,7 +601,7 @@
 \v 27 All the men of his house, those born in the house, and those bought with money from a foreigner, were circumcised with him. 
 \c 18
 \p
-\v 1 Yahweh appeared to him by the oaks of Mamre, as he sat in the tent door in the heat of the day. 
+\v 1 Yahuah appeared to him by the oaks of Mamre, as he sat in the tent door in the heat of the day. 
 \v 2 He lifted up his eyes and looked, and saw that three men stood near him. When he saw them, he ran to meet them from the tent door, and bowed himself to the earth, 
 \v 3 and said, “My lord, if now I have found favor in your sight, please don’t go away from your servant. 
 \v 4 Now let a little water be fetched, wash your feet, and rest yourselves under the tree. 
@@ -620,25 +620,25 @@
 \v 11 Now Abraham and Sarah were old, well advanced in age. Sarah had passed the age of childbearing. 
 \v 12 Sarah laughed within herself, saying, “After I have grown old will I have pleasure, my lord being old also?” 
 \p
-\v 13 Yahweh said to Abraham, “Why did Sarah laugh, saying, ‘Will I really bear a child when I am old?’ 
-\v 14 Is anything too hard for Yahweh? At the set time I will return to you, when the season comes around, and Sarah will have a son.” 
+\v 13 Yahuah said to Abraham, “Why did Sarah laugh, saying, ‘Will I really bear a child when I am old?’ 
+\v 14 Is anything too hard for Yahuah? At the set time I will return to you, when the season comes around, and Sarah will have a son.” 
 \p
 \v 15 Then Sarah denied it, saying, “I didn’t laugh,” for she was afraid. 
 \p He said, “No, but you did laugh.” 
 \p
 \v 16 The men rose up from there, and looked toward Sodom. Abraham went with them to see them on their way. 
-\v 17 Yahweh said, “Will I hide from Abraham what I do, 
+\v 17 Yahuah said, “Will I hide from Abraham what I do, 
 \v 18 since Abraham will surely become a great and mighty nation, and all the nations of the earth will be blessed in him? 
-\v 19 For I have known him, to the end that he may command his children and his household after him, that they may keep the way of Yahweh, to do righteousness and justice; to the end that Yahweh may bring on Abraham that which he has spoken of him.” 
-\v 20 Yahweh said, “Because the cry of Sodom and Gomorrah is great, and because their sin is very grievous, 
+\v 19 For I have known him, to the end that he may command his children and his household after him, that they may keep the way of Yahuah, to do righteousness and justice; to the end that Yahuah may bring on Abraham that which he has spoken of him.” 
+\v 20 Yahuah said, “Because the cry of Sodom and Gomorrah is great, and because their sin is very grievous, 
 \v 21 I will go down now, and see whether their deeds are as bad as the reports which have come to me. If not, I will know.” 
 \p
-\v 22 The men turned from there, and went toward Sodom, but Abraham stood yet before Yahweh. 
+\v 22 The men turned from there, and went toward Sodom, but Abraham stood yet before Yahuah. 
 \v 23 Abraham came near, and said, “Will you consume the righteous with the wicked? 
 \v 24 What if there are fifty righteous within the city? Will you consume and not spare the place for the fifty righteous who are in it? 
 \v 25 May it be far from you to do things like that, to kill the righteous with the wicked, so that the righteous should be like the wicked. May that be far from you. Shouldn’t the Judge of all the earth do right?” 
 \p
-\v 26 Yahweh said, “If I find in Sodom fifty righteous within the city, then I will spare the whole place for their sake.” 
+\v 26 Yahuah said, “If I find in Sodom fifty righteous within the city, then I will spare the whole place for their sake.” 
 \v 27 Abraham answered, “See now, I have taken it on myself to speak to the Lord, although I am dust and ashes. 
 \v 28 What if there will lack five of the fifty righteous? Will you destroy all the city for lack of five?” 
 \p He said, “I will not destroy it if I find forty-five there.” 
@@ -655,7 +655,7 @@
 \v 32 He said, “Oh don’t let the Lord be angry, and I will speak just once more. What if ten are found there?” 
 \p He said, “I will not destroy it for the ten’s sake.” 
 \p
-\v 33 Yahweh went his way as soon as he had finished communing with Abraham, and Abraham returned to his place. 
+\v 33 Yahuah went his way as soon as he had finished communing with Abraham, and Abraham returned to his place. 
 \c 19
 \p
 \v 1 The two angels came to Sodom at evening. Lot sat in the gate of Sodom. Lot saw them, and rose up to meet them. He bowed himself with his face to the earth, 
@@ -675,12 +675,12 @@
 \v 11 They struck the men who were at the door of the house with blindness, both small and great, so that they wearied themselves to find the door. 
 \p
 \v 12 The men said to Lot, “Do you have anybody else here? Sons-in-law, your sons, your daughters, and whomever you have in the city, bring them out of the place: 
-\v 13 for we will destroy this place, because the outcry against them has grown so great before Yahweh that Yahweh has sent us to destroy it.” 
+\v 13 for we will destroy this place, because the outcry against them has grown so great before Yahuah that Yahuah has sent us to destroy it.” 
 \p
-\v 14 Lot went out, and spoke to his sons-in-law, who took his daughters, and said, “Get up! Get out of this place, for Yahweh will destroy the city!” 
+\v 14 Lot went out, and spoke to his sons-in-law, who took his daughters, and said, “Get up! Get out of this place, for Yahuah will destroy the city!” 
 \p But he seemed to his sons-in-law to be joking. 
 \v 15 When the morning came, then the angels hurried Lot, saying, “Get up! Take your woman and your two daughters who are here, lest you be consumed in the iniquity of the city.” 
-\v 16 But he lingered; and the men grabbed his hand, his woman’s hand, and his two daughters’ hands, Yahweh being merciful to him; and they took him out, and set him outside of the city. 
+\v 16 But he lingered; and the men grabbed his hand, his woman’s hand, and his two daughters’ hands, Yahuah being merciful to him; and they took him out, and set him outside of the city. 
 \v 17 It came to pass, when they had taken them out, that he said, “Escape for your life! Don’t look behind you, and don’t stay anywhere in the plain. Escape to the mountains, lest you be consumed!” 
 \p
 \v 18 Lot said to them, “Oh, not so, my lord. 
@@ -691,11 +691,11 @@
 \v 22 Hurry, escape there, for I can’t do anything until you get there.” Therefore the name of the city was called Zoar. 
 \p
 \v 23 The sun had risen on the earth when Lot came to Zoar. 
-\v 24 Then Yahweh rained on Sodom and on Gomorrah sulfur and fire from Yahweh out of the sky. 
+\v 24 Then Yahuah rained on Sodom and on Gomorrah sulfur and fire from Yahuah out of the sky. 
 \v 25 He overthrew those cities, all the plain, all the inhabitants of the cities, and that which grew on the ground. 
 \v 26 But Lot’s woman looked back from behind him, and she became a pillar of salt. 
 \p
-\v 27 Abraham went up early in the morning to the place where he had stood before Yahweh. 
+\v 27 Abraham went up early in the morning to the place where he had stood before Yahuah. 
 \v 28 He looked toward Sodom and Gomorrah, and toward all the land of the plain, and saw that the smoke of the land went up as the smoke of a furnace. 
 \p
 \v 29 When Elohim destroyed the cities of the plain, Elohim remembered Abraham, and sent Lot out of the middle of the overthrow, when he overthrew the cities in which Lot lived. 
@@ -734,10 +734,10 @@
 \v 16 To Sarah he said, “Behold, I have given your brother a thousand pieces of silver. Behold, it is for you a covering of the eyes to all that are with you. In front of all you are vindicated.” 
 \p
 \v 17 Abraham prayed to Elohim. So Elohim healed Abimelech, his woman, and his female servants, and they bore children. 
-\v 18 For Yahweh had closed up tight all the wombs of the house of Abimelech, because of Sarah, Abraham’s woman. 
+\v 18 For Yahuah had closed up tight all the wombs of the house of Abimelech, because of Sarah, Abraham’s woman. 
 \c 21
 \p
-\v 1 Yahweh visited Sarah as he had said, and Yahweh did to Sarah as he had spoken. 
+\v 1 Yahuah visited Sarah as he had said, and Yahuah did to Sarah as he had spoken. 
 \v 2 Sarah conceived, and bore Abraham a son in his old age, at the set time of which Elohim had spoken to him. 
 \v 3 Abraham called his son who was born to him, whom Sarah bore to him, Isaac. 
 \v 4 Abraham circumcised his son, Isaac, when he was eight days old, as Elohim had commanded him. 
@@ -778,7 +778,7 @@
 \v 30 He said, “You shall take these seven ewe lambs from my hand, that it may be a witness to me, that I have dug this well.” 
 \v 31 Therefore he called that place Beersheba, because they both swore an oath there. 
 \v 32 So they made a covenant at Beersheba. Abimelech rose up with Phicol, the captain of his army, and they returned into the land of the Philistines. 
-\v 33 Abraham planted a tamarisk tree in Beersheba, and there he called on the name of Yahweh, the Everlasting Elohim. 
+\v 33 Abraham planted a tamarisk tree in Beersheba, and there he called on the name of Yahuah, the Everlasting Elohim. 
 \v 34 Abraham lived as a foreigner in the land of the Philistines many days. 
 \c 22
 \p
@@ -799,16 +799,16 @@
 \v 9 They came to the place which Elohim had told him of. Abraham built the altar there, and laid the wood in order, bound Isaac his son, and laid him on the altar, on the wood. 
 \v 10 Abraham stretched out his hand, and took the knife to kill his son. 
 \p
-\v 11 Yahweh’s angel called to him out of the sky, and said, “Abraham, Abraham!” 
+\v 11 Yahuah’s angel called to him out of the sky, and said, “Abraham, Abraham!” 
 \p He said, “Here I am.” 
 \p
 \v 12 He said, “Don’t lay your hand on the boy or do anything to him. For now I know that you fear Elohim, since you have not withheld your son, your only son, from me.” 
 \p
 \v 13 Abraham lifted up his eyes, and looked, and saw that behind him was a ram caught in the thicket by his horns. Abraham went and took the ram, and offered him up for a burnt offering instead of his son. 
-\v 14 Abraham called the name of that place “Yahweh Will Provide”. As it is said to this day, “On Yahweh’s mountain, it will be provided.” 
+\v 14 Abraham called the name of that place “Yahuah Will Provide”. As it is said to this day, “On Yahuah’s mountain, it will be provided.” 
 \p
-\v 15 Yahweh’s angel called to Abraham a second time out of the sky, 
-\v 16 and said, “ ‘I have sworn by myself,’ says Yahweh, ‘because you have done this thing, and have not withheld your son, your only son, 
+\v 15 Yahuah’s angel called to Abraham a second time out of the sky, 
+\v 16 and said, “ ‘I have sworn by myself,’ says Yahuah, ‘because you have done this thing, and have not withheld your son, your only son, 
 \v 17 that I will bless you greatly, and I will multiply your offspring greatly like the stars of the heavens, and like the sand which is on the seashore. Your offspring will possess the gate of his enemies. 
 \v 18 All the nations of the earth will be blessed by your offspring, because you have obeyed my voice.’ ” 
 \p
@@ -850,21 +850,21 @@
 \v 20 The field, and the cave that is in it, were deeded to Abraham by the children of Heth as a possession for a burial place. 
 \c 24
 \p
-\v 1 Abraham was old, and well advanced in age. Yahweh had blessed Abraham in all things. 
+\v 1 Abraham was old, and well advanced in age. Yahuah had blessed Abraham in all things. 
 \v 2 Abraham said to his servant, the elder of his house, who ruled over all that he had, “Please put your hand under my thigh. 
-\v 3 I will make you swear by Yahweh, the Elohim of heaven and the Elohim of the earth, that you shall not take a woman for my son of the daughters of the Canaanites, among whom I live. 
+\v 3 I will make you swear by Yahuah, the Elohim of heaven and the Elohim of the earth, that you shall not take a woman for my son of the daughters of the Canaanites, among whom I live. 
 \v 4 But you shall go to my country, and to my relatives, and take a woman for my son Isaac.” 
 \p
 \v 5 The servant said to him, “What if the woman isn’t willing to follow me to this land? Must I bring your son again to the land you came from?” 
 \p
 \v 6 Abraham said to him, “Beware that you don’t bring my son there again. 
-\v 7 Yahweh, the Elohim of heaven—who took me from my father’s house, and from the land of my birth, who spoke to me, and who swore to me, saying, ‘I will give this land to your offspring—he will send his angel before you, and you shall take a woman for my son from there. 
+\v 7 Yahuah, the Elohim of heaven—who took me from my father’s house, and from the land of my birth, who spoke to me, and who swore to me, saying, ‘I will give this land to your offspring—he will send his angel before you, and you shall take a woman for my son from there. 
 \v 8 If the woman isn’t willing to follow you, then you shall be clear from this oath to me. Only you shall not bring my son there again.” 
 \p
 \v 9 The servant put his hand under the thigh of Abraham his master, and swore to him concerning this matter. 
 \v 10 The servant took ten of his master’s camels, and departed, having a variety of good things of his master’s with him. He arose, and went to Mesopotamia, to the city of Nahor. 
 \v 11 He made the camels kneel down outside the city by the well of water at the time of evening, the time that women go out to draw water. 
-\v 12 He said, “Yahweh, the Elohim of my master Abraham, please give me success today, and show kindness to my master Abraham. 
+\v 12 He said, “Yahuah, the Elohim of my master Abraham, please give me success today, and show kindness to my master Abraham. 
 \v 13 Behold, I am standing by the spring of water. The daughters of the men of the city are coming out to draw water. 
 \v 14 Let it happen, that the young lady to whom I will say, ‘Please let down your pitcher, that I may drink,’ then she says, ‘Drink, and I will also give your camels a drink,’—let her be the one you have appointed for your servant Isaac. By this I will know that you have shown kindness to my master.” 
 \p
@@ -876,51 +876,51 @@
 \v 19 When she had finished giving him a drink, she said, “I will also draw for your camels, until they have finished drinking.” 
 \v 20 She hurried, and emptied her pitcher into the trough, and ran again to the well to draw, and drew for all his camels. 
 \p
-\v 21 The man looked steadfastly at her, remaining silent, to know whether Yahweh had made his journey prosperous or not. 
+\v 21 The man looked steadfastly at her, remaining silent, to know whether Yahuah had made his journey prosperous or not. 
 \v 22 As the camels had done drinking, the man took a golden ring of half a shekel weight, and two bracelets for her hands of ten shekels weight of gold, 
 \v 23 and said, “Whose daughter are you? Please tell me. Is there room in your father’s house for us to stay?” 
 \p
 \v 24 She said to him, “I am the daughter of Bethuel the son of Milcah, whom she bore to Nahor.” 
 \v 25 She said moreover to him, “We have both straw and feed enough, and room to lodge in.” 
 \p
-\v 26 The man bowed his head, and worshiped Yahweh. 
-\v 27 He said, “Blessed be Yahweh, the Elohim of my master Abraham, who has not forsaken his loving kindness and his truth toward my master. As for me, Yahweh has led me on the way to the house of my master’s relatives.” 
+\v 26 The man bowed his head, and worshiped Yahuah. 
+\v 27 He said, “Blessed be Yahuah, the Elohim of my master Abraham, who has not forsaken his loving kindness and his truth toward my master. As for me, Yahuah has led me on the way to the house of my master’s relatives.” 
 \p
 \v 28 The young lady ran, and told her mother’s house about these words. 
 \v 29 Rebekah had a brother, and his name was Laban. Laban ran out to the man, to the spring. 
 \v 30 When he saw the ring, and the bracelets on his sister’s hands, and when he heard the words of Rebekah his sister, saying, “This is what the man said to me,” he came to the man. Behold, he was standing by the camels at the spring. 
-\v 31 He said, “Come in, you blessed of Yahweh. Why do you stand outside? For I have prepared the house, and room for the camels.” 
+\v 31 He said, “Come in, you blessed of Yahuah. Why do you stand outside? For I have prepared the house, and room for the camels.” 
 \p
 \v 32 The man came into the house, and he unloaded the camels. He gave straw and feed for the camels, and water to wash his feet and the feet of the men who were with him. 
 \v 33 Food was set before him to eat, but he said, “I will not eat until I have told my message.” 
 \p Laban said, “Speak on.” 
 \p
 \v 34 He said, “I am Abraham’s servant. 
-\v 35 Yahweh has blessed my master greatly. He has become great. Yahweh has given him flocks and herds, silver and gold, male servants and female servants, and camels and donkeys. 
+\v 35 Yahuah has blessed my master greatly. He has become great. Yahuah has given him flocks and herds, silver and gold, male servants and female servants, and camels and donkeys. 
 \v 36 Sarah, my master’s woman, bore a son to my master when she was old. He has given all that he has to him. 
 \v 37 My master made me swear, saying, ‘You shall not take a woman for my son from the daughters of the Canaanites, in whose land I live, 
 \v 38 but you shall go to my father’s house, and to my relatives, and take a woman for my son.’ 
 \v 39 I asked my master, ‘What if the woman will not follow me?’ 
-\v 40 He said to me, ‘Yahweh, before whom I walk, will send his angel with you, and prosper your way. You shall take a woman for my son from my relatives, and of my father’s house. 
+\v 40 He said to me, ‘Yahuah, before whom I walk, will send his angel with you, and prosper your way. You shall take a woman for my son from my relatives, and of my father’s house. 
 \v 41 Then you will be clear from my oath, when you come to my relatives. If they don’t give her to you, you shall be clear from my oath.’ 
-\v 42 I came today to the spring, and said, ‘Yahweh, the Elohim of my master Abraham, if now you do prosper my way which I go—\v 43 behold, I am standing by this spring of water. Let it happen, that the maiden who comes out to draw, to whom I will say, “Please give me a little water from your pitcher to drink,” 
-\v 44 then she tells me, “Drink, and I will also draw for your camels,”—let her be the woman whom Yahweh has appointed for my master’s son.’ 
+\v 42 I came today to the spring, and said, ‘Yahuah, the Elohim of my master Abraham, if now you do prosper my way which I go—\v 43 behold, I am standing by this spring of water. Let it happen, that the maiden who comes out to draw, to whom I will say, “Please give me a little water from your pitcher to drink,” 
+\v 44 then she tells me, “Drink, and I will also draw for your camels,”—let her be the woman whom Yahuah has appointed for my master’s son.’ 
 \v 45 Before I had finished speaking in my heart, behold, Rebekah came out with her pitcher on her shoulder. She went down to the spring, and drew. I said to her, ‘Please let me drink.’ 
 \v 46 She hurried and let down her pitcher from her shoulder, and said, ‘Drink, and I will also give your camels a drink.’ So I drank, and she also gave the camels a drink. 
 \v 47 I asked her, and said, ‘Whose daughter are you?’ She said, ‘The daughter of Bethuel, Nahor’s son, whom Milcah bore to him.’ I put the ring on her nose, and the bracelets on her hands. 
-\v 48 I bowed my head, and worshiped Yahweh, and blessed Yahweh, the Elohim of my master Abraham, who had led me in the right way to take my master’s brother’s daughter for his son. 
+\v 48 I bowed my head, and worshiped Yahuah, and blessed Yahuah, the Elohim of my master Abraham, who had led me in the right way to take my master’s brother’s daughter for his son. 
 \v 49 Now if you will deal kindly and truly with my master, tell me. If not, tell me, that I may turn to the right hand, or to the left.” 
 \p
-\v 50 Then Laban and Bethuel answered, “The thing proceeds from Yahweh. We can’t speak to you bad or good. 
-\v 51 Behold, Rebekah is before you. Take her, and go, and let her be your master’s son’s woman, as Yahweh has spoken.” 
+\v 50 Then Laban and Bethuel answered, “The thing proceeds from Yahuah. We can’t speak to you bad or good. 
+\v 51 Behold, Rebekah is before you. Take her, and go, and let her be your master’s son’s woman, as Yahuah has spoken.” 
 \p
-\v 52 When Abraham’s servant heard their words, he bowed himself down to the earth to Yahweh. 
+\v 52 When Abraham’s servant heard their words, he bowed himself down to the earth to Yahuah. 
 \v 53 The servant brought out jewels of silver, and jewels of gold, and clothing, and gave them to Rebekah. He also gave precious things to her brother and her mother. 
 \v 54 They ate and drank, he and the men who were with him, and stayed all night. They rose up in the morning, and he said, “Send me away to my master.” 
 \p
 \v 55 Her brother and her mother said, “Let the young lady stay with us a few days, at least ten. After that she will go.” 
 \p
-\v 56 He said to them, “Don’t hinder me, since Yahweh has prospered my way. Send me away that I may go to my master.” 
+\v 56 He said to them, “Don’t hinder me, since Yahuah has prospered my way. Send me away that I may go to my master.” 
 \p
 \v 57 They said, “We will call the young lady, and ask her.” 
 \v 58 They called Rebekah, and said to her, “Will you go with this man?” 
@@ -962,9 +962,9 @@
 \p
 \v 19 This is the history of the generations of Isaac, Abraham’s son. Abraham brought forth Isaac. 
 \v 20 Isaac was forty years old when he took Rebekah, the daughter of Bethuel the Syrian of Paddan Aram, the sister of Laban the Syrian, to be his woman. 
-\v 21 Isaac entreated Yahweh for his woman, because she was barren. Yahweh was entreated by him, and Rebekah his woman conceived. 
-\v 22 The children struggled together within her. She said, “If it is like this, why do I live?” She went to inquire of Yahweh. 
-\v 23 Yahweh said to her, 
+\v 21 Isaac entreated Yahuah for his woman, because she was barren. Yahuah was entreated by him, and Rebekah his woman conceived. 
+\v 22 The children struggled together within her. She said, “If it is like this, why do I live?” She went to inquire of Yahuah. 
+\v 23 Yahuah said to her, 
 \q1 “Two nations are in your womb. 
 \q1 Two peoples will be separated from your body. 
 \q1 The one people will be stronger than the other people. 
@@ -989,7 +989,7 @@
 \c 26
 \p
 \v 1 There was a famine in the land, in addition to the first famine that was in the days of Abraham. Isaac went to Abimelech king of the Philistines, to Gerar. 
-\v 2 Yahweh appeared to him, and said, “Don’t go down into Egypt. Live in the land I will tell you about. 
+\v 2 Yahuah appeared to him, and said, “Don’t go down into Egypt. Live in the land I will tell you about. 
 \v 3 Live in this land, and I will be with you, and will bless you. For I will give to you, and to your offspring, all these lands, and I will establish the oath which I swore to Abraham your father. 
 \v 4 I will multiply your offspring as the stars of the sky, and will give all these lands to your offspring. In your offspring all the nations of the earth will be blessed, 
 \v 5 because Abraham obeyed my voice, and kept my requirements, my commandments, my statutes, and my laws.” 
@@ -1004,7 +1004,7 @@
 \p
 \v 11 Abimelech commanded all the people, saying, “He who touches this man or his woman will surely be put to death.” 
 \p
-\v 12 Isaac sowed in that land, and reaped in the same year one hundred times what he planted. Yahweh blessed him. 
+\v 12 Isaac sowed in that land, and reaped in the same year one hundred times what he planted. Yahuah blessed him. 
 \v 13 The man grew great, and grew more and more until he became very great. 
 \v 14 He had possessions of flocks, possessions of herds, and a great household. The Philistines envied him. 
 \v 15 Now all the wells which his father’s servants had dug in the days of Abraham his father, the Philistines had stopped, and filled with earth. 
@@ -1016,18 +1016,18 @@
 \v 19 Isaac’s servants dug in the valley, and found there a well of flowing water. 
 \v 20 The herdsmen of Gerar argued with Isaac’s herdsmen, saying, “The water is ours.” So he called the name of the well Esek, because they contended with him. 
 \v 21 They dug another well, and they argued over that, also. So he called its name Sitnah. 
-\v 22 He left that place, and dug another well. They didn’t argue over that one. So he called it Rehoboth. He said, “For now Yahweh has made room for us, and we will be fruitful in the land.” 
+\v 22 He left that place, and dug another well. They didn’t argue over that one. So he called it Rehoboth. He said, “For now Yahuah has made room for us, and we will be fruitful in the land.” 
 \p
 \v 23 He went up from there to Beersheba. 
-\v 24 Yahweh appeared to him the same night, and said, “I am the Elohim of Abraham your father. Don’t be afraid, for I am with you, and will bless you, and multiply your offspring for my servant Abraham’s sake.” 
+\v 24 Yahuah appeared to him the same night, and said, “I am the Elohim of Abraham your father. Don’t be afraid, for I am with you, and will bless you, and multiply your offspring for my servant Abraham’s sake.” 
 \p
-\v 25 He built an altar there, and called on Yahweh’s name, and pitched his tent there. There Isaac’s servants dug a well. 
+\v 25 He built an altar there, and called on Yahuah’s name, and pitched his tent there. There Isaac’s servants dug a well. 
 \p
 \v 26 Then Abimelech went to him from Gerar with Ahuzzath his friend, and Phicol the captain of his army. 
 \v 27 Isaac said to them, “Why have you come to me, since you hate me, and have sent me away from you?” 
 \p
-\v 28 They said, “We saw plainly that Yahweh was with you. We said, ‘Let there now be an oath between us, even between us and you, and let’s make a covenant with you, 
-\v 29 that you will do us no harm, as we have not touched you, and as we have done to you nothing but good, and have sent you away in peace.’ You are now the blessed of Yahweh.” 
+\v 28 They said, “We saw plainly that Yahuah was with you. We said, ‘Let there now be an oath between us, even between us and you, and let’s make a covenant with you, 
+\v 29 that you will do us no harm, as we have not touched you, and as we have done to you nothing but good, and have sent you away in peace.’ You are now the blessed of Yahuah.” 
 \p
 \v 30 He made them a feast, and they ate and drank. 
 \v 31 They rose up some time in the morning, and swore an oath to one another. Isaac sent them away, and they departed from him in peace. 
@@ -1047,7 +1047,7 @@
 \p
 \v 5 Rebekah heard when Isaac spoke to Esau his son. Esau went to the field to hunt for venison, and to bring it. 
 \v 6 Rebekah spoke to Jacob her son, saying, “Behold, I heard your father speak to Esau your brother, saying, 
-\v 7 ‘Bring me venison, and make me savory food, that I may eat, and bless you before Yahweh before my death.’ 
+\v 7 ‘Bring me venison, and make me savory food, that I may eat, and bless you before Yahuah before my death.’ 
 \v 8 Now therefore, my son, obey my voice according to that which I command you. 
 \v 9 Go now to the flock and get me two good young goats from there. I will make them savory food for your father, such as he loves. 
 \v 10 You shall bring it to your father, that he may eat, so that he may bless you before his death.” 
@@ -1068,7 +1068,7 @@
 \v 19 Jacob said to his father, “I am Esau your firstborn. I have done what you asked me to do. Please arise, sit and eat of my venison, that your soul may bless me.” 
 \p
 \v 20 Isaac said to his son, “How is it that you have found it so quickly, my son?” 
-\p He said, “Because Yahweh your Elohim gave me success.” 
+\p He said, “Because Yahuah your Elohim gave me success.” 
 \p
 \v 21 Isaac said to Jacob, “Please come near, that I may feel you, my son, whether you are really my son Esau or not.” 
 \p
@@ -1082,7 +1082,7 @@
 \v 26 His father Isaac said to him, “Come near now, and kiss me, my son.” 
 \v 27 He came near, and kissed him. He smelled the smell of his clothing, and blessed him, and said, 
 \q1 “Behold, the smell of my son 
-\q2 is as the smell of a field which Yahweh has blessed. 
+\q2 is as the smell of a field which Yahuah has blessed. 
 \q1
 \v 28 Elohim give you of the dew of the sky, 
 \q2 of the fatness of the earth, 
@@ -1145,17 +1145,17 @@
 \v 10 Jacob went out from Beersheba, and went toward Haran. 
 \v 11 He came to a certain place, and stayed there all night, because the sun had set. He took one of the stones of the place, and put it under his head, and lay down in that place to sleep. 
 \v 12 He dreamed and saw a stairway set upon the earth, and its top reached to heaven. Behold, the angels of Elohim were ascending and descending on it. 
-\v 13 Behold, Yahweh stood above it, and said, “I am Yahweh, the Elohim of Abraham your father, and the Elohim of Isaac. I will give the land you lie on to you and to your offspring. 
+\v 13 Behold, Yahuah stood above it, and said, “I am Yahuah, the Elohim of Abraham your father, and the Elohim of Isaac. I will give the land you lie on to you and to your offspring. 
 \v 14 Your offspring will be as the dust of the earth, and you will spread abroad to the west, and to the east, and to the north, and to the south. In you and in your offspring, all the families of the earth will be blessed. 
 \v 15 Behold, I am with you, and will keep you, wherever you go, and will bring you again into this land. For I will not leave you until I have done that which I have spoken of to you.” 
 \p
-\v 16 Jacob awakened out of his sleep, and he said, “Surely Yahweh is in this place, and I didn’t know it.” 
+\v 16 Jacob awakened out of his sleep, and he said, “Surely Yahuah is in this place, and I didn’t know it.” 
 \v 17 He was afraid, and said, “How awesome this place is! This is none other than Elohim’s house, and this is the gate of heaven.” 
 \p
 \v 18 Jacob rose up early in the morning, and took the stone that he had put under his head, and set it up for a pillar, and poured oil on its top. 
 \v 19 He called the name of that place Bethel, but the name of the city was Luz at the first. 
 \v 20 Jacob vowed a vow, saying, “If Elohim will be with me, and will keep me in this way that I go, and will give me bread to eat, and clothing to put on, 
-\v 21 so that I come again to my father’s house in peace, and Yahweh will be my Elohim, 
+\v 21 so that I come again to my father’s house in peace, and Yahuah will be my Elohim, 
 \v 22 then this stone, which I have set up for a pillar, will be Elohim’s house. Of all that you will give me I will surely give a tenth to you.” 
 \c 29
 \p
@@ -1206,11 +1206,11 @@
 \v 29 Laban gave Bilhah, his servant, to his daughter Rachel to be her servant. 
 \v 30 He went in also to Rachel, and he loved also Rachel more than Leah, and served with him seven more years. 
 \p
-\v 31 Yahweh saw that Leah was hated, and he opened her womb, but Rachel was barren. 
-\v 32 Leah conceived, and bore a son, and she named him Reuben. For she said, “Because Yahweh has looked at my affliction; for now my man will love me.” 
-\v 33 She conceived again, and bore a son, and said, “Because Yahweh has heard that I am hated, he has therefore given me this son also.” She named him Simeon. 
+\v 31 Yahuah saw that Leah was hated, and he opened her womb, but Rachel was barren. 
+\v 32 Leah conceived, and bore a son, and she named him Reuben. For she said, “Because Yahuah has looked at my affliction; for now my man will love me.” 
+\v 33 She conceived again, and bore a son, and said, “Because Yahuah has heard that I am hated, he has therefore given me this son also.” She named him Simeon. 
 \v 34 She conceived again, and bore a son. She said, “Now this time my man will be joined to me, because I have borne him three sons.” Therefore his name was called Levi. 
-\v 35 She conceived again, and bore a son. She said, “This time I will praise Yahweh.” Therefore she named him Judah. Then she stopped bearing. 
+\v 35 She conceived again, and bore a son. She said, “This time I will praise Yahuah.” Therefore she named him Judah. Then she stopped bearing. 
 \c 30
 \p
 \v 1 When Rachel saw that she bore Jacob no children, Rachel envied her sister. She said to Jacob, “Give me children, or else I will die.” 
@@ -1245,16 +1245,16 @@
 \p
 \v 22 Elohim remembered Rachel, and Elohim listened to her, and opened her womb. 
 \v 23 She conceived, bore a son, and said, “Elohim has taken away my reproach.” 
-\v 24 She named him Joseph, saying, “May Yahweh add another son to me.” 
+\v 24 She named him Joseph, saying, “May Yahuah add another son to me.” 
 \p
 \v 25 When Rachel had borne Joseph, Jacob said to Laban, “Send me away, that I may go to my own place, and to my country. 
 \v 26 Give me my women and my children for whom I have served you, and let me go; for you know my service with which I have served you.” 
 \p
-\v 27 Laban said to him, “If now I have found favor in your eyes, stay here, for I have divined that Yahweh has blessed me for your sake.” 
+\v 27 Laban said to him, “If now I have found favor in your eyes, stay here, for I have divined that Yahuah has blessed me for your sake.” 
 \v 28 He said, “Appoint me your wages, and I will give it.” 
 \p
 \v 29 Jacob said to him, “You know how I have served you, and how your livestock have fared with me. 
-\v 30 For it was little which you had before I came, and it has increased to a multitude. Yahweh has blessed you wherever I turned. Now when will I provide for my own house also?” 
+\v 30 For it was little which you had before I came, and it has increased to a multitude. Yahuah has blessed you wherever I turned. Now when will I provide for my own house also?” 
 \p
 \v 31 Laban said, “What shall I give you?” 
 \p Jacob said, “You shall not give me anything. If you will do this thing for me, I will again feed your flock and keep it. 
@@ -1277,7 +1277,7 @@
 \p
 \v 1 Jacob heard Laban’s sons’ words, saying, “Jacob has taken away all that was our father’s. He has obtained all this wealth from that which was our father’s.” 
 \v 2 Jacob saw the expression on Laban’s face, and, behold, it was not toward him as before. 
-\v 3 Yahweh said to Jacob, “Return to the land of your fathers, and to your relatives, and I will be with you.” 
+\v 3 Yahuah said to Jacob, “Return to the land of your fathers, and to your relatives, and I will be with you.” 
 \p
 \v 4 Jacob sent and called Rachel and Leah to the field to his flock, 
 \v 5 and said to them, “I see the expression on your father’s face, that it is not toward me as before; but the Elohim of my father has been with me. 
@@ -1335,7 +1335,7 @@
 \v 46 Jacob said to his relatives, “Gather stones.” They took stones, and made a heap. They ate there by the heap. 
 \v 47 Laban called it Jegar Sahadutha, but Jacob called it Galeed. 
 \v 48 Laban said, “This heap is witness between me and you today.” Therefore it was named Galeed 
-\v 49 and Mizpah, for he said, “Yahweh watch between me and you, when we are absent one from another. 
+\v 49 and Mizpah, for he said, “Yahuah watch between me and you, when we are absent one from another. 
 \v 50 If you afflict my daughters, or if you take women in addition to my daughters, no man is with us; behold, Elohim is witness between me and you.” 
 \v 51 Laban said to Jacob, “See this heap, and see the pillar, which I have set between me and you. 
 \v 52 May this heap be a witness, and the pillar be a witness, that I will not pass over this heap to you, and that you will not pass over this heap and this pillar to me, for harm. 
@@ -1353,7 +1353,7 @@
 \v 6 The messengers returned to Jacob, saying, “We came to your brother Esau. He is coming to meet you, and four hundred men are with him.” 
 \v 7 Then Jacob was greatly afraid and was distressed. He divided the people who were with him, along with the flocks, the herds, and the camels, into two companies. 
 \v 8 He said, “If Esau comes to the one company, and strikes it, then the company which is left will escape.” 
-\v 9 Jacob said, “Elohim of my father Abraham, and Elohim of my father Isaac, Yahweh, who said to me, ‘Return to your country, and to your relatives, and I will do you good,’ 
+\v 9 Jacob said, “Elohim of my father Abraham, and Elohim of my father Isaac, Yahuah, who said to me, ‘Return to your country, and to your relatives, and I will do you good,’ 
 \v 10 I am not worthy of the least of all the loving kindnesses, and of all the truth, which you have shown to your servant; for with just my staff I crossed over this Jordan; and now I have become two companies. 
 \v 11 Please deliver me from the hand of my brother, from the hand of Esau; for I fear him, lest he come and strike me and the mothers with the children. 
 \v 12 You said, ‘I will surely do you good, and make your offspring as the sand of the sea, which can’t be counted because there are so many.’ ” 
@@ -1606,10 +1606,10 @@
 \v 4 She conceived again, and bore a son; and she named him Onan. 
 \v 5 She yet again bore a son, and named him Shelah. He was at Chezib when she bore him. 
 \v 6 Judah took a woman for Er, his firstborn, and her name was Tamar. 
-\v 7 Er, Judah’s firstborn, was wicked in Yahweh’s sight. So Yahweh killed him. 
+\v 7 Er, Judah’s firstborn, was wicked in Yahuah’s sight. So Yahuah killed him. 
 \v 8 Judah said to Onan, “Go in to your brother’s woman, and perform the duty of a brother-in-law to her, and raise up offspring for your brother.” 
 \v 9 Onan knew that the offspring wouldn’t be his; and when he went in to his brother’s woman, he spilled his semen on the ground, lest he should give offspring to his brother. 
-\v 10 The thing which he did was evil in Yahweh’s sight, and he killed him also. 
+\v 10 The thing which he did was evil in Yahuah’s sight, and he killed him also. 
 \v 11 Then Judah said to Tamar, his daughter-in-law, “Remain a widow in your father’s house, until Shelah, my son, is grown up;” for he said, “Lest he also die, like his brothers.” Tamar went and lived in her father’s house. 
 \p
 \v 12 After many days, Shua’s daughter, the woman of Judah, died. Judah was comforted, and went up to his sheep shearers to Timnah, he and his friend Hirah, the Adullamite. 
@@ -1646,10 +1646,10 @@
 \c 39
 \p
 \v 1 Joseph was brought down to Egypt. Potiphar, an officer of Pharaoh’s, the captain of the guard, an Egyptian, bought him from the hand of the Ishmaelites that had brought him down there. 
-\v 2 Yahweh was with Joseph, and he was a prosperous man. He was in the house of his master the Egyptian. 
-\v 3 His master saw that Yahweh was with him, and that Yahweh made all that he did prosper in his hand. 
+\v 2 Yahuah was with Joseph, and he was a prosperous man. He was in the house of his master the Egyptian. 
+\v 3 His master saw that Yahuah was with him, and that Yahuah made all that he did prosper in his hand. 
 \v 4 Joseph found favor in his sight. He ministered to him, and Potiphar made him overseer over his house, and all that he had he put into his hand. 
-\v 5 From the time that he made him overseer in his house, and over all that he had, Yahweh blessed the Egyptian’s house for Joseph’s sake. Yahweh’s blessing was on all that he had, in the house and in the field. 
+\v 5 From the time that he made him overseer in his house, and over all that he had, Yahuah blessed the Egyptian’s house for Joseph’s sake. Yahuah’s blessing was on all that he had, in the house and in the field. 
 \v 6 He left all that he had in Joseph’s hand. He didn’t concern himself with anything, except for the food which he ate. 
 \p Joseph was well-built and handsome. 
 \v 7 After these things, his master’s woman set her eyes on Joseph; and she said, “Lie with me.” 
@@ -1670,9 +1670,9 @@
 \p
 \v 19 When his master heard the words of his woman, which she spoke to him, saying, “This is what your servant did to me,” his wrath was kindled. 
 \v 20 Joseph’s master took him, and put him into the prison, the place where the king’s prisoners were bound, and he was there in custody. 
-\v 21 But Yahweh was with Joseph, and showed kindness to him, and gave him favor in the sight of the keeper of the prison. 
+\v 21 But Yahuah was with Joseph, and showed kindness to him, and gave him favor in the sight of the keeper of the prison. 
 \v 22 The keeper of the prison committed to Joseph’s hand all the prisoners who were in the prison. Whatever they did there, he was responsible for it. 
-\v 23 The keeper of the prison didn’t look after anything that was under his hand, because Yahweh was with him; and that which he did, Yahweh made it prosper. 
+\v 23 The keeper of the prison didn’t look after anything that was under his hand, because Yahuah was with him; and that which he did, Yahuah made it prosper. 
 \c 40
 \p
 \v 1 After these things, the butler of the king of Egypt and his baker offended their lord, the king of Egypt. 
@@ -2149,7 +2149,7 @@
 \q1 that bites the horse’s heels, 
 \q2 so that his rider falls backward. 
 \q1
-\v 18 I have waited for your salvation, Yahweh. 
+\v 18 I have waited for your salvation, Yahuah. 
 \b
 \q1
 \v 19 “A troop will press on Gad, 

--- a/usfm/habakkuk.usfm
+++ b/usfm/habakkuk.usfm
@@ -4,7 +4,7 @@
 \c 1
 \p
 \v 1 The revelation which Habakkuk the prophet saw. 
-\v 2 Yahweh, how long will I cry, and you will not hear? I cry out to you “Violence!” and will you not save? 
+\v 2 Yahuah, how long will I cry, and you will not hear? I cry out to you “Violence!” and will you not save? 
 \v 3 Why do you show me iniquity, and look at perversity? For destruction and violence are before me. There is strife, and contention rises up. 
 \v 4 Therefore the law is paralyzed, and justice never prevails; for the wicked surround the righteous; therefore justice comes out perverted. 
 \p
@@ -16,7 +16,7 @@
 \v 10 Yes, they scoff at kings, and princes are a derision to them. They laugh at every stronghold, for they build up an earthen ramp and take it. 
 \v 11 Then they sweep by like the wind and go on. They are indeed guilty, whose strength is their elohim.” 
 \p
-\v 12 Aren’t you from everlasting, Yahweh my Elohim, my Set-Apart One? We will not die. Yahweh, you have appointed them for judgment. You, Rock, have established him to punish. 
+\v 12 Aren’t you from everlasting, Yahuah my Elohim, my Set-Apart One? We will not die. Yahuah, you have appointed them for judgment. You, Rock, have established him to punish. 
 \v 13 You who have purer eyes than to see evil, and who cannot look on perversity, why do you tolerate those who deal treacherously and keep silent when the wicked swallows up the man who is more righteous than he, 
 \v 14 and make men like the fish of the sea, like the creeping things that have no ruler over them? 
 \v 15 He takes up all of them with the hook. He catches them in his net and gathers them in his dragnet. Therefore he rejoices and is glad. 
@@ -26,7 +26,7 @@
 \p
 \v 1 I will stand at my watch and set myself on the ramparts, and will look out to see what he will say to me, and what I will answer concerning my complaint. 
 \p
-\v 2 Yahweh answered me, “Write the vision, and make it plain on tablets, that he who runs may read it. 
+\v 2 Yahuah answered me, “Write the vision, and make it plain on tablets, that he who runs may read it. 
 \v 3 For the vision is yet for the appointed time, and it hurries toward the end, and won’t prove false. Though it takes time, wait for it, because it will surely come. It won’t delay. 
 \v 4 Behold, his soul is puffed up. It is not upright in him, but the righteous will live by his faith. 
 \v 5 Yes, moreover, wine is treacherous: an arrogant man who doesn’t stay at home, who enlarges his desire as Sheol; he is like death and can’t be satisfied, but gathers to himself all nations and heaps to himself all peoples. 
@@ -40,22 +40,22 @@
 \v 11 For the stone will cry out of the wall, and the beam out of the woodwork will answer it. 
 \p
 \v 12 Woe to him who builds a town with blood, and establishes a city by iniquity! 
-\v 13 Behold, isn’t it from Yahweh of Armies that the peoples labor for the fire, and the nations weary themselves for vanity? 
-\v 14 For the earth will be filled with the knowledge of Yahweh’s glory, as the waters cover the sea. 
+\v 13 Behold, isn’t it from Yahuah of Armies that the peoples labor for the fire, and the nations weary themselves for vanity? 
+\v 14 For the earth will be filled with the knowledge of Yahuah’s glory, as the waters cover the sea. 
 \p
 \v 15 “Woe to him who gives his neighbor drink, pouring your inflaming wine until they are drunk, so that you may gaze at their naked bodies! 
-\v 16 You are filled with shame, and not glory. You will also drink and be exposed! The cup of Yahweh’s right hand will come around to you, and disgrace will cover your glory. 
+\v 16 You are filled with shame, and not glory. You will also drink and be exposed! The cup of Yahuah’s right hand will come around to you, and disgrace will cover your glory. 
 \v 17 For the violence done to Lebanon will overwhelm you, and the destruction of the animals will terrify you, because of men’s blood and for the violence done to the land, to every city and to those who dwell in them. 
 \p
 \v 18 “What value does the engraved image have, that its maker has engraved it; the molten image, even the teacher of lies, that he who fashions its form trusts in it, to make mute idols? 
 \v 19 Woe to him who says to the wood, ‘Awake!’ or to the mute stone, ‘Arise!’ Shall this teach? Behold, it is overlaid with gold and silver, and there is no breath at all within it. 
-\v 20 But Yahweh is in his set-apart temple. Let all the earth be silent before him!” 
+\v 20 But Yahuah is in his set-apart temple. Let all the earth be silent before him!” 
 \c 3
 \p
 \v 1 A prayer of Habakkuk, the prophet, set to victorious music. 
 \q1
-\v 2 Yahweh, I have heard of your fame. 
-\q2 I stand in awe of your deeds, Yahweh. 
+\v 2 Yahuah, I have heard of your fame. 
+\q2 I stand in awe of your deeds, Yahuah. 
 \q1 Renew your work in the middle of the years. 
 \q2 In the middle of the years make it known. 
 \q2 In wrath, you remember mercy. 
@@ -81,7 +81,7 @@
 \v 7 I saw the tents of Cushan in affliction. 
 \q2 The dwellings of the land of Midian trembled. 
 \q1
-\v 8 Was Yahweh displeased with the rivers? 
+\v 8 Was Yahuah displeased with the rivers? 
 \q2 Was your anger against the rivers, 
 \q2 or your wrath against the sea, 
 \q2 that you rode on your horses, 
@@ -128,10 +128,10 @@
 \q2 the flocks are cut off from the fold, 
 \q2 and there is no herd in the stalls, 
 \q1
-\v 18 yet I will rejoice in Yahweh. 
+\v 18 yet I will rejoice in Yahuah. 
 \q2 I will be joyful in the Elohim of my salvation! 
 \q1
-\v 19 Yahweh, the Lord, is my strength. 
+\v 19 Yahuah, the Lord, is my strength. 
 \q2 He makes my feet like deer’s feet, 
 \q2 and enables me to go in high places. 
 \p For the music director, on my stringed instruments. 

--- a/usfm/haggai.usfm
+++ b/usfm/haggai.usfm
@@ -3,54 +3,54 @@
 \h Haggai
 \c 1
 \p
-\v 1 In the second year of Darius the king, in the sixth month, in the first day of the month, Yahweh’s word came by Haggai the prophet, to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Jehozadak, the high priest, saying, 
-\v 2 “This is what Yahweh of Armies says: These people say, ‘The time hasn’t yet come, the time for Yahweh’s house to be built.’ ” 
+\v 1 In the second year of Darius the king, in the sixth month, in the first day of the month, Yahuah’s word came by Haggai the prophet, to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Jehozadak, the high priest, saying, 
+\v 2 “This is what Yahuah of Armies says: These people say, ‘The time hasn’t yet come, the time for Yahuah’s house to be built.’ ” 
 \p
-\v 3 Then Yahweh’s word came by Haggai the prophet, saying, 
+\v 3 Then Yahuah’s word came by Haggai the prophet, saying, 
 \v 4 “Is it a time for you yourselves to dwell in your paneled houses, while this house lies waste? 
-\v 5 Now therefore this is what Yahweh of Armies says: ‘Consider your ways. 
+\v 5 Now therefore this is what Yahuah of Armies says: ‘Consider your ways. 
 \v 6 You have sown much, and bring in little. You eat, but you don’t have enough. You drink, but you aren’t filled with drink. You clothe yourselves, but no one is warm; and he who earns wages earns wages to put them into a bag with holes in it.’ 
 \p
-\v 7 “This is what Yahweh of Armies says: ‘Consider your ways. 
-\v 8 Go up to the mountain, bring wood, and build the house. I will take pleasure in it, and I will be glorified,” says Yahweh. 
-\v 9 “You looked for much, and, behold, it came to little; and when you brought it home, I blew it away. Why?” says Yahweh of Armies, “Because of my house that lies waste, while each of you is busy with his own house. 
+\v 7 “This is what Yahuah of Armies says: ‘Consider your ways. 
+\v 8 Go up to the mountain, bring wood, and build the house. I will take pleasure in it, and I will be glorified,” says Yahuah. 
+\v 9 “You looked for much, and, behold, it came to little; and when you brought it home, I blew it away. Why?” says Yahuah of Armies, “Because of my house that lies waste, while each of you is busy with his own house. 
 \v 10 Therefore for your sake the heavens withhold the dew, and the earth withholds its fruit. 
 \v 11 I called for a drought on the land, on the mountains, on the grain, on the new wine, on the oil, on that which the ground produces, on men, on livestock, and on all the labor of the hands.” 
 \p
-\v 12 Then Zerubbabel the son of Shealtiel and Joshua the son of Jehozadak, the high priest, with all the remnant of the people, obeyed Yahweh their Elohim’s voice, and the words of Haggai the prophet, as Yahweh their Elohim had sent him; and the people feared Yahweh. 
+\v 12 Then Zerubbabel the son of Shealtiel and Joshua the son of Jehozadak, the high priest, with all the remnant of the people, obeyed Yahuah their Elohim’s voice, and the words of Haggai the prophet, as Yahuah their Elohim had sent him; and the people feared Yahuah. 
 \p
-\v 13 Then Haggai, Yahweh’s messenger, spoke Yahweh’s message to the people, saying, “I am with you,” says Yahweh. 
+\v 13 Then Haggai, Yahuah’s messenger, spoke Yahuah’s message to the people, saying, “I am with you,” says Yahuah. 
 \p
-\v 14 Yahweh stirred up the spirit of Zerubbabel the son of Shealtiel, governor of Judah, and the spirit of Joshua the son of Jehozadak, the high priest, and the spirit of all the remnant of the people; and they came and worked on the house of Yahweh of Armies, their Elohim, 
+\v 14 Yahuah stirred up the spirit of Zerubbabel the son of Shealtiel, governor of Judah, and the spirit of Joshua the son of Jehozadak, the high priest, and the spirit of all the remnant of the people; and they came and worked on the house of Yahuah of Armies, their Elohim, 
 \v 15 in the twenty-fourth day of the month, in the sixth month, in the second year of Darius the king. 
 \c 2
 \p
-\v 1 In the seventh month, in the twenty-first day of the month, Yahweh’s word came by Haggai the prophet, saying, 
+\v 1 In the seventh month, in the twenty-first day of the month, Yahuah’s word came by Haggai the prophet, saying, 
 \v 2 “Speak now to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Jehozadak, the high priest, and to the remnant of the people, saying, 
 \v 3 ‘Who is left among you who saw this house in its former glory? How do you see it now? Isn’t it in your eyes as nothing? 
-\v 4 Yet now be strong, Zerubbabel,’ says Yahweh. ‘Be strong, Joshua son of Jehozadak, the high priest. Be strong, all you people of the land,’ says Yahweh, ‘and work, for I am with you,’ says Yahweh of Armies. 
+\v 4 Yet now be strong, Zerubbabel,’ says Yahuah. ‘Be strong, Joshua son of Jehozadak, the high priest. Be strong, all you people of the land,’ says Yahuah, ‘and work, for I am with you,’ says Yahuah of Armies. 
 \v 5 This is the word that I covenanted with you when you came out of Egypt, and my Spirit lived among you. ‘Don’t be afraid.’ 
-\v 6 For this is what Yahweh of Armies says: ‘Yet once more, it is a little while, and I will shake the heavens, the earth, the sea, and the dry land; 
-\v 7 and I will shake all nations. The treasure of all nations will come, and I will fill this house with glory, says Yahweh of Armies. 
-\v 8 The silver is mine, and the gold is mine,’ says Yahweh of Armies. 
-\v 9 ‘The latter glory of this house will be greater than the former,’ says Yahweh of Armies; ‘and in this place I will give peace,’ says Yahweh of Armies.” 
+\v 6 For this is what Yahuah of Armies says: ‘Yet once more, it is a little while, and I will shake the heavens, the earth, the sea, and the dry land; 
+\v 7 and I will shake all nations. The treasure of all nations will come, and I will fill this house with glory, says Yahuah of Armies. 
+\v 8 The silver is mine, and the gold is mine,’ says Yahuah of Armies. 
+\v 9 ‘The latter glory of this house will be greater than the former,’ says Yahuah of Armies; ‘and in this place I will give peace,’ says Yahuah of Armies.” 
 \p
-\v 10 In the twenty-fourth day of the ninth month, in the second year of Darius, Yahweh’s word came by Haggai the prophet, saying, 
-\v 11 “Yahweh of Armies says: Ask now the priests concerning the law, saying, 
+\v 10 In the twenty-fourth day of the ninth month, in the second year of Darius, Yahuah’s word came by Haggai the prophet, saying, 
+\v 11 “Yahuah of Armies says: Ask now the priests concerning the law, saying, 
 \v 12 ‘If someone carries set-apart meat in the fold of his garment, and with his fold touches bread, stew, wine, oil, or any food, will it become set-apart?’ ” 
 \p The priests answered, “No.” 
 \p
 \v 13 Then Haggai said, “If one who is unclean by reason of a dead body touch any of these, will it be unclean?” 
 \p The priests answered, “It will be unclean.” 
 \p
-\v 14 Then Haggai answered, “ ‘So is this people, and so is this nation before me,’ says Yahweh; ‘and so is every work of their hands. That which they offer there is unclean. 
-\v 15 Now, please consider from this day and backward, before a stone was laid on a stone in Yahweh’s temple. 
+\v 14 Then Haggai answered, “ ‘So is this people, and so is this nation before me,’ says Yahuah; ‘and so is every work of their hands. That which they offer there is unclean. 
+\v 15 Now, please consider from this day and backward, before a stone was laid on a stone in Yahuah’s temple. 
 \v 16 Through all that time, when one came to a heap of twenty measures, there were only ten. When one came to the wine vat to draw out fifty, there were only twenty. 
-\v 17 I struck you with blight, mildew, and hail in all the work of your hands; yet you didn’t turn to me,’ says Yahweh. 
-\v 18 ‘Consider, please, from this day and backward, from the twenty-fourth day of the ninth month, since the day that the foundation of Yahweh’s temple was laid, consider it. 
+\v 17 I struck you with blight, mildew, and hail in all the work of your hands; yet you didn’t turn to me,’ says Yahuah. 
+\v 18 ‘Consider, please, from this day and backward, from the twenty-fourth day of the ninth month, since the day that the foundation of Yahuah’s temple was laid, consider it. 
 \v 19 Is the seed yet in the barn? Yes, the vine, the fig tree, the pomegranate, and the olive tree haven’t produced. From today I will bless you.’ ” 
 \p
-\v 20 Yahweh’s word came the second time to Haggai in the twenty-fourth day of the month, saying, 
+\v 20 Yahuah’s word came the second time to Haggai in the twenty-fourth day of the month, saying, 
 \v 21 “Speak to Zerubbabel, governor of Judah, saying, ‘I will shake the heavens and the earth. 
 \v 22 I will overthrow the throne of kingdoms. I will destroy the strength of the kingdoms of the nations. I will overthrow the chariots and those who ride in them. The horses and their riders will come down, everyone by the sword of his brother. 
-\v 23 In that day, says Yahweh of Armies, I will take you, Zerubbabel my servant, the son of Shealtiel,’ says Yahweh, ‘and will make you like a signet ring, for I have chosen you,’ says Yahweh of Armies.” 
+\v 23 In that day, says Yahuah of Armies, I will take you, Zerubbabel my servant, the son of Shealtiel,’ says Yahuah, ‘and will make you like a signet ring, for I have chosen you,’ says Yahuah of Armies.” 

--- a/usfm/hosea.usfm
+++ b/usfm/hosea.usfm
@@ -3,18 +3,18 @@
 \h Hosea
 \c 1
 \p
-\v 1 Yahweh’s word that came to Hosea the son of Beeri, in the days of Uzziah, Jotham, Ahaz, and Hezekiah, kings of Judah, and in the days of Jeroboam the son of Joash, king of Israel. 
+\v 1 Yahuah’s word that came to Hosea the son of Beeri, in the days of Uzziah, Jotham, Ahaz, and Hezekiah, kings of Judah, and in the days of Jeroboam the son of Joash, king of Israel. 
 \p
-\v 2 When Yahweh spoke at first by Hosea, Yahweh said to Hosea, “Go, take for yourself a woman of prostitution and children of unfaithfulness; for the land commits great adultery, forsaking Yahweh.” 
+\v 2 When Yahuah spoke at first by Hosea, Yahuah said to Hosea, “Go, take for yourself a woman of prostitution and children of unfaithfulness; for the land commits great adultery, forsaking Yahuah.” 
 \p
 \v 3 So he went and took Gomer the daughter of Diblaim; and she conceived, and bore him a son. 
 \p
-\v 4 Yahweh said to him, “Call his name Jezreel, for yet a little while, and I will avenge the blood of Jezreel on the house of Jehu, and will cause the kingdom of the house of Israel to cease. 
+\v 4 Yahuah said to him, “Call his name Jezreel, for yet a little while, and I will avenge the blood of Jezreel on the house of Jehu, and will cause the kingdom of the house of Israel to cease. 
 \v 5 It will happen in that day that I will break the bow of Israel in the valley of Jezreel.” 
 \p
 \v 6 She conceived again, and bore a daughter. 
 \p Then he said to him, “Call her name Lo-Ruhamah, for I will no longer have mercy on the house of Israel, that I should in any way pardon them. 
-\v 7 But I will have mercy on the house of Judah, and will save them by Yahweh their Elohim, and will not save them by bow, sword, battle, horses, or horsemen.” 
+\v 7 But I will have mercy on the house of Judah, and will save them by Yahuah their Elohim, and will not save them by bow, sword, battle, horses, or horsemen.” 
 \p
 \v 8 Now when she had weaned Lo-Ruhamah, she conceived, and bore a son. 
 \p
@@ -81,7 +81,7 @@
 \q2 to which she burned incense 
 \q1 when she decked herself with her earrings and her jewels, 
 \q2 and went after her lovers 
-\q2 and forgot me,” says Yahweh. 
+\q2 and forgot me,” says Yahuah. 
 \q1
 \v 14 “Therefore behold, I will allure her, 
 \q2 and bring her into the wilderness, 
@@ -93,7 +93,7 @@
 \q2 as in the days of her youth, 
 \q2 and as in the day when she came up out of the land of Egypt. 
 \q1
-\v 16 It will be in that day,” says Yahweh, 
+\v 16 It will be in that day,” says Yahuah, 
 \q2 “that you will call me ‘my man,’ 
 \q2 and no longer call me ‘my owner.’ 
 \q1
@@ -110,9 +110,9 @@
 \q2 Yes, I will betroth you to me in righteousness, in justice, in loving kindness, and in compassion. 
 \q1
 \v 20 I will even betroth you to me in faithfulness; 
-\q2 and you shall know Yahweh. 
+\q2 and you shall know Yahuah. 
 \q1
-\v 21 It will happen in that day, that I will respond,” says Yahweh. 
+\v 21 It will happen in that day, that I will respond,” says Yahuah. 
 \q2 “I will respond to the heavens, 
 \q2 and they will respond to the earth; 
 \q2
@@ -125,17 +125,17 @@
 \q2 and they will say, ‘You are My Elohim!’ ” 
 \c 3
 \p
-\v 1 Yahweh said to me, “Go again, love a woman loved by another, and an adulteress, even as Yahweh loves the children of Israel, though they turn to other elohims, and love cakes of raisins.” 
+\v 1 Yahuah said to me, “Go again, love a woman loved by another, and an adulteress, even as Yahuah loves the children of Israel, though they turn to other elohims, and love cakes of raisins.” 
 \p
 \v 2 So I bought her for myself for fifteen pieces of silver and a homer and a half of barley. 
 \v 3 I said to her, “You shall stay with me many days. You shall not play the prostitute, and you shall not be with any other man. I will also be so toward you.” 
 \p
 \v 4 For the children of Israel shall live many days without king, without prince, without sacrifice, without sacred stone, and without ephod or idols. 
-\v 5 Afterward the children of Israel shall return and seek Yahweh their Elohim, and David their king, and shall come with trembling to Yahweh and to his blessings in the last days. 
+\v 5 Afterward the children of Israel shall return and seek Yahuah their Elohim, and David their king, and shall come with trembling to Yahuah and to his blessings in the last days. 
 \c 4
 \p
-\v 1 Hear Yahweh’s word, you children of Israel, 
-\q2 for Yahweh has a charge against the inhabitants of the land: 
+\v 1 Hear Yahuah’s word, you children of Israel, 
+\q2 for Yahuah has a charge against the inhabitants of the land: 
 \q1 “Indeed there is no truth, nor goodness, 
 \q2 nor knowledge of Elohim in the land. 
 \q1
@@ -174,7 +174,7 @@
 \q1
 \v 10 They will eat, and not have enough. 
 \q2 They will play the prostitute, and will not increase; 
-\q2 because they have abandoned listening to Yahweh. 
+\q2 because they have abandoned listening to Yahuah. 
 \q1
 \v 11 Prostitution, wine, and new wine take away understanding. 
 \q2
@@ -200,10 +200,10 @@
 \q2 yet don’t let Judah offend; 
 \q2 and don’t come to Gilgal, 
 \q2 neither go up to Beth Aven, 
-\q2 nor swear, ‘As Yahweh lives.’ 
+\q2 nor swear, ‘As Yahuah lives.’ 
 \q1
 \v 16 For Israel has behaved extremely stubbornly, like a stubborn heifer. 
-\q2 Then how will Yahweh feed them like a lamb in a meadow? 
+\q2 Then how will Yahuah feed them like a lamb in a meadow? 
 \q1
 \v 17 Ephraim is joined to idols. 
 \q2 Leave him alone! 
@@ -234,17 +234,17 @@
 \q1
 \v 4 Their deeds won’t allow them to turn to their Elohim, 
 \q2 for the spirit of prostitution is within them, 
-\q2 and they don’t know Yahweh. 
+\q2 and they don’t know Yahuah. 
 \q1
 \v 5 The pride of Israel testifies to his face. 
 \q2 Therefore Israel and Ephraim will stumble in their iniquity. 
 \q2 Judah also will stumble with them. 
 \q1
-\v 6 They will go with their flocks and with their herds to seek Yahweh, 
+\v 6 They will go with their flocks and with their herds to seek Yahuah, 
 \q2 but they won’t find him. 
 \q2 He has withdrawn himself from them. 
 \q1
-\v 7 They are unfaithful to Yahweh; 
+\v 7 They are unfaithful to Yahuah; 
 \q2 for they have borne illegitimate children. 
 \q2 Now the new moon will devour them with their fields. 
 \b
@@ -286,7 +286,7 @@
 \b
 \c 6
 \p
-\v 1 “Come! Let’s return to Yahweh; 
+\v 1 “Come! Let’s return to Yahuah; 
 \q2 for he has torn us to pieces, 
 \q2 and he will heal us; 
 \q1 he has injured us, 
@@ -296,10 +296,10 @@
 \q2 On the third day he will raise us up, 
 \q2 and we will live before him. 
 \q1
-\v 3 Let’s acknowledge Yahweh. 
-\q2 Let’s press on to know Yahweh. 
+\v 3 Let’s acknowledge Yahuah. 
+\q2 Let’s press on to know Yahuah. 
 \q1 As surely as the sun rises, 
-\q2 Yahweh will appear. 
+\q2 Yahuah will appear. 
 \q1 He will come to us like the rain, 
 \q2 like the spring rain that waters the earth.” 
 \b
@@ -375,7 +375,7 @@
 \q2 and he doesn’t realize it. 
 \q1
 \v 10 The pride of Israel testifies to his face; 
-\q2 yet they haven’t returned to Yahweh their Elohim, 
+\q2 yet they haven’t returned to Yahuah their Elohim, 
 \q2 nor sought him, for all this. 
 \b
 \q1
@@ -410,7 +410,7 @@
 \c 8
 \p
 \v 1 “Put the trumpet to your lips! 
-\q2 Something like an eagle is over Yahweh’s house, 
+\q2 Something like an eagle is over Yahuah’s house, 
 \q2 because they have broken my covenant 
 \q2 and rebelled against my law. 
 \q1
@@ -457,7 +457,7 @@
 \q1
 \v 13 As for the sacrifices of my offerings, 
 \q2 they sacrifice meat and eat it, 
-\q2 but Yahweh doesn’t accept them. 
+\q2 but Yahuah doesn’t accept them. 
 \q1 Now he will remember their iniquity, 
 \q2 and punish their sins. 
 \q2 They will return to Egypt. 
@@ -476,19 +476,19 @@
 \v 2 The threshing floor and the wine press won’t feed them, 
 \q2 and the new wine will fail her. 
 \q1
-\v 3 They won’t dwell in Yahweh’s land; 
+\v 3 They won’t dwell in Yahuah’s land; 
 \q2 but Ephraim will return to Egypt, 
 \q2 and they will eat unclean food in Assyria. 
 \q1
-\v 4 They won’t pour out wine offerings to Yahweh, 
+\v 4 They won’t pour out wine offerings to Yahuah, 
 \q2 neither will they be pleasing to him. 
 \q2 Their sacrifices will be to them like the bread of mourners; 
 \q2 all who eat of it will be polluted; 
 \q2 for their bread will be for their appetite. 
-\q2 It will not come into Yahweh’s house. 
+\q2 It will not come into Yahuah’s house. 
 \q1
 \v 5 What will you do in the day of solemn assembly, 
-\q2 and in the day of the feast of Yahweh? 
+\q2 and in the day of the feast of Yahuah? 
 \q1
 \v 6 For, behold, when they flee destruction, 
 \q2 Egypt will gather them up. 
@@ -527,7 +527,7 @@
 \v 13 I have seen Ephraim, like Tyre, planted in a pleasant place; 
 \q2 but Ephraim will bring out his children to the murderer. 
 \q1
-\v 14 Give them—Yahweh what will you give? 
+\v 14 Give them—Yahuah what will you give? 
 \q2 Give them a miscarrying womb and dry breasts. 
 \b
 \q1
@@ -556,7 +556,7 @@
 \q2 He will demolish their altars. 
 \q2 He will destroy their sacred stones. 
 \q1
-\v 3 Surely now they will say, “We have no king; for we don’t fear Yahweh; 
+\v 3 Surely now they will say, “We have no king; for we don’t fear Yahuah; 
 \q2 and the king, what can he do for us?” 
 \q1
 \v 4 They make promises, swearing falsely in making covenants. 
@@ -596,7 +596,7 @@
 \v 12 Sow to yourselves in righteousness, 
 \q2 reap according to kindness. 
 \q1 Break up your fallow ground, 
-\q2 for it is time to seek Yahweh, 
+\q2 for it is time to seek Yahuah, 
 \q2 until he comes and rains righteousness on you. 
 \q1
 \v 13 You have plowed wickedness. 
@@ -655,13 +655,13 @@
 \q2 for I am Elohim, and not man—the Set-Apart One among you. 
 \q2 I will not come in wrath. 
 \q1
-\v 10 They will walk after Yahweh, 
+\v 10 They will walk after Yahuah, 
 \q2 who will roar like a lion; 
 \q2 for he will roar, and the children will come trembling from the west. 
 \q1
 \v 11 They will come trembling like a bird out of Egypt, 
 \q2 and like a dove out of the land of Assyria; 
-\q1 and I will settle them in their houses,” says Yahweh. 
+\q1 and I will settle them in their houses,” says Yahuah. 
 \b
 \q1
 \v 12 Ephraim surrounds me with falsehood, 
@@ -676,7 +676,7 @@
 \q2 They make a covenant with Assyria, 
 \q2 and oil is carried into Egypt. 
 \q1
-\v 2 Yahweh also has a controversy with Judah, 
+\v 2 Yahuah also has a controversy with Judah, 
 \q2 and will punish Jacob according to his ways; 
 \q2 according to his deeds he will repay him. 
 \q1
@@ -686,8 +686,8 @@
 \v 4 Indeed, he struggled with the angel, and prevailed; 
 \q2 he wept, and made supplication to him. 
 \q2 He found him at Bethel, and there he spoke with us—\q2
-\v 5 even Yahweh, the Elohim of Armies. 
-\q2 Yahweh is his name of renown! 
+\v 5 even Yahuah, the Elohim of Armies. 
+\q2 Yahuah is his name of renown! 
 \q1
 \v 6 Therefore turn to your Elohim. 
 \q2 Keep kindness and justice, 
@@ -702,7 +702,7 @@
 \q2 In all my wealth they won’t find in me any iniquity that is sin.” 
 \b
 \q1
-\v 9 “But I am Yahweh your Elohim from the land of Egypt. 
+\v 9 “But I am Yahuah your Elohim from the land of Egypt. 
 \q2 I will yet again make you dwell in tents, 
 \q2 as in the days of the solemn feast. 
 \q1
@@ -719,7 +719,7 @@
 \q2 Israel served to get a woman. 
 \q2 For a woman he tended flocks and herds. 
 \q1
-\v 13 By a prophet Yahweh brought Israel up out of Egypt, 
+\v 13 By a prophet Yahuah brought Israel up out of Egypt, 
 \q2 and by a prophet he was preserved. 
 \q1
 \v 14 Ephraim has bitterly provoked anger. 
@@ -743,7 +743,7 @@
 \q2 and like the smoke out of the chimney. 
 \b
 \q1
-\v 4 “Yet I am Yahweh your Elohim from the land of Egypt; 
+\v 4 “Yet I am Yahuah your Elohim from the land of Egypt; 
 \q2 and you shall acknowledge no elohim but me, 
 \q2 and besides me there is no savior. 
 \q1
@@ -786,7 +786,7 @@
 \q1 “Compassion will be hidden from my eyes. 
 \q2
 \v 15 Though he is fruitful among his brothers, an east wind will come, 
-\q2 the breath of Yahweh coming up from the wilderness; 
+\q2 the breath of Yahuah coming up from the wilderness; 
 \q2 and his spring will become dry, 
 \q2 and his fountain will be dried up. 
 \q2 He will plunder the storehouse of treasure. 
@@ -799,10 +799,10 @@
 \b
 \c 14
 \q1
-\v 1 Israel, return to Yahweh your Elohim; 
+\v 1 Israel, return to Yahuah your Elohim; 
 \q2 for you have fallen because of your sin. 
 \q1
-\v 2 Take words with you, and return to Yahweh. 
+\v 2 Take words with you, and return to Yahuah. 
 \q2 Tell him, “Forgive all our sins, 
 \q2 and accept that which is good; 
 \q2 so we offer bulls as we vowed of our lips. 
@@ -838,6 +838,6 @@
 \q1
 \v 9 Who is wise, that he may understand these things? 
 \q2 Who is prudent, that he may know them? 
-\q2 For the ways of Yahweh are right, 
+\q2 For the ways of Yahuah are right, 
 \q2 and the righteous walk in them, 
 \q2 but the rebellious stumble in them. 

--- a/usfm/isaiah.usfm
+++ b/usfm/isaiah.usfm
@@ -6,7 +6,7 @@
 \v 1 The vision of Isaiah the son of Amoz, which he saw concerning Judah and Jerusalem, in the days of Uzziah, Jotham, Ahaz, and Hezekiah, kings of Judah. 
 \q1
 \v 2 Hear, heavens, 
-\q2 and listen, earth; for Yahweh has spoken: 
+\q2 and listen, earth; for Yahuah has spoken: 
 \q1 “I have nourished and brought up children 
 \q2 and they have rebelled against me. 
 \q1
@@ -19,7 +19,7 @@
 \q2 a people loaded with iniquity, 
 \q2 offspring of evildoers, 
 \q2 children who deal corruptly! 
-\q1 They have forsaken Yahweh. 
+\q1 They have forsaken Yahuah. 
 \q2 They have despised the Set-Apart One of Israel. 
 \q2 They are estranged and backward. 
 \q1
@@ -42,15 +42,15 @@
 \q2 like a hut in a field of melons, 
 \q2 like a besieged city. 
 \q1
-\v 9 Unless Yahweh of Armies had left to us a very small remnant, 
+\v 9 Unless Yahuah of Armies had left to us a very small remnant, 
 \q2 we would have been as Sodom. 
 \q2 We would have been like Gomorrah. 
 \b
 \q1
-\v 10 Hear Yahweh’s word, you rulers of Sodom! 
+\v 10 Hear Yahuah’s word, you rulers of Sodom! 
 \q2 Listen to the law of our Elohim, you people of Gomorrah! 
 \q1
-\v 11 “What are the multitude of your sacrifices to me?”, says Yahweh. 
+\v 11 “What are the multitude of your sacrifices to me?”, says Yahuah. 
 \q2 “I have had enough of the burnt offerings of rams 
 \q2 and the fat of fed animals. 
 \q2 I don’t delight in the blood of bulls, 
@@ -83,7 +83,7 @@
 \q2 Plead for the widow.” 
 \b
 \q1
-\v 18 “Come now, and let’s reason together,” says Yahweh: 
+\v 18 “Come now, and let’s reason together,” says Yahuah: 
 \q2 “Though your sins are as scarlet, they shall be as white as snow. 
 \q2 Though they are red like crimson, they shall be as wool. 
 \q1
@@ -91,7 +91,7 @@
 \q2 you will eat the good of the land; 
 \q2
 \v 20 but if you refuse and rebel, you will be devoured with the sword; 
-\q2 for Yahweh’s mouth has spoken it.” 
+\q2 for Yahuah’s mouth has spoken it.” 
 \b
 \q1
 \v 21 How the faithful city has become a prostitute! 
@@ -108,7 +108,7 @@
 \q2 neither does the cause of the widow come to them. 
 \b
 \q1
-\v 24 Therefore the Lord, Yahweh of Armies, 
+\v 24 Therefore the Lord, Yahuah of Armies, 
 \q2 the Mighty One of Israel, says: 
 \q1 “Ah, I will get relief from my adversaries, 
 \q2 and avenge myself on my enemies. 
@@ -126,7 +126,7 @@
 \q2 and her converts with righteousness. 
 \q1
 \v 28 But the destruction of transgressors and sinners shall be together, 
-\q2 and those who forsake Yahweh shall be consumed. 
+\q2 and those who forsake Yahuah shall be consumed. 
 \q1
 \v 29 For they shall be ashamed of the oaks which you have desired, 
 \q2 and you shall be confounded for the gardens that you have chosen. 
@@ -142,17 +142,17 @@
 \p
 \v 1 This is what Isaiah the son of Amoz saw concerning Judah and Jerusalem. 
 \q1
-\v 2 It shall happen in the latter days, that the mountain of Yahweh’s house shall be established on the top of the mountains, 
+\v 2 It shall happen in the latter days, that the mountain of Yahuah’s house shall be established on the top of the mountains, 
 \q2 and shall be raised above the hills; 
 \q2 and all nations shall flow to it. 
 \q1
 \v 3 Many peoples shall go and say, 
-\q2 “Come, let’s go up to the mountain of Yahweh, 
+\q2 “Come, let’s go up to the mountain of Yahuah, 
 \q2 to the house of the Elohim of Jacob; 
 \q2 and he will teach us of his ways, 
 \q2 and we will walk in his paths.” 
 \q1 For the law shall go out of Zion, 
-\q2 and Yahweh’s word from Jerusalem. 
+\q2 and Yahuah’s word from Jerusalem. 
 \q1
 \v 4 He will judge between the nations, 
 \q2 and will decide concerning many peoples. 
@@ -162,7 +162,7 @@
 \q2 neither shall they learn war any more. 
 \b
 \q1
-\v 5 House of Jacob, come, and let’s walk in the light of Yahweh. 
+\v 5 House of Jacob, come, and let’s walk in the light of Yahuah. 
 \q1
 \v 6 For you have forsaken your people, the house of Jacob, 
 \q2 because they are filled from the east, 
@@ -184,15 +184,15 @@
 \q1
 \v 10 Enter into the rock, 
 \q2 and hide in the dust, 
-\q1 from before the terror of Yahweh, 
+\q1 from before the terror of Yahuah, 
 \q2 and from the glory of his majesty. 
 \q1
 \v 11 The lofty looks of man will be brought low, 
 \q2 the arrogance of men will be bowed down, 
-\q2 and Yahweh alone will be exalted in that day. 
+\q2 and Yahuah alone will be exalted in that day. 
 \b
 \q1
-\v 12 For there will be a day of Yahweh of Armies for all that is proud and arrogant, 
+\v 12 For there will be a day of Yahuah of Armies for all that is proud and arrogant, 
 \q2 and for all that is lifted up, 
 \q2 and it shall be brought low—\q2
 \v 13 for all the cedars of Lebanon, that are high and lifted up, 
@@ -209,13 +209,13 @@
 \q1
 \v 17 The loftiness of man shall be bowed down, 
 \q2 and the arrogance of men shall be brought low; 
-\q2 and Yahweh alone shall be exalted in that day. 
+\q2 and Yahuah alone shall be exalted in that day. 
 \q1
 \v 18 The idols shall utterly pass away. 
 \q1
 \v 19 Men shall go into the caves of the rocks, 
 \q2 and into the holes of the earth, 
-\q2 from before the terror of Yahweh, 
+\q2 from before the terror of Yahuah, 
 \q2 and from the glory of his majesty, 
 \q2 when he arises to shake the earth mightily. 
 \q1
@@ -226,7 +226,7 @@
 \q2
 \v 21 to go into the caverns of the rocks, 
 \q2 and into the clefts of the ragged rocks, 
-\q2 from before the terror of Yahweh, 
+\q2 from before the terror of Yahuah, 
 \q2 and from the glory of his majesty, 
 \q2 when he arises to shake the earth mightily. 
 \q1
@@ -234,7 +234,7 @@
 \q2 for of what account is he? 
 \c 3
 \q1
-\v 1 For, behold, the Lord, Yahweh of Armies, takes away from Jerusalem and from Judah supply and support, 
+\v 1 For, behold, the Lord, Yahuah of Armies, takes away from Jerusalem and from Judah supply and support, 
 \q2 the whole supply of bread, 
 \q2 and the whole supply of water; 
 \q2
@@ -269,7 +269,7 @@
 \q2 You shall not make me ruler of the people.” 
 \q1
 \v 8 For Jerusalem is ruined, and Judah is fallen; 
-\q2 because their tongue and their doings are against Yahweh, 
+\q2 because their tongue and their doings are against Yahuah, 
 \q1 to provoke the eyes of his glory. 
 \q1
 \v 9 The look of their faces testify against them. 
@@ -291,25 +291,25 @@
 \q2 and destroy the way of your paths. 
 \b
 \q1
-\v 13 Yahweh stands up to contend, 
+\v 13 Yahuah stands up to contend, 
 \q2 and stands to judge the peoples. 
 \q1
-\v 14 Yahweh will enter into judgment with the elders of his people 
+\v 14 Yahuah will enter into judgment with the elders of his people 
 \q2 and their leaders: 
 \q2 “It is you who have eaten up the vineyard. 
 \q2 The plunder of the poor is in your houses. 
 \q2
 \v 15 What do you mean that you crush my people, 
-\q2 and grind the face of the poor?” says the Lord, Yahweh of Armies. 
+\q2 and grind the face of the poor?” says the Lord, Yahuah of Armies. 
 \b
 \q1
-\v 16 Moreover Yahweh said, “Because the daughters of Zion are arrogant, 
+\v 16 Moreover Yahuah said, “Because the daughters of Zion are arrogant, 
 \q2 and walk with outstretched necks and flirting eyes, 
 \q2 walking daintily as they go, 
 \q2 jingling ornaments on their feet; 
 \q1
 \v 17 therefore the Lord brings sores on the crown of the head of the women of Zion, 
-\q2 and Yahweh will make their scalps bald.” 
+\q2 and Yahuah will make their scalps bald.” 
 \p
 \v 18 In that day the Lord will take away the beauty of their anklets, the headbands, the crescent necklaces, 
 \v 19 the earrings, the bracelets, the veils, 
@@ -333,10 +333,10 @@
 \p
 \v 1 Seven women shall take hold of one man in that day, saying, “We will eat our own bread, and wear our own clothing. Just let us be called by your name. Take away our reproach.” 
 \p
-\v 2 In that day, Yahweh’s branch will be beautiful and glorious, and the fruit of the land will be the beauty and glory of the survivors of Israel. 
+\v 2 In that day, Yahuah’s branch will be beautiful and glorious, and the fruit of the land will be the beauty and glory of the survivors of Israel. 
 \v 3 It will happen that he who is left in Zion and he who remains in Jerusalem shall be called set-apart, even everyone who is written among the living in Jerusalem, 
 \v 4 when the Lord shall have washed away the filth of the daughters of Zion, and shall have purged the blood of Jerusalem from within it, by the spirit of justice and by the spirit of burning. 
-\v 5 Yahweh will create over the whole habitation of Mount Zion and over her assemblies, a cloud and smoke by day, and the shining of a flaming fire by night, for over all the glory will be a canopy. 
+\v 5 Yahuah will create over the whole habitation of Mount Zion and over her assemblies, a cloud and smoke by day, and the shining of a flaming fire by night, for over all the glory will be a canopy. 
 \v 6 There will be a pavilion for a shade in the daytime from the heat, and for a refuge and for a shelter from storm and from rain. 
 \c 5
 \q1
@@ -367,7 +367,7 @@
 \q2 but it will grow briers and thorns. 
 \q2 I will also command the clouds that they rain no rain on it.” 
 \q1
-\v 7 For the vineyard of Yahweh of Armies is the house of Israel, 
+\v 7 For the vineyard of Yahuah of Armies is the house of Israel, 
 \q2 and the men of Judah his pleasant plant. 
 \q2 He looked for justice, but behold, oppression, 
 \q2 for righteousness, but behold, a cry of distress. 
@@ -377,7 +377,7 @@
 \q2 who lay field to field, until there is no room, 
 \q2 and you are made to dwell alone in the middle of the land! 
 \q1
-\v 9 In my ears, Yahweh of Armies says: “Surely many houses will be desolate, 
+\v 9 In my ears, Yahuah of Armies says: “Surely many houses will be desolate, 
 \q2 even great and beautiful, unoccupied. 
 \q1
 \v 10 For ten acres of vineyard shall yield one bath, 
@@ -387,7 +387,7 @@
 \q2 who stay late into the night, until wine inflames them! 
 \q1
 \v 12 The harp, lyre, tambourine, and flute, with wine, are at their feasts; 
-\q2 but they don’t respect the work of Yahweh, 
+\q2 but they don’t respect the work of Yahuah, 
 \q2 neither have they considered the operation of his hands. 
 \b
 \q1
@@ -403,7 +403,7 @@
 \q2 mankind is humbled, 
 \q2 and the eyes of the arrogant ones are humbled; 
 \q1
-\v 16 but Yahweh of Armies is exalted in justice, 
+\v 16 but Yahuah of Armies is exalted in justice, 
 \q2 and Elohim the Set-Apart One is sanctified in righteousness. 
 \q1
 \v 17 Then the lambs will graze as in their pasture, 
@@ -437,10 +437,10 @@
 \q2 and as the dry grass sinks down in the flame, 
 \q2 so their root shall be as rottenness, 
 \q2 and their blossom shall go up as dust, 
-\q1 because they have rejected the law of Yahweh of Armies, 
+\q1 because they have rejected the law of Yahuah of Armies, 
 \q2 and despised the word of the Set-Apart One of Israel. 
 \q1
-\v 25 Therefore Yahweh’s anger burns against his people, 
+\v 25 Therefore Yahuah’s anger burns against his people, 
 \q2 and he has stretched out his hand against them and has struck them. 
 \q1 The mountains tremble, 
 \q2 and their dead bodies are as refuse in the middle of the streets. 
@@ -476,11 +476,11 @@
 \v 1 In the year that King Uzziah died, I saw the Lord sitting on a throne, high and lifted up; and his train filled the temple. 
 \v 2 Above him stood the seraphim. Each one had six wings. With two he covered his face. With two he covered his feet. With two he flew. 
 \v 3 One called to another, and said, 
-\q1 “Set-Apart, set-apart, set-apart, is Yahweh of Armies! 
+\q1 “Set-Apart, set-apart, set-apart, is Yahuah of Armies! 
 \q2 The whole earth is full of his glory!” 
 \p
 \v 4 The foundations of the thresholds shook at the voice of him who called, and the house was filled with smoke. 
-\v 5 Then I said, “Woe is me! For I am undone, because I am a man of unclean lips and I live among a people of unclean lips, for my eyes have seen the King, Yahweh of Armies!” 
+\v 5 Then I said, “Woe is me! For I am undone, because I am a man of unclean lips and I live among a people of unclean lips, for my eyes have seen the King, Yahuah of Armies!” 
 \p
 \v 6 Then one of the seraphim flew to me, having a live coal in his hand, which he had taken with the tongs from off the altar. 
 \v 7 He touched my mouth with it, and said, “Behold, this has touched your lips; and your iniquity is taken away, and your sin forgiven.” 
@@ -507,7 +507,7 @@
 \q2 houses without man, 
 \q2 the land becomes utterly waste, 
 \q2
-\v 12 and Yahweh has removed men far away, 
+\v 12 and Yahuah has removed men far away, 
 \q2 and the forsaken places are many within the land. 
 \q1
 \v 13 If there is a tenth left in it, 
@@ -519,26 +519,26 @@
 \v 1 In the days of Ahaz the son of Jotham, the son of Uzziah, king of Judah, Rezin the king of Syria and Pekah the son of Remaliah, king of Israel, went up to Jerusalem to war against it, but could not prevail against it. 
 \v 2 David’s house was told, “Syria is allied with Ephraim.” His heart trembled, and the heart of his people, as the trees of the forest tremble with the wind. 
 \p
-\v 3 Then Yahweh said to Isaiah, “Go out now to meet Ahaz, you, and Shearjashub your son, at the end of the conduit of the upper pool, on the highway of the fuller’s field. 
+\v 3 Then Yahuah said to Isaiah, “Go out now to meet Ahaz, you, and Shearjashub your son, at the end of the conduit of the upper pool, on the highway of the fuller’s field. 
 \v 4 Tell him, ‘Be careful, and keep calm. Don’t be afraid, neither let your heart be faint because of these two tails of smoking torches, for the fierce anger of Rezin and Syria, and of the son of Remaliah. 
 \v 5 Because Syria, Ephraim, and the son of Remaliah, have plotted evil against you, saying, 
 \v 6 “Let’s go up against Judah, and tear it apart, and let’s divide it among ourselves, and set up a king within it, even the son of Tabeel.” 
-\v 7 This is what the Lord Yahweh says: “It shall not stand, neither shall it happen.” 
+\v 7 This is what the Lord Yahuah says: “It shall not stand, neither shall it happen.” 
 \v 8 For the head of Syria is Damascus, and the head of Damascus is Rezin. Within sixty-five years Ephraim shall be broken in pieces, so that it shall not be a people. 
 \v 9 The head of Ephraim is Samaria, and the head of Samaria is Remaliah’s son. If you will not believe, surely you shall not be established.’ ” 
 \p
-\v 10 Yahweh spoke again to Ahaz, saying, 
-\v 11 “Ask a sign of Yahweh your Elohim; ask it either in the depth, or in the height above.” 
+\v 10 Yahuah spoke again to Ahaz, saying, 
+\v 11 “Ask a sign of Yahuah your Elohim; ask it either in the depth, or in the height above.” 
 \p
-\v 12 But Ahaz said, “I won’t ask. I won’t tempt Yahweh.” 
+\v 12 But Ahaz said, “I won’t ask. I won’t tempt Yahuah.” 
 \p
 \v 13 He said, “Listen now, house of David. Is it not enough for you to try the patience of men, that you will try the patience of my Elohim also? 
 \v 14 Therefore the Lord himself will give you a sign. Behold, the young woman will conceive, and bear a son, and shall call his name Immanuel. 
 \v 15 He shall eat butter and honey when he knows to refuse the evil and choose the good. 
 \v 16 For before the child knows to refuse the evil and choose the good, the land whose two kings you abhor shall be forsaken. 
-\v 17 Yahweh will bring on you, on your people, and on your father’s house days that have not come, from the day that Ephraim departed from Judah, even the king of Assyria. 
+\v 17 Yahuah will bring on you, on your people, and on your father’s house days that have not come, from the day that Ephraim departed from Judah, even the king of Assyria. 
 \p
-\v 18 It will happen in that day that Yahweh will whistle for the fly that is in the uttermost part of the rivers of Egypt, and for the bee that is in the land of Assyria. 
+\v 18 It will happen in that day that Yahuah will whistle for the fly that is in the uttermost part of the rivers of Egypt, and for the bee that is in the land of Assyria. 
 \v 19 They shall come, and shall all rest in the desolate valleys, in the clefts of the rocks, on all thorn hedges, and on all pastures. 
 \p
 \v 20 In that day the Lord will shave with a razor that is hired in the parts beyond the River, even with the king of Assyria, the head and the hair of the feet; and it shall also consume the beard. 
@@ -551,13 +551,13 @@
 \v 25 All the hills that were cultivated with the hoe, you shall not come there for fear of briers and thorns; but it shall be for the sending out of oxen, and for sheep to tread on.” 
 \c 8
 \p
-\v 1 Yahweh said to me, “Take a large tablet, and write on it with a man’s pen, ‘For Maher Shalal Hash Baz’; 
+\v 1 Yahuah said to me, “Take a large tablet, and write on it with a man’s pen, ‘For Maher Shalal Hash Baz’; 
 \v 2 and I will take for myself faithful witnesses to testify: Uriah the priest, and Zechariah the son of Jeberechiah.” 
 \p
-\v 3 I went to the prophetess, and she conceived, and bore a son. Then Yahweh said to me, “Call his name ‘Maher Shalal Hash Baz.’ 
+\v 3 I went to the prophetess, and she conceived, and bore a son. Then Yahuah said to me, “Call his name ‘Maher Shalal Hash Baz.’ 
 \v 4 For before the child knows how to say, ‘My father’ and ‘My mother,’ the riches of Damascus and the plunder of Samaria will be carried away by the king of Assyria.” 
 \p
-\v 5 Yahweh spoke to me yet again, saying, 
+\v 5 Yahuah spoke to me yet again, saying, 
 \v 6 “Because this people has refused the waters of Shiloah that go softly, and rejoice in Rezin and Remaliah’s son; 
 \v 7 now therefore, behold, the Lord brings upon them the mighty flood waters of the River: the king of Assyria and all his glory. It will come up over all its channels, and go over all its banks. 
 \v 8 It will sweep onward into Judah. It will overflow and pass through. It will reach even to the neck. The stretching out of its wings will fill the width of your land, O Immanuel. 
@@ -565,15 +565,15 @@
 \v 9 Make an uproar, you peoples, and be broken in pieces! Listen, all you from far countries: dress for battle, and be shattered! Dress for battle, and be shattered! 
 \v 10 Take counsel together, and it will be brought to nothing; speak the word, and it will not stand, for Elohim is with us.” 
 \p
-\v 11 For Yahweh spoke this to me with a strong hand, and instructed me not to walk in the way of this people, saying, 
+\v 11 For Yahuah spoke this to me with a strong hand, and instructed me not to walk in the way of this people, saying, 
 \v 12 “Don’t call a conspiracy all that this people call a conspiracy. Don’t fear their threats or be terrorized. 
-\v 13 Yahweh of Armies is who you must respect as set-apart. He is the one you must fear. He is the one you must dread. 
+\v 13 Yahuah of Armies is who you must respect as set-apart. He is the one you must fear. He is the one you must dread. 
 \v 14 He will be a sanctuary, but for both houses of Israel, he will be a stumbling stone and a rock that makes them fall. For the people of Jerusalem, he will be a trap and a snare. 
 \v 15 Many will stumble over it, fall, be broken, be snared, and be captured.” 
 \p
 \v 16 Wrap up the covenant. Seal the law among my disciples. 
-\v 17 I will wait for Yahweh, who hides his face from the house of Jacob, and I will look for him. 
-\v 18 Behold, I and the children whom Yahweh has given me are for signs and for wonders in Israel from Yahweh of Armies, who dwells in Mount Zion. 
+\v 17 I will wait for Yahuah, who hides his face from the house of Jacob, and I will look for him. 
+\v 18 Behold, I and the children whom Yahuah has given me are for signs and for wonders in Israel from Yahuah of Armies, who dwells in Mount Zion. 
 \p
 \v 19 When they tell you, “Consult with those who have familiar spirits and with the wizards, who chirp and who mutter,” shouldn’t a people consult with their Elohim? Should they consult the dead on behalf of the living? 
 \v 20 Turn to the law and to the covenant! If they don’t speak according to this word, surely there is no morning for them. 
@@ -592,7 +592,7 @@
 \v 4 For the yoke of his burden, and the staff of his shoulder, the rod of his oppressor, you have broken as in the day of Midian. 
 \v 5 For all the armor of the armed man in the noisy battle, and the garments rolled in blood, will be for burning, fuel for the fire. 
 \v 6 For a child is born to us. A son is given to us; and the government will be on his shoulders. His name will be called Wonderful Counselor, Mighty Elohim, Everlasting Father, Prince of Peace. 
-\v 7 Of the increase of his government and of peace there shall be no end, on David’s throne, and on his kingdom, to establish it, and to uphold it with justice and with righteousness from that time on, even forever. The zeal of Yahweh of Armies will perform this. 
+\v 7 Of the increase of his government and of peace there shall be no end, on David’s throne, and on his kingdom, to establish it, and to uphold it with justice and with righteousness from that time on, even forever. The zeal of Yahuah of Armies will perform this. 
 \p
 \v 8 The Lord sent a word into Jacob, 
 \q2 and it falls on Israel. 
@@ -605,7 +605,7 @@
 \q1 The sycamore fig trees have been cut down, 
 \q2 but we will put cedars in their place.” 
 \q1
-\v 11 Therefore Yahweh will set up on high against him the adversaries of Rezin, 
+\v 11 Therefore Yahuah will set up on high against him the adversaries of Rezin, 
 \q2 and will stir up his enemies, 
 \q2
 \v 12 The Syrians in front, 
@@ -616,9 +616,9 @@
 \b
 \q1
 \v 13 Yet the people have not turned to him who struck them, 
-\q2 neither have they sought Yahweh of Armies. 
+\q2 neither have they sought Yahuah of Armies. 
 \q1
-\v 14 Therefore Yahweh will cut off from Israel head and tail, 
+\v 14 Therefore Yahuah will cut off from Israel head and tail, 
 \q2 palm branch and reed, in one day. 
 \q1
 \v 15 The elder and the honorable man is the head, 
@@ -640,7 +640,7 @@
 \q2 yes, it kindles in the thickets of the forest, 
 \q2 and they roll upward in a column of smoke. 
 \q1
-\v 19 Through Yahweh of Armies’ wrath, the land is burned up; 
+\v 19 Through Yahuah of Armies’ wrath, the land is burned up; 
 \q2 and the people are the fuel for the fire. 
 \q2 No one spares his brother. 
 \q1
@@ -676,19 +676,19 @@
 \v 14 My hand has found the riches of the peoples like a nest, and like one gathers eggs that are abandoned, I have gathered all the earth. There was no one who moved their wing, or that opened their mouth, or chirped.” 
 \p
 \v 15 Should an ax brag against him who chops with it? Should a saw exalt itself above him who saws with it? As if a rod should lift those who lift it up, or as if a staff should lift up someone who is not wood. 
-\v 16 Therefore the Lord, Yahweh of Armies, will send among his fat ones leanness; and under his glory a burning will be kindled like the burning of fire. 
+\v 16 Therefore the Lord, Yahuah of Armies, will send among his fat ones leanness; and under his glory a burning will be kindled like the burning of fire. 
 \v 17 The light of Israel will be for a fire, and his Set-Apart One for a flame; and it will burn and devour his thorns and his briers in one day. 
 \v 18 He will consume the glory of his forest and of his fruitful field, both soul and body. It will be as when a standard bearer faints. 
 \v 19 The remnant of the trees of his forest shall be few, so that a child could write their number. 
 \p
-\v 20 It will come to pass in that day that the remnant of Israel, and those who have escaped from the house of Jacob will no more again lean on him who struck them, but shall lean on Yahweh, the Set-Apart One of Israel, in truth. 
+\v 20 It will come to pass in that day that the remnant of Israel, and those who have escaped from the house of Jacob will no more again lean on him who struck them, but shall lean on Yahuah, the Set-Apart One of Israel, in truth. 
 \v 21 A remnant will return, even the remnant of Jacob, to the mighty Elohim. 
 \v 22 For though your people, Israel, are like the sand of the sea, only a remnant of them will return. A destruction is determined, overflowing with righteousness. 
-\v 23 For the Lord, Yahweh of Armies, will make a full end, and that determined, throughout all the earth. 
+\v 23 For the Lord, Yahuah of Armies, will make a full end, and that determined, throughout all the earth. 
 \p
-\v 24 Therefore the Lord, Yahweh of Armies, says, “My people who dwell in Zion, don’t be afraid of the Assyrian, though he strike you with the rod, and lift up his staff against you, as Egypt did. 
+\v 24 Therefore the Lord, Yahuah of Armies, says, “My people who dwell in Zion, don’t be afraid of the Assyrian, though he strike you with the rod, and lift up his staff against you, as Egypt did. 
 \v 25 For yet a very little while, and the indignation against you will be accomplished, and my anger will be directed to his destruction.” 
-\v 26 Yahweh of Armies will stir up a scourge against him, as in the slaughter of Midian at the rock of Oreb. His rod will be over the sea, and he will lift it up like he did against Egypt. 
+\v 26 Yahuah of Armies will stir up a scourge against him, as in the slaughter of Midian at the rock of Oreb. His rod will be over the sea, and he will lift it up like he did against Egypt. 
 \v 27 It will happen in that day that his burden will depart from off your shoulder, and his yoke from off your neck, and the yoke shall be destroyed because of the anointing oil. 
 \p
 \v 28 He has come to Aiath. He has passed through Migron. At Michmash he stores his baggage. 
@@ -697,19 +697,19 @@
 \v 31 Madmenah is a fugitive. The inhabitants of Gebim flee for safety. 
 \v 32 This very day he will halt at Nob. He shakes his hand at the mountain of the daughter of Zion, the hill of Jerusalem. 
 \p
-\v 33 Behold, the Lord, Yahweh of Armies, will lop the boughs with terror. The tall will be cut down, and the lofty will be brought low. 
+\v 33 Behold, the Lord, Yahuah of Armies, will lop the boughs with terror. The tall will be cut down, and the lofty will be brought low. 
 \v 34 He will cut down the thickets of the forest with iron, and Lebanon will fall by the Mighty One. 
 \c 11
 \q1
 \v 1 A shoot will come out of the stock of Jesse, 
 \q2 and a branch out of his roots will bear fruit. 
 \q1
-\v 2 Yahweh’s Spirit will rest on him: 
+\v 2 Yahuah’s Spirit will rest on him: 
 \q2 the spirit of wisdom and understanding, 
 \q2 the spirit of counsel and might, 
-\q2 the spirit of knowledge and of the fear of Yahweh. 
+\q2 the spirit of knowledge and of the fear of Yahuah. 
 \q1
-\v 3 His delight will be in the fear of Yahweh. 
+\v 3 His delight will be in the fear of Yahuah. 
 \q1 He will not judge by the sight of his eyes, 
 \q2 neither decide by the hearing of his ears; 
 \q1
@@ -735,7 +735,7 @@
 \q2 and the weaned child will put his hand on the viper’s den. 
 \q1
 \v 9 They will not hurt nor destroy in all my set-apart mountain; 
-\q2 for the earth will be full of the knowledge of Yahweh, 
+\q2 for the earth will be full of the knowledge of Yahuah, 
 \q2 as the waters cover the sea. 
 \b
 \p
@@ -745,15 +745,15 @@
 \v 12 He will set up a banner for the nations, and will assemble the outcasts of Israel, and gather together the dispersed of Judah from the four corners of the earth. 
 \v 13 The envy also of Ephraim will depart, and those who persecute Judah will be cut off. Ephraim won’t envy Judah, and Judah won’t persecute Ephraim. 
 \v 14 They will fly down on the shoulders of the Philistines on the west. Together they will plunder the children of the east. They will extend their power over Edom and Moab, and the children of Ammon will obey them. 
-\v 15 Yahweh will utterly destroy the tongue of the Egyptian sea; and with his scorching wind he will wave his hand over the River, and will split it into seven streams, and cause men to march over in sandals. 
+\v 15 Yahuah will utterly destroy the tongue of the Egyptian sea; and with his scorching wind he will wave his hand over the River, and will split it into seven streams, and cause men to march over in sandals. 
 \v 16 There will be a highway for the remnant that is left of his people from Assyria, like there was for Israel in the day that he came up out of the land of Egypt. 
 \c 12
 \p
-\v 1 In that day you will say, “I will give thanks to you, Yahweh; for though you were angry with me, your anger has turned away and you comfort me. 
-\v 2 Behold, Elohim is my salvation. I will trust, and will not be afraid; for Yah, Yahweh, is my strength and song; and he has become my salvation.” 
+\v 1 In that day you will say, “I will give thanks to you, Yahuah; for though you were angry with me, your anger has turned away and you comfort me. 
+\v 2 Behold, Elohim is my salvation. I will trust, and will not be afraid; for Yah, Yahuah, is my strength and song; and he has become my salvation.” 
 \v 3 Therefore with joy you will draw water out of the wells of salvation. 
-\v 4 In that day you will say, “Give thanks to Yahweh! Call on his name! Declare his doings among the peoples! Proclaim that his name is exalted! 
-\v 5 Sing to Yahweh, for he has done excellent things! Let this be known in all the earth! 
+\v 4 In that day you will say, “Give thanks to Yahuah! Call on his name! Declare his doings among the peoples! Proclaim that his name is exalted! 
+\v 5 Sing to Yahuah, for he has done excellent things! Let this be known in all the earth! 
 \v 6 Cry aloud and shout, you inhabitant of Zion, for the Set-Apart One of Israel is great among you!” 
 \c 13
 \p
@@ -761,17 +761,17 @@
 \p
 \v 2 Set up a banner on the bare mountain! Lift up your voice to them! Wave your hand, that they may go into the gates of the nobles. 
 \v 3 I have commanded my consecrated ones; yes, I have called my mighty men for my anger, even my proudly exulting ones. 
-\v 4 The noise of a multitude is in the mountains, as of a great people; the noise of an uproar of the kingdoms of the nations gathered together! Yahweh of Armies is mustering the army for the battle. 
-\v 5 They come from a far country, from the uttermost part of heaven, even Yahweh, and the weapons of his indignation, to destroy the whole land. 
+\v 4 The noise of a multitude is in the mountains, as of a great people; the noise of an uproar of the kingdoms of the nations gathered together! Yahuah of Armies is mustering the army for the battle. 
+\v 5 They come from a far country, from the uttermost part of heaven, even Yahuah, and the weapons of his indignation, to destroy the whole land. 
 \p
-\v 6 Wail, for Yahweh’s day is at hand! It will come as destruction from the Almighty. 
+\v 6 Wail, for Yahuah’s day is at hand! It will come as destruction from the Almighty. 
 \v 7 Therefore all hands will be feeble, and everyone’s heart will melt. 
 \v 8 They will be dismayed. Pangs and sorrows will seize them. They will be in pain like a woman in labor. They will look in amazement one at another. Their faces will be faces of flame. 
-\v 9 Behold, the day of Yahweh comes, cruel, with wrath and fierce anger; to make the land a desolation, and to destroy its sinners out of it. 
+\v 9 Behold, the day of Yahuah comes, cruel, with wrath and fierce anger; to make the land a desolation, and to destroy its sinners out of it. 
 \v 10 For the stars of the sky and its constellations will not give their light. The sun will be darkened in its going out, and the moon will not cause its light to shine. 
 \v 11 I will punish the world for their evil, and the wicked for their iniquity. I will cause the arrogance of the proud to cease, and will humble the arrogance of the terrible. 
 \v 12 I will make people more rare than fine gold, even a person than the pure gold of Ophir. 
-\v 13 Therefore I will make the heavens tremble, and the earth will be shaken out of its place in Yahweh of Armies’ wrath, and in the day of his fierce anger. 
+\v 13 Therefore I will make the heavens tremble, and the earth will be shaken out of its place in Yahuah of Armies’ wrath, and in the day of his fierce anger. 
 \v 14 It will happen that like a hunted gazelle and like sheep that no one gathers, they will each turn to their own people, and will each flee to their own land. 
 \v 15 Everyone who is found will be thrust through. Everyone who is captured will fall by the sword. 
 \v 16 Their infants also will be dashed in pieces before their eyes. Their houses will be ransacked, and their women raped. 
@@ -784,12 +784,12 @@
 \v 22 Hyenas will cry in their fortresses, and jackals in the pleasant palaces. Her time is near to come, and her days will not be prolonged. 
 \c 14
 \p
-\v 1 For Yahweh will have compassion on Jacob, and will yet choose Israel, and set them in their own land. The foreigner will join himself with them, and they will unite with the house of Jacob. 
-\v 2 The peoples will take them, and bring them to their place. The house of Israel will possess them in Yahweh’s land for servants and for handmaids. They will take as captives those whose captives they were; and they shall rule over their oppressors. 
+\v 1 For Yahuah will have compassion on Jacob, and will yet choose Israel, and set them in their own land. The foreigner will join himself with them, and they will unite with the house of Jacob. 
+\v 2 The peoples will take them, and bring them to their place. The house of Israel will possess them in Yahuah’s land for servants and for handmaids. They will take as captives those whose captives they were; and they shall rule over their oppressors. 
 \p
-\v 3 It will happen in the day that Yahweh will give you rest from your sorrow, from your trouble, and from the hard service in which you were made to serve, 
+\v 3 It will happen in the day that Yahuah will give you rest from your sorrow, from your trouble, and from the hard service in which you were made to serve, 
 \v 4 that you will take up this parable against the king of Babylon, and say, “How the oppressor has ceased! The golden city has ceased!” 
-\v 5 Yahweh has broken the staff of the wicked, the scepter of the rulers, 
+\v 5 Yahuah has broken the staff of the wicked, the scepter of the rulers, 
 \v 6 who struck the peoples in wrath with a continual stroke, who ruled the nations in anger, with a persecution that no one restrained. 
 \v 7 The whole earth is at rest, and is quiet. They break out in song. 
 \v 8 Yes, the cypress trees rejoice with you, with the cedars of Lebanon, saying, “Since you are humbled, no lumberjack has come up against us.” 
@@ -809,13 +809,13 @@
 \v 20 You will not join them in burial, because you have destroyed your land. You have killed your people. The offspring of evildoers will not be named forever. 
 \p
 \v 21 Prepare for slaughter of his children because of the iniquity of their fathers, that they not rise up and possess the earth, and fill the surface of the world with cities. 
-\v 22 “I will rise up against them,” says Yahweh of Armies, “and cut off from Babylon name and remnant, and son and son’s son,” says Yahweh. 
-\v 23 “I will also make it a possession for the porcupine, and pools of water. I will sweep it with the broom of destruction,” says Yahweh of Armies. 
+\v 22 “I will rise up against them,” says Yahuah of Armies, “and cut off from Babylon name and remnant, and son and son’s son,” says Yahuah. 
+\v 23 “I will also make it a possession for the porcupine, and pools of water. I will sweep it with the broom of destruction,” says Yahuah of Armies. 
 \p
-\v 24 Yahweh of Armies has sworn, saying, “Surely, as I have thought, so shall it happen; and as I have purposed, so shall it stand: 
+\v 24 Yahuah of Armies has sworn, saying, “Surely, as I have thought, so shall it happen; and as I have purposed, so shall it stand: 
 \v 25 that I will break the Assyrian in my land, and tread him under foot on my mountains. Then his yoke will leave them, and his burden leave their shoulders. 
 \v 26 This is the plan that is determined for the whole earth. This is the hand that is stretched out over all the nations. 
-\v 27 For Yahweh of Armies has planned, and who can stop it? His hand is stretched out, and who can turn it back?” 
+\v 27 For Yahuah of Armies has planned, and who can stop it? His hand is stretched out, and who can turn it back?” 
 \p
 \v 28 This burden was in the year that King Ahaz died. 
 \p
@@ -824,7 +824,7 @@
 \p
 \v 31 Howl, gate! Cry, city! You are melted away, Philistia, all of you; for smoke comes out of the north, and there is no straggler in his ranks. 
 \p
-\v 32 What will they answer the messengers of the nation? That Yahweh has founded Zion, and in her the afflicted of his people will take refuge. 
+\v 32 What will they answer the messengers of the nation? That Yahuah has founded Zion, and in her the afflicted of his people will take refuge. 
 \c 15
 \p
 \v 1 The burden of Moab. 
@@ -853,18 +853,18 @@
 \v 11 Therefore my heart sounds like a harp for Moab, and my inward parts for Kir Heres. 
 \v 12 It will happen that when Moab presents himself, when he wearies himself on the high place, and comes to his sanctuary to pray, that he will not prevail. 
 \p
-\v 13 This is the word that Yahweh spoke concerning Moab in time past. 
-\v 14 But now Yahweh has spoken, saying, “Within three years, as a worker bound by contract would count them, the glory of Moab shall be brought into contempt, with all his great multitude; and the remnant will be very small and feeble.” 
+\v 13 This is the word that Yahuah spoke concerning Moab in time past. 
+\v 14 But now Yahuah has spoken, saying, “Within three years, as a worker bound by contract would count them, the glory of Moab shall be brought into contempt, with all his great multitude; and the remnant will be very small and feeble.” 
 \c 17
 \p
 \v 1 The burden of Damascus. 
 \p “Behold, Damascus is taken away from being a city, and it will be a ruinous heap. 
 \v 2 The cities of Aroer are forsaken. They will be for flocks, which shall lie down, and no one shall make them afraid. 
-\v 3 The fortress shall cease from Ephraim, and the kingdom from Damascus, and the remnant of Syria. They will be as the glory of the children of Israel,” says Yahweh of Armies. 
+\v 3 The fortress shall cease from Ephraim, and the kingdom from Damascus, and the remnant of Syria. They will be as the glory of the children of Israel,” says Yahuah of Armies. 
 \p
 \v 4 “It will happen in that day that the glory of Jacob will be made thin, and the fatness of his flesh will become lean. 
 \v 5 It will be like when the harvester gathers the wheat, and his arm reaps the grain. Yes, it will be like when one gleans grain in the valley of Rephaim. 
-\v 6 Yet gleanings will be left there, like the shaking of an olive tree, two or three olives in the top of the uppermost bough, four or five in the outermost branches of a fruitful tree,” says Yahweh, the Elohim of Israel. 
+\v 6 Yet gleanings will be left there, like the shaking of an olive tree, two or three olives in the top of the uppermost bough, four or five in the outermost branches of a fruitful tree,” says Yahuah, the Elohim of Israel. 
 \v 7 In that day, people will look to their Maker, and their eyes will have respect for the Set-Apart One of Israel. 
 \v 8 They will not look to the altars, the work of their hands; neither shall they respect that which their fingers have made, either the Asherah poles or the incense altars. 
 \v 9 In that day, their strong cities will be like the forsaken places in the woods and on the mountain top, which were forsaken from before the children of Israel; and it will be a desolation. 
@@ -880,17 +880,17 @@
 \v 2 that sends ambassadors by the sea, even in vessels of papyrus on the waters, saying, “Go, you swift messengers, to a nation tall and smooth, to a people awesome from their beginning onward, a nation that measures out and treads down, whose land the rivers divide!” 
 \v 3 All you inhabitants of the world, and you dwellers on the earth, when a banner is lifted up on the mountains, look! When the trumpet is blown, listen! 
 \p
-\v 4 For Yahweh said to me, “I will be still, and I will see in my dwelling place, like clear heat in sunshine, like a cloud of dew in the heat of harvest.” 
+\v 4 For Yahuah said to me, “I will be still, and I will see in my dwelling place, like clear heat in sunshine, like a cloud of dew in the heat of harvest.” 
 \v 5 For before the harvest, when the blossom is over, and the flower becomes a ripening grape, he will cut off the sprigs with pruning hooks, and he will cut down and take away the spreading branches. 
 \v 6 They will be left together for the ravenous birds of the mountains, and for the animals of the earth. The ravenous birds will eat them in the summer, and all the animals of the earth will eat them in the winter. 
-\v 7 In that time, a present will be brought to Yahweh of Armies from a people tall and smooth, even from a people awesome from their beginning onward, a nation that measures out and treads down, whose land the rivers divide, to the place of the name of Yahweh of Armies, Mount Zion. 
+\v 7 In that time, a present will be brought to Yahuah of Armies from a people tall and smooth, even from a people awesome from their beginning onward, a nation that measures out and treads down, whose land the rivers divide, to the place of the name of Yahuah of Armies, Mount Zion. 
 \c 19
 \p
 \v 1 The burden of Egypt. 
-\p “Behold, Yahweh rides on a swift cloud, and comes to Egypt. The idols of Egypt will tremble at his presence; and the heart of Egypt will melt within it. 
+\p “Behold, Yahuah rides on a swift cloud, and comes to Egypt. The idols of Egypt will tremble at his presence; and the heart of Egypt will melt within it. 
 \v 2 I will stir up the Egyptians against the Egyptians, and they will fight everyone against his brother, and everyone against his neighbor; city against city, and kingdom against kingdom. 
 \v 3 The spirit of the Egyptians will fail within them. I will destroy their counsel. They will seek the idols, the charmers, those who have familiar spirits, and the wizards. 
-\v 4 I will give over the Egyptians into the hand of a cruel lord. A fierce king will rule over them,” says the Lord, Yahweh of Armies. 
+\v 4 I will give over the Egyptians into the hand of a cruel lord. A fierce king will rule over them,” says the Lord, Yahuah of Armies. 
 \p
 \v 5 The waters will fail from the sea, and the river will be wasted and become dry. 
 \v 6 The rivers will become foul. The streams of Egypt will be diminished and dried up. The reeds and flags will wither away. 
@@ -900,28 +900,28 @@
 \v 10 The pillars will be broken in pieces. All those who work for hire will be grieved in soul. 
 \p
 \v 11 The princes of Zoan are utterly foolish. The counsel of the wisest counselors of Pharaoh has become stupid. How do you say to Pharaoh, “I am the son of the wise, the son of ancient kings”? 
-\v 12 Where then are your wise men? Let them tell you now; and let them know what Yahweh of Armies has purposed concerning Egypt. 
+\v 12 Where then are your wise men? Let them tell you now; and let them know what Yahuah of Armies has purposed concerning Egypt. 
 \v 13 The princes of Zoan have become fools. The princes of Memphis are deceived. They have caused Egypt to go astray, those who are the cornerstone of her tribes. 
-\v 14 Yahweh has mixed a spirit of perverseness in the middle of her; and they have caused Egypt to go astray in all of its works, like a drunken man staggers in his vomit. 
+\v 14 Yahuah has mixed a spirit of perverseness in the middle of her; and they have caused Egypt to go astray in all of its works, like a drunken man staggers in his vomit. 
 \v 15 Neither shall there be any work for Egypt, which head or tail, palm branch or rush, may do. 
-\v 16 In that day the Egyptians will be like women. They will tremble and fear because of the shaking of Yahweh of Armies’s hand, which he shakes over them. 
-\v 17 The land of Judah will become a terror to Egypt. Everyone to whom mention is made of it will be afraid, because of the plans of Yahweh of Armies, which he determines against it. 
-\v 18 In that day, there will be five cities in the land of Egypt that speak the language of Canaan, and swear to Yahweh of Armies. One will be called “The city of destruction.” 
+\v 16 In that day the Egyptians will be like women. They will tremble and fear because of the shaking of Yahuah of Armies’s hand, which he shakes over them. 
+\v 17 The land of Judah will become a terror to Egypt. Everyone to whom mention is made of it will be afraid, because of the plans of Yahuah of Armies, which he determines against it. 
+\v 18 In that day, there will be five cities in the land of Egypt that speak the language of Canaan, and swear to Yahuah of Armies. One will be called “The city of destruction.” 
 \p
-\v 19 In that day, there will be an altar to Yahweh in the middle of the land of Egypt, and a pillar to Yahweh at its border. 
-\v 20 It will be for a sign and for a witness to Yahweh of Armies in the land of Egypt; for they will cry to Yahweh because of oppressors, and he will send them a savior and a defender, and he will deliver them. 
-\v 21 Yahweh will be known to Egypt, and the Egyptians will know Yahweh in that day. Yes, they will worship with sacrifice and offering, and will vow a vow to Yahweh, and will perform it. 
-\v 22 Yahweh will strike Egypt, striking and healing. They will return to Yahweh, and he will be entreated by them, and will heal them. 
+\v 19 In that day, there will be an altar to Yahuah in the middle of the land of Egypt, and a pillar to Yahuah at its border. 
+\v 20 It will be for a sign and for a witness to Yahuah of Armies in the land of Egypt; for they will cry to Yahuah because of oppressors, and he will send them a savior and a defender, and he will deliver them. 
+\v 21 Yahuah will be known to Egypt, and the Egyptians will know Yahuah in that day. Yes, they will worship with sacrifice and offering, and will vow a vow to Yahuah, and will perform it. 
+\v 22 Yahuah will strike Egypt, striking and healing. They will return to Yahuah, and he will be entreated by them, and will heal them. 
 \p
 \v 23 In that day there will be a highway out of Egypt to Assyria, and the Assyrian shall come into Egypt, and the Egyptian into Assyria; and the Egyptians will worship with the Assyrians. 
 \p
 \v 24 In that day, Israel will be the third with Egypt and with Assyria, a blessing within the earth; 
-\v 25 because Yahweh of Armies has blessed them, saying, “Blessed be Egypt my people, Assyria the work of my hands, and Israel my inheritance.” 
+\v 25 because Yahuah of Armies has blessed them, saying, “Blessed be Egypt my people, Assyria the work of my hands, and Israel my inheritance.” 
 \c 20
 \p
 \v 1 In the year that Tartan came to Ashdod, when Sargon the king of Assyria sent him, and he fought against Ashdod and took it; 
-\v 2 at that time Yahweh spoke by Isaiah the son of Amoz, saying, “Go, and loosen the sackcloth from off your waist, and take your sandals from off your feet.” He did so, walking naked and barefoot. 
-\v 3 Yahweh said, “As my servant Isaiah has walked naked and barefoot three years for a sign and a wonder concerning Egypt and concerning Ethiopia, 
+\v 2 at that time Yahuah spoke by Isaiah the son of Amoz, saying, “Go, and loosen the sackcloth from off your waist, and take your sandals from off your feet.” He did so, walking naked and barefoot. 
+\v 3 Yahuah said, “As my servant Isaiah has walked naked and barefoot three years for a sign and a wonder concerning Egypt and concerning Ethiopia, 
 \v 4 so the king of Assyria will lead away the captives of Egypt and the exiles of Ethiopia, young and old, naked and barefoot, and with buttocks uncovered, to the shame of Egypt. 
 \v 5 They will be dismayed and confounded, because of Ethiopia their expectation, and of Egypt their glory. 
 \v 6 The inhabitants of this coast land will say in that day, ‘Behold, this is our expectation, where we fled for help to be delivered from the king of Assyria. And we, how will we escape?’ ” 
@@ -938,7 +938,7 @@
 \v 8 He cried like a lion: “Lord, I stand continually on the watchtower in the daytime, and every night I stay at my post. 
 \v 9 Behold, here comes a troop of men, horsemen in pairs.” He answered, “Fallen, fallen is Babylon; and all the engraved images of her elohims are broken to the ground. 
 \p
-\v 10 You are my threshing, and the grain of my floor!” That which I have heard from Yahweh of Armies, the Elohim of Israel, I have declared to you. 
+\v 10 You are my threshing, and the grain of my floor!” That which I have heard from Yahuah of Armies, the Elohim of Israel, I have declared to you. 
 \p
 \v 11 The burden of Dumah. 
 \p One calls to me out of Seir, “Watchman, what of the night? Watchman, what of the night?” 
@@ -949,7 +949,7 @@
 \v 14 They brought water to him who was thirsty. The inhabitants of the land of Tema met the fugitives with their bread. 
 \v 15 For they fled away from the swords, from the drawn sword, from the bent bow, and from the heat of battle. 
 \v 16 For the Lord said to me, “Within a year, as a worker bound by contract would count it, all the glory of Kedar will fail, 
-\v 17 and the residue of the number of the archers, the mighty men of the children of Kedar, will be few; for Yahweh, the Elohim of Israel, has spoken it.” 
+\v 17 and the residue of the number of the archers, the mighty men of the children of Kedar, will be few; for Yahuah, the Elohim of Israel, has spoken it.” 
 \c 22
 \p
 \v 1 The burden of the valley of vision. 
@@ -958,7 +958,7 @@
 \v 3 All your rulers fled away together. They were bound by the archers. All who were found by you were bound together. They fled far away. 
 \v 4 Therefore I said, “Look away from me. I will weep bitterly. Don’t labor to comfort me for the destruction of the daughter of my people. 
 \p
-\v 5 For it is a day of confusion, and of treading down, and of perplexity from the Lord, Yahweh of Armies, in the valley of vision, a breaking down of the walls, and a crying to the mountains.” 
+\v 5 For it is a day of confusion, and of treading down, and of perplexity from the Lord, Yahuah of Armies, in the valley of vision, a breaking down of the walls, and a crying to the mountains.” 
 \v 6 Elam carried his quiver, with chariots of men and horsemen; and Kir uncovered the shield. 
 \v 7 Your choicest valleys were full of chariots, and the horsemen set themselves in array at the gate. 
 \v 8 He took away the covering of Judah; and you looked in that day to the armor in the house of the forest. 
@@ -966,13 +966,13 @@
 \v 10 You counted the houses of Jerusalem, and you broke down the houses to fortify the wall. 
 \v 11 You also made a reservoir between the two walls for the water of the old pool. But you didn’t look to him who had done this, neither did you have respect for him who planned it long ago. 
 \p
-\v 12 In that day, the Lord, Yahweh of Armies, called to weeping, to mourning, to baldness, and to dressing in sackcloth; 
+\v 12 In that day, the Lord, Yahuah of Armies, called to weeping, to mourning, to baldness, and to dressing in sackcloth; 
 \v 13 and behold, there is joy and gladness, killing cattle and killing sheep, eating meat and drinking wine: “Let’s eat and drink, for tomorrow we will die.” 
-\v 14 Yahweh of Armies revealed himself in my ears, “Surely this iniquity will not be forgiven you until you die,” says the Lord, Yahweh of Armies. 
+\v 14 Yahuah of Armies revealed himself in my ears, “Surely this iniquity will not be forgiven you until you die,” says the Lord, Yahuah of Armies. 
 \p
-\v 15 The Lord, Yahweh of Armies says, “Go, get yourself to this treasurer, even to Shebna, who is over the house, and say, 
+\v 15 The Lord, Yahuah of Armies says, “Go, get yourself to this treasurer, even to Shebna, who is over the house, and say, 
 \v 16 ‘What are you doing here? Who has you here, that you have dug out a tomb here?’ Cutting himself out a tomb on high, chiseling a habitation for himself in the rock!” 
-\v 17 Behold, Yahweh will overcome you and hurl you away violently. Yes, he will grasp you firmly. 
+\v 17 Behold, Yahuah will overcome you and hurl you away violently. Yes, he will grasp you firmly. 
 \v 18 He will surely wind you around and around, and throw you like a ball into a large country. There you will die, and there the chariots of your glory will be, you disgrace of your lord’s house. 
 \v 19 I will thrust you from your office. You will be pulled down from your station. 
 \p
@@ -981,7 +981,7 @@
 \v 22 I will lay the key of David’s house on his shoulder. He will open, and no one will shut. He will shut, and no one will open. 
 \v 23 I will fasten him like a nail in a sure place. He will be for a throne of glory to his father’s house. 
 \v 24 They will hang on him all the glory of his father’s house, the offspring and the issue, every small vessel, from the cups even to all the pitchers. 
-\v 25 “In that day,” says Yahweh of Armies, “the nail that was fastened in a sure place will give way. It will be cut down and fall. The burden that was on it will be cut off, for Yahweh has spoken it.” 
+\v 25 “In that day,” says Yahuah of Armies, “the nail that was fastened in a sure place will give way. It will be cut down and fall. The burden that was on it will be cut off, for Yahuah has spoken it.” 
 \c 23
 \p
 \v 1 The burden of Tyre. 
@@ -994,22 +994,22 @@
 \v 7 Is this your joyous city, whose antiquity is of ancient days, whose feet carried her far away to travel? 
 \p
 \v 8 Who has planned this against Tyre, the giver of crowns, whose merchants are princes, whose traders are the honorable of the earth? 
-\v 9 Yahweh of Armies has planned it, to stain the pride of all glory, to bring into contempt all the honorable of the earth. 
+\v 9 Yahuah of Armies has planned it, to stain the pride of all glory, to bring into contempt all the honorable of the earth. 
 \v 10 Pass through your land like the Nile, daughter of Tarshish. There is no restraint any more. 
-\v 11 He has stretched out his hand over the sea. He has shaken the kingdoms. Yahweh has ordered the destruction of Canaan’s strongholds. 
+\v 11 He has stretched out his hand over the sea. He has shaken the kingdoms. Yahuah has ordered the destruction of Canaan’s strongholds. 
 \v 12 He said, “You shall rejoice no more, you oppressed virgin daughter of Sidon. Arise, pass over to Kittim. Even there you will have no rest.” 
 \p
 \v 13 Behold, the land of the Chaldeans. This people didn’t exist. The Assyrians founded it for those who dwell in the wilderness. They set up their towers. They overthrew its palaces. They made it a ruin. 
 \v 14 Howl, you ships of Tarshish, for your stronghold is laid waste! 
 \v 15 It will come to pass in that day that Tyre will be forgotten seventy years, according to the days of one king. After the end of seventy years it will be to Tyre like in the song of the prostitute. 
 \v 16 Take a harp; go about the city, you prostitute that has been forgotten. Make sweet melody. Sing many songs, that you may be remembered. 
-\v 17 It will happen after the end of seventy years that Yahweh will visit Tyre. She will return to her wages, and will play the prostitute with all the kingdoms of the world on the surface of the earth. 
-\v 18 Her merchandise and her wages will be set-apartness to Yahweh. It will not be treasured nor laid up; for her merchandise will be for those who dwell before Yahweh, to eat sufficiently, and for durable clothing. 
+\v 17 It will happen after the end of seventy years that Yahuah will visit Tyre. She will return to her wages, and will play the prostitute with all the kingdoms of the world on the surface of the earth. 
+\v 18 Her merchandise and her wages will be set-apartness to Yahuah. It will not be treasured nor laid up; for her merchandise will be for those who dwell before Yahuah, to eat sufficiently, and for durable clothing. 
 \c 24
 \p
-\v 1 Behold, Yahweh makes the earth empty, makes it waste, turns it upside down, and scatters its inhabitants. 
+\v 1 Behold, Yahuah makes the earth empty, makes it waste, turns it upside down, and scatters its inhabitants. 
 \v 2 It will be as with the people, so with the priest; as with the servant, so with his master; as with the maid, so with her mistress; as with the buyer, so with the seller; as with the creditor, so with the debtor; as with the taker of interest, so with the giver of interest. 
-\v 3 The earth will be utterly emptied and utterly laid waste; for Yahweh has spoken this word. 
+\v 3 The earth will be utterly emptied and utterly laid waste; for Yahuah has spoken this word. 
 \v 4 The earth mourns and fades away. The world languishes and fades away. The lofty people of the earth languish. 
 \v 5 The earth also is polluted under its inhabitants, because they have transgressed the laws, violated the statutes, and broken the everlasting covenant. 
 \v 6 Therefore the curse has devoured the earth, and those who dwell therein are found guilty. Therefore the inhabitants of the earth are burned, and few men are left. 
@@ -1021,8 +1021,8 @@
 \v 12 The city is left in desolation, and the gate is struck with destruction. 
 \v 13 For it will be so within the earth among the peoples, as the shaking of an olive tree, as the gleanings when the vintage is done. 
 \p
-\v 14 These shall lift up their voice. They will shout for the majesty of Yahweh. They cry aloud from the sea. 
-\v 15 Therefore glorify Yahweh in the east, even the name of Yahweh, the Elohim of Israel, in the islands of the sea! 
+\v 14 These shall lift up their voice. They will shout for the majesty of Yahuah. They cry aloud from the sea. 
+\v 15 Therefore glorify Yahuah in the east, even the name of Yahuah, the Elohim of Israel, in the islands of the sea! 
 \v 16 From the uttermost part of the earth have we heard songs. Glory to the righteous! 
 \p But I said, “I pine away! I pine away! woe is me!” The treacherous have dealt treacherously. Yes, the treacherous have dealt very treacherously. 
 \v 17 Fear, the pit, and the snare are on you who inhabit the earth. 
@@ -1030,23 +1030,23 @@
 \v 19 The earth is utterly broken. The earth is torn apart. The earth is shaken violently. 
 \v 20 The earth will stagger like a drunken man, and will sway back and forth like a hammock. Its disobedience will be heavy on it, and it will fall and not rise again. 
 \p
-\v 21 It will happen in that day that Yahweh will punish the army of the high ones on high, and the kings of the earth on the earth. 
+\v 21 It will happen in that day that Yahuah will punish the army of the high ones on high, and the kings of the earth on the earth. 
 \v 22 They will be gathered together, as prisoners are gathered in the pit, and will be shut up in the prison; and after many days they will be visited. 
-\v 23 Then the moon will be confounded, and the sun ashamed; for Yahweh of Armies will reign on Mount Zion and in Jerusalem; and glory will be before his elders. 
+\v 23 Then the moon will be confounded, and the sun ashamed; for Yahuah of Armies will reign on Mount Zion and in Jerusalem; and glory will be before his elders. 
 \c 25
 \p
-\v 1 Yahweh, you are my Elohim. I will exalt you! I will praise your name, for you have done wonderful things, things planned long ago, in complete faithfulness and truth. 
+\v 1 Yahuah, you are my Elohim. I will exalt you! I will praise your name, for you have done wonderful things, things planned long ago, in complete faithfulness and truth. 
 \v 2 For you have made a city into a heap, a fortified city into a ruin, a palace of strangers to be no city. It will never be built. 
 \v 3 Therefore a strong people will glorify you. A city of awesome nations will fear you. 
 \v 4 For you have been a stronghold to the poor, a stronghold to the needy in his distress, a refuge from the storm, a shade from the heat, when the blast of the dreaded ones is like a storm against the wall. 
 \v 5 As the heat in a dry place you will bring down the noise of strangers; as the heat by the shade of a cloud, the song of the dreaded ones will be brought low. 
 \p
-\v 6 In this mountain, Yahweh of Armies will make all peoples a feast of choice meat, a feast of choice wines, of choice meat full of marrow, of well refined choice wines. 
+\v 6 In this mountain, Yahuah of Armies will make all peoples a feast of choice meat, a feast of choice wines, of choice meat full of marrow, of well refined choice wines. 
 \v 7 He will destroy in this mountain the surface of the covering that covers all peoples, and the veil that is spread over all nations. 
-\v 8 He has swallowed up death forever! The Lord Yahweh will wipe away tears from off all faces. He will take the reproach of his people away from off all the earth, for Yahweh has spoken it. 
+\v 8 He has swallowed up death forever! The Lord Yahuah will wipe away tears from off all faces. He will take the reproach of his people away from off all the earth, for Yahuah has spoken it. 
 \p
-\v 9 It shall be said in that day, “Behold, this is our Elohim! We have waited for him, and he will save us! This is Yahweh! We have waited for him. We will be glad and rejoice in his salvation!” 
-\v 10 For Yahweh’s hand will rest in this mountain. 
+\v 9 It shall be said in that day, “Behold, this is our Elohim! We have waited for him, and he will save us! This is Yahuah! We have waited for him. We will be glad and rejoice in his salvation!” 
+\v 10 For Yahuah’s hand will rest in this mountain. 
 \p Moab will be trodden down in his place, even like straw is trodden down in the water of the dunghill. 
 \v 11 He will spread out his hands in the middle of it, like one who swims spreads out hands to swim, but his pride will be humbled together with the craft of his hands. 
 \v 12 He has brought the high fortress of your walls down, laid low, and brought to the ground, even to the dust. 
@@ -1062,8 +1062,8 @@
 \v 3 You will keep whoever’s mind is steadfast in perfect peace, 
 \q2 because he trusts in you. 
 \q1
-\v 4 Trust in Yahweh forever; 
-\q2 for in Yah, Yahweh, is an everlasting Rock. 
+\v 4 Trust in Yahuah forever; 
+\q2 for in Yah, Yahuah, is an everlasting Rock. 
 \q1
 \v 5 For he has brought down those who dwell on high, the lofty city. 
 \q2 He lays it low. 
@@ -1078,7 +1078,7 @@
 \q2 You who are upright make the path of the righteous level. 
 \b
 \q1
-\v 8 Yes, in the way of your judgments, Yahweh, we have waited for you. 
+\v 8 Yes, in the way of your judgments, Yahuah, we have waited for you. 
 \q2 Your name and your renown are the desire of our soul. 
 \q1
 \v 9 With my soul I have desired you in the night. 
@@ -1088,17 +1088,17 @@
 \v 10 Let favor be shown to the wicked, 
 \q2 yet he will not learn righteousness. 
 \q1 In the land of uprightness he will deal wrongfully, 
-\q2 and will not see Yahweh’s majesty. 
+\q2 and will not see Yahuah’s majesty. 
 \b
 \q1
-\v 11 Yahweh, your hand is lifted up, yet they don’t see; 
+\v 11 Yahuah, your hand is lifted up, yet they don’t see; 
 \q2 but they will see your zeal for the people and be disappointed. 
 \q2 Yes, fire will consume your adversaries. 
 \q1
-\v 12 Yahweh, you will ordain peace for us, 
+\v 12 Yahuah, you will ordain peace for us, 
 \q2 for you have also done all our work for us. 
 \q1
-\v 13 Yahweh our Elohim, other lords besides you have had dominion over us, 
+\v 13 Yahuah our Elohim, other lords besides you have had dominion over us, 
 \q2 but we will only acknowledge your name. 
 \q1
 \v 14 The dead shall not live. 
@@ -1106,18 +1106,18 @@
 \q1 Therefore you have visited and destroyed them, 
 \q2 and caused all memory of them to perish. 
 \q1
-\v 15 You have increased the nation, O Yahweh. 
+\v 15 You have increased the nation, O Yahuah. 
 \q2 You have increased the nation! 
 \q1 You are glorified! 
 \q2 You have enlarged all the borders of the land. 
 \b
 \q1
-\v 16 Yahweh, in trouble they have visited you. 
+\v 16 Yahuah, in trouble they have visited you. 
 \q2 They poured out a prayer when your chastening was on them. 
 \q1
 \v 17 Just as a woman with child, who draws near the time of her delivery, 
 \q2 is in pain and cries out in her pangs, 
-\q2 so we have been before you, Yahweh. 
+\q2 so we have been before you, Yahuah. 
 \q1
 \v 18 We have been with child. 
 \q2 We have been in pain. 
@@ -1137,14 +1137,14 @@
 \q1 Hide yourself for a little moment, 
 \q2 until the indignation is past. 
 \q1
-\v 21 For, behold, Yahweh comes out of his place to punish the inhabitants of the earth for their iniquity. 
+\v 21 For, behold, Yahuah comes out of his place to punish the inhabitants of the earth for their iniquity. 
 \q2 The earth also will disclose her blood, and will no longer cover her slain. 
 \c 27
 \p
-\v 1 In that day, Yahweh with his hard and great and strong sword will punish leviathan, the fleeing serpent, and leviathan, the twisted serpent; and he will kill the dragon that is in the sea. 
+\v 1 In that day, Yahuah with his hard and great and strong sword will punish leviathan, the fleeing serpent, and leviathan, the twisted serpent; and he will kill the dragon that is in the sea. 
 \p
 \v 2 In that day, sing to her, “A pleasant vineyard! 
-\v 3 I, Yahweh, am its keeper. I will water it every moment. Lest anyone damage it, I will keep it night and day. 
+\v 3 I, Yahuah, am its keeper. I will water it every moment. Lest anyone damage it, I will keep it night and day. 
 \v 4 Wrath is not in me, but if I should find briers and thorns, I would do battle! I would march on them and I would burn them together. 
 \v 5 Or else let him take hold of my strength, that he may make peace with me. Let him make peace with me.” 
 \p
@@ -1155,16 +1155,16 @@
 \v 10 For the fortified city is solitary, a habitation deserted and forsaken, like the wilderness. The calf will feed there, and there he will lie down, and consume its branches. 
 \v 11 When its boughs are withered, they will be broken off. The women will come and set them on fire, for they are a people of no understanding. Therefore he who made them will not have compassion on them, and he who formed them will show them no favor. 
 \p
-\v 12 It will happen in that day that Yahweh will thresh from the flowing stream of the Euphrates to the brook of Egypt; and you will be gathered one by one, children of Israel. 
+\v 12 It will happen in that day that Yahuah will thresh from the flowing stream of the Euphrates to the brook of Egypt; and you will be gathered one by one, children of Israel. 
 \p
-\v 13 It will happen in that day that a great trumpet will be blown; and those who were ready to perish in the land of Assyria, and those who were outcasts in the land of Egypt, shall come; and they will worship Yahweh in the set-apart mountain at Jerusalem. 
+\v 13 It will happen in that day that a great trumpet will be blown; and those who were ready to perish in the land of Assyria, and those who were outcasts in the land of Egypt, shall come; and they will worship Yahuah in the set-apart mountain at Jerusalem. 
 \c 28
 \p
 \v 1 Woe to the crown of pride of the drunkards of Ephraim, and to the fading flower of his glorious beauty, which is on the head of the fertile valley of those who are overcome with wine! 
 \v 2 Behold, the Lord has one who is mighty and strong. Like a storm of hail, a destroying storm, and like a storm of mighty waters overflowing, he will cast them down to the earth with his hand. 
 \v 3 The crown of pride of the drunkards of Ephraim will be trodden under foot. 
 \v 4 The fading flower of his glorious beauty, which is on the head of the fertile valley, shall be like the first-ripe fig before the summer, which someone picks and eats as soon as he sees it. 
-\v 5 In that day, Yahweh of Armies will become a crown of glory and a diadem of beauty to the residue of his people, 
+\v 5 In that day, Yahuah of Armies will become a crown of glory and a diadem of beauty to the residue of his people, 
 \v 6 and a spirit of justice to him who sits in judgment, and strength to those who turn back the battle at the gate. 
 \p
 \v 7 They also reel with wine, and stagger with strong drink. The priest and the prophet reel with strong drink. They are swallowed up by wine. They stagger with strong drink. They err in vision. They stumble in judgment. 
@@ -1175,17 +1175,17 @@
 \p
 \v 11 But he will speak to this nation with stammering lips and in another language, 
 \v 12 to whom he said, “This is the resting place. Give rest to the weary,” and “This is the refreshing;” yet they would not hear. 
-\v 13 Therefore Yahweh’s word will be to them precept on precept, precept on precept; line on line, line on line; here a little, there a little; that they may go, fall backward, be broken, be snared, and be taken. 
+\v 13 Therefore Yahuah’s word will be to them precept on precept, precept on precept; line on line, line on line; here a little, there a little; that they may go, fall backward, be broken, be snared, and be taken. 
 \p
-\v 14 Therefore hear Yahweh’s word, you scoffers, that rule this people in Jerusalem: 
+\v 14 Therefore hear Yahuah’s word, you scoffers, that rule this people in Jerusalem: 
 \v 15 “Because you have said, ‘We have made a covenant with death, and we are in agreement with Sheol. When the overflowing scourge passes through, it won’t come to us; for we have made lies our refuge, and we have hidden ourselves under falsehood.’ ” 
-\v 16 Therefore the Lord Yahweh says, “Behold, I lay in Zion for a foundation a stone, a tried stone, a precious cornerstone of a sure foundation. He who believes shall not act hastily. 
+\v 16 Therefore the Lord Yahuah says, “Behold, I lay in Zion for a foundation a stone, a tried stone, a precious cornerstone of a sure foundation. He who believes shall not act hastily. 
 \v 17 I will make justice the measuring line, and righteousness the plumb line. The hail will sweep away the refuge of lies, and the waters will overflow the hiding place. 
 \v 18 Your covenant with death shall be annulled, and your agreement with Sheol shall not stand. When the overflowing scourge passes through, then you will be trampled down by it. 
 \v 19 As often as it passes through, it will seize you; for morning by morning it will pass through, by day and by night; and it will be nothing but terror to understand the message.” 
 \v 20 For the bed is too short to stretch out on, and the blanket is too narrow to wrap oneself in. 
-\v 21 For Yahweh will rise up as on Mount Perazim. He will be angry as in the valley of Gibeon; that he may do his work, his unusual work, and bring to pass his act, his extraordinary act. 
-\v 22 Now therefore don’t be scoffers, lest your bonds be made strong; for I have heard a decree of destruction from the Lord, Yahweh of Armies, on the whole earth. 
+\v 21 For Yahuah will rise up as on Mount Perazim. He will be angry as in the valley of Gibeon; that he may do his work, his unusual work, and bring to pass his act, his extraordinary act. 
+\v 22 Now therefore don’t be scoffers, lest your bonds be made strong; for I have heard a decree of destruction from the Lord, Yahuah of Armies, on the whole earth. 
 \p
 \v 23 Give ear, and hear my voice! Listen, and hear my speech! 
 \v 24 Does he who plows to sow plow continually? Does he keep turning the soil and breaking the clods? 
@@ -1193,7 +1193,7 @@
 \v 26 For his Elohim instructs him in right judgment and teaches him. 
 \v 27 For the dill isn’t threshed with a sharp instrument, neither is a cart wheel turned over the cumin; but the dill is beaten out with a stick, and the cumin with a rod. 
 \v 28 Bread flour must be ground; so he will not always be threshing it. Although he drives the wheel of his threshing cart over it, his horses don’t grind it. 
-\v 29 This also comes out from Yahweh of Armies, who is wonderful in counsel, and excellent in wisdom. 
+\v 29 This also comes out from Yahuah of Armies, who is wonderful in counsel, and excellent in wisdom. 
 \c 29
 \p
 \v 1 Woe to Ariel! Ariel, the city where David encamped! Add year to year; let the feasts come around; 
@@ -1202,32 +1202,32 @@
 \v 4 You will be brought down, and will speak out of the ground. Your speech will mumble out of the dust. Your voice will be as of one who has a familiar spirit, out of the ground, and your speech will whisper out of the dust. 
 \p
 \v 5 But the multitude of your foes will be like fine dust, and the multitude of the ruthless ones like chaff that blows away. Yes, it will be in an instant, suddenly. 
-\v 6 She will be visited by Yahweh of Armies with thunder, with earthquake, with great noise, with whirlwind and storm, and with the flame of a devouring fire. 
+\v 6 She will be visited by Yahuah of Armies with thunder, with earthquake, with great noise, with whirlwind and storm, and with the flame of a devouring fire. 
 \v 7 The multitude of all the nations that fight against Ariel, even all who fight against her and her stronghold, and who distress her, will be like a dream, a vision of the night. 
 \v 8 It will be like when a hungry man dreams, and behold, he eats; but he awakes, and his hunger isn’t satisfied; or like when a thirsty man dreams, and behold, he drinks; but he awakes, and behold, he is faint, and he is still thirsty. The multitude of all the nations that fight against Mount Zion will be like that. 
 \p
 \v 9 Pause and wonder! Blind yourselves and be blind! They are drunken, but not with wine; they stagger, but not with strong drink. 
-\v 10 For Yahweh has poured out on you a spirit of deep sleep, and has closed your eyes, the prophets; and he has covered your heads, the seers. 
+\v 10 For Yahuah has poured out on you a spirit of deep sleep, and has closed your eyes, the prophets; and he has covered your heads, the seers. 
 \v 11 All vision has become to you like the words of a book that is sealed, which men deliver to one who is educated, saying, “Read this, please;” and he says, “I can’t, for it is sealed;” 
 \v 12 and the book is delivered to one who is not educated, saying, “Read this, please;” and he says, “I can’t read.” 
 \p
 \v 13 The Lord said, “Because this people draws near with their mouth and honors me with their lips, but they have removed their heart far from me, and their fear of me is a commandment of men which has been taught; 
 \v 14 therefore, behold, I will proceed to do a marvelous work among this people, even a marvelous work and a wonder; and the wisdom of their wise men will perish, and the understanding of their prudent men will be hidden.” 
 \p
-\v 15 Woe to those who deeply hide their counsel from Yahweh, and whose deeds are in the dark, and who say, “Who sees us?” and “Who knows us?” 
+\v 15 Woe to those who deeply hide their counsel from Yahuah, and whose deeds are in the dark, and who say, “Who sees us?” and “Who knows us?” 
 \v 16 You turn things upside down! Should the potter be thought to be like clay, that the thing made should say about him who made it, “He didn’t make me;” or the thing formed say of him who formed it, “He has no understanding”? 
 \p
 \v 17 Isn’t it yet a very little while, and Lebanon will be turned into a fruitful field, and the fruitful field will be regarded as a forest? 
 \v 18 In that day, the deaf will hear the words of the book, and the eyes of the blind will see out of obscurity and out of darkness. 
-\v 19 The humble also will increase their joy in Yahweh, and the poor among men will rejoice in the Set-Apart One of Israel. 
+\v 19 The humble also will increase their joy in Yahuah, and the poor among men will rejoice in the Set-Apart One of Israel. 
 \v 20 For the ruthless is brought to nothing, and the scoffer ceases, and all those who are alert to do evil are cut off—\v 21 who cause a person to be indicted by a word, and lay a snare for one who reproves in the gate, and who deprive the innocent of justice with false testimony. 
 \p
-\v 22 Therefore Yahweh, who redeemed Abraham, says concerning the house of Jacob: “Jacob shall no longer be ashamed, neither shall his face grow pale. 
+\v 22 Therefore Yahuah, who redeemed Abraham, says concerning the house of Jacob: “Jacob shall no longer be ashamed, neither shall his face grow pale. 
 \v 23 But when he sees his children, the work of my hands, in the middle of him, they will sanctify my name. Yes, they will sanctify the Set-Apart One of Jacob, and will stand in awe of the Elohim of Israel. 
 \v 24 They also who err in spirit will come to understanding, and those who grumble will receive instruction.” 
 \c 30
 \p
-\v 1 “Woe to the rebellious children”, says Yahweh, “who take counsel, but not from me; and who make an alliance, but not with my Spirit, that they may add sin to sin; 
+\v 1 “Woe to the rebellious children”, says Yahuah, “who take counsel, but not from me; and who make an alliance, but not with my Spirit, that they may add sin to sin; 
 \v 2 who set out to go down into Egypt without asking for my advice, to strengthen themselves in the strength of Pharaoh, and to take refuge in the shadow of Egypt! 
 \v 3 Therefore the strength of Pharaoh will be your shame, and the refuge in the shadow of Egypt your confusion. 
 \v 4 For their princes are at Zoan, and their ambassadors have come to Hanes. 
@@ -1237,18 +1237,18 @@
 \p Through the land of trouble and anguish, of the lioness and the lion, the viper and fiery flying serpent, they carry their riches on the shoulders of young donkeys, and their treasures on the humps of camels, to an unprofitable people. 
 \v 7 For Egypt helps in vain, and to no purpose; therefore I have called her Rahab who sits still. 
 \v 8 Now go, write it before them on a tablet, and inscribe it in a book, that it may be for the time to come forever and ever. 
-\v 9 For it is a rebellious people, lying children, children who will not hear Yahweh’s law; 
+\v 9 For it is a rebellious people, lying children, children who will not hear Yahuah’s law; 
 \v 10 who tell the seers, “Don’t see!” and the prophets, “Don’t prophesy to us right things. Tell us pleasant things. Prophesy deceits. 
 \v 11 Get out of the way. Turn away from the path. Cause the Set-Apart One of Israel to cease from before us.” 
 \v 12 Therefore the Set-Apart One of Israel says, “Because you despise this word, and trust in oppression and perverseness, and rely on it, 
 \v 13 therefore this iniquity shall be to you like a breach ready to fall, swelling out in a high wall, whose breaking comes suddenly in an instant. 
 \v 14 He will break it as a potter’s vessel is broken, breaking it in pieces without sparing, so that there won’t be found among the broken pieces a piece good enough to take fire from the hearth, or to dip up water out of the cistern.” 
 \p
-\v 15 For thus said the Lord Yahweh, the Set-Apart One of Israel, “You will be saved in returning and rest. Your strength will be in quietness and in confidence.” You refused, 
+\v 15 For thus said the Lord Yahuah, the Set-Apart One of Israel, “You will be saved in returning and rest. Your strength will be in quietness and in confidence.” You refused, 
 \v 16 but you said, “No, for we will flee on horses;” therefore you will flee; and, “We will ride on the swift;” therefore those who pursue you will be swift. 
 \v 17 One thousand will flee at the threat of one. At the threat of five, you will flee until you are left like a beacon on the top of a mountain, and like a banner on a hill. 
 \p
-\v 18 Therefore Yahweh will wait, that he may be gracious to you; and therefore he will be exalted, that he may have mercy on you, for Yahweh is an Elohim of justice. Blessed are all those who wait for him. 
+\v 18 Therefore Yahuah will wait, that he may be gracious to you; and therefore he will be exalted, that he may have mercy on you, for Yahuah is an Elohim of justice. Blessed are all those who wait for him. 
 \v 19 For the people will dwell in Zion at Jerusalem. You will weep no more. He will surely be gracious to you at the voice of your cry. When he hears you, he will answer you. 
 \v 20 Though the Lord may give you the bread of adversity and the water of affliction, yet your teachers won’t be hidden any more, but your eyes will see your teachers; 
 \v 21 and when you turn to the right hand, and when you turn to the left, your ears will hear a voice behind you, saying, “This is the way. Walk in it.” 
@@ -1257,15 +1257,15 @@
 \v 23 He will give the rain for your seed, with which you will sow the ground; and bread of the increase of the ground will be rich and plentiful. In that day, your livestock will feed in large pastures. 
 \v 24 The oxen likewise and the young donkeys that till the ground will eat savory feed, which has been winnowed with the shovel and with the fork. 
 \v 25 There will be brooks and streams of water on every lofty mountain and on every high hill in the day of the great slaughter, when the towers fall. 
-\v 26 Moreover the light of the moon will be like the light of the sun, and the light of the sun will be seven times brighter, like the light of seven days, in the day that Yahweh binds up the fracture of his people, and heals the wound they were struck with. 
+\v 26 Moreover the light of the moon will be like the light of the sun, and the light of the sun will be seven times brighter, like the light of seven days, in the day that Yahuah binds up the fracture of his people, and heals the wound they were struck with. 
 \p
-\v 27 Behold, Yahweh’s name comes from far away, burning with his anger, and in thick rising smoke. His lips are full of indignation. His tongue is as a devouring fire. 
+\v 27 Behold, Yahuah’s name comes from far away, burning with his anger, and in thick rising smoke. His lips are full of indignation. His tongue is as a devouring fire. 
 \v 28 His breath is as an overflowing stream that reaches even to the neck, to sift the nations with the sieve of destruction. A bridle that leads to ruin will be in the jaws of the peoples. 
-\v 29 You will have a song, as in the night when a set-apart feast is kept, and gladness of heart, as when one goes with a flute to come to Yahweh’s mountain, to Israel’s Rock. 
-\v 30 Yahweh will cause his glorious voice to be heard, and will show the descent of his arm, with the indignation of his anger and the flame of a devouring fire, with a blast, storm, and hailstones. 
-\v 31 For through Yahweh’s voice the Assyrian will be dismayed. He will strike him with his rod. 
-\v 32 Every stroke of the rod of punishment, which Yahweh will lay on him, will be with the sound of tambourines and harps. He will fight with them in battles, brandishing weapons. 
-\v 33 For his burning place has long been ready. Yes, it is prepared for the king. He has made its pyre deep and large with fire and much wood. Yahweh’s breath, like a stream of sulfur, kindles it. 
+\v 29 You will have a song, as in the night when a set-apart feast is kept, and gladness of heart, as when one goes with a flute to come to Yahuah’s mountain, to Israel’s Rock. 
+\v 30 Yahuah will cause his glorious voice to be heard, and will show the descent of his arm, with the indignation of his anger and the flame of a devouring fire, with a blast, storm, and hailstones. 
+\v 31 For through Yahuah’s voice the Assyrian will be dismayed. He will strike him with his rod. 
+\v 32 Every stroke of the rod of punishment, which Yahuah will lay on him, will be with the sound of tambourines and harps. He will fight with them in battles, brandishing weapons. 
+\v 33 For his burning place has long been ready. Yes, it is prepared for the king. He has made its pyre deep and large with fire and much wood. Yahuah’s breath, like a stream of sulfur, kindles it. 
 \c 31
 \q1
 \v 1 Woe to those who go down to Egypt for help, 
@@ -1273,7 +1273,7 @@
 \q2 and trust in chariots because they are many, 
 \q2 and in horsemen because they are very strong, 
 \q2 but they don’t look to the Set-Apart One of Israel, 
-\q2 and they don’t seek Yahweh! 
+\q2 and they don’t seek Yahuah! 
 \q1
 \v 2 Yet he also is wise, and will bring disaster, 
 \q2 and will not call back his words, but will arise against the house of the evildoers, 
@@ -1281,19 +1281,19 @@
 \q1
 \v 3 Now the Egyptians are men, and not Elohim; 
 \q2 and their horses flesh, and not spirit. 
-\q1 When Yahweh stretches out his hand, both he who helps shall stumble, 
+\q1 When Yahuah stretches out his hand, both he who helps shall stumble, 
 \q2 and he who is helped shall fall, 
 \q2 and they all shall be consumed together. 
 \b
 \q1
-\v 4 For Yahweh says to me, 
+\v 4 For Yahuah says to me, 
 \q1 “As the lion and the young lion growling over his prey, 
 \q2 if a multitude of shepherds is called together against him, 
 \q2 will not be dismayed at their voice, 
 \q2 nor abase himself for their noise, 
-\q2 so Yahweh of Armies will come down to fight on Mount Zion and on its heights. 
+\q2 so Yahuah of Armies will come down to fight on Mount Zion and on its heights. 
 \q1
-\v 5 As birds hovering, so Yahweh of Armies will protect Jerusalem. 
+\v 5 As birds hovering, so Yahuah of Armies will protect Jerusalem. 
 \q2 He will protect and deliver it. 
 \q2 He will pass over and preserve it.” 
 \q1
@@ -1307,7 +1307,7 @@
 \q1
 \v 9 His rock will pass away by reason of terror, 
 \q2 and his princes will be afraid of the banner,” 
-\q1 says Yahweh, whose fire is in Zion, 
+\q1 says Yahuah, whose fire is in Zion, 
 \q2 and his furnace in Jerusalem. 
 \c 32
 \q1
@@ -1331,7 +1331,7 @@
 \v 6 For the fool will speak folly, 
 \q2 and his heart will work iniquity, 
 \q2 to practice profanity, 
-\q2 and to utter error against Yahweh, 
+\q2 and to utter error against Yahuah, 
 \q2 to make empty the soul of the hungry, 
 \q2 and to cause the drink of the thirsty to fail. 
 \q1
@@ -1395,7 +1395,7 @@
 \q2 and when you have finished betrayal, you will be betrayed. 
 \b
 \q1
-\v 2 Yahweh, be gracious to us. We have waited for you. 
+\v 2 Yahuah, be gracious to us. We have waited for you. 
 \q2 Be our strength every morning, 
 \q2 our salvation also in the time of trouble. 
 \q1
@@ -1405,11 +1405,11 @@
 \v 4 Your plunder will be gathered as the caterpillar gathers. 
 \q2 Men will leap on it as locusts leap. 
 \q1
-\v 5 Yahweh is exalted, for he dwells on high. 
+\v 5 Yahuah is exalted, for he dwells on high. 
 \q2 He has filled Zion with justice and righteousness. 
 \q1
 \v 6 There will be stability in your times, abundance of salvation, wisdom, and knowledge. 
-\q2 The fear of Yahweh is your treasure. 
+\q2 The fear of Yahuah is your treasure. 
 \b
 \q1
 \v 7 Behold, their valiant ones cry outside; 
@@ -1425,7 +1425,7 @@
 \q2 Lebanon is confounded and withers away. 
 \q2 Sharon is like a desert, and Bashan and Carmel are stripped bare. 
 \q1
-\v 10 “Now I will arise,” says Yahweh. 
+\v 10 “Now I will arise,” says Yahuah. 
 \q2 “Now I will lift myself up. 
 \q2 Now I will be exalted. 
 \q1
@@ -1475,14 +1475,14 @@
 \q1 Its stakes will never be plucked up, 
 \q2 nor will any of its cords be broken. 
 \q1
-\v 21 But there Yahweh will be with us in majesty, 
+\v 21 But there Yahuah will be with us in majesty, 
 \q2 a place of wide rivers and streams, 
 \q2 in which no galley with oars will go, 
 \q2 neither will any gallant ship pass by there. 
 \q1
-\v 22 For Yahweh is our judge. 
-\q2 Yahweh is our lawgiver. 
-\q2 Yahweh is our king. 
+\v 22 For Yahuah is our judge. 
+\q2 Yahuah is our lawgiver. 
+\q2 Yahuah is our king. 
 \q2 He will save us. 
 \b
 \q1
@@ -1502,7 +1502,7 @@
 \q2 Let the earth and all it contains hear, 
 \q2 the world, and everything that comes from it. 
 \q1
-\v 2 For Yahweh is enraged against all the nations, 
+\v 2 For Yahuah is enraged against all the nations, 
 \q2 and angry with all their armies. 
 \q1 He has utterly destroyed them. 
 \q2 He has given them over for slaughter. 
@@ -1520,10 +1520,10 @@
 \q2 Behold, it will come down on Edom, 
 \q2 and on the people of my curse, for judgment. 
 \q1
-\v 6 Yahweh’s sword is filled with blood. 
+\v 6 Yahuah’s sword is filled with blood. 
 \q2 It is covered with fat, with the blood of lambs and goats, 
 \q2 with the fat of the kidneys of rams; 
-\q2 for Yahweh has a sacrifice in Bozrah, 
+\q2 for Yahuah has a sacrifice in Bozrah, 
 \q2 and a great slaughter in the land of Edom. 
 \q1
 \v 7 The wild oxen will come down with them, 
@@ -1532,7 +1532,7 @@
 \q2 and their dust made greasy with fat. 
 \b
 \q1
-\v 8 For Yahweh has a day of vengeance, 
+\v 8 For Yahuah has a day of vengeance, 
 \q2 a year of recompense for the cause of Zion. 
 \q1
 \v 9 Its streams will be turned into pitch, 
@@ -1567,7 +1567,7 @@
 \q2 Yes, the kites will be gathered there, every one with her mate. 
 \b
 \q1
-\v 16 Search in the book of Yahweh, and read: 
+\v 16 Search in the book of Yahuah, and read: 
 \q2 not one of these will be missing. 
 \q2 None will lack her mate. 
 \q2 For my mouth has commanded, 
@@ -1587,7 +1587,7 @@
 \q2 and rejoice even with joy and singing. 
 \q2 Lebanon’s glory will be given to it, 
 \q2 the excellence of Carmel and Sharon. 
-\q2 They will see Yahweh’s glory, 
+\q2 They will see Yahuah’s glory, 
 \q2 the excellence of our Elohim. 
 \b
 \q1
@@ -1623,7 +1623,7 @@
 \q2 They will not be found there; 
 \q2 but the redeemed will walk there. 
 \q1
-\v 10 Then Yahweh’s ransomed ones will return, 
+\v 10 Then Yahuah’s ransomed ones will return, 
 \q2 and come with singing to Zion; 
 \q2 and everlasting joy will be on their heads. 
 \q1 They will obtain gladness and joy, 
@@ -1637,36 +1637,36 @@
 \v 4 Rabshakeh said to them, “Now tell Hezekiah, ‘The great king, the king of Assyria, says, “What confidence is this in which you trust? 
 \v 5 I say that your counsel and strength for the war are only vain words. Now in whom do you trust, that you have rebelled against me? 
 \v 6 Behold, you trust in the staff of this bruised reed, even in Egypt, which if a man leans on it, it will go into his hand and pierce it. So is Pharaoh king of Egypt to all who trust in him. 
-\v 7 But if you tell me, ‘We trust in Yahweh our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar’?” 
+\v 7 But if you tell me, ‘We trust in Yahuah our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar’?” 
 \v 8 Now therefore, please make a pledge to my master the king of Assyria, and I will give you two thousand horses, if you are able on your part to set riders on them. 
 \v 9 How then can you turn away the face of one captain of the least of my master’s servants, and put your trust in Egypt for chariots and for horsemen? 
-\v 10 Have I come up now without Yahweh against this land to destroy it? Yahweh said to me, “Go up against this land, and destroy it.” ’ ” 
+\v 10 Have I come up now without Yahuah against this land to destroy it? Yahuah said to me, “Go up against this land, and destroy it.” ’ ” 
 \p
 \v 11 Then Eliakim, Shebna and Joah said to Rabshakeh, “Please speak to your servants in Aramaic, for we understand it. Don’t speak to us in the Jews’ language in the hearing of the people who are on the wall.” 
 \p
 \v 12 But Rabshakeh said, “Has my master sent me only to your master and to you, to speak these words, and not to the men who sit on the wall, who will eat their own dung and drink their own urine with you?” 
 \v 13 Then Rabshakeh stood, and called out with a loud voice in the Jews’ language, and said, “Hear the words of the great king, the king of Assyria! 
 \v 14 The king says, ‘Don’t let Hezekiah deceive you; for he will not be able to deliver you. 
-\v 15 Don’t let Hezekiah make you trust in Yahweh, saying, “Yahweh will surely deliver us. This city won’t be given into the hand of the king of Assyria.” ’ 
+\v 15 Don’t let Hezekiah make you trust in Yahuah, saying, “Yahuah will surely deliver us. This city won’t be given into the hand of the king of Assyria.” ’ 
 \v 16 Don’t listen to Hezekiah, for the king of Assyria says, ‘Make your peace with me, and come out to me; and each of you eat from his vine, and each one from his fig tree, and each one of you drink the waters of his own cistern; 
 \v 17 until I come and take you away to a land like your own land, a land of grain and new wine, a land of bread and vineyards. 
-\v 18 Beware lest Hezekiah persuade you, saying, “Yahweh will deliver us.” Have any of the elohims of the nations delivered their lands from the hand of the king of Assyria? 
+\v 18 Beware lest Hezekiah persuade you, saying, “Yahuah will deliver us.” Have any of the elohims of the nations delivered their lands from the hand of the king of Assyria? 
 \v 19 Where are the elohims of Hamath and Arpad? Where are the elohims of Sepharvaim? Have they delivered Samaria from my hand? 
-\v 20 Who are they among all the elohims of these countries that have delivered their country out of my hand, that Yahweh should deliver Jerusalem out of my hand?’ ” 
+\v 20 Who are they among all the elohims of these countries that have delivered their country out of my hand, that Yahuah should deliver Jerusalem out of my hand?’ ” 
 \p
 \v 21 But they remained silent, and said nothing in reply, for the king’s commandment was, “Don’t answer him.” 
 \p
 \v 22 Then Eliakim the son of Hilkiah, who was over the household, and Shebna the scribe, and Joah, the son of Asaph the recorder, came to Hezekiah with their clothes torn, and told him the words of Rabshakeh. 
 \c 37
 \p
-\v 1 When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahweh’s house. 
+\v 1 When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahuah’s house. 
 \v 2 He sent Eliakim, who was over the household, and Shebna the scribe, and the elders of the priests, covered with sackcloth, to Isaiah the prophet, the son of Amoz. 
 \v 3 They said to him, “Hezekiah says, ‘Today is a day of trouble, and of rebuke, and of rejection; for the children have come to the birth, and there is no strength to give birth. 
-\v 4 It may be Yahweh your Elohim will hear the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahweh your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’ ” 
+\v 4 It may be Yahuah your Elohim will hear the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahuah your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’ ” 
 \p
 \v 5 So the servants of King Hezekiah came to Isaiah. 
 \p
-\v 6 Isaiah said to them, “Tell your master, ‘Yahweh says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
+\v 6 Isaiah said to them, “Tell your master, ‘Yahuah says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
 \v 7 Behold, I will put a spirit in him and he will hear news, and will return to his own land. I will cause him to fall by the sword in his own land.” ’ ” 
 \p
 \v 8 So Rabshakeh returned, and found the king of Assyria warring against Libnah, for he heard that he had departed from Lachish. 
@@ -1676,16 +1676,16 @@
 \v 12 Have the elohims of the nations delivered them, which my fathers have destroyed, Gozan, Haran, Rezeph, and the children of Eden who were in Telassar? 
 \v 13 Where is the king of Hamath, and the king of Arpad, and the king of the city of Sepharvaim, of Hena, and Ivvah?’ ” 
 \p
-\v 14 Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahweh’s house, and spread it before Yahweh. 
-\v 15 Hezekiah prayed to Yahweh, saying, 
-\v 16 “Yahweh of Armies, the Elohim of Israel, who is enthroned among the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
-\v 17 Turn your ear, Yahweh, and hear. Open your eyes, Yahweh, and behold. Hear all of the words of Sennacherib, who has sent to defy the living Elohim. 
-\v 18 Truly, Yahweh, the kings of Assyria have destroyed all the countries and their land, 
+\v 14 Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahuah’s house, and spread it before Yahuah. 
+\v 15 Hezekiah prayed to Yahuah, saying, 
+\v 16 “Yahuah of Armies, the Elohim of Israel, who is enthroned among the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
+\v 17 Turn your ear, Yahuah, and hear. Open your eyes, Yahuah, and behold. Hear all of the words of Sennacherib, who has sent to defy the living Elohim. 
+\v 18 Truly, Yahuah, the kings of Assyria have destroyed all the countries and their land, 
 \v 19 and have cast their elohims into the fire; for they were no elohims, but the work of men’s hands, wood and stone; therefore they have destroyed them. 
-\v 20 Now therefore, Yahweh our Elohim, save us from his hand, that all the kingdoms of the earth may know that you are Yahweh, even you only.” 
+\v 20 Now therefore, Yahuah our Elohim, save us from his hand, that all the kingdoms of the earth may know that you are Yahuah, even you only.” 
 \p
-\v 21 Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahweh, the Elohim of Israel says, ‘Because you have prayed to me against Sennacherib king of Assyria, 
-\v 22 this is the word which Yahweh has spoken concerning him: The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
+\v 21 Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahuah, the Elohim of Israel says, ‘Because you have prayed to me against Sennacherib king of Assyria, 
+\v 22 this is the word which Yahuah has spoken concerning him: The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
 \v 23 Whom have you defied and blasphemed? Against whom have you exalted your voice and lifted up your eyes on high? Against the Set-Apart One of Israel. 
 \v 24 By your servants, you have defied the Lord, and have said, “With the multitude of my chariots I have come up to the height of the mountains, to the innermost parts of Lebanon. I will cut down its tall cedars and its choice cypress trees. I will enter into its farthest height, the forest of its fruitful field. 
 \v 25 I have dug and drunk water, and with the sole of my feet I will dry up all the rivers of Egypt.” 
@@ -1697,26 +1697,26 @@
 \p
 \v 30 “ ‘This shall be the sign to you: You will eat this year that which grows of itself, and in the second year that which springs from it; and in the third year sow and reap and plant vineyards, and eat their fruit. 
 \v 31 The remnant that is escaped of the house of Judah will again take root downward, and bear fruit upward. 
-\v 32 For out of Jerusalem a remnant will go out, and survivors will escape from Mount Zion. The zeal of Yahweh of Armies will perform this.’ 
+\v 32 For out of Jerusalem a remnant will go out, and survivors will escape from Mount Zion. The zeal of Yahuah of Armies will perform this.’ 
 \p
-\v 33 “Therefore Yahweh says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there, neither will he come before it with shield, nor cast up a mound against it. 
-\v 34 He will return the way that he came, and he won’t come to this city,’ says Yahweh. 
+\v 33 “Therefore Yahuah says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there, neither will he come before it with shield, nor cast up a mound against it. 
+\v 34 He will return the way that he came, and he won’t come to this city,’ says Yahuah. 
 \v 35 ‘For I will defend this city to save it, for my own sake, and for my servant David’s sake.’ ” 
 \p
-\v 36 Then Yahweh’s angel went out and struck one hundred and eighty-five thousand men in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
+\v 36 Then Yahuah’s angel went out and struck one hundred and eighty-five thousand men in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
 \v 37 So Sennacherib king of Assyria departed, went away, returned to Nineveh, and stayed there. 
 \v 38 As he was worshiping in the house of Nisroch his elohim, Adrammelech and Sharezer his sons struck him with the sword; and they escaped into the land of Ararat. Esar Haddon his son reigned in his place. 
 \c 38
 \p
-\v 1 In those days Hezekiah was sick and near death. Isaiah the prophet, the son of Amoz, came to him, and said to him, “Yahweh says, ‘Set your house in order, for you will die, and not live.’ ” 
+\v 1 In those days Hezekiah was sick and near death. Isaiah the prophet, the son of Amoz, came to him, and said to him, “Yahuah says, ‘Set your house in order, for you will die, and not live.’ ” 
 \p
-\v 2 Then Hezekiah turned his face to the wall and prayed to Yahweh, 
-\v 3 and said, “Remember now, Yahweh, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” Then Hezekiah wept bitterly. 
+\v 2 Then Hezekiah turned his face to the wall and prayed to Yahuah, 
+\v 3 and said, “Remember now, Yahuah, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” Then Hezekiah wept bitterly. 
 \p
-\v 4 Then Yahweh’s word came to Isaiah, saying, 
-\v 5 “Go, and tell Hezekiah, ‘Yahweh, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will add fifteen years to your life. 
+\v 4 Then Yahuah’s word came to Isaiah, saying, 
+\v 5 “Go, and tell Hezekiah, ‘Yahuah, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will add fifteen years to your life. 
 \v 6 I will deliver you and this city out of the hand of the king of Assyria, and I will defend this city. 
-\v 7 This shall be the sign to you from Yahweh, that Yahweh will do this thing that he has spoken. 
+\v 7 This shall be the sign to you from Yahuah, that Yahuah will do this thing that he has spoken. 
 \v 8 Behold, I will cause the shadow on the sundial, which has gone down on the sundial of Ahaz with the sun, to return backward ten steps.” ’ ” So the sun returned ten steps on the sundial on which it had gone down. 
 \p
 \v 9 The writing of Hezekiah king of Judah, when he had been sick, and had recovered of his sickness: 
@@ -1763,11 +1763,11 @@
 \v 19 The living, the living, he shall praise you, as I do today. 
 \q2 The father shall make known your truth to the children. 
 \q1
-\v 20 Yahweh will save me. 
-\q2 Therefore we will sing my songs with stringed instruments all the days of our life in Yahweh’s house. 
+\v 20 Yahuah will save me. 
+\q2 Therefore we will sing my songs with stringed instruments all the days of our life in Yahuah’s house. 
 \p
 \v 21 Now Isaiah had said, “Let them take a cake of figs, and lay it for a poultice on the boil, and he shall recover.” 
-\v 22 Hezekiah also had said, “What is the sign that I will go up to Yahweh’s house?” 
+\v 22 Hezekiah also had said, “What is the sign that I will go up to Yahuah’s house?” 
 \c 39
 \p
 \v 1 At that time, Merodach-baladan the son of Baladan, king of Babylon, sent letters and a present to Hezekiah, for he heard that he had been sick, and had recovered. 
@@ -1778,18 +1778,18 @@
 \v 4 Then he asked, “What have they seen in your house?” 
 \p Hezekiah answered, “They have seen all that is in my house. There is nothing among my treasures that I have not shown them.” 
 \p
-\v 5 Then Isaiah said to Hezekiah, “Hear the word of Yahweh of Armies: 
-\v 6 ‘Behold, the days are coming when all that is in your house, and that which your fathers have stored up until today, will be carried to Babylon. Nothing will be left,’ says Yahweh. 
+\v 5 Then Isaiah said to Hezekiah, “Hear the word of Yahuah of Armies: 
+\v 6 ‘Behold, the days are coming when all that is in your house, and that which your fathers have stored up until today, will be carried to Babylon. Nothing will be left,’ says Yahuah. 
 \v 7 ‘They will take away your sons who will issue from you, whom you shall father, and they will be eunuchs in the king of Babylon’s palace.’ ” 
 \p
-\v 8 Then Hezekiah said to Isaiah, “Yahweh’s word which you have spoken is good.” He said moreover, “For there will be peace and truth in my days.” 
+\v 8 Then Hezekiah said to Isaiah, “Yahuah’s word which you have spoken is good.” He said moreover, “For there will be peace and truth in my days.” 
 \c 40
 \p
 \v 1 “Comfort, comfort my people,” says your Elohim. 
-\v 2 “Speak comfortably to Jerusalem, and call out to her that her warfare is accomplished, that her iniquity is pardoned, that she has received of Yahweh’s hand double for all her sins.” 
+\v 2 “Speak comfortably to Jerusalem, and call out to her that her warfare is accomplished, that her iniquity is pardoned, that she has received of Yahuah’s hand double for all her sins.” 
 \q1
 \v 3 The voice of one who calls out, 
-\q2 “Prepare the way of Yahweh in the wilderness! 
+\q2 “Prepare the way of Yahuah in the wilderness! 
 \q2 Make a level highway in the desert for our Elohim. 
 \q1
 \v 4 Every valley shall be exalted, 
@@ -1797,9 +1797,9 @@
 \q2 The uneven shall be made level, 
 \q2 and the rough places a plain. 
 \q1
-\v 5 Yahweh’s glory shall be revealed, 
+\v 5 Yahuah’s glory shall be revealed, 
 \q2 and all flesh shall see it together; 
-\q2 for the mouth of Yahweh has spoken it.” 
+\q2 for the mouth of Yahuah has spoken it.” 
 \b
 \q1
 \v 6 The voice of one saying, “Cry out!” 
@@ -1809,7 +1809,7 @@
 \q1
 \v 7 The grass withers, 
 \q2 the flower fades, 
-\q2 because Yahweh’s breath blows on it. 
+\q2 because Yahuah’s breath blows on it. 
 \q2 Surely the people are like grass. 
 \q1
 \v 8 The grass withers, 
@@ -1822,7 +1822,7 @@
 \q2 Lift it up! Don’t be afraid! 
 \q2 Say to the cities of Judah, “Behold, your Elohim!” 
 \q1
-\v 10 Behold, the Lord Yahweh will come as a mighty one, 
+\v 10 Behold, the Lord Yahuah will come as a mighty one, 
 \q2 and his arm will rule for him. 
 \q2 Behold, his reward is with him, 
 \q2 and his recompense before him. 
@@ -1839,7 +1839,7 @@
 \q2 and weighed the mountains in scales, 
 \q2 and the hills in a balance? 
 \q1
-\v 13 Who has directed Yahweh’s Spirit, 
+\v 13 Who has directed Yahuah’s Spirit, 
 \q2 or has taught him as his counselor? 
 \q1
 \v 14 Who did he take counsel with, 
@@ -1904,12 +1904,12 @@
 \q1
 \v 27 Why do you say, Jacob, 
 \q2 and speak, Israel, 
-\q2 “My way is hidden from Yahweh, 
+\q2 “My way is hidden from Yahuah, 
 \q2 and the justice due me is disregarded by my Elohim”? 
 \q1
 \v 28 Haven’t you known? 
 \q2 Haven’t you heard? 
-\q2 The everlasting Elohim, Yahweh, 
+\q2 The everlasting Elohim, Yahuah, 
 \q2 the Creator of the ends of the earth, doesn’t faint. 
 \q2 He isn’t weary. 
 \q2 His understanding is unsearchable. 
@@ -1920,7 +1920,7 @@
 \v 30 Even the youths faint and get weary, 
 \q2 and the young men utterly fall; 
 \q2
-\v 31 but those who wait for Yahweh will renew their strength. 
+\v 31 but those who wait for Yahuah will renew their strength. 
 \q2 They will mount up with wings like eagles. 
 \q2 They will run, and not be weary. 
 \q2 They will walk, and not faint. 
@@ -1945,7 +1945,7 @@
 \q1
 \v 4 Who has worked and done it, 
 \q2 calling the generations from the beginning? 
-\q2 I, Yahweh, the first, and with the last, I am he.” 
+\q2 I, Yahuah, the first, and with the last, I am he.” 
 \b
 \q1
 \v 5 The islands have seen, and fear. 
@@ -1983,13 +1983,13 @@
 \q2 Those who war against you will be as nothing, 
 \q2 as a nonexistent thing. 
 \q1
-\v 13 For I, Yahweh your Elohim, will hold your right hand, 
+\v 13 For I, Yahuah your Elohim, will hold your right hand, 
 \q2 saying to you, ‘Don’t be afraid. 
 \q2 I will help you.’ 
 \q1
 \v 14 Don’t be afraid, you worm Jacob, 
 \q2 and you men of Israel. 
-\q2 I will help you,” says Yahweh. 
+\q2 I will help you,” says Yahuah. 
 \q2 “Your Redeemer is the Set-Apart One of Israel. 
 \q1
 \v 15 Behold, I have made you into a new sharp threshing instrument with teeth. 
@@ -2000,13 +2000,13 @@
 \v 16 You will winnow them, 
 \q2 and the wind will carry them away, 
 \q2 and the whirlwind will scatter them. 
-\q1 You will rejoice in Yahweh. 
+\q1 You will rejoice in Yahuah. 
 \q2 You will glory in the Set-Apart One of Israel. 
 \b
 \q1
 \v 17 The poor and needy seek water, and there is none. 
 \q2 Their tongue fails for thirst. 
-\q1 I, Yahweh, will answer them. 
+\q1 I, Yahuah, will answer them. 
 \q2 I, the Elohim of Israel, will not forsake them. 
 \q1
 \v 18 I will open rivers on the bare heights, 
@@ -2018,11 +2018,11 @@
 \q2 I will set cypress trees, pine, and box trees together in the desert; 
 \q2
 \v 20 that they may see, know, consider, and understand together, 
-\q2 that Yahweh’s hand has done this, 
+\q2 that Yahuah’s hand has done this, 
 \q2 and the Set-Apart One of Israel has created it. 
 \b
 \q1
-\v 21 Produce your cause,” says Yahweh. 
+\v 21 Produce your cause,” says Yahuah. 
 \q2 “Bring out your strong reasons!” says the King of Jacob. 
 \q1
 \v 22 “Let them announce and declare to us what will happen! 
@@ -2080,12 +2080,12 @@
 \q2 and the islands wait for his law.” 
 \b
 \q1
-\v 5 Elohim Yahweh, 
+\v 5 Elohim Yahuah, 
 \q2 he who created the heavens and stretched them out, 
 \q2 he who spread out the earth and that which comes out of it, 
 \q2 he who gives breath to its people and spirit to those who walk in it, says: 
 \q1
-\v 6 “I, Yahweh, have called you in righteousness. 
+\v 6 “I, Yahuah, have called you in righteousness. 
 \q2 I will hold your hand. 
 \q2 I will keep you, 
 \q2 and make you a covenant for the people, 
@@ -2096,7 +2096,7 @@
 \q2 and those who sit in darkness out of the prison. 
 \b
 \q1
-\v 8 “I am Yahweh. 
+\v 8 “I am Yahuah. 
 \q2 That is my name. 
 \q2 I will not give my glory to another, 
 \q2 nor my praise to engraved images. 
@@ -2106,7 +2106,7 @@
 \q2 I tell you about them before they come up.” 
 \b
 \q1
-\v 10 Sing to Yahweh a new song, 
+\v 10 Sing to Yahuah a new song, 
 \q2 and his praise from the end of the earth, 
 \q2 you who go down to the sea, 
 \q2 and all that is therein, 
@@ -2117,10 +2117,10 @@
 \q2 Let the inhabitants of Sela sing. 
 \q2 Let them shout from the top of the mountains! 
 \q1
-\v 12 Let them give glory to Yahweh, 
+\v 12 Let them give glory to Yahuah, 
 \q2 and declare his praise in the islands. 
 \q1
-\v 13 Yahweh will go out like a mighty man. 
+\v 13 Yahuah will go out like a mighty man. 
 \q2 He will stir up zeal like a man of war. 
 \q2 He will raise a war cry. 
 \q2 Yes, he will shout aloud. 
@@ -2158,12 +2158,12 @@
 \v 19 Who is blind, but my servant? 
 \q2 Or who is as deaf as my messenger whom I send? 
 \q1 Who is as blind as he who is at peace, 
-\q2 and as blind as Yahweh’s servant? 
+\q2 and as blind as Yahuah’s servant? 
 \q1
 \v 20 You see many things, but don’t observe. 
 \q2 His ears are open, but he doesn’t listen. 
 \q1
-\v 21 It pleased Yahweh, for his righteousness’ sake, to magnify the law 
+\v 21 It pleased Yahuah, for his righteousness’ sake, to magnify the law 
 \q2 and make it honorable. 
 \q1
 \v 22 But this is a robbed and plundered people. 
@@ -2178,7 +2178,7 @@
 \q1
 \v 24 Who gave Jacob as plunder, 
 \q2 and Israel to the robbers? 
-\q2 Didn’t Yahweh, he against whom we have sinned? 
+\q2 Didn’t Yahuah, he against whom we have sinned? 
 \q2 For they would not walk in his ways, 
 \q2 and they disobeyed his law. 
 \q1
@@ -2188,7 +2188,7 @@
 \q2 It burned him, but he didn’t take it to heart.” 
 \c 43
 \q1
-\v 1 But now Yahweh who created you, Jacob, 
+\v 1 But now Yahuah who created you, Jacob, 
 \q2 and he who formed you, Israel, says: 
 \q1 “Don’t be afraid, for I have redeemed you. 
 \q2 I have called you by your name. 
@@ -2199,7 +2199,7 @@
 \q1 When you walk through the fire, you will not be burned, 
 \q2 and flame will not scorch you. 
 \q1
-\v 3 For I am Yahweh your Elohim, 
+\v 3 For I am Yahuah your Elohim, 
 \q2 the Set-Apart One of Israel, 
 \q2 your Savior. 
 \q1 I have given Egypt as your ransom, 
@@ -2235,29 +2235,29 @@
 \q2 or let them hear, and say, “That is true.” 
 \b
 \q1
-\v 10 “You are my witnesses,” says Yahweh, 
+\v 10 “You are my witnesses,” says Yahuah, 
 \q2 “With my servant whom I have chosen; 
 \q2 that you may know and believe me, 
 \q2 and understand that I am he. 
 \q1 Before me there was no Elohim formed, 
 \q2 neither will there be after me. 
 \q1
-\v 11 I myself am Yahweh. 
+\v 11 I myself am Yahuah. 
 \q2 Besides me, there is no savior. 
 \q1
 \v 12 I have declared, I have saved, and I have shown, 
 \q2 and there was no strange elohim among you. 
 \q1 Therefore you are my witnesses”, 
-\q2 says Yahweh, “and I am Elohim. 
+\q2 says Yahuah, “and I am Elohim. 
 \q1
 \v 13 Yes, since the day was, I am he. 
 \q2 There is no one who can deliver out of my hand. 
 \q2 I will work, and who can hinder it?” 
 \p
-\v 14 Yahweh, your Redeemer, the Set-Apart One of Israel says: “For your sake, I have sent to Babylon, and I will bring all of them down as fugitives, even the Chaldeans, in the ships of their rejoicing. 
-\v 15 I am Yahweh, your Set-Apart One, the Creator of Israel, your King.” 
+\v 14 Yahuah, your Redeemer, the Set-Apart One of Israel says: “For your sake, I have sent to Babylon, and I will bring all of them down as fugitives, even the Chaldeans, in the ships of their rejoicing. 
+\v 15 I am Yahuah, your Set-Apart One, the Creator of Israel, your King.” 
 \p
-\v 16 Yahweh, who makes a way in the sea, 
+\v 16 Yahuah, who makes a way in the sea, 
 \q2 and a path in the mighty waters, 
 \q1
 \v 17 who brings out the chariot and horse, 
@@ -2315,7 +2315,7 @@
 \v 1 Yet listen now, Jacob my servant, 
 \q2 and Israel, whom I have chosen. 
 \q1
-\v 2 This is what Yahweh who made you, 
+\v 2 This is what Yahuah who made you, 
 \q2 and formed you from the womb, 
 \q2 who will help you says: 
 \q1 “Don’t be afraid, Jacob my servant; 
@@ -2329,14 +2329,14 @@
 \v 4 and they will spring up among the grass, 
 \q2 as willows by the watercourses. 
 \q1
-\v 5 One will say, ‘I am Yahweh’s.’ 
+\v 5 One will say, ‘I am Yahuah’s.’ 
 \q2 Another will be called by the name of Jacob; 
-\q2 and another will write with his hand ‘to Yahweh,’ 
+\q2 and another will write with his hand ‘to Yahuah,’ 
 \q2 and honor the name of Israel.” 
 \b
 \q1
-\v 6 This is what Yahweh, the King of Israel, 
-\q2 and his Redeemer, Yahweh of Armies, says: 
+\v 6 This is what Yahuah, the King of Israel, 
+\q2 and his Redeemer, Yahuah of Armies, says: 
 \q1 “I am the first, and I am the last; 
 \q2 and besides me there is no Elohim. 
 \q1
@@ -2443,16 +2443,16 @@
 \q2 Return to me, for I have redeemed you. 
 \b
 \q1
-\v 23 Sing, you heavens, for Yahweh has done it! 
+\v 23 Sing, you heavens, for Yahuah has done it! 
 \q2 Shout, you lower parts of the earth! 
 \q2 Break out into singing, you mountains, O forest, all of your trees, 
-\q2 for Yahweh has redeemed Jacob, 
+\q2 for Yahuah has redeemed Jacob, 
 \q2 and will glorify himself in Israel. 
 \b
 \q1
-\v 24 Yahweh, your Redeemer, 
+\v 24 Yahuah, your Redeemer, 
 \q2 and he who formed you from the womb says: 
-\q1 “I am Yahweh, who makes all things; 
+\q1 “I am Yahuah, who makes all things; 
 \q2 who alone stretches out the heavens; 
 \q2 who spreads out the earth by myself; 
 \q1
@@ -2475,7 +2475,7 @@
 \q2 and of the temple, ‘Your foundation will be laid.’ ” 
 \c 45
 \p
-\v 1 Yahweh says to his anointed, to Cyrus, whose right hand I have held to subdue nations before him and strip kings of their armor, to open the doors before him, and the gates shall not be shut: 
+\v 1 Yahuah says to his anointed, to Cyrus, whose right hand I have held to subdue nations before him and strip kings of their armor, to open the doors before him, and the gates shall not be shut: 
 \q1
 \v 2 “I will go before you 
 \q2 and make the rough places smooth. 
@@ -2484,7 +2484,7 @@
 \q1
 \v 3 I will give you the treasures of darkness 
 \q2 and hidden riches of secret places, 
-\q1 that you may know that it is I, Yahweh, who calls you by your name, 
+\q1 that you may know that it is I, Yahuah, who calls you by your name, 
 \q2 even the Elohim of Israel. 
 \q1
 \v 4 For Jacob my servant’s sake, 
@@ -2493,7 +2493,7 @@
 \q2 I have given you a title, 
 \q2 though you have not known me. 
 \q1
-\v 5 I am Yahweh, and there is no one else. 
+\v 5 I am Yahuah, and there is no one else. 
 \q2 Besides me, there is no Elohim. 
 \q1 I will strengthen you, 
 \q2 though you have not known me, 
@@ -2501,13 +2501,13 @@
 \v 6 that they may know from the rising of the sun, 
 \q2 and from the west, 
 \q1 that there is no one besides me. 
-\q2 I am Yahweh, and there is no one else. 
+\q2 I am Yahuah, and there is no one else. 
 \q1
 \v 7 I form the light 
 \q2 and create darkness. 
 \q1 I make peace 
 \q2 and create calamity. 
-\q1 I am Yahweh, 
+\q1 I am Yahuah, 
 \q2 who does all these things. 
 \b
 \q1
@@ -2515,7 +2515,7 @@
 \q2 and let the skies pour down righteousness. 
 \q1 Let the earth open, that it may produce salvation, 
 \q2 and let it cause righteousness to spring up with it. 
-\q1 I, Yahweh, have created it. 
+\q1 I, Yahuah, have created it. 
 \b
 \q1
 \v 9 Woe to him who strives with his Maker—\q2 a clay pot among the clay pots of the earth! 
@@ -2526,7 +2526,7 @@
 \q2 or to a mother, ‘What have you given birth to?’ ” 
 \b
 \q1
-\v 11 Yahweh, the Set-Apart One of Israel 
+\v 11 Yahuah, the Set-Apart One of Israel 
 \q2 and his Maker says: 
 \q1 “You ask me about the things that are to come, concerning my sons, 
 \q2 and you command me concerning the work of my hands! 
@@ -2539,10 +2539,10 @@
 \q2 and I will make all his ways straight. 
 \q1 He shall build my city, 
 \q2 and he shall let my exiles go free, 
-\q2 not for price nor reward,” says Yahweh of Armies. 
+\q2 not for price nor reward,” says Yahuah of Armies. 
 \b
 \q1
-\v 14 Yahweh says: “The labor of Egypt, 
+\v 14 Yahuah says: “The labor of Egypt, 
 \q2 and the merchandise of Ethiopia, 
 \q2 and the Sabeans, men of stature, will come over to you, 
 \q2 and they will be yours. 
@@ -2560,21 +2560,21 @@
 \q2 yes, confounded, all of them. 
 \q2 Those who are makers of idols will go into confusion together. 
 \q1
-\v 17 Israel will be saved by Yahweh with an everlasting salvation. 
+\v 17 Israel will be saved by Yahuah with an everlasting salvation. 
 \q2 You will not be disappointed nor confounded to ages everlasting. 
 \b
 \q1
-\v 18 For Yahweh who created the heavens, 
+\v 18 For Yahuah who created the heavens, 
 \q2 the Elohim who formed the earth and made it, 
 \q2 who established it and didn’t create it a waste, 
 \q2 who formed it to be inhabited says: 
-\q1 “I am Yahweh. 
+\q1 “I am Yahuah. 
 \q2 There is no other. 
 \q1
 \v 19 I have not spoken in secret, 
 \q2 in a place of the land of darkness. 
 \q1 I didn’t say to the offspring of Jacob, ‘Seek me in vain.’ 
-\q2 I, Yahweh, speak righteousness. 
+\q2 I, Yahuah, speak righteousness. 
 \q2 I declare things that are right. 
 \b
 \q1
@@ -2587,7 +2587,7 @@
 \q2 Yes, let them take counsel together. 
 \q1 Who has shown this from ancient time? 
 \q2 Who has declared it of old? 
-\q2 Haven’t I, Yahweh? 
+\q2 Haven’t I, Yahuah? 
 \q1 There is no other Elohim besides me, a just Elohim and a Savior. 
 \q2 There is no one besides me. 
 \b
@@ -2601,11 +2601,11 @@
 \q2 every tongue shall take an oath. 
 \q1
 \v 24 They will say of me, 
-\q2 ‘There is righteousness and strength only in Yahweh.’ ” 
+\q2 ‘There is righteousness and strength only in Yahuah.’ ” 
 \q1 Even to him will men come. 
 \q2 All those who raged against him will be disappointed. 
 \q1
-\v 25 All the offspring of Israel will be justified in Yahweh, 
+\v 25 All the offspring of Israel will be justified in Yahuah, 
 \q2 and will rejoice! 
 \c 46
 \q1
@@ -2693,7 +2693,7 @@
 \q2 and will spare no one.” 
 \b
 \q1
-\v 4 Our Redeemer, Yahweh of Armies is his name, 
+\v 4 Our Redeemer, Yahuah of Armies is his name, 
 \q2 is the Set-Apart One of Israel. 
 \b
 \q1
@@ -2763,12 +2763,12 @@
 \v 1 “Hear this, house of Jacob, 
 \q2 you who are called by the name of Israel, 
 \q2 and have come out of the waters of Judah. 
-\q1 You swear by Yahweh’s name, 
+\q1 You swear by Yahuah’s name, 
 \q2 and make mention of the Elohim of Israel, 
 \q2 but not in truth, nor in righteousness—\q1
 \v 2 for they call themselves citizens of the set-apart city, 
 \q2 and rely on the Elohim of Israel; 
-\q2 Yahweh of Armies is his name. 
+\q2 Yahuah of Armies is his name. 
 \q1
 \v 3 I have declared the former things from of old. 
 \q2 Yes, they went out of my mouth, and I revealed them. 
@@ -2827,7 +2827,7 @@
 \q1
 \v 14 “Assemble yourselves, all of you, and hear! 
 \q2 Who among them has declared these things? 
-\q1 He whom Yahweh loves will do what he likes to Babylon, 
+\q1 He whom Yahuah loves will do what he likes to Babylon, 
 \q2 and his arm will be against the Chaldeans. 
 \q1
 \v 15 I, even I, have spoken. 
@@ -2840,14 +2840,14 @@
 \q1 “From the beginning I have not spoken in secret; 
 \q2 from the time that it happened, I was there.” 
 \b
-\q1 Now the Lord Yahweh has sent me 
+\q1 Now the Lord Yahuah has sent me 
 \q2 with his Spirit. 
 \b
 \q1
-\v 17 Yahweh, 
+\v 17 Yahuah, 
 \q2 your Redeemer, 
 \q2 the Set-Apart One of Israel, says: 
-\q1 “I am Yahweh your Elohim, 
+\q1 “I am Yahuah your Elohim, 
 \q2 who teaches you to profit, 
 \q2 who leads you by the way that you should go. 
 \q1
@@ -2864,19 +2864,19 @@
 \q2 Flee from the Chaldeans! 
 \q1 With the sound of joyful shouting announce this, 
 \q2 tell it even to the end of the earth; 
-\q2 say, “Yahweh has redeemed his servant Jacob!” 
+\q2 say, “Yahuah has redeemed his servant Jacob!” 
 \q1
 \v 21 They didn’t thirst when he led them through the deserts. 
 \q2 He caused the waters to flow out of the rock for them. 
 \q2 He also split the rock and the waters gushed out. 
 \b
 \q1
-\v 22 “There is no peace”, says Yahweh, “for the wicked.” 
+\v 22 “There is no peace”, says Yahuah, “for the wicked.” 
 \c 49
 \q1
 \v 1 Listen, islands, to me. 
 \q2 Listen, you peoples, from afar: 
-\q1 Yahweh has called me from the womb; 
+\q1 Yahuah has called me from the womb; 
 \q2 from the inside of my mother, he has mentioned my name. 
 \q1
 \v 2 He has made my mouth like a sharp sword. 
@@ -2889,14 +2889,14 @@
 \q1
 \v 4 But I said, “I have labored in vain. 
 \q2 I have spent my strength in vain for nothing; 
-\q1 yet surely the justice due to me is with Yahweh, 
+\q1 yet surely the justice due to me is with Yahuah, 
 \q2 and my reward with my Elohim.” 
 \b
 \q1
-\v 5 Now Yahweh, he who formed me from the womb to be his servant, 
+\v 5 Now Yahuah, he who formed me from the womb to be his servant, 
 \q2 says to bring Jacob again to him, 
 \q2 and to gather Israel to him, 
-\q2 for I am honorable in Yahweh’s eyes, 
+\q2 for I am honorable in Yahuah’s eyes, 
 \q2 and my Elohim has become my strength. 
 \q1
 \v 6 Indeed, he says, “It is too light a thing that you should be my servant to raise up the tribes of Jacob, 
@@ -2904,14 +2904,14 @@
 \q1 I will also give you as a light to the nations, 
 \q2 that you may be my salvation to the end of the earth.” 
 \q1
-\v 7 Yahweh, the Redeemer of Israel, and his Set-Apart One, 
+\v 7 Yahuah, the Redeemer of Israel, and his Set-Apart One, 
 \q2 says to him whom man despises, to him whom the nation abhors, to a servant of rulers: 
 \q1 “Kings shall see and rise up, 
 \q2 princes, and they shall worship, 
-\q2 because of Yahweh who is faithful, even the Set-Apart One of Israel, who has chosen you.” 
+\q2 because of Yahuah who is faithful, even the Set-Apart One of Israel, who has chosen you.” 
 \b
 \q1
-\v 8 Yahweh says, “I have answered you in an acceptable time. 
+\v 8 Yahuah says, “I have answered you in an acceptable time. 
 \q2 I have helped you in a day of salvation. 
 \q1 I will preserve you and give you for a covenant of the people, 
 \q2 to raise up the land, to make them inherit the desolate heritage, 
@@ -2935,11 +2935,11 @@
 \q1
 \v 13 Sing, heavens, and be joyful, earth! 
 \q2 Break out into singing, mountains! 
-\q1 For Yahweh has comforted his people, 
+\q1 For Yahuah has comforted his people, 
 \q2 and will have compassion on his afflicted. 
 \b
 \q1
-\v 14 But Zion said, “Yahweh has forsaken me, 
+\v 14 But Zion said, “Yahuah has forsaken me, 
 \q2 and the Lord has forgotten me.” 
 \q1
 \v 15 “Can a woman forget her nursing child, 
@@ -2955,7 +2955,7 @@
 \q1
 \v 18 Lift up your eyes all around, and see: 
 \q2 all these gather themselves together, and come to you. 
-\q1 As I live,” says Yahweh, “you shall surely clothe yourself with them all as with an ornament, 
+\q1 As I live,” says Yahuah, “you shall surely clothe yourself with them all as with an ornament, 
 \q2 and dress yourself with them, like a bride. 
 \q1
 \v 19 “For, as for your waste and your desolate places, 
@@ -2973,7 +2973,7 @@
 \q2 Behold, I was left alone. Where were these?’ ” 
 \b
 \q1
-\v 22 The Lord Yahweh says, “Behold, I will lift up my hand to the nations, 
+\v 22 The Lord Yahuah says, “Behold, I will lift up my hand to the nations, 
 \q2 and lift up my banner to the peoples. 
 \q1 They shall bring your sons in their bosom, 
 \q2 and your daughters shall be carried on their shoulders. 
@@ -2982,25 +2982,25 @@
 \q2 and their queens your nursing mothers. 
 \q1 They will bow down to you with their faces to the earth, 
 \q2 and lick the dust of your feet. 
-\q1 Then you will know that I am Yahweh; 
+\q1 Then you will know that I am Yahuah; 
 \q2 and those who wait for me won’t be disappointed.” 
 \b
 \q1
 \v 24 Shall the plunder be taken from the mighty, 
 \q2 or the lawful captives be delivered? 
 \q1
-\v 25 But Yahweh says, “Even the captives of the mighty shall be taken away, 
+\v 25 But Yahuah says, “Even the captives of the mighty shall be taken away, 
 \q2 and the plunder retrieved from the fierce, 
 \q1 for I will contend with him who contends with you 
 \q2 and I will save your children. 
 \q1
 \v 26 I will feed those who oppress you with their own flesh; 
 \q2 and they will be drunk on their own blood, as with sweet wine. 
-\q1 Then all flesh shall know that I, Yahweh, am your Savior 
+\q1 Then all flesh shall know that I, Yahuah, am your Savior 
 \q2 and your Redeemer, the Mighty One of Jacob.” 
 \c 50
 \q1
-\v 1 Yahweh says, “Where is the bill of your mother’s divorce, with which I have put her away? 
+\v 1 Yahuah says, “Where is the bill of your mother’s divorce, with which I have put her away? 
 \q2 Or to which of my creditors have I sold you? 
 \q1 Behold, you were sold for your iniquities, 
 \q2 and your mother was put away for your transgressions. 
@@ -3017,12 +3017,12 @@
 \q2 I make sackcloth their covering.” 
 \b
 \q1
-\v 4 The Lord Yahweh has given me the tongue of those who are taught, 
+\v 4 The Lord Yahuah has given me the tongue of those who are taught, 
 \q2 that I may know how to sustain with words him who is weary. 
 \q1 He awakens morning by morning, 
 \q2 he awakens my ear to hear as those who are taught. 
 \q1
-\v 5 The Lord Yahweh has opened my ear. 
+\v 5 The Lord Yahuah has opened my ear. 
 \q2 I was not rebellious. 
 \q2 I have not turned back. 
 \q1
@@ -3030,7 +3030,7 @@
 \q2 and my cheeks to those who plucked off the hair. 
 \q2 I didn’t hide my face from shame and spitting. 
 \q1
-\v 7 For the Lord Yahweh will help me. 
+\v 7 For the Lord Yahuah will help me. 
 \q2 Therefore I have not been confounded. 
 \q1 Therefore I have set my face like a flint, 
 \q2 and I know that I won’t be disappointed. 
@@ -3041,17 +3041,17 @@
 \q2 Who is my adversary? 
 \q2 Let him come near to me. 
 \q1
-\v 9 Behold, the Lord Yahweh will help me! 
+\v 9 Behold, the Lord Yahuah will help me! 
 \q2 Who is he who will condemn me? 
 \q1 Behold, they will all grow old like a garment. 
 \q2 The moths will eat them up. 
 \b
 \q1
-\v 10 Who among you fears Yahweh 
+\v 10 Who among you fears Yahuah 
 \q2 and obeys the voice of his servant? 
 \q1 He who walks in darkness 
 \q2 and has no light, 
-\q1 let him trust in Yahweh’s name, 
+\q1 let him trust in Yahuah’s name, 
 \q2 and rely on his Elohim. 
 \q1
 \v 11 Behold, all you who kindle a fire, 
@@ -3063,7 +3063,7 @@
 \c 51
 \q1
 \v 1 “Listen to me, you who follow after righteousness, 
-\q2 you who seek Yahweh. 
+\q2 you who seek Yahuah. 
 \q1 Look to the rock you were cut from, 
 \q2 and to the quarry you were dug from. 
 \q1
@@ -3073,10 +3073,10 @@
 \q2 I blessed him, 
 \q2 and made him many. 
 \q1
-\v 3 For Yahweh has comforted Zion. 
+\v 3 For Yahuah has comforted Zion. 
 \q2 He has comforted all her waste places, 
 \q2 and has made her wilderness like Eden, 
-\q2 and her desert like the garden of Yahweh. 
+\q2 and her desert like the garden of Yahuah. 
 \q1 Joy and gladness will be found in them, 
 \q2 thanksgiving, and the voice of melody. 
 \b
@@ -3112,7 +3112,7 @@
 \q2 and my salvation to all generations.” 
 \b
 \q1
-\v 9 Awake, awake, put on strength, arm of Yahweh! 
+\v 9 Awake, awake, put on strength, arm of Yahuah! 
 \q2 Awake, as in the days of old, 
 \q2 the generations of ancient times. 
 \q1 Isn’t it you who cut Rahab in pieces, 
@@ -3122,7 +3122,7 @@
 \q2 the waters of the great deep; 
 \q2 who made the depths of the sea a way for the redeemed to pass over? 
 \q1
-\v 11 Those ransomed by Yahweh will return, 
+\v 11 Those ransomed by Yahuah will return, 
 \q2 and come with singing to Zion. 
 \q2 Everlasting joy shall be on their heads. 
 \q1 They will obtain gladness and joy. 
@@ -3133,7 +3133,7 @@
 \q2 Who are you, that you are afraid of man who shall die, 
 \q2 and of the son of man who will be made as grass? 
 \q1
-\v 13 Have you forgotten Yahweh your Maker, 
+\v 13 Have you forgotten Yahuah your Maker, 
 \q2 who stretched out the heavens, 
 \q2 and laid the foundations of the earth? 
 \q1 Do you live in fear continually all day because of the fury of the oppressor, 
@@ -3144,9 +3144,9 @@
 \q2 He will not die and go down into the pit. 
 \q2 His bread won’t fail. 
 \q1
-\v 15 For I am Yahweh your Elohim, who stirs up the sea 
+\v 15 For I am Yahuah your Elohim, who stirs up the sea 
 \q2 so that its waves roar. 
-\q2 Yahweh of Armies is his name. 
+\q2 Yahuah of Armies is his name. 
 \q1
 \v 16 I have put my words in your mouth 
 \q2 and have covered you in the shadow of my hand, 
@@ -3157,7 +3157,7 @@
 \q1
 \v 17 Awake, awake! 
 \q2 Stand up, Jerusalem, 
-\q2 you who have drunk from Yahweh’s hand the cup of his wrath. 
+\q2 you who have drunk from Yahuah’s hand the cup of his wrath. 
 \q1 You have drunken the bowl of the cup of staggering, 
 \q2 and drained it. 
 \q1
@@ -3171,14 +3171,14 @@
 \v 20 Your sons have fainted. 
 \q2 They lie at the head of all the streets, 
 \q2 like an antelope in a net. 
-\q1 They are full of Yahweh’s wrath, 
+\q1 They are full of Yahuah’s wrath, 
 \q2 the rebuke of your Elohim. 
 \b
 \q1
 \v 21 Therefore now hear this, you afflicted, 
 \q2 and drunken, but not with wine: 
 \q1
-\v 22 Your Lord Yahweh, 
+\v 22 Your Lord Yahuah, 
 \q2 your Elohim who pleads the cause of his people, says, 
 \q1 “Behold, I have taken out of your hand the cup of staggering, 
 \q2 even the bowl of the cup of my wrath. 
@@ -3199,18 +3199,18 @@
 \q2 Release yourself from the bonds of your neck, captive daughter of Zion! 
 \b
 \q1
-\v 3 For Yahweh says, “You were sold for nothing; 
+\v 3 For Yahuah says, “You were sold for nothing; 
 \q2 and you will be redeemed without money.” 
 \b
 \p
-\v 4 For the Lord Yahweh says: 
+\v 4 For the Lord Yahuah says: 
 \q1 “My people went down at the first into Egypt to live there; 
 \q2 and the Assyrian has oppressed them without cause. 
 \b
 \q1
-\v 5 “Now therefore, what do I do here,” says Yahweh, 
+\v 5 “Now therefore, what do I do here,” says Yahuah, 
 \q2 “seeing that my people are taken away for nothing? 
-\q1 Those who rule over them mock,” says Yahweh, 
+\q1 Those who rule over them mock,” says Yahuah, 
 \q2 “and my name is blasphemed continually all day long. 
 \q1
 \v 6 Therefore my people shall know my name. 
@@ -3226,24 +3226,24 @@
 \q1
 \v 8 Your watchmen lift up their voice. 
 \q2 Together they sing; 
-\q2 for they shall see eye to eye when Yahweh returns to Zion. 
+\q2 for they shall see eye to eye when Yahuah returns to Zion. 
 \q1
 \v 9 Break out into joy! 
 \q2 Sing together, you waste places of Jerusalem; 
-\q2 for Yahweh has comforted his people. 
+\q2 for Yahuah has comforted his people. 
 \q2 He has redeemed Jerusalem. 
 \q1
-\v 10 Yahweh has made his set-apart arm bare in the eyes of all the nations. 
+\v 10 Yahuah has made his set-apart arm bare in the eyes of all the nations. 
 \q2 All the ends of the earth have seen the salvation of our Elohim. 
 \b
 \q1
 \v 11 Depart! Depart! Go out from there! Touch no unclean thing! 
 \q2 Go out from among her! 
-\q2 Cleanse yourselves, you who carry Yahweh’s vessels. 
+\q2 Cleanse yourselves, you who carry Yahuah’s vessels. 
 \q1
 \v 12 For you shall not go out in haste, 
 \q2 neither shall you go by flight; 
-\q1 for Yahweh will go before you, 
+\q1 for Yahuah will go before you, 
 \q2 and the Elohim of Israel will be your rear guard. 
 \b
 \q1
@@ -3259,7 +3259,7 @@
 \c 53
 \q1
 \v 1 Who has believed our message? 
-\q2 To whom has Yahweh’s arm been revealed? 
+\q2 To whom has Yahuah’s arm been revealed? 
 \q1
 \v 2 For he grew up before him as a tender plant, 
 \q2 and as a root out of dry ground. 
@@ -3286,7 +3286,7 @@
 \q1
 \v 6 All we like sheep have gone astray. 
 \q2 Everyone has turned to his own way; 
-\q2 and Yahweh has laid on him the iniquity of us all. 
+\q2 and Yahuah has laid on him the iniquity of us all. 
 \b
 \q1
 \v 7 He was oppressed, 
@@ -3306,12 +3306,12 @@
 \q2 nor was any deceit in his mouth. 
 \b
 \q1
-\v 10 Yet it pleased Yahweh to bruise him. 
+\v 10 Yet it pleased Yahuah to bruise him. 
 \q2 He has caused him to suffer. 
 \q1 When you make his soul an offering for sin, 
 \q2 he will see his offspring. 
 \q1 He will prolong his days 
-\q2 and Yahweh’s pleasure will prosper in his hand. 
+\q2 and Yahuah’s pleasure will prosper in his hand. 
 \q1
 \v 11 After the suffering of his soul, 
 \q2 he will see the light and be satisfied. 
@@ -3328,7 +3328,7 @@
 \q1
 \v 1 “Sing, barren, you who didn’t give birth! 
 \q2 Break out into singing, and cry aloud, you who didn’t travail with child! 
-\q2 For more are the children of the desolate than the children of the owned woman,” says Yahweh. 
+\q2 For more are the children of the desolate than the children of the owned woman,” says Yahuah. 
 \q1
 \v 2 “Enlarge the place of your tent, 
 \q2 and let them stretch out the curtains of your habitations; 
@@ -3344,11 +3344,11 @@
 \q1 For you will forget the shame of your youth. 
 \q2 You will remember the reproach of your widowhood no more. 
 \q1
-\v 5 For your Maker is your owner; Yahweh of Armies is his name. 
+\v 5 For your Maker is your owner; Yahuah of Armies is his name. 
 \q2 The Set-Apart One of Israel is your Redeemer. 
 \q2 He will be called the Elohim of the whole earth. 
 \q1
-\v 6 For Yahweh has called you as a woman forsaken and grieved in spirit, 
+\v 6 For Yahuah has called you as a woman forsaken and grieved in spirit, 
 \q2 even a woman of youth, when she is cast off,” says your Elohim. 
 \b
 \q1
@@ -3356,7 +3356,7 @@
 \q2 but I will gather you with great mercies. 
 \q1
 \v 8 In overflowing wrath I hid my face from you for a moment, 
-\q2 but with everlasting loving kindness I will have mercy on you,” says Yahweh your Redeemer. 
+\q2 but with everlasting loving kindness I will have mercy on you,” says Yahuah your Redeemer. 
 \b
 \q1
 \v 9 “For this is like the waters of Noah to me; 
@@ -3367,7 +3367,7 @@
 \q2 and the hills be removed, 
 \q1 but my loving kindness will not depart from you, 
 \q2 and my covenant of peace will not be removed,” 
-\q2 says Yahweh who has mercy on you. 
+\q2 says Yahuah who has mercy on you. 
 \b
 \q1
 \v 11 “You afflicted, tossed with storms, and not comforted, 
@@ -3378,7 +3378,7 @@
 \q2 your gates of sparkling jewels, 
 \q2 and all your walls of precious stones. 
 \q1
-\v 13 All your children will be taught by Yahweh, 
+\v 13 All your children will be taught by Yahuah, 
 \q2 and your children’s peace will be great. 
 \q1
 \v 14 You will be established in righteousness. 
@@ -3397,8 +3397,8 @@
 \q1
 \v 17 No weapon that is formed against you will prevail; 
 \q2 and you will condemn every tongue that rises against you in judgment. 
-\q1 This is the heritage of Yahweh’s servants, 
-\q2 and their righteousness is of me,” says Yahweh. 
+\q1 This is the heritage of Yahuah’s servants, 
+\q2 and their righteousness is of me,” says Yahuah. 
 \c 55
 \q1
 \v 1 “Hey! Come, everyone who thirsts, to the waters! 
@@ -3419,22 +3419,22 @@
 \q1
 \v 5 Behold, you shall call a nation that you don’t know; 
 \q2 and a nation that didn’t know you shall run to you, 
-\q2 because of Yahweh your Elohim, 
+\q2 because of Yahuah your Elohim, 
 \q2 and for the Set-Apart One of Israel; 
 \q2 for he has glorified you.” 
 \b
 \q1
-\v 6 Seek Yahweh while he may be found. 
+\v 6 Seek Yahuah while he may be found. 
 \q2 Call on him while he is near. 
 \q1
 \v 7 Let the wicked forsake his way, 
 \q2 and the unrighteous man his thoughts. 
-\q1 Let him return to Yahweh, and he will have mercy on him, 
+\q1 Let him return to Yahuah, and he will have mercy on him, 
 \q2 to our Elohim, for he will freely pardon. 
 \b
 \q1
 \v 8 “For my thoughts are not your thoughts, 
-\q2 and your ways are not my ways,” says Yahweh. 
+\q2 and your ways are not my ways,” says Yahuah. 
 \q1
 \v 9 “For as the heavens are higher than the earth, 
 \q2 so are my ways higher than your ways, 
@@ -3457,11 +3457,11 @@
 \q1
 \v 13 Instead of the thorn the cypress tree will come up; 
 \q2 and instead of the brier the myrtle tree will come up. 
-\q1 It will make a name for Yahweh, 
+\q1 It will make a name for Yahuah, 
 \q2 for an everlasting sign that will not be cut off.” 
 \c 56
 \p
-\v 1 Yahweh says: 
+\v 1 Yahuah says: 
 \q1 “Maintain justice 
 \q2 and do what is right, 
 \q1 for my salvation is near 
@@ -3473,12 +3473,12 @@
 \q2 and keeps his hand from doing any evil.” 
 \b
 \q1
-\v 3 Let no foreigner who has joined himself to Yahweh speak, saying, 
-\q2 “Yahweh will surely separate me from his people.” 
+\v 3 Let no foreigner who has joined himself to Yahuah speak, saying, 
+\q2 “Yahuah will surely separate me from his people.” 
 \q2 Do not let the eunuch say, “Behold, I am a dry tree.” 
 \b
 \q1
-\v 4 For Yahweh says, “To the eunuchs who keep my Sabbaths, 
+\v 4 For Yahuah says, “To the eunuchs who keep my Sabbaths, 
 \q2 choose the things that please me, 
 \q2 and hold fast to my covenant, 
 \q1
@@ -3486,9 +3486,9 @@
 \q2 I will give them an everlasting name that will not be cut off. 
 \b
 \q1
-\v 6 Also the foreigners who join themselves to Yahweh 
+\v 6 Also the foreigners who join themselves to Yahuah 
 \q2 to serve him, 
-\q1 and to love Yahweh’s name, 
+\q1 and to love Yahuah’s name, 
 \q2 to be his servants, 
 \q1 everyone who keeps the Sabbath from profaning it, 
 \q2 and holds fast my covenant, 
@@ -3498,7 +3498,7 @@
 \q1 Their burnt offerings and their sacrifices will be accepted on my altar; 
 \q2 for my house will be called a house of prayer for all peoples.” 
 \q1
-\v 8 The Lord Yahweh, who gathers the outcasts of Israel, says, 
+\v 8 The Lord Yahuah, who gathers the outcasts of Israel, says, 
 \q2 “I will yet gather others to him, 
 \q2 in addition to his own who are gathered.” 
 \b
@@ -3615,7 +3615,7 @@
 \q1
 \v 19 I create the fruit of the lips: 
 \q2 Peace, peace, to him who is far off and to him who is near,” 
-\q2 says Yahweh; “and I will heal them.” 
+\q2 says Yahuah; “and I will heal them.” 
 \q1
 \v 20 But the wicked are like the troubled sea; 
 \q2 for it can’t rest and its waters cast up mire and mud. 
@@ -3651,7 +3651,7 @@
 \q1 Is it to bow down his head like a reed, 
 \q2 and to spread sackcloth and ashes under himself? 
 \q1 Will you call this a fast, 
-\q2 and an acceptable day to Yahweh? 
+\q2 and an acceptable day to Yahuah? 
 \b
 \q1
 \v 6 “Isn’t this the fast that I have chosen: 
@@ -3669,9 +3669,9 @@
 \v 8 Then your light will break out as the morning, 
 \q2 and your healing will appear quickly; 
 \q1 then your righteousness shall go before you, 
-\q2 and Yahweh’s glory will be your rear guard. 
+\q2 and Yahuah’s glory will be your rear guard. 
 \q1
-\v 9 Then you will call, and Yahweh will answer. 
+\v 9 Then you will call, and Yahuah will answer. 
 \q2 You will cry for help, and he will say, ‘Here I am.’ 
 \b
 \q1 “If you take away from among you the yoke, 
@@ -3683,7 +3683,7 @@
 \q1 then your light will rise in darkness, 
 \q2 and your obscurity will be as the noonday; 
 \q1
-\v 11 and Yahweh will guide you continually, 
+\v 11 and Yahuah will guide you continually, 
 \q2 satisfy your soul in dry places, 
 \q2 and make your bones strong. 
 \q1 You will be like a watered garden, 
@@ -3699,19 +3699,19 @@
 \v 13 “If you turn away your foot from the Sabbath, 
 \q2 from doing your pleasure on my set-apart day, 
 \q1 and call the Sabbath a delight, 
-\q2 and the set-apart of Yahweh honorable, 
+\q2 and the set-apart of Yahuah honorable, 
 \q2 and honor it, 
 \q2 not doing your own ways, 
 \q2 nor finding your own pleasure, 
 \q2 nor speaking your own words, 
 \q1
-\v 14 then you will delight yourself in Yahweh, 
+\v 14 then you will delight yourself in Yahuah, 
 \q2 and I will make you to ride on the high places of the earth, 
 \q2 and I will feed you with the heritage of Jacob your father;” 
-\q2 for Yahweh’s mouth has spoken it. 
+\q2 for Yahuah’s mouth has spoken it. 
 \c 59
 \q1
-\v 1 Behold, Yahweh’s hand is not shortened, that it can’t save; 
+\v 1 Behold, Yahuah’s hand is not shortened, that it can’t save; 
 \q2 nor his ear dull, that it can’t hear. 
 \q1
 \v 2 But your iniquities have separated you and your Elohim, 
@@ -3772,7 +3772,7 @@
 \q1 for our transgressions are with us, 
 \q2 and as for our iniquities, we know them: 
 \q1
-\v 13 transgressing and denying Yahweh, 
+\v 13 transgressing and denying Yahuah, 
 \q2 and turning away from following our Elohim, 
 \q2 speaking oppression and revolt, 
 \q2 conceiving and uttering from the heart words of falsehood. 
@@ -3785,7 +3785,7 @@
 \v 15 Yes, truth is lacking; 
 \q2 and he who departs from evil makes himself a prey. 
 \b
-\q1 Yahweh saw it, 
+\q1 Yahuah saw it, 
 \q2 and it displeased him that there was no justice. 
 \q1
 \v 16 He saw that there was no man, 
@@ -3804,24 +3804,24 @@
 \q2 recompense to his enemies. 
 \q2 He will repay the islands their due. 
 \q1
-\v 19 So they will fear Yahweh’s name from the west, 
+\v 19 So they will fear Yahuah’s name from the west, 
 \q2 and his glory from the rising of the sun; 
 \q1 for he will come as a rushing stream, 
-\q2 which Yahweh’s breath drives. 
+\q2 which Yahuah’s breath drives. 
 \b
 \q1
 \v 20 “A Redeemer will come to Zion, 
-\q2 and to those who turn from disobedience in Jacob,” says Yahweh. 
+\q2 and to those who turn from disobedience in Jacob,” says Yahuah. 
 \p
-\v 21 “As for me, this is my covenant with them,” says Yahweh. “My Spirit who is on you, and my words which I have put in your mouth shall not depart out of your mouth, nor out of the mouth of your offspring, nor out of the mouth of your offspring’s offspring,” says Yahweh, “from now on and forever.” 
+\v 21 “As for me, this is my covenant with them,” says Yahuah. “My Spirit who is on you, and my words which I have put in your mouth shall not depart out of your mouth, nor out of the mouth of your offspring, nor out of the mouth of your offspring’s offspring,” says Yahuah, “from now on and forever.” 
 \c 60
 \q1
 \v 1 “Arise, shine; for your light has come, 
-\q2 and Yahweh’s glory has risen on you! 
+\q2 and Yahuah’s glory has risen on you! 
 \q1
 \v 2 For behold, darkness will cover the earth, 
 \q2 and thick darkness the peoples; 
-\q1 but Yahweh will arise on you, 
+\q1 but Yahuah will arise on you, 
 \q2 and his glory shall be seen on you. 
 \q1
 \v 3 Nations will come to your light, 
@@ -3843,7 +3843,7 @@
 \q2 the dromedaries of Midian and Ephah. 
 \q1 All from Sheba will come. 
 \q2 They will bring gold and frankincense, 
-\q2 and will proclaim the praises of Yahweh. 
+\q2 and will proclaim the praises of Yahuah. 
 \q1
 \v 7 All the flocks of Kedar will be gathered together to you. 
 \q2 The rams of Nebaioth will serve you. 
@@ -3858,7 +3858,7 @@
 \q2 and the ships of Tarshish first, 
 \q1 to bring your sons from far away, 
 \q2 their silver and their gold with them, 
-\q1 for the name of Yahweh your Elohim, 
+\q1 for the name of Yahuah your Elohim, 
 \q2 and for the Set-Apart One of Israel, 
 \q2 because he has glorified you. 
 \b
@@ -3877,7 +3877,7 @@
 \q1
 \v 14 The sons of those who afflicted you will come bowing to you; 
 \q2 and all those who despised you will bow themselves down at the soles of your feet. 
-\q1 They will call you Yahweh’s City, 
+\q1 They will call you Yahuah’s City, 
 \q2 the Zion of the Set-Apart One of Israel. 
 \b
 \q1
@@ -3888,7 +3888,7 @@
 \q1
 \v 16 You will also drink the milk of the nations, 
 \q2 and will nurse from royal breasts. 
-\q1 Then you will know that I, Yahweh, am your Savior, 
+\q1 Then you will know that I, Yahuah, am your Savior, 
 \q2 your Redeemer, 
 \q2 the Mighty One of Jacob. 
 \q1
@@ -3906,12 +3906,12 @@
 \q1
 \v 19 The sun will be no more your light by day, 
 \q2 nor will the brightness of the moon give light to you, 
-\q1 but Yahweh will be your everlasting light, 
+\q1 but Yahuah will be your everlasting light, 
 \q2 and your Elohim will be your glory. 
 \q1
 \v 20 Your sun will not go down any more, 
 \q2 nor will your moon withdraw itself; 
-\q1 for Yahweh will be your everlasting light, 
+\q1 for Yahuah will be your everlasting light, 
 \q2 and the days of your mourning will end. 
 \q1
 \v 21 Then your people will all be righteous. 
@@ -3922,16 +3922,16 @@
 \q1
 \v 22 The little one will become a thousand, 
 \q2 and the small one a strong nation. 
-\q2 I, Yahweh, will do this quickly in its time.” 
+\q2 I, Yahuah, will do this quickly in its time.” 
 \c 61
 \q1
-\v 1 The Lord Yahweh’s Spirit is on me, 
-\q2 because Yahweh has anointed me to preach good news to the humble. 
+\v 1 The Lord Yahuah’s Spirit is on me, 
+\q2 because Yahuah has anointed me to preach good news to the humble. 
 \q1 He has sent me to bind up the broken hearted, 
 \q2 to proclaim liberty to the captives 
 \q2 and release to those who are bound, 
 \q1
-\v 2 to proclaim the year of Yahweh’s favor 
+\v 2 to proclaim the year of Yahuah’s favor 
 \q2 and the day of vengeance of our Elohim, 
 \q2 to comfort all who mourn, 
 \q1
@@ -3940,7 +3940,7 @@
 \q2 the oil of joy for mourning, 
 \q2 the garment of praise for the spirit of heaviness, 
 \q1 that they may be called trees of righteousness, 
-\q2 the planting of Yahweh, 
+\q2 the planting of Yahuah, 
 \q2 that he may be glorified. 
 \b
 \q1
@@ -3952,7 +3952,7 @@
 \v 5 Strangers will stand and feed your flocks. 
 \q2 Foreigners will work your fields and your vineyards. 
 \q1
-\v 6 But you will be called Yahweh’s priests. 
+\v 6 But you will be called Yahuah’s priests. 
 \q2 Men will call you the servants of our Elohim. 
 \q1 You will eat the wealth of the nations. 
 \q2 You will boast in their glory. 
@@ -3962,7 +3962,7 @@
 \q1 Therefore in their land they will possess double. 
 \q2 Everlasting joy will be to them. 
 \q1
-\v 8 “For I, Yahweh, love justice. 
+\v 8 “For I, Yahuah, love justice. 
 \q2 I hate robbery and iniquity. 
 \q1 I will give them their reward in truth 
 \q2 and I will make an everlasting covenant with them. 
@@ -3970,10 +3970,10 @@
 \v 9 Their offspring will be known among the nations, 
 \q2 and their offspring among the peoples. 
 \q1 All who see them will acknowledge them, 
-\q2 that they are the offspring which Yahweh has blessed.” 
+\q2 that they are the offspring which Yahuah has blessed.” 
 \b
 \q1
-\v 10 I will greatly rejoice in Yahweh! 
+\v 10 I will greatly rejoice in Yahuah! 
 \q2 My soul will be joyful in my Elohim, 
 \q1 for he has clothed me with the garments of salvation. 
 \q2 He has covered me with the robe of righteousness, 
@@ -3982,7 +3982,7 @@
 \q1
 \v 11 For as the earth produces its bud, 
 \q2 and as the garden causes the things that are sown in it to spring up, 
-\q2 so the Lord Yahweh will cause righteousness and praise to spring up before all the nations. 
+\q2 so the Lord Yahuah will cause righteousness and praise to spring up before all the nations. 
 \c 62
 \q1
 \v 1 For Zion’s sake I will not hold my peace, 
@@ -3993,16 +3993,16 @@
 \v 2 The nations will see your righteousness, 
 \q2 and all kings your glory. 
 \q1 You will be called by a new name, 
-\q2 which Yahweh’s mouth will name. 
+\q2 which Yahuah’s mouth will name. 
 \q1
-\v 3 You will also be a crown of beauty in Yahweh’s hand, 
+\v 3 You will also be a crown of beauty in Yahuah’s hand, 
 \q2 and a royal diadem in your Elohim’s hand. 
 \q1
 \v 4 You will not be called Forsaken any more, 
 \q2 nor will your land be called Desolate any more; 
 \q1 but you will be called Hephzibah, 
 \q2 and your land Beulah; 
-\q1 for Yahweh delights in you, 
+\q1 for Yahuah delights in you, 
 \q2 and your land will be owned. 
 \q1
 \v 5 For as a young man owns a virgin, 
@@ -4013,18 +4013,18 @@
 \q1
 \v 6 I have set watchmen on your walls, Jerusalem. 
 \q2 They will never be silent day nor night. 
-\q1 You who call on Yahweh, take no rest, 
+\q1 You who call on Yahuah, take no rest, 
 \q2
 \v 7 and give him no rest until he establishes, 
 \q2 and until he makes Jerusalem a praise in the earth. 
 \b
 \q1
-\v 8 Yahweh has sworn by his right hand, 
+\v 8 Yahuah has sworn by his right hand, 
 \q2 and by the arm of his strength, 
 \q1 “Surely I will no more give your grain to be food for your enemies, 
 \q2 and foreigners will not drink your new wine, for which you have labored, 
 \q1
-\v 9 but those who have harvested it will eat it, and praise Yahweh. 
+\v 9 but those who have harvested it will eat it, and praise Yahuah. 
 \q2 Those who have gathered it will drink it in the courts of my sanctuary.” 
 \b
 \q1
@@ -4034,14 +4034,14 @@
 \q2 Gather out the stones! 
 \q2 Lift up a banner for the peoples. 
 \q1
-\v 11 Behold, Yahweh has proclaimed to the end of the earth: 
+\v 11 Behold, Yahuah has proclaimed to the end of the earth: 
 \q2 “Say to the daughter of Zion, 
 \q2 ‘Behold, your salvation comes! 
 \q1 Behold, his reward is with him, 
 \q2 and his recompense before him!’ ” 
 \q1
 \v 12 They will call them “The Set-Apart People, 
-\q2 Yahweh’s Redeemed”. 
+\q2 Yahuah’s Redeemed”. 
 \q1 You will be called “Sought Out, 
 \q2 A City Not Forsaken”. 
 \c 63
@@ -4077,9 +4077,9 @@
 \q2 I poured their lifeblood out on the earth.” 
 \b
 \q1
-\v 7 I will tell of the loving kindnesses of Yahweh 
-\q2 and the praises of Yahweh, 
-\q2 according to all that Yahweh has given to us, 
+\v 7 I will tell of the loving kindnesses of Yahuah 
+\q2 and the praises of Yahuah, 
+\q2 according to all that Yahuah has given to us, 
 \q1 and the great goodness toward the house of Israel, 
 \q2 which he has given to them according to his mercies, 
 \q2 and according to the multitude of his loving kindnesses. 
@@ -4114,7 +4114,7 @@
 \q2 so that they didn’t stumble? 
 \q1
 \v 14 As the livestock that go down into the valley, 
-\q2 Yahweh’s Spirit caused them to rest. 
+\q2 Yahuah’s Spirit caused them to rest. 
 \q2 So you led your people to make yourself a glorious name. 
 \b
 \q1
@@ -4126,10 +4126,10 @@
 \v 16 For you are our Father, 
 \q2 though Abraham doesn’t know us, 
 \q2 and Israel does not acknowledge us. 
-\q1 You, Yahweh, are our Father. 
+\q1 You, Yahuah, are our Father. 
 \q2 Our Redeemer from everlasting is your name. 
 \q1
-\v 17 O Yahweh, why do you make us wander from your ways, 
+\v 17 O Yahuah, why do you make us wander from your ways, 
 \q2 and harden our heart from your fear? 
 \q1 Return for your servants’ sake, 
 \q2 the tribes of your inheritance. 
@@ -4174,11 +4174,11 @@
 \q2 and have consumed us by means of our iniquities. 
 \b
 \q1
-\v 8 But now, Yahweh, you are our Father. 
+\v 8 But now, Yahuah, you are our Father. 
 \q2 We are the clay and you our potter. 
 \q2 We all are the work of your hand. 
 \q1
-\v 9 Don’t be furious, Yahweh. 
+\v 9 Don’t be furious, Yahuah. 
 \q2 Don’t remember iniquity forever. 
 \q1 Look and see, we beg you, 
 \q2 we are all your people. 
@@ -4191,7 +4191,7 @@
 \q2 is burned with fire. 
 \q2 All our pleasant places are laid waste. 
 \q1
-\v 12 Will you hold yourself back for these things, Yahweh? 
+\v 12 Will you hold yourself back for these things, Yahuah? 
 \q2 Will you keep silent and punish us very severely? 
 \c 65
 \q1
@@ -4224,13 +4224,13 @@
 \q2 but will repay, 
 \q2 yes, I will repay into their bosom 
 \q1
-\v 7 your own iniquities and the iniquities of your fathers together”, says Yahweh, 
+\v 7 your own iniquities and the iniquities of your fathers together”, says Yahuah, 
 \q2 “who have burned incense on the mountains, 
 \q2 and blasphemed me on the hills. 
 \q2 Therefore I will first measure their work into their bosom.” 
 \b
 \p
-\v 8 Yahweh says, 
+\v 8 Yahuah says, 
 \q1 “As the new wine is found in the cluster, 
 \q2 and one says, ‘Don’t destroy it, for a blessing is in it:’ 
 \q1 so I will do for my servants’ sake, 
@@ -4246,7 +4246,7 @@
 \q2 for my people who have sought me. 
 \b
 \q1
-\v 11 “But you who forsake Yahweh, 
+\v 11 “But you who forsake Yahuah, 
 \q2 who forget my set-apart mountain, 
 \q2 who prepare a table for Fortune, 
 \q2 and who fill up mixed wine to Destiny; 
@@ -4259,7 +4259,7 @@
 \q2 and chose that in which I didn’t delight.” 
 \b
 \p
-\v 13 Therefore the Lord Yahweh says, 
+\v 13 Therefore the Lord Yahuah says, 
 \q1 “Behold, my servants will eat, 
 \q2 but you will be hungry; 
 \q1 behold, my servants will drink, 
@@ -4272,7 +4272,7 @@
 \q2 and will wail for anguish of spirit. 
 \q1
 \v 15 You will leave your name for a curse to my chosen, 
-\q2 and the Lord Yahweh will kill you. 
+\q2 and the Lord Yahuah will kill you. 
 \q1 He will call his servants by another name, 
 \q2
 \v 16 so that he who blesses himself in the earth will bless himself in the Elohim of truth; 
@@ -4310,7 +4310,7 @@
 \q1
 \v 23 They will not labor in vain 
 \q2 nor give birth for calamity; 
-\q1 for they are the offspring of Yahweh’s blessed 
+\q1 for they are the offspring of Yahuah’s blessed 
 \q2 and their descendants with them. 
 \q1
 \v 24 It will happen that before they call, I will answer; 
@@ -4320,16 +4320,16 @@
 \q2 The lion will eat straw like the ox. 
 \q2 Dust will be the serpent’s food. 
 \q1 They will not hurt nor destroy in all my set-apart mountain,” 
-\q2 says Yahweh. 
+\q2 says Yahuah. 
 \c 66
 \p
-\v 1 Yahweh says: 
+\v 1 Yahuah says: 
 \q1 “Heaven is my throne, and the earth is my footstool. 
 \q2 What kind of house will you build to me? 
 \q2 Where will I rest? 
 \q1
 \v 2 For my hand has made all these things, 
-\q2 and so all these things came to be,” says Yahweh: 
+\q2 and so all these things came to be,” says Yahuah: 
 \q1 “but I will look to this man, 
 \q2 even to he who is poor and of a contrite spirit, 
 \q2 and who trembles at my word. 
@@ -4349,17 +4349,17 @@
 \q2 and chose that in which I didn’t delight.” 
 \b
 \q1
-\v 5 Hear Yahweh’s word, 
+\v 5 Hear Yahuah’s word, 
 \q2 you who tremble at his word: 
 \q1 “Your brothers who hate you, 
 \q2 who cast you out for my name’s sake, have said, 
-\q1 ‘Let Yahweh be glorified, 
+\q1 ‘Let Yahuah be glorified, 
 \q2 that we may see your joy;’ 
 \q2 but it is those who shall be disappointed. 
 \q1
 \v 6 A voice of tumult from the city, 
 \q2 a voice from the temple, 
-\q2 a voice of Yahweh that repays his enemies what they deserve. 
+\q2 a voice of Yahuah that repays his enemies what they deserve. 
 \b
 \q1
 \v 7 “Before she travailed, she gave birth. 
@@ -4372,7 +4372,7 @@
 \q1 For as soon as Zion travailed, 
 \q2 she gave birth to her children. 
 \q1
-\v 9 Shall I bring to the birth, and not cause to be delivered?” says Yahweh. 
+\v 9 Shall I bring to the birth, and not cause to be delivered?” says Yahuah. 
 \q2 “Shall I who cause to give birth shut the womb?” says your Elohim. 
 \b
 \q1
@@ -4384,7 +4384,7 @@
 \q2 and be delighted with the abundance of her glory.” 
 \b
 \q1
-\v 12 For Yahweh says, “Behold, I will extend peace to her like a river, 
+\v 12 For Yahuah says, “Behold, I will extend peace to her like a river, 
 \q2 and the glory of the nations like an overflowing stream, 
 \q2 and you will nurse. 
 \q1 You will be carried on her side, 
@@ -4397,26 +4397,26 @@
 \q1
 \v 14 You will see it, and your heart shall rejoice, 
 \q2 and your bones will flourish like the tender grass. 
-\q1 Yahweh’s hand will be known among his servants; 
+\q1 Yahuah’s hand will be known among his servants; 
 \q2 and he will have indignation against his enemies. 
 \b
 \q1
-\v 15 For, behold, Yahweh will come with fire, 
+\v 15 For, behold, Yahuah will come with fire, 
 \q2 and his chariots will be like the whirlwind; 
 \q1 to render his anger with fierceness, 
 \q2 and his rebuke with flames of fire. 
 \q1
-\v 16 For Yahweh will execute judgment by fire and by his sword on all flesh; 
-\q2 and those slain by Yahweh will be many. 
+\v 16 For Yahuah will execute judgment by fire and by his sword on all flesh; 
+\q2 and those slain by Yahuah will be many. 
 \p
-\v 17 “Those who sanctify themselves and purify themselves to go to the gardens, following one in the middle, eating pig’s meat, abominable things, and the mouse, they shall come to an end together,” says Yahweh. 
+\v 17 “Those who sanctify themselves and purify themselves to go to the gardens, following one in the middle, eating pig’s meat, abominable things, and the mouse, they shall come to an end together,” says Yahuah. 
 \p
 \v 18 “For I know their works and their thoughts. The time comes that I will gather all nations and languages, and they will come, and will see my glory. 
 \p
 \v 19 “I will set a sign among them, and I will send those who escape of them to the nations, to Tarshish, Pul, and Lud, who draw the bow, to Tubal and Javan, to far-away islands, who have not heard my fame, nor have seen my glory; and they shall declare my glory among the nations. 
-\v 20 They shall bring all your brothers out of all the nations for an offering to Yahweh, on horses, in chariots, in litters, on mules, and on camels, to my set-apart mountain Jerusalem, says Yahweh, as the children of Israel bring their offering in a clean vessel into Yahweh’s house. 
-\v 21 Of them I will also select priests and Levites,” says Yahweh. 
+\v 20 They shall bring all your brothers out of all the nations for an offering to Yahuah, on horses, in chariots, in litters, on mules, and on camels, to my set-apart mountain Jerusalem, says Yahuah, as the children of Israel bring their offering in a clean vessel into Yahuah’s house. 
+\v 21 Of them I will also select priests and Levites,” says Yahuah. 
 \p
-\v 22 “For as the new heavens and the new earth, which I will make, shall remain before me,” says Yahweh, “so your offspring and your name shall remain. 
-\v 23 It shall happen that from one new moon to another, and from one Sabbath to another, all flesh will come to worship before me,” says Yahweh. 
+\v 22 “For as the new heavens and the new earth, which I will make, shall remain before me,” says Yahuah, “so your offspring and your name shall remain. 
+\v 23 It shall happen that from one new moon to another, and from one Sabbath to another, all flesh will come to worship before me,” says Yahuah. 
 \v 24 “They will go out, and look at the dead bodies of the men who have transgressed against me; for their worm will not die, nor will their fire be quenched, and they will be loathsome to all mankind.” 

--- a/usfm/jeremiah.usfm
+++ b/usfm/jeremiah.usfm
@@ -4,32 +4,32 @@
 \c 1
 \p
 \v 1 The words of Jeremiah the son of Hilkiah, one of the priests who were in Anathoth in the land of Benjamin. 
-\v 2 Yahweh’s word came to him in the days of Josiah the son of Amon, king of Judah, in the thirteenth year of his reign. 
+\v 2 Yahuah’s word came to him in the days of Josiah the son of Amon, king of Judah, in the thirteenth year of his reign. 
 \v 3 It came also in the days of Jehoiakim the son of Josiah, king of Judah, to the end of the eleventh year of Zedekiah, the son of Josiah, king of Judah, to the carrying away of Jerusalem captive in the fifth month. 
-\v 4 Now Yahweh’s word came to me, saying, 
+\v 4 Now Yahuah’s word came to me, saying, 
 \q1
 \v 5 “Before I formed you in the womb, I knew you. 
 \q2 Before you were born, I sanctified you. 
 \q2 I have appointed you a prophet to the nations.” 
 \p
-\v 6 Then I said, “Ah, Lord Yahweh! Behold, I don’t know how to speak; for I am a child.” 
+\v 6 Then I said, “Ah, Lord Yahuah! Behold, I don’t know how to speak; for I am a child.” 
 \p
-\v 7 But Yahweh said to me, “Don’t say, ‘I am a child;’ for you must go to whomever I send you, and you must say whatever I command you. 
-\v 8 Don’t be afraid because of them, for I am with you to rescue you,” says Yahweh. 
+\v 7 But Yahuah said to me, “Don’t say, ‘I am a child;’ for you must go to whomever I send you, and you must say whatever I command you. 
+\v 8 Don’t be afraid because of them, for I am with you to rescue you,” says Yahuah. 
 \p
-\v 9 Then Yahweh stretched out his hand and touched my mouth. Then Yahweh said to me, “Behold, I have put my words in your mouth. 
+\v 9 Then Yahuah stretched out his hand and touched my mouth. Then Yahuah said to me, “Behold, I have put my words in your mouth. 
 \v 10 Behold, I have today set you over the nations and over the kingdoms, to uproot and to tear down, to destroy and to overthrow, to build and to plant.” 
 \p
-\v 11 Moreover Yahweh’s word came to me, saying, “Jeremiah, what do you see?” 
+\v 11 Moreover Yahuah’s word came to me, saying, “Jeremiah, what do you see?” 
 \p I said, “I see a branch of an almond tree.” 
 \p
-\v 12 Then Yahweh said to me, “You have seen well; for I watch over my word to perform it.” 
+\v 12 Then Yahuah said to me, “You have seen well; for I watch over my word to perform it.” 
 \p
-\v 13 Yahweh’s word came to me the second time, saying, “What do you see?” 
+\v 13 Yahuah’s word came to me the second time, saying, “What do you see?” 
 \p I said, “I see a boiling cauldron; and it is tipping away from the north.” 
 \p
-\v 14 Then Yahweh said to me, “Out of the north, evil will break out on all the inhabitants of the land. 
-\v 15 For behold, I will call all the families of the kingdoms of the north,” says Yahweh. 
+\v 14 Then Yahuah said to me, “Out of the north, evil will break out on all the inhabitants of the land. 
+\v 15 For behold, I will call all the families of the kingdoms of the north,” says Yahuah. 
 \q1 “They will come, and they will each set his throne at the entrance of the gates of Jerusalem, 
 \q2 and against all its walls all around, and against all the cities of Judah. 
 \q1
@@ -40,29 +40,29 @@
 \p
 \v 17 “You therefore put your belt on your waist, arise, and say to them all that I command you. Don’t be dismayed at them, lest I dismay you before them. 
 \v 18 For behold, I have made you today a fortified city, an iron pillar, and bronze walls against the whole land—against the kings of Judah, against its princes, against its priests, and against the people of the land. 
-\v 19 They will fight against you, but they will not prevail against you; for I am with you”, says Yahweh, “to rescue you.” 
+\v 19 They will fight against you, but they will not prevail against you; for I am with you”, says Yahuah, “to rescue you.” 
 \c 2
 \p
-\v 1 Yahweh’s word came to me, saying, 
-\v 2 “Go and proclaim in the ears of Jerusalem, saying, ‘Yahweh says, 
+\v 1 Yahuah’s word came to me, saying, 
+\v 2 “Go and proclaim in the ears of Jerusalem, saying, ‘Yahuah says, 
 \q1 “I remember for you the kindness of your youth, 
 \q2 your love as a bride, 
 \q1 how you went after me in the wilderness, 
 \q2 in a land that was not sown. 
 \q1
-\v 3 Israel was set-apartness to Yahweh, 
+\v 3 Israel was set-apartness to Yahuah, 
 \q2 the first fruits of his increase. 
 \q1 All who devour him will be held guilty. 
-\q2 Evil will come on them,” ’ says Yahweh.” 
+\q2 Evil will come on them,” ’ says Yahuah.” 
 \p
-\v 4 Hear Yahweh’s word, O house of Jacob, and all the families of the house of Israel! 
-\v 5 Yahweh says, 
+\v 4 Hear Yahuah’s word, O house of Jacob, and all the families of the house of Israel! 
+\v 5 Yahuah says, 
 \q1 “What unrighteousness have your fathers found in me, 
 \q2 that they have gone far from me, 
 \q1 and have walked after worthless vanity, 
 \q2 and have become worthless? 
 \q1
-\v 6 They didn’t say, ‘Where is Yahweh who brought us up out of the land of Egypt, 
+\v 6 They didn’t say, ‘Where is Yahuah who brought us up out of the land of Egypt, 
 \q2 who led us through the wilderness, 
 \q2 through a land of deserts and of pits, 
 \q2 through a land of drought and of the shadow of death, 
@@ -74,13 +74,13 @@
 \q1 but when you entered, you defiled my land, 
 \q2 and made my heritage an abomination. 
 \q1
-\v 8 The priests didn’t say, ‘Where is Yahweh?’ 
+\v 8 The priests didn’t say, ‘Where is Yahuah?’ 
 \q2 and those who handle the law didn’t know me. 
 \q1 The rulers also transgressed against me, 
 \q2 and the prophets prophesied by Baal 
 \q2 and followed things that do not profit. 
 \q1
-\v 9 “Therefore I will yet contend with you,” says Yahweh, 
+\v 9 “Therefore I will yet contend with you,” says Yahuah, 
 \q2 “and I will contend with your children’s children. 
 \q1
 \v 10 For pass over to the islands of Kittim, and see. 
@@ -93,7 +93,7 @@
 \q1
 \v 12 “Be astonished, you heavens, at this 
 \q2 and be horribly afraid. 
-\q2 Be very desolate,” says Yahweh. 
+\q2 Be very desolate,” says Yahuah. 
 \q1
 \v 13 “For my people have committed two evils: 
 \q2 they have forsaken me, the spring of living waters, 
@@ -110,7 +110,7 @@
 \v 16 The children also of Memphis and Tahpanhes have broken the crown of your head. 
 \q1
 \v 17 “Haven’t you brought this on yourself, 
-\q2 in that you have forsaken Yahweh your Elohim, when he led you by the way? 
+\q2 in that you have forsaken Yahuah your Elohim, when he led you by the way? 
 \q1
 \v 18 Now what do you gain by going to Egypt, to drink the waters of the Shihor? 
 \q2 Or why do you go on the way to Assyria, to drink the waters of the River? 
@@ -118,8 +118,8 @@
 \v 19 “Your own wickedness will correct you, 
 \q2 and your backsliding will rebuke you. 
 \q1 Know therefore and see that it is an evil and bitter thing, 
-\q2 that you have forsaken Yahweh your Elohim, 
-\q2 and that my fear is not in you,” says the Lord, Yahweh of Armies. 
+\q2 that you have forsaken Yahuah your Elohim, 
+\q2 and that my fear is not in you,” says the Lord, Yahuah of Armies. 
 \q1
 \v 20 “For long ago I broke off your yoke, 
 \q2 and burst your bonds. 
@@ -133,7 +133,7 @@
 \q1
 \v 22 For though you wash yourself with lye, 
 \q2 and use much soap, 
-\q2 yet your iniquity is marked before me,” says the Lord Yahweh. 
+\q2 yet your iniquity is marked before me,” says the Lord Yahuah. 
 \q1
 \v 23 “How can you say, ‘I am not defiled. 
 \q2 I have not gone after the Baals’? 
@@ -164,14 +164,14 @@
 \q2 for you have as many elohims as you have towns, O Judah. 
 \q1
 \v 29 “Why will you contend with me? 
-\q2 You all have transgressed against me,” says Yahweh. 
+\q2 You all have transgressed against me,” says Yahuah. 
 \q1
 \v 30 “I have struck your children in vain. 
 \q2 They received no correction. 
 \q1 Your own sword has devoured your prophets, 
 \q2 like a destroying lion. 
 \q1
-\v 31 Generation, consider Yahweh’s word. 
+\v 31 Generation, consider Yahuah’s word. 
 \q2 Have I been a wilderness to Israel? 
 \q2 Or a land of thick darkness? 
 \q1 Why do my people say, ‘We have broken loose. 
@@ -198,11 +198,11 @@
 \q2 as you were ashamed of Assyria. 
 \q1
 \v 37 You will also leave that place with your hands on your head; 
-\q2 for Yahweh has rejected those in whom you trust, 
+\q2 for Yahuah has rejected those in whom you trust, 
 \q2 and you won’t prosper with them. 
 \c 3
 \p
-\v 1 “They say, ‘If a man puts away his woman, and she goes from him, and becomes another man’s, should he return to her again?’ Wouldn’t that land be greatly polluted? But you have played the prostitute with many lovers; yet return again to me,” says Yahweh. 
+\v 1 “They say, ‘If a man puts away his woman, and she goes from him, and becomes another man’s, should he return to her again?’ Wouldn’t that land be greatly polluted? But you have played the prostitute with many lovers; yet return again to me,” says Yahuah. 
 \p
 \v 2 “Lift up your eyes to the bare heights, and see! Where have you not been lain with? You have sat waiting for them by the road, as an Arabian in the wilderness. You have polluted the land with your prostitution and with your wickedness. 
 \v 3 Therefore the showers have been withheld and there has been no latter rain; yet you have had a prostitute’s forehead and you refused to be ashamed. 
@@ -210,45 +210,45 @@
 \p
 \v 5 “ ‘Will he retain his anger forever? Will he keep it to the end?’ Behold, you have spoken and have done evil things, and have had your way.” 
 \p
-\v 6 Moreover, Yahweh said to me in the days of Josiah the king, “Have you seen that which backsliding Israel has done? She has gone up on every high mountain and under every green tree, and has played the prostitute there. 
+\v 6 Moreover, Yahuah said to me in the days of Josiah the king, “Have you seen that which backsliding Israel has done? She has gone up on every high mountain and under every green tree, and has played the prostitute there. 
 \v 7 I said after she had done all these things, ‘She will return to me;’ but she didn’t return, and her treacherous sister Judah saw it. 
 \v 8 I saw when, for this very cause, that backsliding Israel had committed adultery, I had put her away and given her a certificate of divorce, yet treacherous Judah, her sister, had no fear, but she also went and played the prostitute. 
 \v 9 Because she took her prostitution lightly, the land was polluted, and she committed adultery with stones and with wood. 
-\v 10 Yet for all this her treacherous sister, Judah, has not returned to me with her whole heart, but only in pretense,” says Yahweh. 
+\v 10 Yet for all this her treacherous sister, Judah, has not returned to me with her whole heart, but only in pretense,” says Yahuah. 
 \p
-\v 11 Yahweh said to me, “Backsliding Israel has shown herself more righteous than treacherous Judah. 
-\v 12 Go, and proclaim these words toward the north, and say, ‘Return, you backsliding Israel,’ says Yahweh; ‘I will not look in anger on you, for I am merciful,’ says Yahweh. ‘I will not keep anger forever. 
-\v 13 Only acknowledge your iniquity, that you have transgressed against Yahweh your Elohim, and have scattered your ways to the strangers under every green tree, and you have not obeyed my voice,’ ” says Yahweh. 
-\v 14 “Return, backsliding children,” says Yahweh, “for I am an owner to you. I will take one of you from a city, and two from a family, and I will bring you to Zion. 
+\v 11 Yahuah said to me, “Backsliding Israel has shown herself more righteous than treacherous Judah. 
+\v 12 Go, and proclaim these words toward the north, and say, ‘Return, you backsliding Israel,’ says Yahuah; ‘I will not look in anger on you, for I am merciful,’ says Yahuah. ‘I will not keep anger forever. 
+\v 13 Only acknowledge your iniquity, that you have transgressed against Yahuah your Elohim, and have scattered your ways to the strangers under every green tree, and you have not obeyed my voice,’ ” says Yahuah. 
+\v 14 “Return, backsliding children,” says Yahuah, “for I am an owner to you. I will take one of you from a city, and two from a family, and I will bring you to Zion. 
 \v 15 I will give you shepherds according to my heart, who will feed you with knowledge and understanding. 
-\v 16 It will come to pass, when you are multiplied and increased in the land in those days,” says Yahweh, “they will no longer say, ‘the ark of Yahweh’s covenant!’ It will not come to mind. They won’t remember it. They won’t miss it, nor will another be made. 
-\v 17 At that time they will call Jerusalem ‘Yahweh’s Throne;’ and all the nations will be gathered to it, to Yahweh’s name, to Jerusalem. They will no longer walk after the stubbornness of their evil heart. 
+\v 16 It will come to pass, when you are multiplied and increased in the land in those days,” says Yahuah, “they will no longer say, ‘the ark of Yahuah’s covenant!’ It will not come to mind. They won’t remember it. They won’t miss it, nor will another be made. 
+\v 17 At that time they will call Jerusalem ‘Yahuah’s Throne;’ and all the nations will be gathered to it, to Yahuah’s name, to Jerusalem. They will no longer walk after the stubbornness of their evil heart. 
 \v 18 In those days the house of Judah will walk with the house of Israel, and they will come together out of the land of the north to the land that I gave for an inheritance to your fathers. 
 \p
 \v 19 “But I said, ‘How I desire to put you among the children, and give you a pleasant land, a goodly heritage of the armies of the nations!’ and I said, ‘You shall call me “My Father”, and shall not turn away from following me.’ 
 \p
-\v 20 “Surely as a woman treacherously departs from her friend, so you have dealt treacherously with me, house of Israel,” says Yahweh. 
-\v 21 A voice is heard on the bare heights, the weeping and the petitions of the children of Israel; because they have perverted their way, they have forgotten Yahweh their Elohim. 
+\v 20 “Surely as a woman treacherously departs from her friend, so you have dealt treacherously with me, house of Israel,” says Yahuah. 
+\v 21 A voice is heard on the bare heights, the weeping and the petitions of the children of Israel; because they have perverted their way, they have forgotten Yahuah their Elohim. 
 \v 22 Return, you backsliding children, and I will heal your backsliding. 
-\p “Behold, we have come to you; for you are Yahweh our Elohim. 
-\v 23 Truly help from the hills, the tumult on the mountains, is in vain. Truly the salvation of Israel is in Yahweh our Elohim. 
+\p “Behold, we have come to you; for you are Yahuah our Elohim. 
+\v 23 Truly help from the hills, the tumult on the mountains, is in vain. Truly the salvation of Israel is in Yahuah our Elohim. 
 \v 24 But the shameful thing has devoured the labor of our fathers from our youth, their flocks and their herds, their sons and their daughters. 
-\v 25 Let us lie down in our shame, and let our confusion cover us; for we have sinned against Yahweh our Elohim, we and our fathers, from our youth even to this day. We have not obeyed Yahweh our Elohim’s voice.” 
+\v 25 Let us lie down in our shame, and let our confusion cover us; for we have sinned against Yahuah our Elohim, we and our fathers, from our youth even to this day. We have not obeyed Yahuah our Elohim’s voice.” 
 \c 4
 \p
-\v 1 “If you will return, Israel,” says Yahweh, “if you will return to me, and if you will put away your abominations out of my sight; then you will not be removed; 
-\v 2 and you will swear, ‘As Yahweh lives,’ in truth, in justice, and in righteousness. The nations will bless themselves in him, and they will glory in him.” 
+\v 1 “If you will return, Israel,” says Yahuah, “if you will return to me, and if you will put away your abominations out of my sight; then you will not be removed; 
+\v 2 and you will swear, ‘As Yahuah lives,’ in truth, in justice, and in righteousness. The nations will bless themselves in him, and they will glory in him.” 
 \p
-\v 3 For Yahweh says to the men of Judah and to Jerusalem, “Break up your fallow ground, and don’t sow among thorns. 
-\v 4 Circumcise yourselves to Yahweh, and take away the foreskins of your heart, you men of Judah and inhabitants of Jerusalem; lest my wrath go out like fire, and burn so that no one can quench it, because of the evil of your doings. 
+\v 3 For Yahuah says to the men of Judah and to Jerusalem, “Break up your fallow ground, and don’t sow among thorns. 
+\v 4 Circumcise yourselves to Yahuah, and take away the foreskins of your heart, you men of Judah and inhabitants of Jerusalem; lest my wrath go out like fire, and burn so that no one can quench it, because of the evil of your doings. 
 \v 5 Declare in Judah, and publish in Jerusalem; and say, ‘Blow the trumpet in the land!’ Cry aloud and say, ‘Assemble yourselves! Let’s go into the fortified cities!’ 
 \v 6 Set up a standard toward Zion. Flee for safety! Don’t wait; for I will bring evil from the north, and a great destruction.” 
 \p
 \v 7 A lion has gone up from his thicket, and a destroyer of nations. He is on his way. He has gone out from his place, to make your land desolate, that your cities be laid waste, without inhabitant. 
-\v 8 For this, clothe yourself with sackcloth, lament and wail; for the fierce anger of Yahweh hasn’t turned back from us. 
-\v 9 “It will happen at that day,” says Yahweh, “that the heart of the king will perish, along with the heart of the princes. The priests will be astonished, and the prophets will wonder.” 
+\v 8 For this, clothe yourself with sackcloth, lament and wail; for the fierce anger of Yahuah hasn’t turned back from us. 
+\v 9 “It will happen at that day,” says Yahuah, “that the heart of the king will perish, along with the heart of the princes. The priests will be astonished, and the prophets will wonder.” 
 \p
-\v 10 Then I said, “Ah, Lord Yahweh! Surely you have greatly deceived this people and Jerusalem, saying, ‘You will have peace;’ whereas the sword reaches to the heart.” 
+\v 10 Then I said, “Ah, Lord Yahuah! Surely you have greatly deceived this people and Jerusalem, saying, ‘You will have peace;’ whereas the sword reaches to the heart.” 
 \p
 \v 11 At that time it will be said to this people and to Jerusalem, “A hot wind blows from the bare heights in the wilderness toward the daughter of my people, not to winnow, nor to cleanse. 
 \v 12 A full wind from these will come for me. Now I will also utter judgments against them.” 
@@ -257,7 +257,7 @@
 \v 14 Jerusalem, wash your heart from wickedness, that you may be saved. How long will your evil thoughts lodge within you? 
 \v 15 For a voice declares from Dan, and publishes evil from the hills of Ephraim: 
 \v 16 “Tell the nations, behold, publish against Jerusalem, ‘Watchers come from a far country, and raise their voice against the cities of Judah. 
-\v 17 As keepers of a field, they are against her all around, because she has been rebellious against me,’ ” says Yahweh. 
+\v 17 As keepers of a field, they are against her all around, because she has been rebellious against me,’ ” says Yahuah. 
 \v 18 “Your way and your doings have brought these things to you. This is your wickedness, for it is bitter, for it reaches to your heart.” 
 \p
 \v 19 My anguish, my anguish! I am pained at my very heart! My heart trembles within me. I can’t hold my peace, because you have heard, O my soul, the sound of the trumpet, the alarm of war. 
@@ -268,8 +268,8 @@
 \v 23 I saw the earth and, behold, it was waste and void, and the heavens, and they had no light. 
 \v 24 I saw the mountains, and behold, they trembled, and all the hills moved back and forth. 
 \v 25 I saw, and behold, there was no man, and all the birds of the sky had fled. 
-\v 26 I saw, and behold, the fruitful field was a wilderness, and all its cities were broken down at the presence of Yahweh, before his fierce anger. 
-\v 27 For Yahweh says, “The whole land will be a desolation; yet I will not make a full end. 
+\v 26 I saw, and behold, the fruitful field was a wilderness, and all its cities were broken down at the presence of Yahuah, before his fierce anger. 
+\v 27 For Yahuah says, “The whole land will be a desolation; yet I will not make a full end. 
 \v 28 For this the earth will mourn, and the heavens above be black, because I have spoken it. I have planned it, and I have not repented, neither will I turn back from it.” 
 \p
 \v 29 Every city flees for the noise of the horsemen and archers. They go into the thickets and climb up on the rocks. Every city is forsaken, and not a man dwells therein. 
@@ -278,45 +278,45 @@
 \c 5
 \p
 \v 1 “Run back and forth through the streets of Jerusalem, and see now, and know, and seek in its wide places, if you can find a man, if there is anyone who does justly, who seeks truth, then I will pardon her. 
-\v 2 Though they say, ‘As Yahweh lives,’ surely they swear falsely.” 
+\v 2 Though they say, ‘As Yahuah lives,’ surely they swear falsely.” 
 \p
-\v 3 O Yahweh, don’t your eyes look on truth? You have stricken them, but they were not grieved. You have consumed them, but they have refused to receive correction. They have made their faces harder than a rock. They have refused to return. 
+\v 3 O Yahuah, don’t your eyes look on truth? You have stricken them, but they were not grieved. You have consumed them, but they have refused to receive correction. They have made their faces harder than a rock. They have refused to return. 
 \p
-\v 4 Then I said, “Surely these are poor. They are foolish; for they don’t know Yahweh’s way, nor the law of their Elohim. 
-\v 5 I will go to the great men and will speak to them, for they know the way of Yahweh, and the law of their Elohim.” But these with one accord have broken the yoke, and burst the bonds. 
+\v 4 Then I said, “Surely these are poor. They are foolish; for they don’t know Yahuah’s way, nor the law of their Elohim. 
+\v 5 I will go to the great men and will speak to them, for they know the way of Yahuah, and the law of their Elohim.” But these with one accord have broken the yoke, and burst the bonds. 
 \v 6 Therefore a lion out of the forest will kill them. A wolf of the evenings will destroy them. A leopard will watch against their cities. Everyone who goes out there will be torn in pieces, because their transgressions are many and their backsliding has increased. 
 \p
 \v 7 “How can I pardon you? Your children have forsaken me, and sworn by what are no elohims. When I had fed them to the full, they committed adultery, and assembled themselves in troops at the prostitutes’ houses. 
 \v 8 They were as fed horses roaming at large. Everyone neighed after his neighbor’s woman. 
-\v 9 Shouldn’t I punish them for these things?” says Yahweh. “Shouldn’t my soul be avenged on such a nation as this? 
+\v 9 Shouldn’t I punish them for these things?” says Yahuah. “Shouldn’t my soul be avenged on such a nation as this? 
 \p
-\v 10 “Go up on her walls, and destroy, but don’t make a full end. Take away her branches, for they are not Yahweh’s. 
-\v 11 For the house of Israel and the house of Judah have dealt very treacherously against me,” says Yahweh. 
+\v 10 “Go up on her walls, and destroy, but don’t make a full end. Take away her branches, for they are not Yahuah’s. 
+\v 11 For the house of Israel and the house of Judah have dealt very treacherously against me,” says Yahuah. 
 \p
-\v 12 They have denied Yahweh, and said, “It is not he. Evil won’t come on us. We won’t see sword or famine. 
+\v 12 They have denied Yahuah, and said, “It is not he. Evil won’t come on us. We won’t see sword or famine. 
 \v 13 The prophets will become wind, and the word is not in them. Thus it will be done to them.” 
 \p
-\v 14 Therefore Yahweh, the Elohim of Armies says, “Because you speak this word, behold, I will make my words in your mouth fire, and this people wood, and it will devour them. 
-\v 15 Behold, I will bring a nation on you from far away, house of Israel,” says Yahweh. “It is a mighty nation. It is an ancient nation, a nation whose language you don’t know and don’t understand what they say. 
+\v 14 Therefore Yahuah, the Elohim of Armies says, “Because you speak this word, behold, I will make my words in your mouth fire, and this people wood, and it will devour them. 
+\v 15 Behold, I will bring a nation on you from far away, house of Israel,” says Yahuah. “It is a mighty nation. It is an ancient nation, a nation whose language you don’t know and don’t understand what they say. 
 \v 16 Their quiver is an open tomb. They are all mighty men. 
 \v 17 They will eat up your harvest and your bread, which your sons and your daughters should eat. They will eat up your flocks and your herds. They will eat up your vines and your fig trees. They will beat down your fortified cities in which you trust with the sword. 
 \p
-\v 18 “But even in those days,” says Yahweh, “I will not make a full end of you. 
-\v 19 It will happen when you say, ‘Why has Yahweh our Elohim done all these things to us?’ Then you shall say to them, ‘Just as you have forsaken me and served foreign elohims in your land, so you will serve strangers in a land that is not yours.’ 
+\v 18 “But even in those days,” says Yahuah, “I will not make a full end of you. 
+\v 19 It will happen when you say, ‘Why has Yahuah our Elohim done all these things to us?’ Then you shall say to them, ‘Just as you have forsaken me and served foreign elohims in your land, so you will serve strangers in a land that is not yours.’ 
 \p
 \v 20 “Declare this in the house of Jacob, and publish it in Judah, saying, 
 \v 21 ‘Hear this now, foolish people without understanding, who have eyes, and don’t see, who have ears, and don’t hear: 
-\v 22 Don’t you fear me?’ says Yahweh; ‘Won’t you tremble at my presence, who have placed the sand for the bound of the sea by a perpetual decree, that it can’t pass it? Though its waves toss themselves, yet they can’t prevail. Though they roar, they still can’t pass over it.’ 
+\v 22 Don’t you fear me?’ says Yahuah; ‘Won’t you tremble at my presence, who have placed the sand for the bound of the sea by a perpetual decree, that it can’t pass it? Though its waves toss themselves, yet they can’t prevail. Though they roar, they still can’t pass over it.’ 
 \p
 \v 23 “But this people has a revolting and a rebellious heart. They have revolted and gone. 
-\v 24 They don’t say in their heart, ‘Let’s now fear Yahweh our Elohim, who gives rain, both the former and the latter, in its season, who preserves to us the appointed weeks of the harvest.’ 
+\v 24 They don’t say in their heart, ‘Let’s now fear Yahuah our Elohim, who gives rain, both the former and the latter, in its season, who preserves to us the appointed weeks of the harvest.’ 
 \p
 \v 25 “Your iniquities have turned away these things, and your sins have withheld good from you. 
 \v 26 For wicked men are found among my people. They watch, as fowlers lie in wait. They set a trap. They catch men. 
 \v 27 As a cage is full of birds, so are their houses full of deceit. Therefore they have become great, and grew rich. 
 \v 28 They have grown fat. They shine; yes, they excel in deeds of wickedness. They don’t plead the cause, the cause of the fatherless, that they may prosper; and they don’t defend the rights of the needy. 
 \p
-\v 29 “Shouldn’t I punish for these things?” says Yahweh. “Shouldn’t my soul be avenged on such a nation as this? 
+\v 29 “Shouldn’t I punish for these things?” says Yahuah. “Shouldn’t my soul be avenged on such a nation as this? 
 \p
 \v 30 “An astonishing and horrible thing has happened in the land. 
 \v 31 The prophets prophesy falsely, and the priests rule by their own authority; and my people love to have it so. What will you do in the end of it? 
@@ -328,14 +328,14 @@
 \p
 \v 4 “Prepare war against her! Arise! Let’s go up at noon. Woe to us! For the day declines, for the shadows of the evening are stretched out. 
 \v 5 Arise! Let’s go up by night, and let’s destroy her palaces.” 
-\v 6 For Yahweh of Armies said, “Cut down trees, and cast up a mound against Jerusalem. This is the city to be visited. She is filled with oppression within herself. 
+\v 6 For Yahuah of Armies said, “Cut down trees, and cast up a mound against Jerusalem. This is the city to be visited. She is filled with oppression within herself. 
 \v 7 As a well produces its waters, so she produces her wickedness. Violence and destruction is heard in her. Sickness and wounds are continually before me. 
 \v 8 Be instructed, Jerusalem, lest my soul be alienated from you, lest I make you a desolation, an uninhabited land.” 
 \p
-\v 9 Yahweh of Armies says, “They will thoroughly glean the remnant of Israel like a vine. Turn again your hand as a grape gatherer into the baskets.” 
+\v 9 Yahuah of Armies says, “They will thoroughly glean the remnant of Israel like a vine. Turn again your hand as a grape gatherer into the baskets.” 
 \p
-\v 10 To whom should I speak and testify, that they may hear? Behold, their ear is uncircumcised, and they can’t listen. Behold, Yahweh’s word has become a reproach to them. They have no delight in it. 
-\v 11 Therefore I am full of Yahweh’s wrath. I am weary with holding it in. 
+\v 10 To whom should I speak and testify, that they may hear? Behold, their ear is uncircumcised, and they can’t listen. Behold, Yahuah’s word has become a reproach to them. They have no delight in it. 
+\v 11 Therefore I am full of Yahuah’s wrath. I am weary with holding it in. 
 \q1 “Pour it out on the children in the street, 
 \q2 and on the assembly of young men together; 
 \q1 for even the man with the woman will be taken, 
@@ -343,7 +343,7 @@
 \q1
 \v 12 Their houses will be turned to others, 
 \q2 their fields and their women together; 
-\q1 for I will stretch out my hand on the inhabitants of the land, says Yahweh.” 
+\q1 for I will stretch out my hand on the inhabitants of the land, says Yahuah.” 
 \q1
 \v 13 “For from their least even to their greatest, everyone is given to desire. 
 \q2 From the prophet even to the priest, everyone deals falsely. 
@@ -354,16 +354,16 @@
 \v 15 Were they ashamed when they had committed abomination? 
 \q2 No, they were not at all ashamed, neither could they blush. 
 \q1 Therefore they will fall among those who fall. 
-\q2 When I visit them, they will be cast down,” says Yahweh. 
+\q2 When I visit them, they will be cast down,” says Yahuah. 
 \p
-\v 16 Yahweh says, “Stand in the ways and see, and ask for the old paths, ‘Where is the good way?’ and walk in it, and you will find rest for your souls. But they said, ‘We will not walk in it.’ 
+\v 16 Yahuah says, “Stand in the ways and see, and ask for the old paths, ‘Where is the good way?’ and walk in it, and you will find rest for your souls. But they said, ‘We will not walk in it.’ 
 \v 17 I set watchmen over you, saying, ‘Listen to the sound of the trumpet!’ But they said, ‘We will not listen!’ 
 \v 18 Therefore hear, you nations, and know, congregation, what is among them. 
 \v 19 Hear, earth! Behold, I will bring evil on this people, even the fruit of their thoughts, because they have not listened to my words; and as for my law, they have rejected it. 
 \v 20 To what purpose does frankincense from Sheba come to me, and the sweet cane from a far country? Your burnt offerings are not acceptable, and your sacrifices are not pleasing to me.” 
 \p
-\v 21 Therefore Yahweh says, “Behold, I will lay stumbling blocks before this people. The fathers and the sons together will stumble against them. The neighbor and his friend will perish.” 
-\v 22 Yahweh says, “Behold, a people comes from the north country. A great nation will be stirred up from the uttermost parts of the earth. 
+\v 21 Therefore Yahuah says, “Behold, I will lay stumbling blocks before this people. The fathers and the sons together will stumble against them. The neighbor and his friend will perish.” 
+\v 22 Yahuah says, “Behold, a people comes from the north country. A great nation will be stirred up from the uttermost parts of the earth. 
 \v 23 They take hold of bow and spear. They are cruel, and have no mercy. Their voice roars like the sea, and they ride on horses, everyone set in array, as a man to the battle, against you, daughter of Zion.” 
 \p
 \v 24 We have heard its report. Our hands become feeble. Anguish has taken hold of us, and pains as of a woman in labor. 
@@ -373,35 +373,35 @@
 \v 27 “I have made you a tester of metals and a fortress among my people, that you may know and try their way. 
 \v 28 They are all grievous rebels, going around to slander. They are bronze and iron. All of them deal corruptly. 
 \v 29 The bellows blow fiercely. The lead is consumed in the fire. In vain they go on refining, for the wicked are not plucked away. 
-\v 30 Men will call them rejected silver, because Yahweh has rejected them.” 
+\v 30 Men will call them rejected silver, because Yahuah has rejected them.” 
 \c 7
 \p
-\v 1 The word that came to Jeremiah from Yahweh, saying, 
-\v 2 “Stand in the gate of Yahweh’s house, and proclaim this word there, and say, ‘Hear Yahweh’s word, all you of Judah, who enter in at these gates to worship Yahweh.’ ” 
+\v 1 The word that came to Jeremiah from Yahuah, saying, 
+\v 2 “Stand in the gate of Yahuah’s house, and proclaim this word there, and say, ‘Hear Yahuah’s word, all you of Judah, who enter in at these gates to worship Yahuah.’ ” 
 \p
-\v 3 Yahweh of Armies, the Elohim of Israel says, “Amend your ways and your doings, and I will cause you to dwell in this place. 
-\v 4 Don’t trust in lying words, saying, ‘Yahweh’s temple, Yahweh’s temple, Yahweh’s temple, are these.’ 
+\v 3 Yahuah of Armies, the Elohim of Israel says, “Amend your ways and your doings, and I will cause you to dwell in this place. 
+\v 4 Don’t trust in lying words, saying, ‘Yahuah’s temple, Yahuah’s temple, Yahuah’s temple, are these.’ 
 \v 5 For if you thoroughly amend your ways and your doings, if you thoroughly execute justice between a man and his neighbor; 
 \v 6 if you don’t oppress the foreigner, the fatherless, and the widow, and don’t shed innocent blood in this place, and don’t walk after other elohims to your own hurt, 
 \v 7 then I will cause you to dwell in this place, in the land that I gave to your fathers, from of old even forever more. 
 \v 8 Behold, you trust in lying words that can’t profit. 
 \v 9 Will you steal, murder, commit adultery, swear falsely, burn incense to Baal, and walk after other elohims that you have not known, 
 \v 10 then come and stand before me in this house, which is called by my name, and say, ‘We are delivered,’ that you may do all these abominations? 
-\v 11 Has this house, which is called by my name, become a den of robbers in your eyes? Behold, I myself have seen it,” says Yahweh. 
+\v 11 Has this house, which is called by my name, become a den of robbers in your eyes? Behold, I myself have seen it,” says Yahuah. 
 \p
 \v 12 “But go now to my place which was in Shiloh, where I caused my name to dwell at the first, and see what I did to it for the wickedness of my people Israel. 
-\v 13 Now, because you have done all these works,” says Yahweh, “and I spoke to you, rising up early and speaking, but you didn’t hear; and I called you, but you didn’t answer; 
+\v 13 Now, because you have done all these works,” says Yahuah, “and I spoke to you, rising up early and speaking, but you didn’t hear; and I called you, but you didn’t answer; 
 \v 14 therefore I will do to the house which is called by my name, in which you trust, and to the place which I gave to you and to your fathers, as I did to Shiloh. 
 \v 15 I will cast you out of my sight, as I have cast out all your brothers, even the whole offspring of Ephraim. 
 \p
 \v 16 “Therefore don’t pray for this people. Don’t lift up a cry or prayer for them or make intercession to me; for I will not hear you. 
 \v 17 Don’t you see what they do in the cities of Judah and in the streets of Jerusalem? 
 \v 18 The children gather wood, and the fathers kindle the fire, and the women knead the dough, to make cakes to the queen of the sky, and to pour out drink offerings to other elohims, that they may provoke me to anger. 
-\v 19 Do they provoke me to anger?” says Yahweh. “Don’t they provoke themselves, to the confusion of their own faces?” 
+\v 19 Do they provoke me to anger?” says Yahuah. “Don’t they provoke themselves, to the confusion of their own faces?” 
 \p
-\v 20 Therefore the Lord Yahweh says: “Behold, my anger and my wrath will be poured out on this place, on man, on animal, on the trees of the field, and on the fruit of the ground; and it will burn and will not be quenched.” 
+\v 20 Therefore the Lord Yahuah says: “Behold, my anger and my wrath will be poured out on this place, on man, on animal, on the trees of the field, and on the fruit of the ground; and it will burn and will not be quenched.” 
 \p
-\v 21 Yahweh of Armies, the Elohim of Israel says: “Add your burnt offerings to your sacrifices and eat meat. 
+\v 21 Yahuah of Armies, the Elohim of Israel says: “Add your burnt offerings to your sacrifices and eat meat. 
 \v 22 For I didn’t speak to your fathers or command them in the day that I brought them out of the land of Egypt concerning burnt offerings or sacrifices; 
 \v 23 but this thing I commanded them, saying, ‘Listen to my voice, and I will be your Elohim, and you shall be my people. Walk in all the way that I command you, that it may be well with you.’ 
 \v 24 But they didn’t listen or turn their ear, but walked in their own counsels and in the stubbornness of their evil heart, and went backward, and not forward. 
@@ -409,20 +409,20 @@
 \v 26 Yet they didn’t listen to me or incline their ear, but made their neck stiff. They did worse than their fathers. 
 \p
 \v 27 “You shall speak all these words to them, but they will not listen to you. You shall also call to them, but they will not answer you. 
-\v 28 You shall tell them, ‘This is the nation that has not listened to Yahweh their Elohim’s voice, nor received instruction. Truth has perished, and is cut off from their mouth.’ 
-\v 29 Cut off your hair, and throw it away, and take up a lamentation on the bare heights; for Yahweh has rejected and forsaken the generation of his wrath. 
+\v 28 You shall tell them, ‘This is the nation that has not listened to Yahuah their Elohim’s voice, nor received instruction. Truth has perished, and is cut off from their mouth.’ 
+\v 29 Cut off your hair, and throw it away, and take up a lamentation on the bare heights; for Yahuah has rejected and forsaken the generation of his wrath. 
 \p
-\v 30 “For the children of Judah have done that which is evil in my sight,” says Yahweh. “They have set their abominations in the house which is called by my name, to defile it. 
+\v 30 “For the children of Judah have done that which is evil in my sight,” says Yahuah. “They have set their abominations in the house which is called by my name, to defile it. 
 \v 31 They have built the high places of Topheth, which is in the valley of the son of Hinnom, to burn their sons and their daughters in the fire, which I didn’t command, nor did it come into my mind. 
-\v 32 Therefore behold, the days come”, says Yahweh, “that it will no more be called ‘Topheth’ or ‘The valley of the son of Hinnom’, but ‘The valley of Slaughter’; for they will bury in Topheth until there is no place to bury. 
+\v 32 Therefore behold, the days come”, says Yahuah, “that it will no more be called ‘Topheth’ or ‘The valley of the son of Hinnom’, but ‘The valley of Slaughter’; for they will bury in Topheth until there is no place to bury. 
 \v 33 The dead bodies of this people will be food for the birds of the sky, and for the animals of the earth. No one will frighten them away. 
 \v 34 Then I will cause to cease from the cities of Judah and from the streets of Jerusalem the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride; for the land will become a waste.” 
 \c 8
 \p
-\v 1 “At that time,” says Yahweh, “they will bring the bones of the kings of Judah, the bones of his princes, the bones of the priests, the bones of the prophets, and the bones of the inhabitants of Jerusalem, out of their graves. 
+\v 1 “At that time,” says Yahuah, “they will bring the bones of the kings of Judah, the bones of his princes, the bones of the priests, the bones of the prophets, and the bones of the inhabitants of Jerusalem, out of their graves. 
 \v 2 They will spread them before the sun, the moon, and all the army of the sky, which they have loved, which they have served, after which they have walked, which they have sought, and which they have worshiped. They will not be gathered or be buried. They will be like dung on the surface of the earth. 
-\v 3 Death will be chosen rather than life by all the residue that remain of this evil family, that remain in all the places where I have driven them,” says Yahweh of Armies. 
-\v 4 “Moreover you shall tell them, ‘Yahweh says: 
+\v 3 Death will be chosen rather than life by all the residue that remain of this evil family, that remain in all the places where I have driven them,” says Yahuah of Armies. 
+\v 4 “Moreover you shall tell them, ‘Yahuah says: 
 \q1 “ ‘Do men fall, and not rise up again? 
 \q2 Does one turn away, and not return? 
 \q1
@@ -437,15 +437,15 @@
 \q1
 \v 7 Yes, the stork in the sky knows her appointed times. 
 \q2 The turtledove, the swallow, and the crane observe the time of their coming; 
-\q2 but my people don’t know Yahweh’s law. 
+\q2 but my people don’t know Yahuah’s law. 
 \b
 \q1
-\v 8 “ ‘How do you say, “We are wise, and Yahweh’s law is with us”? 
+\v 8 “ ‘How do you say, “We are wise, and Yahuah’s law is with us”? 
 \q2 But, behold, the false pen of the scribes has made that a lie. 
 \q1
 \v 9 The wise men are disappointed. 
 \q2 They are dismayed and trapped. 
-\q1 Behold, they have rejected Yahweh’s word. 
+\q1 Behold, they have rejected Yahuah’s word. 
 \q2 What kind of wisdom is in them? 
 \q1
 \v 10 Therefore I will give their women to others 
@@ -460,10 +460,10 @@
 \q2 No, they were not at all ashamed. 
 \q2 They couldn’t blush. 
 \q1 Therefore they will fall among those who fall. 
-\q2 In the time of their visitation they will be cast down, says Yahweh. 
+\q2 In the time of their visitation they will be cast down, says Yahuah. 
 \b
 \q1
-\v 13 “ ‘I will utterly consume them, says Yahweh. 
+\v 13 “ ‘I will utterly consume them, says Yahuah. 
 \q2 No grapes will be on the vine, 
 \q2 no figs on the fig tree, 
 \q2 and the leaf will fade. 
@@ -475,9 +475,9 @@
 \q2 Assemble yourselves! 
 \q2 Let’s enter into the fortified cities, 
 \q2 and let’s be silent there; 
-\q1 for Yahweh our Elohim has put us to silence, 
+\q1 for Yahuah our Elohim has put us to silence, 
 \q2 and given us poisoned water to drink, 
-\q2 because we have sinned against Yahweh. 
+\q2 because we have sinned against Yahuah. 
 \q1
 \v 15 We looked for peace, but no good came; 
 \q2 and for a time of healing, and behold, dismay! 
@@ -490,13 +490,13 @@
 \v 17 “For, behold, I will send serpents, 
 \q2 adders among you, 
 \q2 which will not be charmed; 
-\q2 and they will bite you,” says Yahweh. 
+\q2 and they will bite you,” says Yahuah. 
 \q1
 \v 18 Oh that I could comfort myself against sorrow! 
 \q2 My heart is faint within me. 
 \q1
 \v 19 Behold, the voice of the cry of the daughter of my people from a land that is very far off: 
-\q2 “Isn’t Yahweh in Zion? 
+\q2 “Isn’t Yahuah in Zion? 
 \q2 Isn’t her King in her?” 
 \b
 \q1 “Why have they provoked me to anger with their engraved images, 
@@ -534,7 +534,7 @@
 \q1 They have grown strong in the land, 
 \q2 but not for truth; 
 \q1 for they proceed from evil to evil, 
-\q2 and they don’t know me,” says Yahweh. 
+\q2 and they don’t know me,” says Yahuah. 
 \q1
 \v 4 “Everyone beware of his neighbor, 
 \q2 and don’t trust in any brother; 
@@ -547,9 +547,9 @@
 \q2 They weary themselves committing iniquity. 
 \q1
 \v 6 Your habitation is in the middle of deceit. 
-\q2 Through deceit, they refuse to know me,” says Yahweh. 
+\q2 Through deceit, they refuse to know me,” says Yahuah. 
 \p
-\v 7 Therefore Yahweh of Armies says, 
+\v 7 Therefore Yahuah of Armies says, 
 \q1 “Behold, I will melt them and test them; 
 \q2 for how should I deal with the daughter of my people? 
 \q1
@@ -558,7 +558,7 @@
 \q1 One speaks peaceably to his neighbor with his mouth, 
 \q2 but in his heart, he waits to ambush him. 
 \q1
-\v 9 Shouldn’t I punish them for these things?” says Yahweh. 
+\v 9 Shouldn’t I punish them for these things?” says Yahuah. 
 \q2 “Shouldn’t my soul be avenged on a nation such as this? 
 \q1
 \v 10 I will weep and wail for the mountains, 
@@ -574,14 +574,14 @@
 \q1 I will make the cities of Judah a desolation, 
 \q2 without inhabitant.” 
 \p
-\v 12 Who is wise enough to understand this? Who is he to whom the mouth of Yahweh has spoken, that he may declare it? Why has the land perished and burned up like a wilderness, so that no one passes through? 
+\v 12 Who is wise enough to understand this? Who is he to whom the mouth of Yahuah has spoken, that he may declare it? Why has the land perished and burned up like a wilderness, so that no one passes through? 
 \p
-\v 13 Yahweh says, “Because they have forsaken my law which I set before them, and have not obeyed my voice or walked in my ways, 
+\v 13 Yahuah says, “Because they have forsaken my law which I set before them, and have not obeyed my voice or walked in my ways, 
 \v 14 but have walked after the stubbornness of their own heart and after the Baals, which their fathers taught them.” 
-\v 15 Therefore Yahweh of Armies, the Elohim of Israel, says, “Behold, I will feed them, even this people, with wormwood and give them poisoned water to drink. 
+\v 15 Therefore Yahuah of Armies, the Elohim of Israel, says, “Behold, I will feed them, even this people, with wormwood and give them poisoned water to drink. 
 \v 16 I will scatter them also among the nations, whom neither they nor their fathers have known. I will send the sword after them, until I have consumed them.” 
 \p
-\v 17 Yahweh of Armies says, 
+\v 17 Yahuah of Armies says, 
 \q1 “Consider, and call for the mourning women, that they may come. 
 \q2 Send for the skillful women, that they may come. 
 \q1
@@ -597,7 +597,7 @@
 \q2 because they have cast down our dwellings.’ ” 
 \b
 \q1
-\v 20 Yet hear Yahweh’s word, you women. 
+\v 20 Yet hear Yahuah’s word, you women. 
 \q2 Let your ear receive the word of his mouth. 
 \q1 Teach your daughters wailing. 
 \q2 Everyone teach her neighbor a lamentation. 
@@ -607,27 +607,27 @@
 \q1 to cut off the children from outside, 
 \q2 and the young men from the streets. 
 \p
-\v 22 Speak, “Yahweh says, 
+\v 22 Speak, “Yahuah says, 
 \q1 “ ‘The dead bodies of men will fall as dung on the open field, 
 \q2 and as the handful after the harvester. 
 \q2 No one will gather them.’ ” 
 \p
-\v 23 Yahweh says, 
+\v 23 Yahuah says, 
 \q1 “Don’t let the wise man glory in his wisdom. 
 \q2 Don’t let the mighty man glory in his might. 
 \q2 Don’t let the rich man glory in his riches. 
 \q1
 \v 24 But let him who glories glory in this, 
 \q2 that he has understanding, and knows me, 
-\q1 that I am Yahweh who exercises loving kindness, justice, and righteousness in the earth, 
-\q2 for I delight in these things,” says Yahweh. 
+\q1 that I am Yahuah who exercises loving kindness, justice, and righteousness in the earth, 
+\q2 for I delight in these things,” says Yahuah. 
 \p
-\v 25 “Behold, the days come,” says Yahweh, “that I will punish all those who are circumcised only in their flesh: 
+\v 25 “Behold, the days come,” says Yahuah, “that I will punish all those who are circumcised only in their flesh: 
 \v 26 Egypt, Judah, Edom, the children of Ammon, Moab, and all who have the corners of their hair cut off, who dwell in the wilderness, for all the nations are uncircumcised, and all the house of Israel are uncircumcised in heart.” 
 \c 10
 \p
-\v 1 Hear the word which Yahweh speaks to you, house of Israel! 
-\v 2 Yahweh says, 
+\v 1 Hear the word which Yahuah speaks to you, house of Israel! 
+\v 2 Yahuah says, 
 \q1 “Don’t learn the way of the nations, 
 \q2 and don’t be dismayed at the signs of the sky; 
 \q2 for the nations are dismayed at them. 
@@ -648,7 +648,7 @@
 \q2 for they can’t do evil, 
 \q2 neither is it in them to do good.” 
 \q1
-\v 6 There is no one like you, Yahweh. 
+\v 6 There is no one like you, Yahuah. 
 \q2 You are great, 
 \q2 and your name is great in might. 
 \q1
@@ -669,7 +669,7 @@
 \q1 Their clothing is blue and purple. 
 \q2 They are all the work of skillful men. 
 \q1
-\v 10 But Yahweh is the true Elohim. 
+\v 10 But Yahuah is the true Elohim. 
 \q2 He is the living Elohim, 
 \q2 and an everlasting King. 
 \q1 At his wrath, the earth trembles. 
@@ -698,12 +698,12 @@
 \v 16 The portion of Jacob is not like these; 
 \q2 for he is the maker of all things; 
 \q1 and Israel is the tribe of his inheritance. 
-\q2 Yahweh of Armies is his name. 
+\q2 Yahuah of Armies is his name. 
 \q1
 \v 17 Gather up your wares out of the land, 
 \q2 you who live under siege. 
 \q1
-\v 18 For Yahweh says, 
+\v 18 For Yahuah says, 
 \q2 “Behold, I will sling out the inhabitants of the land at this time, 
 \q2 and will distress them, that they may feel it.” 
 \q1
@@ -719,7 +719,7 @@
 \q2 to set up my curtains. 
 \q1
 \v 21 For the shepherds have become brutish, 
-\q2 and have not inquired of Yahweh. 
+\q2 and have not inquired of Yahuah. 
 \q1 Therefore they have not prospered, 
 \q2 and all their flocks have scattered. 
 \q1
@@ -728,10 +728,10 @@
 \q1 to make the cities of Judah a desolation, 
 \q2 a dwelling place of jackals. 
 \q1
-\v 23 Yahweh, I know that the way of man is not in himself. 
+\v 23 Yahuah, I know that the way of man is not in himself. 
 \q2 It is not in man who walks to direct his steps. 
 \q1
-\v 24 Yahweh, correct me, but gently; 
+\v 24 Yahuah, correct me, but gently; 
 \q2 not in your anger, 
 \q2 lest you reduce me to nothing. 
 \q1
@@ -742,20 +742,20 @@
 \q2 and have laid waste his habitation. 
 \c 11
 \p
-\v 1 The word that came to Jeremiah from Yahweh, saying, 
+\v 1 The word that came to Jeremiah from Yahuah, saying, 
 \v 2 “Hear the words of this covenant, and speak to the men of Judah, and to the inhabitants of Jerusalem; 
-\v 3 and say to them, Yahweh, the Elohim of Israel says: ‘Cursed is the man who doesn’t hear the words of this covenant, 
+\v 3 and say to them, Yahuah, the Elohim of Israel says: ‘Cursed is the man who doesn’t hear the words of this covenant, 
 \v 4 which I commanded your fathers in the day that I brought them out of the land of Egypt, out of the iron furnace,’ saying, ‘Obey my voice and do them, according to all which I command you; so you shall be my people, and I will be your Elohim; 
 \v 5 that I may establish the oath which I swore to your fathers, to give them a land flowing with milk and honey,’ as it is today.” 
-\p Then I answered, and said, “Amen, Yahweh.” 
+\p Then I answered, and said, “Amen, Yahuah.” 
 \p
-\v 6 Yahweh said to me, “Proclaim all these words in the cities of Judah, and in the streets of Jerusalem, saying, ‘Hear the words of this covenant, and do them. 
+\v 6 Yahuah said to me, “Proclaim all these words in the cities of Judah, and in the streets of Jerusalem, saying, ‘Hear the words of this covenant, and do them. 
 \v 7 For I earnestly protested to your fathers in the day that I brought them up out of the land of Egypt, even to this day, rising early and protesting, saying, “Obey my voice.” 
 \v 8 Yet they didn’t obey, nor turn their ear, but everyone walked in the stubbornness of their evil heart. Therefore I brought on them all the words of this covenant, which I commanded them to do, but they didn’t do them.’ ” 
 \p
-\v 9 Yahweh said to me, “A conspiracy is found among the men of Judah, and among the inhabitants of Jerusalem. 
+\v 9 Yahuah said to me, “A conspiracy is found among the men of Judah, and among the inhabitants of Jerusalem. 
 \v 10 They have turned back to the iniquities of their forefathers, who refused to hear my words. They have gone after other elohims to serve them. The house of Israel and the house of Judah have broken my covenant which I made with their fathers. 
-\v 11 Therefore Yahweh says, ‘Behold, I will bring evil on them which they will not be able to escape; and they will cry to me, but I will not listen to them. 
+\v 11 Therefore Yahuah says, ‘Behold, I will bring evil on them which they will not be able to escape; and they will cry to me, but I will not listen to them. 
 \v 12 Then the cities of Judah and the inhabitants of Jerusalem will go and cry to the elohims to which they offer incense, but they will not save them at all in the time of their trouble. 
 \v 13 For according to the number of your cities are your elohims, Judah; and according to the number of the streets of Jerusalem you have set up altars to the shameful thing, even altars to burn incense to Baal.’ 
 \p
@@ -768,29 +768,29 @@
 \q2 then you rejoice.” 
 \b
 \q1
-\v 16 Yahweh called your name, “A green olive tree, 
+\v 16 Yahuah called your name, “A green olive tree, 
 \q2 beautiful with goodly fruit.” 
 \q1 With the noise of a great roar he has kindled fire on it, 
 \q2 and its branches are broken. 
 \m
-\v 17 For Yahweh of Armies, who planted you, has pronounced evil against you, because of the evil of the house of Israel and of the house of Judah, which they have done to themselves in provoking me to anger by offering incense to Baal. 
+\v 17 For Yahuah of Armies, who planted you, has pronounced evil against you, because of the evil of the house of Israel and of the house of Judah, which they have done to themselves in provoking me to anger by offering incense to Baal. 
 \p
-\v 18 Yahweh gave me knowledge of it, and I knew it. Then you showed me their doings. 
+\v 18 Yahuah gave me knowledge of it, and I knew it. Then you showed me their doings. 
 \v 19 But I was like a gentle lamb that is led to the slaughter. I didn’t know that they had devised plans against me, saying, 
 \q1 “Let’s destroy the tree with its fruit, 
 \q2 and let’s cut him off from the land of the living, 
 \q2 that his name may be no more remembered.” 
 \q1
-\v 20 But, Yahweh of Armies, who judges righteously, 
+\v 20 But, Yahuah of Armies, who judges righteously, 
 \q2 who tests the heart and the mind, 
 \q1 I will see your vengeance on them; 
 \q2 for to you I have revealed my cause. 
 \p
-\v 21 “Therefore Yahweh says concerning the men of Anathoth, who seek your life, saying, ‘You shall not prophesy in Yahweh’s name, that you not die by our hand’—\v 22 therefore Yahweh of Armies says, ‘Behold, I will punish them. The young men will die by the sword. Their sons and their daughters will die by famine. 
+\v 21 “Therefore Yahuah says concerning the men of Anathoth, who seek your life, saying, ‘You shall not prophesy in Yahuah’s name, that you not die by our hand’—\v 22 therefore Yahuah of Armies says, ‘Behold, I will punish them. The young men will die by the sword. Their sons and their daughters will die by famine. 
 \v 23 There will be no remnant to them, for I will bring evil on the men of Anathoth, even the year of their visitation.’ ” 
 \c 12
 \q1
-\v 1 You are righteous, Yahweh, 
+\v 1 You are righteous, Yahuah, 
 \q2 when I contend with you; 
 \q1 yet I would like to plead a case with you. 
 \q2 Why does the way of the wicked prosper? 
@@ -801,7 +801,7 @@
 \q1 You are near in their mouth, 
 \q2 and far from their heart. 
 \q1
-\v 3 But you, Yahweh, know me. 
+\v 3 But you, Yahuah, know me. 
 \q2 You see me, and test my heart toward you. 
 \q1 Pull them out like sheep for the slaughter, 
 \q2 and prepare them for the day of slaughter. 
@@ -849,7 +849,7 @@
 \q2 because no one cares. 
 \q1
 \v 12 Destroyers have come on all the bare heights in the wilderness; 
-\q2 for the sword of Yahweh devours from the one end of the land even to the other end of the land. 
+\q2 for the sword of Yahuah devours from the one end of the land even to the other end of the land. 
 \q2 No flesh has peace. 
 \q1
 \v 13 They have sown wheat, 
@@ -857,42 +857,42 @@
 \q1 They have exhausted themselves, 
 \q2 and profit nothing. 
 \q1 You will be ashamed of your fruits, 
-\q2 because of Yahweh’s fierce anger.” 
+\q2 because of Yahuah’s fierce anger.” 
 \b
 \p
-\v 14 Yahweh says, “Concerning all my evil neighbors, who touch the inheritance which I have caused my people Israel to inherit: Behold, I will pluck them up from off their land, and will pluck up the house of Judah from among them. 
+\v 14 Yahuah says, “Concerning all my evil neighbors, who touch the inheritance which I have caused my people Israel to inherit: Behold, I will pluck them up from off their land, and will pluck up the house of Judah from among them. 
 \v 15 It will happen that after I have plucked them up, I will return and have compassion on them. I will bring them again, every man to his heritage, and every man to his land. 
-\v 16 It will happen, if they will diligently learn the ways of my people, to swear by my name, ‘As Yahweh lives;’ even as they taught my people to swear by Baal, then they will be built up in the middle of my people. 
-\v 17 But if they will not hear, then I will pluck up that nation, plucking up and destroying it,” says Yahweh. 
+\v 16 It will happen, if they will diligently learn the ways of my people, to swear by my name, ‘As Yahuah lives;’ even as they taught my people to swear by Baal, then they will be built up in the middle of my people. 
+\v 17 But if they will not hear, then I will pluck up that nation, plucking up and destroying it,” says Yahuah. 
 \c 13
 \p
-\v 1 Yahweh said to me, “Go, and buy yourself a linen belt, and put it on your waist, and don’t put it in water.” 
+\v 1 Yahuah said to me, “Go, and buy yourself a linen belt, and put it on your waist, and don’t put it in water.” 
 \p
-\v 2 So I bought a belt according to Yahweh’s word, and put it on my waist. 
+\v 2 So I bought a belt according to Yahuah’s word, and put it on my waist. 
 \p
-\v 3 Yahweh’s word came to me the second time, saying, 
+\v 3 Yahuah’s word came to me the second time, saying, 
 \v 4 “Take the belt that you have bought, which is on your waist, and arise, go to the Euphrates, and hide it there in a cleft of the rock.” 
 \p
-\v 5 So I went and hid it by the Euphrates, as Yahweh commanded me. 
+\v 5 So I went and hid it by the Euphrates, as Yahuah commanded me. 
 \p
-\v 6 After many days, Yahweh said to me, “Arise, go to the Euphrates, and take the belt from there, which I commanded you to hide there.” 
+\v 6 After many days, Yahuah said to me, “Arise, go to the Euphrates, and take the belt from there, which I commanded you to hide there.” 
 \p
 \v 7 Then I went to the Euphrates, and dug, and took the belt from the place where I had hidden it; and behold, the belt was ruined. It was profitable for nothing. 
 \p
-\v 8 Then Yahweh’s word came to me, saying, 
-\v 9 “Yahweh says, ‘In this way I will ruin the pride of Judah, and the great pride of Jerusalem. 
+\v 8 Then Yahuah’s word came to me, saying, 
+\v 9 “Yahuah says, ‘In this way I will ruin the pride of Judah, and the great pride of Jerusalem. 
 \v 10 This evil people, who refuse to hear my words, who walk in the stubbornness of their heart, and have gone after other elohims to serve them and to worship them, will even be as this belt, which is profitable for nothing. 
-\v 11 For as the belt clings to the waist of a man, so I have caused the whole house of Israel and the whole house of Judah to cling to me,’ says Yahweh; ‘that they may be to me for a people, for a name, for praise, and for glory; but they would not hear.’ 
+\v 11 For as the belt clings to the waist of a man, so I have caused the whole house of Israel and the whole house of Judah to cling to me,’ says Yahuah; ‘that they may be to me for a people, for a name, for praise, and for glory; but they would not hear.’ 
 \p
-\v 12 “Therefore you shall speak to them this word: ‘Yahweh, the Elohim of Israel says, “Every container should be filled with wine.” ’ They will tell you, ‘Do we not certainly know that every container should be filled with wine?’ 
-\v 13 Then tell them, ‘Yahweh says, “Behold, I will fill all the inhabitants of this land, even the kings who sit on David’s throne, the priests, the prophets, and all the inhabitants of Jerusalem, with drunkenness. 
-\v 14 I will dash them one against another, even the fathers and the sons together,” says Yahweh: “I will not pity, spare, or have compassion, that I should not destroy them.” ’ ” 
+\v 12 “Therefore you shall speak to them this word: ‘Yahuah, the Elohim of Israel says, “Every container should be filled with wine.” ’ They will tell you, ‘Do we not certainly know that every container should be filled with wine?’ 
+\v 13 Then tell them, ‘Yahuah says, “Behold, I will fill all the inhabitants of this land, even the kings who sit on David’s throne, the priests, the prophets, and all the inhabitants of Jerusalem, with drunkenness. 
+\v 14 I will dash them one against another, even the fathers and the sons together,” says Yahuah: “I will not pity, spare, or have compassion, that I should not destroy them.” ’ ” 
 \q1
 \v 15 Hear, and give ear. 
 \q2 Don’t be proud, 
-\q2 for Yahweh has spoken. 
+\q2 for Yahuah has spoken. 
 \q1
-\v 16 Give glory to Yahweh your Elohim, 
+\v 16 Give glory to Yahuah your Elohim, 
 \q2 before he causes darkness, 
 \q2 and before your feet stumble on the dark mountains, 
 \q1 and while you look for light, 
@@ -903,7 +903,7 @@
 \q2 my soul will weep in secret for your pride. 
 \q1 My eye will weep bitterly, 
 \q2 and run down with tears, 
-\q2 because Yahweh’s flock has been taken captive. 
+\q2 because Yahuah’s flock has been taken captive. 
 \q1
 \v 18 Say to the king and to the queen mother, 
 \q2 “Humble yourselves. 
@@ -939,7 +939,7 @@
 \q2 by the wind of the wilderness. 
 \q1
 \v 25 This is your lot, 
-\q2 the portion measured to you from me,” says Yahweh, 
+\q2 the portion measured to you from me,” says Yahuah, 
 \q1 “because you have forgotten me, 
 \q2 and trusted in falsehood.” 
 \q1
@@ -954,7 +954,7 @@
 \q2 How long will it yet be?” 
 \c 14
 \p
-\v 1 This is Yahweh’s word that came to Jeremiah concerning the drought: 
+\v 1 This is Yahuah’s word that came to Jeremiah concerning the drought: 
 \q1
 \v 2 “Judah mourns, 
 \q2 and its gates languish. 
@@ -982,7 +982,7 @@
 \q2 because there is no vegetation. 
 \q1
 \v 7 Though our iniquities testify against us, 
-\q2 work for your name’s sake, Yahweh; 
+\q2 work for your name’s sake, Yahuah; 
 \q1 for our rebellions are many. 
 \q2 We have sinned against you. 
 \q1
@@ -993,24 +993,24 @@
 \q1
 \v 9 Why should you be like a scared man, 
 \q2 as a mighty man who can’t save? 
-\q1 Yet you, Yahweh, are in the middle of us, 
+\q1 Yet you, Yahuah, are in the middle of us, 
 \q2 and we are called by your name. 
 \q2 Don’t leave us. 
 \p
-\v 10 Yahweh says to this people: 
+\v 10 Yahuah says to this people: 
 \q1 “Even so they have loved to wander. 
 \q2 They have not restrained their feet. 
-\q1 Therefore Yahweh does not accept them. 
+\q1 Therefore Yahuah does not accept them. 
 \q2 Now he will remember their iniquity, 
 \q2 and punish them for their sins.” 
 \p
-\v 11 Yahweh said to me, “Don’t pray for this people for their good. 
+\v 11 Yahuah said to me, “Don’t pray for this people for their good. 
 \v 12 When they fast, I will not hear their cry; and when they offer burnt offering and meal offering, I will not accept them; but I will consume them by the sword, by famine, and by pestilence.” 
 \p
-\v 13 Then I said, “Ah, Lord Yahweh! Behold, the prophets tell them, ‘You will not see the sword, neither will you have famine; but I will give you assured peace in this place.’ ” 
+\v 13 Then I said, “Ah, Lord Yahuah! Behold, the prophets tell them, ‘You will not see the sword, neither will you have famine; but I will give you assured peace in this place.’ ” 
 \p
-\v 14 Then Yahweh said to me, “The prophets prophesy lies in my name. I didn’t send them. I didn’t command them. I didn’t speak to them. They prophesy to you a lying vision, divination, and a thing of nothing, and the deceit of their own heart. 
-\v 15 Therefore Yahweh says concerning the prophets who prophesy in my name, but I didn’t send them, yet they say, ‘Sword and famine will not be in this land.’ Those prophets will be consumed by sword and famine. 
+\v 14 Then Yahuah said to me, “The prophets prophesy lies in my name. I didn’t send them. I didn’t command them. I didn’t speak to them. They prophesy to you a lying vision, divination, and a thing of nothing, and the deceit of their own heart. 
+\v 15 Therefore Yahuah says concerning the prophets who prophesy in my name, but I didn’t send them, yet they say, ‘Sword and famine will not be in this land.’ Those prophets will be consumed by sword and famine. 
 \v 16 The people to whom they prophesy will be cast out in the streets of Jerusalem because of the famine and the sword. They will have no one to bury them—them, their women, their sons, or their daughters, for I will pour their wickedness on them. 
 \p
 \v 17 “You shall say this word to them: 
@@ -1033,7 +1033,7 @@
 \q2 We looked for peace, but no good came; 
 \q2 and for a time of healing, and behold, dismay! 
 \q1
-\v 20 We acknowledge, Yahweh, our wickedness, 
+\v 20 We acknowledge, Yahuah, our wickedness, 
 \q2 and the iniquity of our fathers; 
 \q2 for we have sinned against you. 
 \q1
@@ -1043,26 +1043,26 @@
 \q1
 \v 22 Are there any among the vanities of the nations that can cause rain? 
 \q2 Or can the sky give showers? 
-\q2 Aren’t you he, Yahweh our Elohim? 
+\q2 Aren’t you he, Yahuah our Elohim? 
 \q1 Therefore we will wait for you; 
 \q2 for you have made all these things. 
 \c 15
 \p
-\v 1 Then Yahweh said to me, “Though Moses and Samuel stood before me, yet my mind would not turn toward this people. Cast them out of my sight, and let them go out! 
-\v 2 It will happen when they ask you, ‘Where shall we go out?’ then you shall tell them, ‘Yahweh says: 
+\v 1 Then Yahuah said to me, “Though Moses and Samuel stood before me, yet my mind would not turn toward this people. Cast them out of my sight, and let them go out! 
+\v 2 It will happen when they ask you, ‘Where shall we go out?’ then you shall tell them, ‘Yahuah says: 
 \q1 “Such as are for death, to death; 
 \q1 such as are for the sword, to the sword; 
 \q1 such as are for the famine, to the famine; 
 \q1 and such as are for captivity, to captivity.” ’ 
 \p
-\v 3 “I will appoint over them four kinds,” says Yahweh: “the sword to kill, the dogs to tear, the birds of the sky, and the animals of the earth, to devour and to destroy. 
+\v 3 “I will appoint over them four kinds,” says Yahuah: “the sword to kill, the dogs to tear, the birds of the sky, and the animals of the earth, to devour and to destroy. 
 \v 4 I will cause them to be tossed back and forth among all the kingdoms of the earth, because of Manasseh, the son of Hezekiah, king of Judah, for that which he did in Jerusalem. 
 \q1
 \v 5 For who will have pity on you, Jerusalem? 
 \q2 Who will mourn you? 
 \q2 Who will come to ask of your welfare? 
 \q1
-\v 6 You have rejected me,” says Yahweh. 
+\v 6 You have rejected me,” says Yahuah. 
 \q2 “You have gone backward. 
 \q1 Therefore I have stretched out my hand against you 
 \q2 and destroyed you. 
@@ -1081,7 +1081,7 @@
 \q2 She has given up the spirit. 
 \q1 Her sun has gone down while it was yet day. 
 \q2 She has been disappointed and confounded. 
-\q2 I will deliver their residue to the sword before their enemies,” says Yahweh. 
+\q2 I will deliver their residue to the sword before their enemies,” says Yahuah. 
 \b
 \q1
 \v 10 Woe is me, my mother, that you have borne me, a man of strife, 
@@ -1089,7 +1089,7 @@
 \q1 I have not lent, neither have men lent to me; 
 \q2 yet every one of them curses me. 
 \p
-\v 11 Yahweh said, 
+\v 11 Yahuah said, 
 \q1 “Most certainly I will strengthen you for good. 
 \q2 Most certainly I will cause the enemy to make supplication to you in the time of evil 
 \q2 and in the time of affliction. 
@@ -1106,7 +1106,7 @@
 \q2 which will burn on you.” 
 \b
 \q1
-\v 15 Yahweh, you know. 
+\v 15 Yahuah, you know. 
 \q2 Remember me, visit me, 
 \q2 and avenge me of my persecutors. 
 \q1 You are patient, so don’t take me away. 
@@ -1115,7 +1115,7 @@
 \v 16 Your words were found, 
 \q2 and I ate them. 
 \q1 Your words were to me a joy and the rejoicing of my heart, 
-\q2 for I am called by your name, Yahweh, Elohim of Armies. 
+\q2 for I am called by your name, Yahuah, Elohim of Armies. 
 \q1
 \v 17 I didn’t sit in the assembly of those who make merry and rejoice. 
 \q2 I sat alone because of your hand, 
@@ -1127,7 +1127,7 @@
 \q1 Will you indeed be to me as a deceitful brook, 
 \q2 like waters that fail? 
 \p
-\v 19 Therefore Yahweh says, 
+\v 19 Therefore Yahuah says, 
 \q1 “If you return, then I will bring you again, 
 \q2 that you may stand before me; 
 \q1 and if you take out the precious from the vile, 
@@ -1139,37 +1139,37 @@
 \q2 They will fight against you, 
 \q2 but they will not prevail against you; 
 \q1 for I am with you to save you 
-\q2 and to deliver you,” says Yahweh. 
+\q2 and to deliver you,” says Yahuah. 
 \q1
 \v 21 “I will deliver you out of the hand of the wicked, 
 \q2 and I will redeem you out of the hand of the terrible.” 
 \c 16
 \p
-\v 1 Then Yahweh’s word came to me, saying, 
+\v 1 Then Yahuah’s word came to me, saying, 
 \v 2 “You shall not take a woman, neither shall you have sons or daughters, in this place.” 
-\v 3 For Yahweh says concerning the sons and concerning the daughters who are born in this place, and concerning their mothers who bore them, and concerning their fathers who became their father in this land: 
+\v 3 For Yahuah says concerning the sons and concerning the daughters who are born in this place, and concerning their mothers who bore them, and concerning their fathers who became their father in this land: 
 \v 4 “They will die grievous deaths. They will not be lamented, neither will they be buried. They will be as dung on the surface of the ground. They will be consumed by the sword and by famine. Their dead bodies will be food for the birds of the sky and for the animals of the earth.” 
 \p
-\v 5 For Yahweh says, “Don’t enter into the house of mourning. Don’t go to lament. Don’t bemoan them, for I have taken away my peace from this people,” says Yahweh, “even loving kindness and tender mercies. 
+\v 5 For Yahuah says, “Don’t enter into the house of mourning. Don’t go to lament. Don’t bemoan them, for I have taken away my peace from this people,” says Yahuah, “even loving kindness and tender mercies. 
 \v 6 Both great and small will die in this land. They will not be buried. Men won’t lament for them, cut themselves, or make themselves bald for them. 
 \v 7 Men won’t break bread for them in mourning, to comfort them for the dead. Men won’t give them the cup of consolation to drink for their father or for their mother. 
 \p
 \v 8 “You shall not go into the house of feasting to sit with them, to eat and to drink.” 
-\v 9 For Yahweh of Armies, the Elohim of Israel says: “Behold, I will cause to cease out of this place, before your eyes and in your days, the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride. 
-\v 10 It will happen, when you tell this people all these words, and they ask you, ‘Why has Yahweh pronounced all this great evil against us?’ or ‘What is our iniquity?’ or ‘What is our sin that we have committed against Yahweh our Elohim?’ 
-\v 11 then you shall tell them, ‘Because your fathers have forsaken me,’ says Yahweh, ‘and have walked after other elohims, have served them, have worshiped them, have forsaken me, and have not kept my law. 
+\v 9 For Yahuah of Armies, the Elohim of Israel says: “Behold, I will cause to cease out of this place, before your eyes and in your days, the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride. 
+\v 10 It will happen, when you tell this people all these words, and they ask you, ‘Why has Yahuah pronounced all this great evil against us?’ or ‘What is our iniquity?’ or ‘What is our sin that we have committed against Yahuah our Elohim?’ 
+\v 11 then you shall tell them, ‘Because your fathers have forsaken me,’ says Yahuah, ‘and have walked after other elohims, have served them, have worshiped them, have forsaken me, and have not kept my law. 
 \v 12 You have done evil more than your fathers, for behold, you each walk after the stubbornness of his evil heart, so that you don’t listen to me. 
 \v 13 Therefore I will cast you out of this land into the land that you have not known, neither you nor your fathers. There you will serve other elohims day and night, for I will show you no favor.’ 
 \p
-\v 14 “Therefore behold, the days come,” says Yahweh, “that it will no more be said, ‘As Yahweh lives, who brought up the children of Israel out of the land of Egypt;’ 
-\v 15 but, ‘As Yahweh lives, who brought up the children of Israel from the land of the north, and from all the countries where he had driven them.’ I will bring them again into their land that I gave to their fathers. 
+\v 14 “Therefore behold, the days come,” says Yahuah, “that it will no more be said, ‘As Yahuah lives, who brought up the children of Israel out of the land of Egypt;’ 
+\v 15 but, ‘As Yahuah lives, who brought up the children of Israel from the land of the north, and from all the countries where he had driven them.’ I will bring them again into their land that I gave to their fathers. 
 \p
-\v 16 “Behold, I will send for many fishermen,” says Yahweh, “and they will fish them up. Afterward I will send for many hunters, and they will hunt them from every mountain, from every hill, and out of the clefts of the rocks. 
+\v 16 “Behold, I will send for many fishermen,” says Yahuah, “and they will fish them up. Afterward I will send for many hunters, and they will hunt them from every mountain, from every hill, and out of the clefts of the rocks. 
 \v 17 For my eyes are on all their ways. They are not hidden from my face. Their iniquity isn’t concealed from my eyes. 
 \v 18 First I will recompense their iniquity and their sin double, because they have polluted my land with the carcasses of their detestable things, and have filled my inheritance with their abominations.” 
 \b
 \q1
-\v 19 Yahweh, my strength, my stronghold, 
+\v 19 Yahuah, my strength, my stronghold, 
 \q2 and my refuge in the day of affliction, 
 \q1 the nations will come to you from the ends of the earth, 
 \q2 and will say, 
@@ -1182,7 +1182,7 @@
 \q1
 \v 21 “Therefore behold, I will cause them to know, 
 \q2 this once I will cause them to know my hand and my might. 
-\q2 Then they will know that my name is Yahweh.” 
+\q2 Then they will know that my name is Yahuah.” 
 \c 17
 \q1
 \v 1 “The sin of Judah is written with a pen of iron, 
@@ -1201,10 +1201,10 @@
 \q2 I will cause you to serve your enemies in the land which you don’t know, 
 \q2 for you have kindled a fire in my anger which will burn forever.” 
 \p
-\v 5 Yahweh says: 
+\v 5 Yahuah says: 
 \q1 “Cursed is the man who trusts in man, 
 \q2 relies on strength of flesh, 
-\q2 and whose heart departs from Yahweh. 
+\q2 and whose heart departs from Yahuah. 
 \q1
 \v 6 For he will be like a bush in the desert, 
 \q2 and will not see when good comes, 
@@ -1212,8 +1212,8 @@
 \q2 an uninhabited salt land. 
 \b
 \q1
-\v 7 “Blessed is the man who trusts in Yahweh, 
-\q2 and whose confidence is in Yahweh. 
+\v 7 “Blessed is the man who trusts in Yahuah, 
+\q2 and whose confidence is in Yahuah. 
 \q1
 \v 8 For he will be as a tree planted by the waters, 
 \q2 who spreads out its roots by the river, 
@@ -1227,7 +1227,7 @@
 \q2 Who can know it? 
 \b
 \q1
-\v 10 “I, Yahweh, search the mind. 
+\v 10 “I, Yahuah, search the mind. 
 \q2 I try the heart, 
 \q1 even to give every man according to his ways, 
 \q2 according to the fruit of his doings.” 
@@ -1241,18 +1241,18 @@
 \v 12 A glorious throne, set on high from the beginning, 
 \q2 is the place of our sanctuary. 
 \q1
-\v 13 Yahweh, the hope of Israel, 
+\v 13 Yahuah, the hope of Israel, 
 \q2 all who forsake you will be disappointed. 
 \q1 Those who depart from me will be written in the earth, 
-\q2 because they have forsaken Yahweh, 
+\q2 because they have forsaken Yahuah, 
 \q2 the spring of living waters. 
 \q1
-\v 14 Heal me, O Yahweh, and I will be healed. 
+\v 14 Heal me, O Yahuah, and I will be healed. 
 \q2 Save me, and I will be saved; 
 \q2 for you are my praise. 
 \q1
 \v 15 Behold, they ask me, 
-\q2 “Where is Yahweh’s word? 
+\q2 “Where is Yahuah’s word? 
 \q2 Let it be fulfilled now.” 
 \q1
 \v 16 As for me, I have not hurried from being a shepherd after you. 
@@ -1269,34 +1269,34 @@
 \q1 Bring on them the day of evil, 
 \q2 and destroy them with double destruction. 
 \p
-\v 19 Yahweh said this to me: “Go and stand in the gate of the children of the people, through which the kings of Judah come in and by which they go out, and in all the gates of Jerusalem. 
-\v 20 Tell them, ‘Hear Yahweh’s word, you kings of Judah, all Judah, and all the inhabitants of Jerusalem, that enter in by these gates: 
-\v 21 Yahweh says, “Be careful, and bear no burden on the Sabbath day, nor bring it in by the gates of Jerusalem. 
+\v 19 Yahuah said this to me: “Go and stand in the gate of the children of the people, through which the kings of Judah come in and by which they go out, and in all the gates of Jerusalem. 
+\v 20 Tell them, ‘Hear Yahuah’s word, you kings of Judah, all Judah, and all the inhabitants of Jerusalem, that enter in by these gates: 
+\v 21 Yahuah says, “Be careful, and bear no burden on the Sabbath day, nor bring it in by the gates of Jerusalem. 
 \v 22 Don’t carry a burden out of your houses on the Sabbath day. Don’t do any work, but make the Sabbath day set-apart, as I commanded your fathers. 
 \v 23 But they didn’t listen. They didn’t turn their ear, but made their neck stiff, that they might not hear, and might not receive instruction. 
-\v 24 It will happen, if you diligently listen to me,” says Yahweh, “to bring in no burden through the gates of this city on the Sabbath day, but to make the Sabbath day set-apart, to do no work therein; 
+\v 24 It will happen, if you diligently listen to me,” says Yahuah, “to bring in no burden through the gates of this city on the Sabbath day, but to make the Sabbath day set-apart, to do no work therein; 
 \v 25 then there will enter in by the gates of this city kings and princes sitting on David’s throne, riding in chariots and on horses, they and their princes, the men of Judah and the inhabitants of Jerusalem; and this city will remain forever. 
-\v 26 They will come from the cities of Judah, and from the places around Jerusalem, from the land of Benjamin, from the lowland, from the hill country, and from the South, bringing burnt offerings, sacrifices, meal offerings, and frankincense, and bringing sacrifices of thanksgiving to Yahweh’s house. 
+\v 26 They will come from the cities of Judah, and from the places around Jerusalem, from the land of Benjamin, from the lowland, from the hill country, and from the South, bringing burnt offerings, sacrifices, meal offerings, and frankincense, and bringing sacrifices of thanksgiving to Yahuah’s house. 
 \v 27 But if you will not listen to me to make the Sabbath day set-apart, and not to bear a burden and enter in at the gates of Jerusalem on the Sabbath day, then I will kindle a fire in its gates, and it will devour the palaces of Jerusalem. It will not be quenched.” ’ ” 
 \c 18
 \p
-\v 1 The word which came to Jeremiah from Yahweh, saying, 
+\v 1 The word which came to Jeremiah from Yahuah, saying, 
 \v 2 “Arise, and go down to the potter’s house, and there I will cause you to hear my words.” 
 \p
 \v 3 Then I went down to the potter’s house, and behold, he was making something on the wheels. 
 \v 4 When the vessel that he made of the clay was marred in the hand of the potter, he made it again another vessel, as seemed good to the potter to make it. 
 \p
-\v 5 Then Yahweh’s word came to me, saying, 
-\v 6 “House of Israel, can’t I do with you as this potter?” says Yahweh. “Behold, as the clay in the potter’s hand, so are you in my hand, house of Israel. 
+\v 5 Then Yahuah’s word came to me, saying, 
+\v 6 “House of Israel, can’t I do with you as this potter?” says Yahuah. “Behold, as the clay in the potter’s hand, so are you in my hand, house of Israel. 
 \v 7 At the instant I speak concerning a nation, and concerning a kingdom, to pluck up and to break down and to destroy it, 
 \v 8 if that nation, concerning which I have spoken, turns from their evil, I will repent of the evil that I thought to do to them. 
 \v 9 At the instant I speak concerning a nation, and concerning a kingdom, to build and to plant it, 
 \v 10 if they do that which is evil in my sight, that they not obey my voice, then I will repent of the good with which I said I would benefit them. 
 \p
-\v 11 “Now therefore, speak to the men of Judah, and to the inhabitants of Jerusalem, saying, ‘Yahweh says: “Behold, I frame evil against you, and devise a plan against you. Everyone return from his evil way now, and amend your ways and your doings.” ’ 
+\v 11 “Now therefore, speak to the men of Judah, and to the inhabitants of Jerusalem, saying, ‘Yahuah says: “Behold, I frame evil against you, and devise a plan against you. Everyone return from his evil way now, and amend your ways and your doings.” ’ 
 \v 12 But they say, ‘It is in vain; for we will walk after our own plans, and we will each follow the stubbornness of his evil heart.’ ” 
 \p
-\v 13 Therefore Yahweh says: 
+\v 13 Therefore Yahuah says: 
 \q1 “Ask now among the nations, 
 \q2 ‘Who has heard such things?’ 
 \q2 The virgin of Israel has done a very horrible thing. 
@@ -1321,7 +1321,7 @@
 \p
 \v 18 Then they said, “Come! Let’s devise plans against Jeremiah; for the law won’t perish from the priest, nor counsel from the wise, nor the word from the prophet. Come, and let’s strike him with the tongue, and let’s not give heed to any of his words.” 
 \q1
-\v 19 Give heed to me, Yahweh, 
+\v 19 Give heed to me, Yahuah, 
 \q2 and listen to the voice of those who contend with me. 
 \q1
 \v 20 Should evil be recompensed for good? 
@@ -1340,49 +1340,49 @@
 \q1 for they have dug a pit to take me 
 \q2 and hidden snares for my feet. 
 \q1
-\v 23 Yet, Yahweh, you know all their counsel against me to kill me. 
+\v 23 Yet, Yahuah, you know all their counsel against me to kill me. 
 \q2 Don’t forgive their iniquity. 
 \q2 Don’t blot out their sin from your sight, 
 \q1 Let them be overthrown before you. 
 \q2 Deal with them in the time of your anger. 
 \c 19
 \p
-\v 1 Thus said Yahweh, “Go, and buy a potter’s earthen container, and take some of the elders of the people and of the elders of the priests; 
+\v 1 Thus said Yahuah, “Go, and buy a potter’s earthen container, and take some of the elders of the people and of the elders of the priests; 
 \v 2 and go out to the valley of the son of Hinnom, which is by the entry of the gate Harsith, and proclaim there the words that I will tell you. 
-\v 3 Say, ‘Hear Yahweh’s word, kings of Judah and inhabitants of Jerusalem: Yahweh of Armies, the Elohim of Israel says, “Behold, I will bring evil on this place, which whoever hears, his ears will tingle. 
+\v 3 Say, ‘Hear Yahuah’s word, kings of Judah and inhabitants of Jerusalem: Yahuah of Armies, the Elohim of Israel says, “Behold, I will bring evil on this place, which whoever hears, his ears will tingle. 
 \v 4 Because they have forsaken me, and have defiled this place, and have burned incense in it to other elohims that they didn’t know—they, their fathers, and the kings of Judah—and have filled this place with the blood of innocents, 
 \v 5 and have built the high places of Baal to burn their children in the fire for burnt offerings to Baal, which I didn’t command, nor speak, which didn’t even enter into my mind. 
-\v 6 Therefore, behold, the days come,” says Yahweh, “that this place will no more be called ‘Topheth’, nor ‘The Valley of the son of Hinnom’, but ‘The valley of Slaughter’. 
+\v 6 Therefore, behold, the days come,” says Yahuah, “that this place will no more be called ‘Topheth’, nor ‘The Valley of the son of Hinnom’, but ‘The valley of Slaughter’. 
 \p
 \v 7 “ ‘ “I will make the counsel of Judah and Jerusalem void in this place. I will cause them to fall by the sword before their enemies, and by the hand of those who seek their life. I will give their dead bodies to be food for the birds of the sky and for the animals of the earth. 
 \v 8 I will make this city an astonishment and a hissing. Everyone who passes by it will be astonished and hiss because of all its plagues. 
 \v 9 I will cause them to eat the flesh of their sons and the flesh of their daughters. They will each eat the flesh of his friend in the siege and in the distress with which their enemies, and those who seek their life, will distress them.” ’ 
 \p
 \v 10 “Then you shall break the container in the sight of the men who go with you, 
-\v 11 and shall tell them, ‘Yahweh of Armies says: “Even so I will break this people and this city as one breaks a potter’s vessel, that can’t be made whole again. They will bury in Topheth until there is no place to bury. 
-\v 12 This is what I will do to this place,” says Yahweh, “and to its inhabitants, even making this city as Topheth. 
+\v 11 and shall tell them, ‘Yahuah of Armies says: “Even so I will break this people and this city as one breaks a potter’s vessel, that can’t be made whole again. They will bury in Topheth until there is no place to bury. 
+\v 12 This is what I will do to this place,” says Yahuah, “and to its inhabitants, even making this city as Topheth. 
 \v 13 The houses of Jerusalem and the houses of the kings of Judah, which are defiled, will be as the place of Topheth, even all the houses on whose roofs they have burned incense to all the army of the sky and have poured out drink offerings to other elohims.” ’ ” 
 \p
-\v 14 Then Jeremiah came from Topheth, where Yahweh had sent him to prophesy, and he stood in the court of Yahweh’s house, and said to all the people: 
-\v 15 “Yahweh of Armies, the Elohim of Israel says, ‘Behold, I will bring on this city and on all its towns all the evil that I have pronounced against it, because they have made their neck stiff, that they may not hear my words.’ ” 
+\v 14 Then Jeremiah came from Topheth, where Yahuah had sent him to prophesy, and he stood in the court of Yahuah’s house, and said to all the people: 
+\v 15 “Yahuah of Armies, the Elohim of Israel says, ‘Behold, I will bring on this city and on all its towns all the evil that I have pronounced against it, because they have made their neck stiff, that they may not hear my words.’ ” 
 \c 20
 \p
-\v 1 Now Pashhur, the son of Immer the priest, who was chief officer in Yahweh’s house, heard Jeremiah prophesying these things. 
-\v 2 Then Pashhur struck Jeremiah the prophet and put him in the stocks that were in the upper gate of Benjamin, which was in Yahweh’s house. 
-\v 3 On the next day, Pashhur released Jeremiah out of the stocks. Then Jeremiah said to him, “Yahweh has not called your name Pashhur, but Magormissabib. 
-\v 4 For Yahweh says, ‘Behold, I will make you a terror to yourself and to all your friends. They will fall by the sword of their enemies, and your eyes will see it. I will give all Judah into the hand of the king of Babylon, and he will carry them captive to Babylon, and will kill them with the sword. 
+\v 1 Now Pashhur, the son of Immer the priest, who was chief officer in Yahuah’s house, heard Jeremiah prophesying these things. 
+\v 2 Then Pashhur struck Jeremiah the prophet and put him in the stocks that were in the upper gate of Benjamin, which was in Yahuah’s house. 
+\v 3 On the next day, Pashhur released Jeremiah out of the stocks. Then Jeremiah said to him, “Yahuah has not called your name Pashhur, but Magormissabib. 
+\v 4 For Yahuah says, ‘Behold, I will make you a terror to yourself and to all your friends. They will fall by the sword of their enemies, and your eyes will see it. I will give all Judah into the hand of the king of Babylon, and he will carry them captive to Babylon, and will kill them with the sword. 
 \v 5 Moreover I will give all the riches of this city, and all its gains, and all its precious things, yes, I will give all the treasures of the kings of Judah into the hand of their enemies. They will make them captives, take them, and carry them to Babylon. 
 \v 6 You, Pashhur, and all who dwell in your house will go into captivity. You will come to Babylon, and there you will die, and there you will be buried, you, and all your friends, to whom you have prophesied falsely.’ ” 
 \b
 \q1
-\v 7 Yahweh, you have persuaded me, and I was persuaded. 
+\v 7 Yahuah, you have persuaded me, and I was persuaded. 
 \q2 You are stronger than I, and have prevailed. 
 \q1 I have become a laughingstock all day. 
 \q2 Everyone mocks me. 
 \q1
 \v 8 For as often as I speak, I cry out; 
 \q2 I cry, “Violence and destruction!” 
-\q1 because Yahweh’s word has been made a reproach to me, 
+\q1 because Yahuah’s word has been made a reproach to me, 
 \q2 and a derision, all day. 
 \q1
 \v 9 If I say that I will not make mention of him, 
@@ -1400,20 +1400,20 @@
 \q2 and we will prevail against him, 
 \q2 and we will take our revenge on him.” 
 \q1
-\v 11 But Yahweh is with me as an awesome mighty one. 
+\v 11 But Yahuah is with me as an awesome mighty one. 
 \q2 Therefore my persecutors will stumble, 
 \q2 and they won’t prevail. 
 \q1 They will be utterly disappointed 
 \q2 because they have not dealt wisely, 
 \q2 even with an everlasting dishonor which will never be forgotten. 
 \q1
-\v 12 But Yahweh of Armies, who tests the righteous, 
+\v 12 But Yahuah of Armies, who tests the righteous, 
 \q2 who sees the heart and the mind, 
 \q1 let me see your vengeance on them, 
 \q2 for I have revealed my cause to you. 
 \q1
-\v 13 Sing to Yahweh! 
-\q2 Praise Yahweh, 
+\v 13 Sing to Yahuah! 
+\q2 Praise Yahuah, 
 \q2 for he has delivered the soul of the needy from the hand of evildoers. 
 \q1
 \v 14 Cursed is the day in which I was born. 
@@ -1422,7 +1422,7 @@
 \v 15 Cursed is the man who brought news to my father, saying, 
 \q2 “A boy is born to you,” making him very glad. 
 \q1
-\v 16 Let that man be as the cities which Yahweh overthrew, 
+\v 16 Let that man be as the cities which Yahuah overthrew, 
 \q2 and didn’t repent. 
 \q1 Let him hear a cry in the morning, 
 \q2 and shouting at noontime, 
@@ -1435,21 +1435,21 @@
 \q2 that my days should be consumed with shame? 
 \c 21
 \p
-\v 1 The word which came to Jeremiah from Yahweh, when King Zedekiah sent to him Pashhur the son of Malchijah, and Zephaniah the son of Maaseiah, the priest, saying, 
-\v 2 “Please inquire of Yahweh for us; for Nebuchadnezzar king of Babylon makes war against us. Perhaps Yahweh will deal with us according to all his wondrous works, that he may withdraw from us.” 
+\v 1 The word which came to Jeremiah from Yahuah, when King Zedekiah sent to him Pashhur the son of Malchijah, and Zephaniah the son of Maaseiah, the priest, saying, 
+\v 2 “Please inquire of Yahuah for us; for Nebuchadnezzar king of Babylon makes war against us. Perhaps Yahuah will deal with us according to all his wondrous works, that he may withdraw from us.” 
 \p
 \v 3 Then Jeremiah said to them, “Tell Zedekiah: 
-\v 4 ‘Yahweh, the Elohim of Israel says, “Behold, I will turn back the weapons of war that are in your hands, with which you fight against the king of Babylon, and against the Chaldeans who besiege you outside the walls; and I will gather them into the middle of this city. 
+\v 4 ‘Yahuah, the Elohim of Israel says, “Behold, I will turn back the weapons of war that are in your hands, with which you fight against the king of Babylon, and against the Chaldeans who besiege you outside the walls; and I will gather them into the middle of this city. 
 \v 5 I myself will fight against you with an outstretched hand and with a strong arm, even in anger, in wrath, and in great indignation. 
 \v 6 I will strike the inhabitants of this city, both man and animal. They will die of a great pestilence. 
-\v 7 Afterward,” says Yahweh, “I will deliver Zedekiah king of Judah, his servants, and the people, even those who are left in this city from the pestilence, from the sword, and from the famine, into the hand of Nebuchadnezzar king of Babylon, and into the hand of their enemies, and into the hand of those who seek their life. He will strike them with the edge of the sword. He will not spare them, have pity, or have mercy.” ’ 
+\v 7 Afterward,” says Yahuah, “I will deliver Zedekiah king of Judah, his servants, and the people, even those who are left in this city from the pestilence, from the sword, and from the famine, into the hand of Nebuchadnezzar king of Babylon, and into the hand of their enemies, and into the hand of those who seek their life. He will strike them with the edge of the sword. He will not spare them, have pity, or have mercy.” ’ 
 \p
-\v 8 “You shall say to this people, ‘Yahweh says: “Behold, I set before you the way of life and the way of death. 
+\v 8 “You shall say to this people, ‘Yahuah says: “Behold, I set before you the way of life and the way of death. 
 \v 9 He who remains in this city will die by the sword, by the famine, and by the pestilence, but he who goes out and passes over to the Chaldeans who besiege you, he will live, and he will escape with his life. 
-\v 10 For I have set my face on this city for evil, and not for good,” says Yahweh. “It will be given into the hand of the king of Babylon, and he will burn it with fire.” ’ 
+\v 10 For I have set my face on this city for evil, and not for good,” says Yahuah. “It will be given into the hand of the king of Babylon, and he will burn it with fire.” ’ 
 \p
-\v 11 “Concerning the house of the king of Judah, hear Yahweh’s word: 
-\v 12 House of David, Yahweh says, 
+\v 11 “Concerning the house of the king of Judah, hear Yahuah’s word: 
+\v 12 House of David, Yahuah says, 
 \q1 ‘Execute justice in the morning, 
 \q2 and deliver him who is robbed out of the hand of the oppressor, 
 \q1 lest my wrath go out like fire, 
@@ -1457,22 +1457,22 @@
 \q2 because of the evil of your doings. 
 \q1
 \v 13 Behold, I am against you, O inhabitant of the valley, 
-\q2 and of the rock of the plain,’ says Yahweh. 
+\q2 and of the rock of the plain,’ says Yahuah. 
 \q1 ‘You that say, “Who would come down against us?” 
 \q2 or, “Who would enter into our homes?” 
 \q1
-\v 14 I will punish you according to the fruit of your doings,’ says Yahweh; 
+\v 14 I will punish you according to the fruit of your doings,’ says Yahuah; 
 \q2 ‘and I will kindle a fire in her forest, 
 \q2 and it will devour all that is around her.’ ” 
 \c 22
 \p
-\v 1 Yahweh said, “Go down to the house of the king of Judah, and speak this word there: 
-\v 2 ‘Hear Yahweh’s word, king of Judah, who sits on David’s throne—you, your servants, and your people who enter in by these gates. 
-\v 3 Yahweh says: “Execute justice and righteousness, and deliver him who is robbed out of the hand of the oppressor. Do no wrong. Do no violence to the foreigner, the fatherless, or the widow. Don’t shed innocent blood in this place. 
+\v 1 Yahuah said, “Go down to the house of the king of Judah, and speak this word there: 
+\v 2 ‘Hear Yahuah’s word, king of Judah, who sits on David’s throne—you, your servants, and your people who enter in by these gates. 
+\v 3 Yahuah says: “Execute justice and righteousness, and deliver him who is robbed out of the hand of the oppressor. Do no wrong. Do no violence to the foreigner, the fatherless, or the widow. Don’t shed innocent blood in this place. 
 \v 4 For if you do this thing indeed, then kings sitting on David’s throne will enter in by the gates of this house, riding in chariots and on horses—they, their servants, and their people. 
-\v 5 But if you will not hear these words, I swear by myself,” says Yahweh, “that this house will become a desolation.” ’ ” 
+\v 5 But if you will not hear these words, I swear by myself,” says Yahuah, “that this house will become a desolation.” ’ ” 
 \p
-\v 6 For Yahweh says concerning the house of the king of Judah: 
+\v 6 For Yahuah says concerning the house of the king of Judah: 
 \q1 “You are Gilead to me, 
 \q2 the head of Lebanon. 
 \q1 Yet surely I will make you a wilderness, 
@@ -1483,8 +1483,8 @@
 \q1 and they will cut down your choice cedars, 
 \q2 and cast them into the fire. 
 \p
-\v 8 “Many nations will pass by this city, and they will each ask his neighbor, ‘Why has Yahweh done this to this great city?’ 
-\v 9 Then they will answer, ‘Because they abandoned the covenant of Yahweh their Elohim, worshiped other elohims, and served them.’ ” 
+\v 8 “Many nations will pass by this city, and they will each ask his neighbor, ‘Why has Yahuah done this to this great city?’ 
+\v 9 Then they will answer, ‘Because they abandoned the covenant of Yahuah their Elohim, worshiped other elohims, and served them.’ ” 
 \q1
 \v 10 Don’t weep for the dead. 
 \q2 Don’t bemoan him; 
@@ -1492,7 +1492,7 @@
 \q2 for he will return no more, 
 \q2 and not see his native country. 
 \m
-\v 11 For Yahweh says touching Shallum the son of Josiah, king of Judah, who reigned instead of Josiah his father, and who went out of this place: “He won’t return there any more. 
+\v 11 For Yahuah says touching Shallum the son of Josiah, king of Judah, who reigned instead of Josiah his father, and who went out of this place: “He won’t return there any more. 
 \v 12 But he will die in the place where they have led him captive. He will see this land no more.” 
 \q1
 \v 13 “Woe to him who builds his house by unrighteousness, 
@@ -1514,13 +1514,13 @@
 \v 16 He judged the cause of the poor and needy; 
 \q2 so then it was well. 
 \q1 Wasn’t this to know me?” 
-\q2 says Yahweh. 
+\q2 says Yahuah. 
 \q1
 \v 17 But your eyes and your heart are only for your desire, 
 \q2 for shedding innocent blood, 
 \q2 for oppression, and for doing violence.” 
 \m
-\v 18 Therefore Yahweh says concerning Jehoiakim the son of Josiah, king of Judah: 
+\v 18 Therefore Yahuah says concerning Jehoiakim the son of Josiah, king of Judah: 
 \q1 “They won’t lament for him, 
 \q2 saying, ‘Ah my brother!’ or, ‘Ah sister!’ 
 \q1 They won’t lament for him, 
@@ -1550,7 +1550,7 @@
 \q1 how greatly to be pitied you will be when pangs come on you, 
 \q2 the pain as of a woman in travail! 
 \p
-\v 24 “As I live,” says Yahweh, “though Coniah the son of Jehoiakim king of Judah were the signet on my right hand, I would still pluck you from there. 
+\v 24 “As I live,” says Yahuah, “though Coniah the son of Jehoiakim king of Judah were the signet on my right hand, I would still pluck you from there. 
 \v 25 I would give you into the hand of those who seek your life, and into the hand of them of whom you are afraid, even into the hand of Nebuchadnezzar king of Babylon, and into the hand of the Chaldeans. 
 \v 26 I will cast you out with your mother who bore you into another country, where you were not born; and there you will die. 
 \v 27 But to the land to which their soul longs to return, there they will not return.” 
@@ -1561,9 +1561,9 @@
 \q2 and cast into a land which they don’t know? 
 \q1
 \v 29 O earth, earth, earth, 
-\q2 hear Yahweh’s word! 
+\q2 hear Yahuah’s word! 
 \q1
-\v 30 Yahweh says, 
+\v 30 Yahuah says, 
 \q2 “Record this man as childless, 
 \q2 a man who will not prosper in his days; 
 \q1 for no more will a man of his offspring prosper, 
@@ -1571,12 +1571,12 @@
 \q2 and ruling in Judah.” 
 \c 23
 \p
-\v 1 “Woe to the shepherds who destroy and scatter the sheep of my pasture!” says Yahweh. 
-\v 2 Therefore Yahweh, the Elohim of Israel, says against the shepherds who feed my people: “You have scattered my flock, driven them away, and have not visited them. Behold, I will visit on you the evil of your doings,” says Yahweh. 
+\v 1 “Woe to the shepherds who destroy and scatter the sheep of my pasture!” says Yahuah. 
+\v 2 Therefore Yahuah, the Elohim of Israel, says against the shepherds who feed my people: “You have scattered my flock, driven them away, and have not visited them. Behold, I will visit on you the evil of your doings,” says Yahuah. 
 \v 3 “I will gather the remnant of my flock out of all the countries where I have driven them, and will bring them again to their folds; and they will be fruitful and multiply. 
-\v 4 I will set up shepherds over them who will feed them. They will no longer be afraid or dismayed, neither will any be lacking,” says Yahweh. 
+\v 4 I will set up shepherds over them who will feed them. They will no longer be afraid or dismayed, neither will any be lacking,” says Yahuah. 
 \q1
-\v 5 “Behold, the days come,” says Yahweh, 
+\v 5 “Behold, the days come,” says Yahuah, 
 \q2 “that I will raise to David a righteous Branch; 
 \q1 and he will reign as king and deal wisely, 
 \q2 and will execute justice and righteousness in the land. 
@@ -1584,17 +1584,17 @@
 \v 6 In his days Judah will be saved, 
 \q2 and Israel will dwell safely. 
 \q1 This is his name by which he will be called: 
-\q2 Yahweh our righteousness. 
+\q2 Yahuah our righteousness. 
 \m
-\v 7 “Therefore, behold, the days come,” says Yahweh, “that they will no more say, ‘As Yahweh lives, who brought up the children of Israel out of the land of Egypt;’ 
-\v 8 but, ‘As Yahweh lives, who brought up and who led the offspring of the house of Israel out of the north country, and from all the countries where I had driven them.’ Then they will dwell in their own land.” 
+\v 7 “Therefore, behold, the days come,” says Yahuah, “that they will no more say, ‘As Yahuah lives, who brought up the children of Israel out of the land of Egypt;’ 
+\v 8 but, ‘As Yahuah lives, who brought up and who led the offspring of the house of Israel out of the north country, and from all the countries where I had driven them.’ Then they will dwell in their own land.” 
 \p
 \v 9 Concerning the prophets: 
 \q1 My heart within me is broken. 
 \q2 All my bones shake. 
 \q1 I am like a drunken man, 
 \q2 and like a man whom wine has overcome, 
-\q1 because of Yahweh, 
+\q1 because of Yahuah, 
 \q2 and because of his set-apart words. 
 \q1
 \v 10 “For the land is full of adulterers; 
@@ -1604,13 +1604,13 @@
 \q2 and their might is not right; 
 \q1
 \v 11 for both prophet and priest are profane. 
-\q2 Yes, in my house I have found their wickedness,” says Yahweh. 
+\q2 Yes, in my house I have found their wickedness,” says Yahuah. 
 \q1
 \v 12 Therefore their way will be to them as slippery places in the darkness. 
 \q2 They will be driven on, 
 \q2 and fall therein; 
 \q1 for I will bring evil on them, 
-\q2 even the year of their visitation,” says Yahweh. 
+\q2 even the year of their visitation,” says Yahuah. 
 \b
 \q1
 \v 13 “I have seen folly in the prophets of Samaria. 
@@ -1624,31 +1624,31 @@
 \q1 They have all become to me as Sodom, 
 \q2 and its inhabitants as Gomorrah.” 
 \p
-\v 15 Therefore Yahweh of Armies says concerning the prophets: 
+\v 15 Therefore Yahuah of Armies says concerning the prophets: 
 \q1 “Behold, I will feed them with wormwood, 
 \q2 and make them drink poisoned water; 
 \q2 for from the prophets of Jerusalem unelohimliness has gone out into all the land.” 
 \p
-\v 16 Yahweh of Armies says, 
+\v 16 Yahuah of Armies says, 
 \q1 “Don’t listen to the words of the prophets who prophesy to you. 
 \q2 They teach you vanity. 
 \q2 They speak a vision of their own heart, 
-\q2 and not out of the mouth of Yahweh. 
+\q2 and not out of the mouth of Yahuah. 
 \q1
 \v 17 They say continually to those who despise me, 
-\q2 ‘Yahweh has said, “You will have peace;” ’ 
+\q2 ‘Yahuah has said, “You will have peace;” ’ 
 \q1 and to everyone who walks in the stubbornness of his own heart they say, 
 \q2 ‘No evil will come on you.’ 
 \q1
-\v 18 For who has stood in the council of Yahweh, 
+\v 18 For who has stood in the council of Yahuah, 
 \q2 that he should perceive and hear his word? 
 \q2 Who has listened to my word, and heard it? 
 \q1
-\v 19 Behold, Yahweh’s storm, his wrath, has gone out. 
+\v 19 Behold, Yahuah’s storm, his wrath, has gone out. 
 \q2 Yes, a whirling storm! 
 \q2 It will burst on the head of the wicked. 
 \q1
-\v 20 Yahweh’s anger will not return until he has executed 
+\v 20 Yahuah’s anger will not return until he has executed 
 \q2 and performed the intents of his heart. 
 \q2 In the latter days, you will understand it perfectly. 
 \q1
@@ -1661,72 +1661,72 @@
 \q2 and from the evil of their doings. 
 \b
 \q1
-\v 23 “Am I an Elohim at hand,” says Yahweh, 
+\v 23 “Am I an Elohim at hand,” says Yahuah, 
 \q2 “and not an Elohim afar off? 
 \q1
 \v 24 Can anyone hide himself in secret places 
-\q2 so that I can’t see him?” says Yahweh. 
-\q2 “Don’t I fill heaven and earth?” says Yahweh. 
+\q2 so that I can’t see him?” says Yahuah. 
+\q2 “Don’t I fill heaven and earth?” says Yahuah. 
 \p
 \v 25 “I have heard what the prophets have said, who prophesy lies in my name, saying, ‘I had a dream! I had a dream!’ 
 \v 26 How long will this be in the heart of the prophets who prophesy lies, even the prophets of the deceit of their own heart? 
 \v 27 They intend to cause my people to forget my name by their dreams which they each tell his neighbor, as their fathers forgot my name because of Baal. 
-\v 28 The prophet who has a dream, let him tell a dream; and he who has my word, let him speak my word faithfully. What is the straw to the wheat?” says Yahweh. 
-\v 29 “Isn’t my word like fire?” says Yahweh; “and like a hammer that breaks the rock in pieces? 
+\v 28 The prophet who has a dream, let him tell a dream; and he who has my word, let him speak my word faithfully. What is the straw to the wheat?” says Yahuah. 
+\v 29 “Isn’t my word like fire?” says Yahuah; “and like a hammer that breaks the rock in pieces? 
 \p
-\v 30 “Therefore behold, I am against the prophets,” says Yahweh, “who each steal my words from his neighbor. 
-\v 31 Behold, I am against the prophets,” says Yahweh, “who use their tongues, and say, ‘He says.’ 
-\v 32 Behold, I am against those who prophesy lying dreams,” says Yahweh, “who tell them, and cause my people to err by their lies, and by their vain boasting; yet I didn’t send them or command them. They don’t profit this people at all,” says Yahweh. 
+\v 30 “Therefore behold, I am against the prophets,” says Yahuah, “who each steal my words from his neighbor. 
+\v 31 Behold, I am against the prophets,” says Yahuah, “who use their tongues, and say, ‘He says.’ 
+\v 32 Behold, I am against those who prophesy lying dreams,” says Yahuah, “who tell them, and cause my people to err by their lies, and by their vain boasting; yet I didn’t send them or command them. They don’t profit this people at all,” says Yahuah. 
 \p
-\v 33 “When this people, or the prophet, or a priest, asks you, saying, ‘What is the message from Yahweh?’ Then you shall tell them, ‘ “What message? I will cast you off,” says Yahweh.’ 
-\v 34 As for the prophet, the priest, and the people, who say, ‘The message from Yahweh,’ I will even punish that man and his household. 
-\v 35 You will say everyone to his neighbor, and everyone to his brother, ‘What has Yahweh answered?’ and, ‘What has Yahweh said?’ 
-\v 36 You will mention the message from Yahweh no more, for every man’s own word has become his message; for you have perverted the words of the living Elohim, of Yahweh of Armies, our Elohim. 
-\v 37 You will say to the prophet, ‘What has Yahweh answered you?’ and, ‘What has Yahweh spoken?’ 
-\v 38 Although you say, ‘The message from Yahweh,’ therefore Yahweh says: ‘Because you say this word, “The message from Yahweh,” and I have sent to you, telling you not to say, “The message from Yahweh,” 
+\v 33 “When this people, or the prophet, or a priest, asks you, saying, ‘What is the message from Yahuah?’ Then you shall tell them, ‘ “What message? I will cast you off,” says Yahuah.’ 
+\v 34 As for the prophet, the priest, and the people, who say, ‘The message from Yahuah,’ I will even punish that man and his household. 
+\v 35 You will say everyone to his neighbor, and everyone to his brother, ‘What has Yahuah answered?’ and, ‘What has Yahuah said?’ 
+\v 36 You will mention the message from Yahuah no more, for every man’s own word has become his message; for you have perverted the words of the living Elohim, of Yahuah of Armies, our Elohim. 
+\v 37 You will say to the prophet, ‘What has Yahuah answered you?’ and, ‘What has Yahuah spoken?’ 
+\v 38 Although you say, ‘The message from Yahuah,’ therefore Yahuah says: ‘Because you say this word, “The message from Yahuah,” and I have sent to you, telling you not to say, “The message from Yahuah,” 
 \v 39 therefore behold, I will utterly forget you, and I will cast you off with the city that I gave to you and to your fathers, away from my presence. 
 \v 40 I will bring an everlasting reproach on you, and a perpetual shame, which will not be forgotten.’ ” 
 \c 24
 \p
-\v 1 Yahweh showed me, and behold, two baskets of figs were set before Yahweh’s temple, after Nebuchadnezzar king of Babylon had carried away captive Jeconiah the son of Jehoiakim, king of Judah, and the princes of Judah, with the craftsmen and smiths, from Jerusalem, and had brought them to Babylon. 
+\v 1 Yahuah showed me, and behold, two baskets of figs were set before Yahuah’s temple, after Nebuchadnezzar king of Babylon had carried away captive Jeconiah the son of Jehoiakim, king of Judah, and the princes of Judah, with the craftsmen and smiths, from Jerusalem, and had brought them to Babylon. 
 \v 2 One basket had very good figs, like the figs that are first-ripe; and the other basket had very bad figs, which could not be eaten, they were so bad. 
 \p
-\v 3 Then Yahweh asked me, “What do you see, Jeremiah?” 
+\v 3 Then Yahuah asked me, “What do you see, Jeremiah?” 
 \p I said, “Figs. The good figs are very good, and the bad are very bad, so bad that they can’t be eaten.” 
 \p
-\v 4 Yahweh’s word came to me, saying, 
-\v 5 “Yahweh, the Elohim of Israel says: ‘Like these good figs, so I will regard the captives of Judah, whom I have sent out of this place into the land of the Chaldeans, as good. 
+\v 4 Yahuah’s word came to me, saying, 
+\v 5 “Yahuah, the Elohim of Israel says: ‘Like these good figs, so I will regard the captives of Judah, whom I have sent out of this place into the land of the Chaldeans, as good. 
 \v 6 For I will set my eyes on them for good, and I will bring them again to this land. I will build them, and not pull them down. I will plant them, and not pluck them up. 
-\v 7 I will give them a heart to know me, that I am Yahweh. They will be my people, and I will be their Elohim; for they will return to me with their whole heart. 
+\v 7 I will give them a heart to know me, that I am Yahuah. They will be my people, and I will be their Elohim; for they will return to me with their whole heart. 
 \p
-\v 8 “ ‘As the bad figs, which can’t be eaten, they are so bad,’ surely Yahweh says, ‘So I will give up Zedekiah the king of Judah, and his princes, and the remnant of Jerusalem who remain in this land, and those who dwell in the land of Egypt. 
+\v 8 “ ‘As the bad figs, which can’t be eaten, they are so bad,’ surely Yahuah says, ‘So I will give up Zedekiah the king of Judah, and his princes, and the remnant of Jerusalem who remain in this land, and those who dwell in the land of Egypt. 
 \v 9 I will even give them up to be tossed back and forth among all the kingdoms of the earth for evil, to be a reproach and a proverb, a taunt and a curse, in all places where I will drive them. 
 \v 10 I will send the sword, the famine, and the pestilence among them, until they are consumed from off the land that I gave to them and to their fathers.’ ” 
 \c 25
 \p
 \v 1 The word that came to Jeremiah concerning all the people of Judah, in the fourth year of Jehoiakim the son of Josiah, king of Judah (this was the first year of Nebuchadnezzar king of Babylon), 
 \v 2 which Jeremiah the prophet spoke to all the people of Judah, and to all the inhabitants of Jerusalem: 
-\v 3 From the thirteenth year of Josiah the son of Amon, king of Judah, even to this day, these twenty-three years, Yahweh’s word has come to me, and I have spoken to you, rising up early and speaking; but you have not listened. 
+\v 3 From the thirteenth year of Josiah the son of Amon, king of Judah, even to this day, these twenty-three years, Yahuah’s word has come to me, and I have spoken to you, rising up early and speaking; but you have not listened. 
 \p
-\v 4 Yahweh has sent to you all his servants the prophets, rising up early and sending them (but you have not listened or inclined your ear to hear), 
-\v 5 saying, “Return now everyone from his evil way, and from the evil of your doings, and dwell in the land that Yahweh has given to you and to your fathers, from of old and even forever more. 
+\v 4 Yahuah has sent to you all his servants the prophets, rising up early and sending them (but you have not listened or inclined your ear to hear), 
+\v 5 saying, “Return now everyone from his evil way, and from the evil of your doings, and dwell in the land that Yahuah has given to you and to your fathers, from of old and even forever more. 
 \v 6 Don’t go after other elohims to serve them or worship them, and don’t provoke me to anger with the work of your hands; then I will do you no harm.” 
 \p
-\v 7 “Yet you have not listened to me,” says Yahweh, “that you may provoke me to anger with the work of your hands to your own hurt.” 
+\v 7 “Yet you have not listened to me,” says Yahuah, “that you may provoke me to anger with the work of your hands to your own hurt.” 
 \p
-\v 8 Therefore Yahweh of Armies says: “Because you have not heard my words, 
-\v 9 behold, I will send and take all the families of the north,” says Yahweh, “and I will send to Nebuchadnezzar the king of Babylon, my servant, and will bring them against this land, and against its inhabitants, and against all these nations around. I will utterly destroy them, and make them an astonishment, and a hissing, and perpetual desolations. 
+\v 8 Therefore Yahuah of Armies says: “Because you have not heard my words, 
+\v 9 behold, I will send and take all the families of the north,” says Yahuah, “and I will send to Nebuchadnezzar the king of Babylon, my servant, and will bring them against this land, and against its inhabitants, and against all these nations around. I will utterly destroy them, and make them an astonishment, and a hissing, and perpetual desolations. 
 \v 10 Moreover I will take from them the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride, the sound of the millstones, and the light of the lamp. 
 \v 11 This whole land will be a desolation, and an astonishment; and these nations will serve the king of Babylon seventy years. 
 \p
-\v 12 “It will happen, when seventy years are accomplished, that I will punish the king of Babylon and that nation,” says Yahweh, “for their iniquity. I will make the land of the Chaldeans desolate forever. 
+\v 12 “It will happen, when seventy years are accomplished, that I will punish the king of Babylon and that nation,” says Yahuah, “for their iniquity. I will make the land of the Chaldeans desolate forever. 
 \v 13 I will bring on that land all my words which I have pronounced against it, even all that is written in this book, which Jeremiah has prophesied against all the nations. 
 \v 14 For many nations and great kings will make bondservants of them, even of them. I will recompense them according to their deeds, and according to the work of their hands.” 
 \p
-\v 15 For Yahweh, the Elohim of Israel, says to me: “Take this cup of the wine of wrath from my hand, and cause all the nations to whom I send you to drink it. 
+\v 15 For Yahuah, the Elohim of Israel, says to me: “Take this cup of the wine of wrath from my hand, and cause all the nations to whom I send you to drink it. 
 \v 16 They will drink, and reel back and forth, and be insane, because of the sword that I will send among them.” 
 \p
-\v 17 Then I took the cup at Yahweh’s hand, and made all the nations to drink, to whom Yahweh had sent me: 
+\v 17 Then I took the cup at Yahuah’s hand, and made all the nations to drink, to whom Yahuah had sent me: 
 \v 18 Jerusalem, and the cities of Judah, with its kings and its princes, to make them a desolation, an astonishment, a hissing, and a curse, as it is today; 
 \v 19 Pharaoh king of Egypt, with his servants, his princes, and all his people; 
 \v 20 and all the mixed people, and all the kings of the land of Uz, all the kings of the Philistines, Ashkelon, Gaza, Ekron, and the remnant of Ashdod; 
@@ -1737,27 +1737,27 @@
 \v 25 and all the kings of Zimri, all the kings of Elam, and all the kings of the Medes; 
 \v 26 and all the kings of the north, far and near, one with another; and all the kingdoms of the world, which are on the surface of the earth. The king of Sheshach will drink after them. 
 \p
-\v 27 “You shall tell them, ‘Yahweh of Armies, the Elohim of Israel says: “Drink, and be drunk, vomit, fall, and rise no more, because of the sword which I will send among you.” ’ 
-\v 28 It shall be, if they refuse to take the cup at your hand to drink, then you shall tell them, ‘Yahweh of Armies says: “You shall surely drink. 
-\v 29 For, behold, I begin to work evil at the city which is called by my name; and should you be utterly unpunished? You will not be unpunished; for I will call for a sword on all the inhabitants of the earth, says Yahweh of Armies.” ’ 
+\v 27 “You shall tell them, ‘Yahuah of Armies, the Elohim of Israel says: “Drink, and be drunk, vomit, fall, and rise no more, because of the sword which I will send among you.” ’ 
+\v 28 It shall be, if they refuse to take the cup at your hand to drink, then you shall tell them, ‘Yahuah of Armies says: “You shall surely drink. 
+\v 29 For, behold, I begin to work evil at the city which is called by my name; and should you be utterly unpunished? You will not be unpunished; for I will call for a sword on all the inhabitants of the earth, says Yahuah of Armies.” ’ 
 \p
 \v 30 “Therefore prophesy against them all these words, and tell them, 
-\q1 “ ‘Yahweh will roar from on high, 
+\q1 “ ‘Yahuah will roar from on high, 
 \q2 and utter his voice from his set-apart habitation. 
 \q2 He will mightily roar against his fold. 
 \q1 He will give a shout, as those who tread grapes, 
 \q2 against all the inhabitants of the earth. 
 \q1
 \v 31 A noise will come even to the end of the earth; 
-\q2 for Yahweh has a controversy with the nations. 
+\q2 for Yahuah has a controversy with the nations. 
 \q1 He will enter into judgment with all flesh. 
-\q2 As for the wicked, he will give them to the sword,” ’ says Yahweh.” 
+\q2 As for the wicked, he will give them to the sword,” ’ says Yahuah.” 
 \p
-\v 32 Yahweh of Armies says, 
+\v 32 Yahuah of Armies says, 
 \q1 “Behold, evil will go out from nation to nation, 
 \q2 and a great storm will be raised up from the uttermost parts of the earth.” 
 \m
-\v 33 The slain of Yahweh will be at that day from one end of the earth even to the other end of the earth. They won’t be lamented. They won’t be gathered or buried. They will be dung on the surface of the ground. 
+\v 33 The slain of Yahuah will be at that day from one end of the earth even to the other end of the earth. They won’t be lamented. They won’t be gathered or buried. They will be dung on the surface of the ground. 
 \q1
 \v 34 Wail, you shepherds, and cry. 
 \q2 Wallow in dust, you leader of the flock; 
@@ -1769,45 +1769,45 @@
 \q1
 \v 36 A voice of the cry of the shepherds, 
 \q2 and the wailing of the leader of the flock, 
-\q2 for Yahweh destroys their pasture. 
+\q2 for Yahuah destroys their pasture. 
 \q1
 \v 37 The peaceful folds are brought to silence 
-\q2 because of the fierce anger of Yahweh. 
+\q2 because of the fierce anger of Yahuah. 
 \q1
 \v 38 He has left his covert, as the lion; 
 \q2 for their land has become an astonishment because of the fierceness of the oppression, 
 \q2 and because of his fierce anger. 
 \c 26
 \p
-\v 1 In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came from Yahweh: 
-\v 2 “Yahweh says: ‘Stand in the court of Yahweh’s house, and speak to all the cities of Judah which come to worship in Yahweh’s house, all the words that I command you to speak to them. Don’t omit a word. 
+\v 1 In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came from Yahuah: 
+\v 2 “Yahuah says: ‘Stand in the court of Yahuah’s house, and speak to all the cities of Judah which come to worship in Yahuah’s house, all the words that I command you to speak to them. Don’t omit a word. 
 \v 3 It may be they will listen, and every man turn from his evil way, that I may relent from the evil which I intend to do to them because of the evil of their doings.’ ” 
-\v 4 You shall tell them, “Yahweh says: ‘If you will not listen to me, to walk in my law which I have set before you, 
+\v 4 You shall tell them, “Yahuah says: ‘If you will not listen to me, to walk in my law which I have set before you, 
 \v 5 to listen to the words of my servants the prophets whom I send to you, even rising up early and sending them—but you have not listened—\v 6 then I will make this house like Shiloh, and will make this city a curse to all the nations of the earth.’ ” 
 \p
-\v 7 The priests and the prophets and all the people heard Jeremiah speaking these words in Yahweh’s house. 
-\v 8 When Jeremiah had finished speaking all that Yahweh had commanded him to speak to all the people, the priests and the prophets and all the people seized him, saying, “You shall surely die! 
-\v 9 Why have you prophesied in Yahweh’s name, saying, ‘This house will be like Shiloh, and this city will be desolate, without inhabitant’?” All the people were crowded around Jeremiah in Yahweh’s house. 
+\v 7 The priests and the prophets and all the people heard Jeremiah speaking these words in Yahuah’s house. 
+\v 8 When Jeremiah had finished speaking all that Yahuah had commanded him to speak to all the people, the priests and the prophets and all the people seized him, saying, “You shall surely die! 
+\v 9 Why have you prophesied in Yahuah’s name, saying, ‘This house will be like Shiloh, and this city will be desolate, without inhabitant’?” All the people were crowded around Jeremiah in Yahuah’s house. 
 \p
-\v 10 When the princes of Judah heard these things, they came up from the king’s house to Yahweh’s house; and they sat in the entry of the new gate of Yahweh’s house. 
+\v 10 When the princes of Judah heard these things, they came up from the king’s house to Yahuah’s house; and they sat in the entry of the new gate of Yahuah’s house. 
 \v 11 Then the priests and the prophets spoke to the princes and to all the people, saying, “This man is worthy of death, for he has prophesied against this city, as you have heard with your ears.” 
 \p
-\v 12 Then Jeremiah spoke to all the princes and to all the people, saying, “Yahweh sent me to prophesy against this house and against this city all the words that you have heard. 
-\v 13 Now therefore amend your ways and your doings, and obey Yahweh your Elohim’s voice; then Yahweh will relent from the evil that he has pronounced against you. 
+\v 12 Then Jeremiah spoke to all the princes and to all the people, saying, “Yahuah sent me to prophesy against this house and against this city all the words that you have heard. 
+\v 13 Now therefore amend your ways and your doings, and obey Yahuah your Elohim’s voice; then Yahuah will relent from the evil that he has pronounced against you. 
 \v 14 But as for me, behold, I am in your hand. Do with me what is good and right in your eyes. 
-\v 15 Only know for certain that if you put me to death, you will bring innocent blood on yourselves, on this city, and on its inhabitants; for in truth Yahweh has sent me to you to speak all these words in your ears.” 
+\v 15 Only know for certain that if you put me to death, you will bring innocent blood on yourselves, on this city, and on its inhabitants; for in truth Yahuah has sent me to you to speak all these words in your ears.” 
 \p
-\v 16 Then the princes and all the people said to the priests and to the prophets: “This man is not worthy of death; for he has spoken to us in the name of Yahweh our Elohim.” 
+\v 16 Then the princes and all the people said to the priests and to the prophets: “This man is not worthy of death; for he has spoken to us in the name of Yahuah our Elohim.” 
 \p
 \v 17 Then certain of the elders of the land rose up, and spoke to all the assembly of the people, saying, 
-\v 18 “Micah the Morashtite prophesied in the days of Hezekiah king of Judah; and he spoke to all the people of Judah, saying, ‘Yahweh of Armies says: 
+\v 18 “Micah the Morashtite prophesied in the days of Hezekiah king of Judah; and he spoke to all the people of Judah, saying, ‘Yahuah of Armies says: 
 \q1 “ ‘Zion will be plowed as a field, 
 \q2 and Jerusalem will become heaps, 
 \q2 and the mountain of the house as the high places of a forest.’ 
 \m
-\v 19 Did Hezekiah king of Judah and all Judah put him to death? Didn’t he fear Yahweh, and entreat the favor of Yahweh, and Yahweh relented of the disaster which he had pronounced against them? We would commit great evil against our own souls that way!” 
+\v 19 Did Hezekiah king of Judah and all Judah put him to death? Didn’t he fear Yahuah, and entreat the favor of Yahuah, and Yahuah relented of the disaster which he had pronounced against them? We would commit great evil against our own souls that way!” 
 \p
-\v 20 There was also a man who prophesied in Yahweh’s name, Uriah the son of Shemaiah of Kiriath Jearim; and he prophesied against this city and against this land according to all the words of Jeremiah. 
+\v 20 There was also a man who prophesied in Yahuah’s name, Uriah the son of Shemaiah of Kiriath Jearim; and he prophesied against this city and against this land according to all the words of Jeremiah. 
 \v 21 When Jehoiakim the king, with all his mighty men and all the princes heard his words, the king sought to put him to death; but when Uriah heard it, he was afraid, and fled, and went into Egypt. 
 \v 22 Then Jehoiakim the king sent Elnathan the son of Achbor and certain men with him into Egypt. 
 \v 23 They fetched Uriah out of Egypt and brought him to Jehoiakim the king, who killed him with the sword and cast his dead body into the graves of the common people. 
@@ -1815,52 +1815,52 @@
 \v 24 But the hand of Ahikam the son of Shaphan was with Jeremiah, so that they didn’t give him into the hand of the people to put him to death. 
 \c 27
 \p
-\v 1 In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahweh, saying, 
-\v 2 Yahweh says to me: “Make bonds and bars, and put them on your neck. 
+\v 1 In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahuah, saying, 
+\v 2 Yahuah says to me: “Make bonds and bars, and put them on your neck. 
 \v 3 Then send them to the king of Edom, to the king of Moab, to the king of the children of Ammon, to the king of Tyre, and to the king of Sidon, by the hand of the messengers who come to Jerusalem to Zedekiah king of Judah. 
-\v 4 Give them a command to their masters, saying, ‘Yahweh of Armies, the Elohim of Israel says, “You shall tell your masters: 
+\v 4 Give them a command to their masters, saying, ‘Yahuah of Armies, the Elohim of Israel says, “You shall tell your masters: 
 \v 5 ‘I have made the earth, the men, and the animals that are on the surface of the earth by my great power and by my outstretched arm. I give it to whom it seems right to me. 
 \v 6 Now I have given all these lands into the hand of Nebuchadnezzar the king of Babylon, my servant. I have also given the animals of the field to him to serve him. 
 \v 7 All the nations will serve him, his son, and his son’s son, until the time of his own land comes. Then many nations and great kings will make him their bondservant. 
 \p
-\v 8 “ ‘ “ ‘It will happen that I will punish the nation and the kingdom which will not serve the same Nebuchadnezzar king of Babylon, and that will not put their neck under the yoke of the king of Babylon,’ says Yahweh, ‘with the sword, with famine, and with pestilence, until I have consumed them by his hand. 
+\v 8 “ ‘ “ ‘It will happen that I will punish the nation and the kingdom which will not serve the same Nebuchadnezzar king of Babylon, and that will not put their neck under the yoke of the king of Babylon,’ says Yahuah, ‘with the sword, with famine, and with pestilence, until I have consumed them by his hand. 
 \v 9 But as for you, don’t listen to your prophets, to your diviners, to your dreams, to your soothsayers, or to your sorcerers, who speak to you, saying, “You shall not serve the king of Babylon;” 
 \v 10 for they prophesy a lie to you, to remove you far from your land, so that I would drive you out, and you would perish. 
-\v 11 But the nation that brings their neck under the yoke of the king of Babylon and serves him, that nation I will let remain in their own land,’ says Yahweh; ‘and they will till it and dwell in it.’ ” ’ ” 
+\v 11 But the nation that brings their neck under the yoke of the king of Babylon and serves him, that nation I will let remain in their own land,’ says Yahuah; ‘and they will till it and dwell in it.’ ” ’ ” 
 \p
 \v 12 I spoke to Zedekiah king of Judah according to all these words, saying, “Bring your necks under the yoke of the king of Babylon, and serve him and his people, and live. 
-\v 13 Why will you die, you and your people, by the sword, by the famine, and by the pestilence, as Yahweh has spoken concerning the nation that will not serve the king of Babylon? 
+\v 13 Why will you die, you and your people, by the sword, by the famine, and by the pestilence, as Yahuah has spoken concerning the nation that will not serve the king of Babylon? 
 \v 14 Don’t listen to the words of the prophets who speak to you, saying, ‘You shall not serve the king of Babylon;’ for they prophesy a lie to you. 
-\v 15 For I have not sent them,” says Yahweh, “but they prophesy falsely in my name; that I may drive you out, and that you may perish, you, and the prophets who prophesy to you.” 
+\v 15 For I have not sent them,” says Yahuah, “but they prophesy falsely in my name; that I may drive you out, and that you may perish, you, and the prophets who prophesy to you.” 
 \p
-\v 16 Also I spoke to the priests and to all this people, saying, Yahweh says, “Don’t listen to the words of your prophets who prophesy to you, saying, ‘Behold, the vessels of Yahweh’s house will now shortly be brought again from Babylon;’ for they prophesy a lie to you. 
+\v 16 Also I spoke to the priests and to all this people, saying, Yahuah says, “Don’t listen to the words of your prophets who prophesy to you, saying, ‘Behold, the vessels of Yahuah’s house will now shortly be brought again from Babylon;’ for they prophesy a lie to you. 
 \v 17 Don’t listen to them. Serve the king of Babylon, and live. Why should this city become a desolation? 
-\v 18 But if they are prophets, and if Yahweh’s word is with them, let them now make intercession to Yahweh of Armies, that the vessels which are left in Yahweh’s house, in the house of the king of Judah, and at Jerusalem, don’t go to Babylon. 
-\v 19 For Yahweh of Armies says concerning the pillars, concerning the sea, concerning the bases, and concerning the rest of the vessels that are left in this city, 
-\v 20 which Nebuchadnezzar king of Babylon didn’t take when he carried away captive Jeconiah the son of Jehoiakim, king of Judah, from Jerusalem to Babylon, and all the nobles of Judah and Jerusalem—\v 21 yes, Yahweh of Armies, the Elohim of Israel, says concerning the vessels that are left in Yahweh’s house, and in the house of the king of Judah, and at Jerusalem: 
-\v 22 ‘They will be carried to Babylon, and there they will be, until the day that I visit them,’ says Yahweh; ‘then I will bring them up, and restore them to this place.’ ” 
+\v 18 But if they are prophets, and if Yahuah’s word is with them, let them now make intercession to Yahuah of Armies, that the vessels which are left in Yahuah’s house, in the house of the king of Judah, and at Jerusalem, don’t go to Babylon. 
+\v 19 For Yahuah of Armies says concerning the pillars, concerning the sea, concerning the bases, and concerning the rest of the vessels that are left in this city, 
+\v 20 which Nebuchadnezzar king of Babylon didn’t take when he carried away captive Jeconiah the son of Jehoiakim, king of Judah, from Jerusalem to Babylon, and all the nobles of Judah and Jerusalem—\v 21 yes, Yahuah of Armies, the Elohim of Israel, says concerning the vessels that are left in Yahuah’s house, and in the house of the king of Judah, and at Jerusalem: 
+\v 22 ‘They will be carried to Babylon, and there they will be, until the day that I visit them,’ says Yahuah; ‘then I will bring them up, and restore them to this place.’ ” 
 \c 28
 \p
-\v 1 That same year, in the beginning of the reign of Zedekiah king of Judah, in the fourth year, in the fifth month, Hananiah the son of Azzur, the prophet, who was of Gibeon, spoke to me in Yahweh’s house, in the presence of the priests and of all the people, saying, 
-\v 2 “Yahweh of Armies, the Elohim of Israel, says, ‘I have broken the yoke of the king of Babylon. 
-\v 3 Within two full years I will bring again into this place all the vessels of Yahweh’s house that Nebuchadnezzar king of Babylon took away from this place and carried to Babylon. 
-\v 4 I will bring again to this place Jeconiah the son of Jehoiakim, king of Judah, with all the captives of Judah, who went to Babylon,’ says Yahweh; ‘for I will break the yoke of the king of Babylon.’ ” 
+\v 1 That same year, in the beginning of the reign of Zedekiah king of Judah, in the fourth year, in the fifth month, Hananiah the son of Azzur, the prophet, who was of Gibeon, spoke to me in Yahuah’s house, in the presence of the priests and of all the people, saying, 
+\v 2 “Yahuah of Armies, the Elohim of Israel, says, ‘I have broken the yoke of the king of Babylon. 
+\v 3 Within two full years I will bring again into this place all the vessels of Yahuah’s house that Nebuchadnezzar king of Babylon took away from this place and carried to Babylon. 
+\v 4 I will bring again to this place Jeconiah the son of Jehoiakim, king of Judah, with all the captives of Judah, who went to Babylon,’ says Yahuah; ‘for I will break the yoke of the king of Babylon.’ ” 
 \p
-\v 5 Then the prophet Jeremiah said to the prophet Hananiah in the presence of the priests, and in the presence of all the people who stood in Yahweh’s house, 
-\v 6 even the prophet Jeremiah said, “Amen! May Yahweh do so. May Yahweh perform your words which you have prophesied, to bring again the vessels of Yahweh’s house, and all those who are captives, from Babylon to this place. 
+\v 5 Then the prophet Jeremiah said to the prophet Hananiah in the presence of the priests, and in the presence of all the people who stood in Yahuah’s house, 
+\v 6 even the prophet Jeremiah said, “Amen! May Yahuah do so. May Yahuah perform your words which you have prophesied, to bring again the vessels of Yahuah’s house, and all those who are captives, from Babylon to this place. 
 \v 7 Nevertheless listen now to this word that I speak in your ears, and in the ears of all the people: 
 \v 8 The prophets who have been before me and before you of old prophesied against many countries, and against great kingdoms, of war, of evil, and of pestilence. 
-\v 9 As for the prophet who prophesies of peace, when the word of the prophet happens, then the prophet will be known, that Yahweh has truly sent him.” 
+\v 9 As for the prophet who prophesies of peace, when the word of the prophet happens, then the prophet will be known, that Yahuah has truly sent him.” 
 \p
 \v 10 Then Hananiah the prophet took the bar from off the prophet Jeremiah’s neck, and broke it. 
-\v 11 Hananiah spoke in the presence of all the people, saying, “Yahweh says: ‘Even so I will break the yoke of Nebuchadnezzar king of Babylon from off the neck of all the nations within two full years.’ ” Then the prophet Jeremiah went his way. 
+\v 11 Hananiah spoke in the presence of all the people, saying, “Yahuah says: ‘Even so I will break the yoke of Nebuchadnezzar king of Babylon from off the neck of all the nations within two full years.’ ” Then the prophet Jeremiah went his way. 
 \p
-\v 12 Then Yahweh’s word came to Jeremiah, after Hananiah the prophet had broken the bar from off the neck of the prophet Jeremiah, saying, 
-\v 13 “Go, and tell Hananiah, saying, ‘Yahweh says, “You have broken the bars of wood, but you have made in their place bars of iron.” 
-\v 14 For Yahweh of Armies, the Elohim of Israel says, “I have put a yoke of iron on the neck of all these nations, that they may serve Nebuchadnezzar king of Babylon; and they will serve him. I have also given him the animals of the field.” ’ ” 
+\v 12 Then Yahuah’s word came to Jeremiah, after Hananiah the prophet had broken the bar from off the neck of the prophet Jeremiah, saying, 
+\v 13 “Go, and tell Hananiah, saying, ‘Yahuah says, “You have broken the bars of wood, but you have made in their place bars of iron.” 
+\v 14 For Yahuah of Armies, the Elohim of Israel says, “I have put a yoke of iron on the neck of all these nations, that they may serve Nebuchadnezzar king of Babylon; and they will serve him. I have also given him the animals of the field.” ’ ” 
 \p
-\v 15 Then the prophet Jeremiah said to Hananiah the prophet, “Listen, Hananiah! Yahweh has not sent you, but you make this people trust in a lie. 
-\v 16 Therefore Yahweh says, ‘Behold, I will send you away from off the surface of the earth. This year you will die, because you have spoken rebellion against Yahweh.’ ” 
+\v 15 Then the prophet Jeremiah said to Hananiah the prophet, “Listen, Hananiah! Yahuah has not sent you, but you make this people trust in a lie. 
+\v 16 Therefore Yahuah says, ‘Behold, I will send you away from off the surface of the earth. This year you will die, because you have spoken rebellion against Yahuah.’ ” 
 \p
 \v 17 So Hananiah the prophet died the same year in the seventh month. 
 \c 29
@@ -1869,47 +1869,47 @@
 \v 2 (after Jeconiah the king, the queen mother, the eunuchs, the princes of Judah and Jerusalem, the craftsmen, and the smiths had departed from Jerusalem), 
 \v 3 by the hand of Elasah the son of Shaphan and Gemariah the son of Hilkiah, (whom Zedekiah king of Judah sent to Babylon to Nebuchadnezzar king of Babylon). It said: 
 \pi1
-\v 4 Yahweh of Armies, the Elohim of Israel, says to all the captives whom I have caused to be carried away captive from Jerusalem to Babylon: 
+\v 4 Yahuah of Armies, the Elohim of Israel, says to all the captives whom I have caused to be carried away captive from Jerusalem to Babylon: 
 \v 5 “Build houses and dwell in them. Plant gardens and eat their fruit. 
 \v 6 Take women and father sons and daughters. Take women for your sons, and give your daughters to men, that they may bear sons and daughters. Multiply there, and don’t be diminished. 
-\v 7 Seek the peace of the city where I have caused you to be carried away captive, and pray to Yahweh for it; for in its peace you will have peace.” 
-\v 8 For Yahweh of Armies, the Elohim of Israel says: “Don’t let your prophets who are among you and your diviners deceive you. Don’t listen to your dreams which you cause to be dreamed. 
-\v 9 For they prophesy falsely to you in my name. I have not sent them,” says Yahweh. 
-\v 10 For Yahweh says, “After seventy years are accomplished for Babylon, I will visit you and perform my good word toward you, in causing you to return to this place. 
-\v 11 For I know the thoughts that I think toward you,” says Yahweh, “thoughts of peace, and not of evil, to give you hope and a future. 
+\v 7 Seek the peace of the city where I have caused you to be carried away captive, and pray to Yahuah for it; for in its peace you will have peace.” 
+\v 8 For Yahuah of Armies, the Elohim of Israel says: “Don’t let your prophets who are among you and your diviners deceive you. Don’t listen to your dreams which you cause to be dreamed. 
+\v 9 For they prophesy falsely to you in my name. I have not sent them,” says Yahuah. 
+\v 10 For Yahuah says, “After seventy years are accomplished for Babylon, I will visit you and perform my good word toward you, in causing you to return to this place. 
+\v 11 For I know the thoughts that I think toward you,” says Yahuah, “thoughts of peace, and not of evil, to give you hope and a future. 
 \v 12 You shall call on me, and you shall go and pray to me, and I will listen to you. 
 \v 13 You shall seek me and find me, when you search for me with all your heart. 
-\v 14 I will be found by you,” says Yahweh, “and I will turn again your captivity, and I will gather you from all the nations, and from all the places where I have driven you, says Yahweh. I will bring you again to the place from where I caused you to be carried away captive.” 
+\v 14 I will be found by you,” says Yahuah, “and I will turn again your captivity, and I will gather you from all the nations, and from all the places where I have driven you, says Yahuah. I will bring you again to the place from where I caused you to be carried away captive.” 
 \pi1
-\v 15 Because you have said, “Yahweh has raised us up prophets in Babylon,” 
-\v 16 Yahweh says concerning the king who sits on David’s throne, and concerning all the people who dwell in this city, your brothers who haven’t gone with you into captivity, 
-\v 17 Yahweh of Armies says: “Behold, I will send on them the sword, the famine, and the pestilence, and will make them like rotten figs that can’t be eaten, they are so bad. 
+\v 15 Because you have said, “Yahuah has raised us up prophets in Babylon,” 
+\v 16 Yahuah says concerning the king who sits on David’s throne, and concerning all the people who dwell in this city, your brothers who haven’t gone with you into captivity, 
+\v 17 Yahuah of Armies says: “Behold, I will send on them the sword, the famine, and the pestilence, and will make them like rotten figs that can’t be eaten, they are so bad. 
 \v 18 I will pursue after them with the sword, with the famine, and with the pestilence, and will deliver them to be tossed back and forth among all the kingdoms of the earth, to be an object of horror, an astonishment, a hissing, and a reproach among all the nations where I have driven them, 
-\v 19 because they have not listened to my words,” says Yahweh, “with which I sent to them my servants the prophets, rising up early and sending them; but you would not hear,” says Yahweh. 
+\v 19 because they have not listened to my words,” says Yahuah, “with which I sent to them my servants the prophets, rising up early and sending them; but you would not hear,” says Yahuah. 
 \pi1
-\v 20 Hear therefore Yahweh’s word, all you captives whom I have sent away from Jerusalem to Babylon. 
-\v 21 Yahweh of Armies, the Elohim of Israel, says concerning Ahab the son of Kolaiah, and concerning Zedekiah the son of Maaseiah, who prophesy a lie to you in my name: “Behold, I will deliver them into the hand of Nebuchadnezzar king of Babylon; and he will kill them before your eyes. 
-\v 22 A curse will be taken up about them by all the captives of Judah who are in Babylon, saying, ‘Yahweh make you like Zedekiah and like Ahab, whom the king of Babylon roasted in the fire;’ 
-\v 23 because they have done foolish things in Israel, and have committed adultery with their neighbors’ women, and have spoken words in my name falsely, which I didn’t command them. I am he who knows, and am witness,” says Yahweh. 
+\v 20 Hear therefore Yahuah’s word, all you captives whom I have sent away from Jerusalem to Babylon. 
+\v 21 Yahuah of Armies, the Elohim of Israel, says concerning Ahab the son of Kolaiah, and concerning Zedekiah the son of Maaseiah, who prophesy a lie to you in my name: “Behold, I will deliver them into the hand of Nebuchadnezzar king of Babylon; and he will kill them before your eyes. 
+\v 22 A curse will be taken up about them by all the captives of Judah who are in Babylon, saying, ‘Yahuah make you like Zedekiah and like Ahab, whom the king of Babylon roasted in the fire;’ 
+\v 23 because they have done foolish things in Israel, and have committed adultery with their neighbors’ women, and have spoken words in my name falsely, which I didn’t command them. I am he who knows, and am witness,” says Yahuah. 
 \p
 \v 24 Concerning Shemaiah the Nehelamite you shall speak, saying, 
-\v 25 “Yahweh of Armies, the Elohim of Israel, says, ‘Because you have sent letters in your own name to all the people who are at Jerusalem, and to Zephaniah the son of Maaseiah, the priest, and to all the priests, saying, 
-\v 26 “Yahweh has made you priest in the place of Jehoiada the priest, that there may be officers in Yahweh’s house, for every man who is crazy and makes himself a prophet, that you should put him in the stocks and in shackles. 
+\v 25 “Yahuah of Armies, the Elohim of Israel, says, ‘Because you have sent letters in your own name to all the people who are at Jerusalem, and to Zephaniah the son of Maaseiah, the priest, and to all the priests, saying, 
+\v 26 “Yahuah has made you priest in the place of Jehoiada the priest, that there may be officers in Yahuah’s house, for every man who is crazy and makes himself a prophet, that you should put him in the stocks and in shackles. 
 \v 27 Now therefore, why have you not rebuked Jeremiah of Anathoth, who makes himself a prophet to you, 
 \v 28 because he has sent to us in Babylon, saying, The captivity is long. Build houses, and dwell in them. Plant gardens, and eat their fruit?” ’ ” 
 \p
 \v 29 Zephaniah the priest read this letter in the hearing of Jeremiah the prophet. 
-\v 30 Then Yahweh’s word came to Jeremiah, saying, 
-\v 31 “Send to all of the captives, saying, ‘Yahweh says concerning Shemaiah the Nehelamite: “Because Shemaiah has prophesied to you, and I didn’t send him, and he has caused you to trust in a lie,” 
-\v 32 therefore Yahweh says, “Behold, I will punish Shemaiah the Nehelamite and his offspring. He will not have a man to dwell among this people. He won’t see the good that I will do to my people,” says Yahweh, “because he has spoken rebellion against Yahweh.” ’ ” 
+\v 30 Then Yahuah’s word came to Jeremiah, saying, 
+\v 31 “Send to all of the captives, saying, ‘Yahuah says concerning Shemaiah the Nehelamite: “Because Shemaiah has prophesied to you, and I didn’t send him, and he has caused you to trust in a lie,” 
+\v 32 therefore Yahuah says, “Behold, I will punish Shemaiah the Nehelamite and his offspring. He will not have a man to dwell among this people. He won’t see the good that I will do to my people,” says Yahuah, “because he has spoken rebellion against Yahuah.” ’ ” 
 \c 30
 \p
-\v 1 The word that came to Jeremiah from Yahweh, saying, 
-\v 2 “Yahweh, the Elohim of Israel, says, ‘Write all the words that I have spoken to you in a book. 
-\v 3 For, behold, the days come,’ says Yahweh, ‘that I will reverse the captivity of my people Israel and Judah,’ says Yahweh. ‘I will cause them to return to the land that I gave to their fathers, and they will possess it.’ ” 
+\v 1 The word that came to Jeremiah from Yahuah, saying, 
+\v 2 “Yahuah, the Elohim of Israel, says, ‘Write all the words that I have spoken to you in a book. 
+\v 3 For, behold, the days come,’ says Yahuah, ‘that I will reverse the captivity of my people Israel and Judah,’ says Yahuah. ‘I will cause them to return to the land that I gave to their fathers, and they will possess it.’ ” 
 \p
-\v 4 These are the words that Yahweh spoke concerning Israel and concerning Judah. 
-\v 5 For Yahweh says: 
+\v 4 These are the words that Yahuah spoke concerning Israel and concerning Judah. 
+\v 5 For Yahuah says: 
 \q1 “We have heard a voice of trembling; 
 \q2 a voice of fear, and not of peace. 
 \q1
@@ -1921,15 +1921,15 @@
 \q2 It is even the time of Jacob’s trouble; 
 \q2 but he will be saved out of it. 
 \q1
-\v 8 It will come to pass in that day, says Yahweh of Armies, that I will break his yoke from off your neck, 
+\v 8 It will come to pass in that day, says Yahuah of Armies, that I will break his yoke from off your neck, 
 \q2 and will burst your bonds. 
 \q2 Strangers will no more make them their bondservants; 
 \q1
-\v 9 but they will serve Yahweh their Elohim, 
+\v 9 but they will serve Yahuah their Elohim, 
 \q2 and David their king, 
 \q2 whom I will raise up to them. 
 \q1
-\v 10 Therefore don’t be afraid, O Jacob my servant, says Yahweh. 
+\v 10 Therefore don’t be afraid, O Jacob my servant, says Yahuah. 
 \q2 Don’t be dismayed, Israel. 
 \q1 For, behold, I will save you from afar, 
 \q2 and save your offspring from the land of their captivity. 
@@ -1937,13 +1937,13 @@
 \q2 and will be quiet and at ease. 
 \q2 No one will make him afraid. 
 \q1
-\v 11 For I am with you, says Yahweh, to save you; 
+\v 11 For I am with you, says Yahuah, to save you; 
 \q2 for I will make a full end of all the nations where I have scattered you, 
 \q2 but I will not make a full end of you; 
 \q1 but I will correct you in measure, 
 \q2 and will in no way leave you unpunished.” 
 \p
-\v 12 For Yahweh says, 
+\v 12 For Yahuah says, 
 \q1 “Your hurt is incurable. 
 \q2 Your wound is grievous. 
 \q1
@@ -1970,11 +1970,11 @@
 \q2 I will make all who prey on you become prey. 
 \q1
 \v 17 For I will restore health to you, 
-\q2 and I will heal you of your wounds,” says Yahweh, 
+\q2 and I will heal you of your wounds,” says Yahuah, 
 \q1 “because they have called you an outcast, 
 \q2 saying, ‘It is Zion, whom no man seeks after.’ ” 
 \p
-\v 18 Yahweh says: 
+\v 18 Yahuah says: 
 \q1 “Behold, I will reverse the captivity of Jacob’s tents, 
 \q2 and have compassion on his dwelling places. 
 \q1 The city will be built on its own hill, 
@@ -1995,25 +1995,25 @@
 \q2 and their ruler will proceed from among them. 
 \q1 I will cause him to draw near, 
 \q2 and he will approach me; 
-\q2 for who is he who has had boldness to approach me?” says Yahweh. 
+\q2 for who is he who has had boldness to approach me?” says Yahuah. 
 \q1
 \v 22 “You shall be my people, 
 \q2 and I will be your Elohim. 
 \q1
-\v 23 Behold, Yahweh’s storm, his wrath, has gone out, 
+\v 23 Behold, Yahuah’s storm, his wrath, has gone out, 
 \q2 a sweeping storm; 
 \q2 it will burst on the head of the wicked. 
 \q1
-\v 24 The fierce anger of Yahweh will not return until he has accomplished, 
+\v 24 The fierce anger of Yahuah will not return until he has accomplished, 
 \q2 and until he has performed the intentions of his heart. 
 \q2 In the latter days you will understand it.” 
 \c 31
 \p
-\v 1 “At that time,” says Yahweh, “I will be the Elohim of all the families of Israel, and they will be my people.” 
+\v 1 “At that time,” says Yahuah, “I will be the Elohim of all the families of Israel, and they will be my people.” 
 \p
-\v 2 Yahweh says, “The people who survive the sword found favor in the wilderness; even Israel, when I went to cause him to rest.” 
+\v 2 Yahuah says, “The people who survive the sword found favor in the wilderness; even Israel, when I went to cause him to rest.” 
 \p
-\v 3 Yahweh appeared of old to me, saying, 
+\v 3 Yahuah appeared of old to me, saying, 
 \q1 “Yes, I have loved you with an everlasting love. 
 \q2 Therefore I have drawn you with loving kindness. 
 \q1
@@ -2027,13 +2027,13 @@
 \q2 and will enjoy its fruit. 
 \q1
 \v 6 For there will be a day that the watchmen on the hills of Ephraim cry, 
-\q2 ‘Arise! Let’s go up to Zion to Yahweh our Elohim.’ ” 
+\q2 ‘Arise! Let’s go up to Zion to Yahuah our Elohim.’ ” 
 \p
-\v 7 For Yahweh says, 
+\v 7 For Yahuah says, 
 \q1 “Sing with gladness for Jacob, 
 \q2 and shout for the chief of the nations. 
 \q1 Publish, praise, and say, 
-\q2 ‘Yahweh, save your people, 
+\q2 ‘Yahuah, save your people, 
 \q2 the remnant of Israel!’ 
 \q1
 \v 8 Behold, I will bring them from the north country, 
@@ -2050,16 +2050,16 @@
 \q2 Ephraim is my firstborn. 
 \b
 \q1
-\v 10 “Hear Yahweh’s word, you nations, 
+\v 10 “Hear Yahuah’s word, you nations, 
 \q2 and declare it in the distant islands. Say, 
 \q1 ‘He who scattered Israel will gather him, 
 \q2 and keep him, as a shepherd does his flock.’ 
 \q1
-\v 11 For Yahweh has ransomed Jacob, 
+\v 11 For Yahuah has ransomed Jacob, 
 \q2 and redeemed him from the hand of him who was stronger than he. 
 \q1
 \v 12 They will come and sing in the height of Zion, 
-\q2 and will flow to the goodness of Yahweh, 
+\q2 and will flow to the goodness of Yahuah, 
 \q1 to the grain, to the new wine, to the oil, 
 \q2 and to the young of the flock and of the herd. 
 \q1 Their soul will be as a watered garden. 
@@ -2071,23 +2071,23 @@
 \q2 and will comfort them, and make them rejoice from their sorrow. 
 \q1
 \v 14 I will satiate the soul of the priests with fatness, 
-\q2 and my people will be satisfied with my goodness,” says Yahweh. 
+\q2 and my people will be satisfied with my goodness,” says Yahuah. 
 \b
 \p
-\v 15 Yahweh says: 
+\v 15 Yahuah says: 
 \q1 “A voice is heard in Ramah, 
 \q2 lamentation and bitter weeping, 
 \q1 Rachel weeping for her children. 
 \q2 She refuses to be comforted for her children, 
 \q2 because they are no more.” 
 \p
-\v 16 Yahweh says: 
+\v 16 Yahuah says: 
 \q1 “Refrain your voice from weeping, 
 \q2 and your eyes from tears, 
-\q2 for your work will be rewarded,” says Yahweh. 
+\q2 for your work will be rewarded,” says Yahuah. 
 \q2 “They will come again from the land of the enemy. 
 \q1
-\v 17 There is hope for your latter end,” says Yahweh. 
+\v 17 There is hope for your latter end,” says Yahuah. 
 \q2 “Your children will come again to their own territory. 
 \b
 \q1
@@ -2095,7 +2095,7 @@
 \q2 ‘You have chastised me, 
 \q2 and I was chastised, as an untrained calf. 
 \q1 Turn me, and I will be turned, 
-\q2 for you are Yahweh my Elohim. 
+\q2 for you are Yahuah my Elohim. 
 \q1
 \v 19 Surely after that I was turned. 
 \q2 I repented. 
@@ -2109,7 +2109,7 @@
 \q1 For as often as I speak against him, 
 \q2 I still earnestly remember him. 
 \q1 Therefore my heart yearns for him. 
-\q2 I will surely have mercy on him,” says Yahweh. 
+\q2 I will surely have mercy on him,” says Yahuah. 
 \b
 \q1
 \v 21 “Set up road signs. 
@@ -2121,81 +2121,81 @@
 \q1
 \v 22 How long will you go here and there, 
 \q2 you backsliding daughter? 
-\q1 For Yahweh has created a new thing in the earth: 
+\q1 For Yahuah has created a new thing in the earth: 
 \q2 a woman will encompass a man.” 
 \b
 \p
-\v 23 Yahweh of Armies, the Elohim of Israel, says: “Yet again they will use this speech in the land of Judah and in its cities, when I reverse their captivity: ‘Yahweh bless you, habitation of righteousness, mountain of set-apartness.’ 
+\v 23 Yahuah of Armies, the Elohim of Israel, says: “Yet again they will use this speech in the land of Judah and in its cities, when I reverse their captivity: ‘Yahuah bless you, habitation of righteousness, mountain of set-apartness.’ 
 \v 24 Judah and all its cities will dwell therein together, the farmers, and those who go about with flocks. 
 \v 25 For I have satiated the weary soul, and I have replenished every sorrowful soul.” 
 \p
 \v 26 On this I awakened, and saw; and my sleep was sweet to me. 
 \p
-\v 27 “Behold, the days come,” says Yahweh, “that I will sow the house of Israel and the house of Judah with the seed of man and with the seed of animal. 
-\v 28 It will happen that, like as I have watched over them to pluck up and to break down and to overthrow and to destroy and to afflict, so I will watch over them to build and to plant,” says Yahweh. 
+\v 27 “Behold, the days come,” says Yahuah, “that I will sow the house of Israel and the house of Judah with the seed of man and with the seed of animal. 
+\v 28 It will happen that, like as I have watched over them to pluck up and to break down and to overthrow and to destroy and to afflict, so I will watch over them to build and to plant,” says Yahuah. 
 \v 29 “In those days they will say no more, 
 \q1 “ ‘The fathers have eaten sour grapes, 
 \q2 and the children’s teeth are set on edge.’ 
 \m
 \v 30 But everyone will die for his own iniquity. Every man who eats the sour grapes, his teeth will be set on edge. 
 \p
-\v 31 “Behold, the days come,” says Yahweh, “that I will make a new covenant with the house of Israel, and with the house of Judah, 
-\v 32 not according to the covenant that I made with their fathers in the day that I took them by the hand to bring them out of the land of Egypt, which covenant of mine they broke, although I was an owner to them,” says Yahweh. 
-\v 33 “But this is the covenant that I will make with the house of Israel after those days,” says Yahweh: 
+\v 31 “Behold, the days come,” says Yahuah, “that I will make a new covenant with the house of Israel, and with the house of Judah, 
+\v 32 not according to the covenant that I made with their fathers in the day that I took them by the hand to bring them out of the land of Egypt, which covenant of mine they broke, although I was an owner to them,” says Yahuah. 
+\v 33 “But this is the covenant that I will make with the house of Israel after those days,” says Yahuah: 
 \q1 “I will put my law in their inward parts, 
 \q2 and I will write it in their heart. 
 \q1 I will be their Elohim, 
 \q2 and they shall be my people. 
 \q1
 \v 34 They will no longer each teach his neighbor, 
-\q2 and every man teach his brother, saying, ‘Know Yahweh;’ 
+\q2 and every man teach his brother, saying, ‘Know Yahuah;’ 
 \q1 for they will all know me, 
-\q2 from their least to their greatest,” says Yahweh, 
+\q2 from their least to their greatest,” says Yahuah, 
 \q1 “for I will forgive their iniquity, 
 \q2 and I will remember their sin no more.” 
 \q1
-\v 35 Yahweh, who gives the sun for a light by day, 
+\v 35 Yahuah, who gives the sun for a light by day, 
 \q2 and the ordinances of the moon and of the stars for a light by night, 
-\q1 who stirs up the sea, so that its waves roar—\q2 Yahweh of Armies is his name, says: 
+\q1 who stirs up the sea, so that its waves roar—\q2 Yahuah of Armies is his name, says: 
 \q1
-\v 36 “If these ordinances depart from before me,” says Yahweh, 
+\v 36 “If these ordinances depart from before me,” says Yahuah, 
 \q2 “then the offspring of Israel also will cease from being a nation before me forever.” 
 \q1
-\v 37 Yahweh says: “If heaven above can be measured, 
+\v 37 Yahuah says: “If heaven above can be measured, 
 \q2 and the foundations of the earth searched out beneath, 
-\q2 then I will also cast off all the offspring of Israel for all that they have done,” says Yahweh. 
+\q2 then I will also cast off all the offspring of Israel for all that they have done,” says Yahuah. 
 \p
-\v 38 “Behold, the days come,” says Yahweh, “that the city will be built to Yahweh from the tower of Hananel to the gate of the corner. 
+\v 38 “Behold, the days come,” says Yahuah, “that the city will be built to Yahuah from the tower of Hananel to the gate of the corner. 
 \v 39 The measuring line will go out further straight onward to the hill Gareb, and will turn toward Goah. 
-\v 40 The whole valley of the dead bodies and of the ashes, and all the fields to the brook Kidron, to the corner of the horse gate toward the east, will be set-apart to Yahweh. It will not be plucked up or thrown down any more forever.” 
+\v 40 The whole valley of the dead bodies and of the ashes, and all the fields to the brook Kidron, to the corner of the horse gate toward the east, will be set-apart to Yahuah. It will not be plucked up or thrown down any more forever.” 
 \c 32
 \p
-\v 1 This is the word that came to Jeremiah from Yahweh in the tenth year of Zedekiah king of Judah, which was the eighteenth year of Nebuchadnezzar. 
+\v 1 This is the word that came to Jeremiah from Yahuah in the tenth year of Zedekiah king of Judah, which was the eighteenth year of Nebuchadnezzar. 
 \v 2 Now at that time the king of Babylon’s army was besieging Jerusalem. Jeremiah the prophet was shut up in the court of the guard, which was in the king of Judah’s house. 
 \p
-\v 3 For Zedekiah king of Judah had shut him up, saying, “Why do you prophesy, and say, ‘Yahweh says, “Behold, I will give this city into the hand of the king of Babylon, and he will take it; 
+\v 3 For Zedekiah king of Judah had shut him up, saying, “Why do you prophesy, and say, ‘Yahuah says, “Behold, I will give this city into the hand of the king of Babylon, and he will take it; 
 \v 4 and Zedekiah king of Judah won’t escape out of the hand of the Chaldeans, but will surely be delivered into the hand of the king of Babylon, and will speak with him mouth to mouth, and his eyes will see his eyes; 
-\v 5 and he will bring Zedekiah to Babylon, and he will be there until I visit him,” says Yahweh, “though you fight with the Chaldeans, you will not prosper” ’?” 
+\v 5 and he will bring Zedekiah to Babylon, and he will be there until I visit him,” says Yahuah, “though you fight with the Chaldeans, you will not prosper” ’?” 
 \p
-\v 6 Jeremiah said, “Yahweh’s word came to me, saying, 
+\v 6 Jeremiah said, “Yahuah’s word came to me, saying, 
 \v 7 ‘Behold, Hanamel the son of Shallum your uncle will come to you, saying, “Buy my field that is in Anathoth; for the right of redemption is yours to buy it.” ’ ” 
 \p
-\v 8 “So Hanamel my uncle’s son came to me in the court of the guard according to Yahweh’s word, and said to me, ‘Please buy my field that is in Anathoth, which is in the land of Benjamin; for the right of inheritance is yours, and the redemption is yours. Buy it for yourself.’ 
-\p “Then I knew that this was Yahweh’s word. 
+\v 8 “So Hanamel my uncle’s son came to me in the court of the guard according to Yahuah’s word, and said to me, ‘Please buy my field that is in Anathoth, which is in the land of Benjamin; for the right of inheritance is yours, and the redemption is yours. Buy it for yourself.’ 
+\p “Then I knew that this was Yahuah’s word. 
 \v 9 I bought the field that was in Anathoth of Hanamel my uncle’s son, and weighed him the money, even seventeen shekels of silver. 
 \v 10 I signed the deed, sealed it, called witnesses, and weighed the money in the balances to him. 
 \v 11 So I took the deed of the purchase, both that which was sealed, containing the terms and conditions, and that which was open; 
 \v 12 and I delivered the deed of the purchase to Baruch the son of Neriah, the son of Mahseiah, in the presence of Hanamel my uncle’s son, and in the presence of the witnesses who signed the deed of the purchase, before all the Jews who sat in the court of the guard. 
 \p
 \v 13 “I commanded Baruch before them, saying, 
-\v 14 Yahweh of Armies, the Elohim of Israel, says: ‘Take these deeds, this deed of the purchase which is sealed, and this deed which is open, and put them in an earthen vessel, that they may last many days.’ 
-\v 15 For Yahweh of Armies, the Elohim of Israel says: ‘Houses and fields and vineyards will yet again be bought in this land.’ 
+\v 14 Yahuah of Armies, the Elohim of Israel, says: ‘Take these deeds, this deed of the purchase which is sealed, and this deed which is open, and put them in an earthen vessel, that they may last many days.’ 
+\v 15 For Yahuah of Armies, the Elohim of Israel says: ‘Houses and fields and vineyards will yet again be bought in this land.’ 
 \p
-\v 16 Now after I had delivered the deed of the purchase to Baruch the son of Neriah, I prayed to Yahweh, saying, 
+\v 16 Now after I had delivered the deed of the purchase to Baruch the son of Neriah, I prayed to Yahuah, saying, 
 \b
 \mi
-\v 17 “Ah Lord Yahweh! Behold, you have made the heavens and the earth by your great power and by your outstretched arm. There is nothing too hard for you. 
-\v 18 You show loving kindness to thousands, and repay the iniquity of the fathers into the bosom of their children after them. The great, the mighty Elohim, Yahweh of Armies is your name: 
+\v 17 “Ah Lord Yahuah! Behold, you have made the heavens and the earth by your great power and by your outstretched arm. There is nothing too hard for you. 
+\v 18 You show loving kindness to thousands, and repay the iniquity of the fathers into the bosom of their children after them. The great, the mighty Elohim, Yahuah of Armies is your name: 
 \v 19 great in counsel, and mighty in work; whose eyes are open to all the ways of the children of men, to give everyone according to his ways, and according to the fruit of his doings; 
 \v 20 who performed signs and wonders in the land of Egypt, even to this day, both in Israel and among other men; and made yourself a name, as it is today; 
 \v 21 and brought your people Israel out of the land of Egypt with signs, with wonders, with a strong hand, with an outstretched arm, and with great terror; 
@@ -2203,49 +2203,49 @@
 \v 23 They came in and possessed it, but they didn’t obey your voice and didn’t walk in your law. They have done nothing of all that you commanded them to do. Therefore you have caused all this evil to come upon them. 
 \pi1
 \v 24 “Behold, siege ramps have been built against the city to take it. The city is given into the hand of the Chaldeans who fight against it, because of the sword, of the famine, and of the pestilence. What you have spoken has happened. Behold, you see it. 
-\v 25 You have said to me, Lord Yahweh, ‘Buy the field for money, and call witnesses;’ whereas the city is given into the hand of the Chaldeans.” 
+\v 25 You have said to me, Lord Yahuah, ‘Buy the field for money, and call witnesses;’ whereas the city is given into the hand of the Chaldeans.” 
 \p
-\v 26 Then Yahweh’s word came to Jeremiah, saying, 
-\v 27 “Behold, I am Yahweh, the Elohim of all flesh. Is there anything too hard for me? 
-\v 28 Therefore Yahweh says: Behold, I will give this city into the hand of the Chaldeans, and into the hand of Nebuchadnezzar king of Babylon, and he will take it. 
+\v 26 Then Yahuah’s word came to Jeremiah, saying, 
+\v 27 “Behold, I am Yahuah, the Elohim of all flesh. Is there anything too hard for me? 
+\v 28 Therefore Yahuah says: Behold, I will give this city into the hand of the Chaldeans, and into the hand of Nebuchadnezzar king of Babylon, and he will take it. 
 \v 29 The Chaldeans, who fight against this city, will come and set this city on fire, and burn it with the houses on whose roofs they have offered incense to Baal, and poured out drink offerings to other elohims, to provoke me to anger. 
 \p
-\v 30 “For the children of Israel and the children of Judah have done only that which was evil in my sight from their youth; for the children of Israel have only provoked me to anger with the work of their hands, says Yahweh. 
+\v 30 “For the children of Israel and the children of Judah have done only that which was evil in my sight from their youth; for the children of Israel have only provoked me to anger with the work of their hands, says Yahuah. 
 \v 31 For this city has been to me a provocation of my anger and of my wrath from the day that they built it even to this day, so that I should remove it from before my face, 
 \v 32 because of all the evil of the children of Israel and of the children of Judah, which they have done to provoke me to anger—they, their kings, their princes, their priests, their prophets, the men of Judah, and the inhabitants of Jerusalem. 
 \v 33 They have turned their backs to me, and not their faces. Although I taught them, rising up early and teaching them, yet they have not listened to receive instruction. 
 \v 34 But they set their abominations in the house which is called by my name, to defile it. 
 \v 35 They built the high places of Baal, which are in the valley of the son of Hinnom, to cause their sons and their daughters to pass through fire to Molech, which I didn’t command them. It didn’t even come into my mind, that they should do this abomination, to cause Judah to sin.” 
 \p
-\v 36 Now therefore Yahweh, the Elohim of Israel, says concerning this city, about which you say, “It is given into the hand of the king of Babylon by the sword, by the famine, and by the pestilence:” 
+\v 36 Now therefore Yahuah, the Elohim of Israel, says concerning this city, about which you say, “It is given into the hand of the king of Babylon by the sword, by the famine, and by the pestilence:” 
 \v 37 “Behold, I will gather them out of all the countries where I have driven them in my anger, and in my wrath, and in great indignation; and I will bring them again to this place. I will cause them to dwell safely. 
 \v 38 Then they will be my people, and I will be their Elohim. 
 \v 39 I will give them one heart and one way, that they may fear me forever, for their good and the good of their children after them. 
 \v 40 I will make an everlasting covenant with them, that I will not turn away from following them, to do them good. I will put my fear in their hearts, that they may not depart from me. 
 \v 41 Yes, I will rejoice over them to do them good, and I will plant them in this land assuredly with my whole heart and with my whole soul.” 
 \p
-\v 42 For Yahweh says: “Just as I have brought all this great evil on this people, so I will bring on them all the good that I have promised them. 
+\v 42 For Yahuah says: “Just as I have brought all this great evil on this people, so I will bring on them all the good that I have promised them. 
 \v 43 Fields will be bought in this land, about which you say, ‘It is desolate, without man or animal. It is given into the hand of the Chaldeans.’ 
-\v 44 Men will buy fields for money, sign the deeds, seal them, and call witnesses, in the land of Benjamin, and in the places around Jerusalem, in the cities of Judah, in the cities of the hill country, in the cities of the lowland, and in the cities of the South; for I will cause their captivity to be reversed,” says Yahweh. 
+\v 44 Men will buy fields for money, sign the deeds, seal them, and call witnesses, in the land of Benjamin, and in the places around Jerusalem, in the cities of Judah, in the cities of the hill country, in the cities of the lowland, and in the cities of the South; for I will cause their captivity to be reversed,” says Yahuah. 
 \c 33
 \nb
-\v 1 Moreover Yahweh’s word came to Jeremiah the second time, while he was still locked up in the court of the guard, saying, 
-\v 2 “Yahweh who does it, Yahweh who forms it to establish it—Yahweh is his name, says: 
+\v 1 Moreover Yahuah’s word came to Jeremiah the second time, while he was still locked up in the court of the guard, saying, 
+\v 2 “Yahuah who does it, Yahuah who forms it to establish it—Yahuah is his name, says: 
 \v 3 ‘Call to me, and I will answer you, and will show you great and difficult things, which you don’t know.’ 
-\v 4 For Yahweh, the Elohim of Israel, says concerning the houses of this city and concerning the houses of the kings of Judah, which are broken down to make a defense against the mounds and against the sword: 
+\v 4 For Yahuah, the Elohim of Israel, says concerning the houses of this city and concerning the houses of the kings of Judah, which are broken down to make a defense against the mounds and against the sword: 
 \v 5 ‘While men come to fight with the Chaldeans, and to fill them with the dead bodies of men, whom I have killed in my anger and in my wrath, and for all whose wickedness I have hidden my face from this city, 
 \v 6 behold, I will bring it health and healing, and I will cure them; and I will reveal to them abundance of peace and truth. 
 \v 7 I will restore the fortunes of Judah and Israel, and will build them as at the first. 
 \v 8 I will cleanse them from all their iniquity by which they have sinned against me. I will pardon all their iniquities by which they have sinned against me and by which they have transgressed against me. 
 \v 9 This city will be to me for a name of joy, for praise, and for glory, before all the nations of the earth, which will hear all the good that I do to them, and will fear and tremble for all the good and for all the peace that I provide to it.’ ” 
 \p
-\v 10 Yahweh says: “Yet again there will be heard in this place, about which you say, ‘It is waste, without man and without animal, even in the cities of Judah, and in the streets of Jerusalem, that are desolate, without man and without inhabitant and without animal,’ 
-\v 11 the voice of joy and the voice of gladness, the voice of the bridegroom and the voice of the bride, the voice of those who say, ‘Give thanks to Yahweh of Armies, for Yahweh is good, for his loving kindness endures forever;’ who bring thanksgiving into Yahweh’s house. For I will cause the captivity of the land to be reversed as at the first,” says Yahweh. 
+\v 10 Yahuah says: “Yet again there will be heard in this place, about which you say, ‘It is waste, without man and without animal, even in the cities of Judah, and in the streets of Jerusalem, that are desolate, without man and without inhabitant and without animal,’ 
+\v 11 the voice of joy and the voice of gladness, the voice of the bridegroom and the voice of the bride, the voice of those who say, ‘Give thanks to Yahuah of Armies, for Yahuah is good, for his loving kindness endures forever;’ who bring thanksgiving into Yahuah’s house. For I will cause the captivity of the land to be reversed as at the first,” says Yahuah. 
 \p
-\v 12 Yahweh of Armies says: “Yet again there will be in this place, which is waste, without man and without animal, and in all its cities, a habitation of shepherds causing their flocks to lie down. 
-\v 13 In the cities of the hill country, in the cities of the lowland, in the cities of the South, in the land of Benjamin, in the places around Jerusalem, and in the cities of Judah, the flocks will again pass under the hands of him who counts them,” says Yahweh. 
+\v 12 Yahuah of Armies says: “Yet again there will be in this place, which is waste, without man and without animal, and in all its cities, a habitation of shepherds causing their flocks to lie down. 
+\v 13 In the cities of the hill country, in the cities of the lowland, in the cities of the South, in the land of Benjamin, in the places around Jerusalem, and in the cities of Judah, the flocks will again pass under the hands of him who counts them,” says Yahuah. 
 \p
-\v 14 “Behold, the days come,” says Yahweh, “that I will perform that good word which I have spoken concerning the house of Israel and concerning the house of Judah. 
+\v 14 “Behold, the days come,” says Yahuah, “that I will perform that good word which I have spoken concerning the house of Israel and concerning the house of Judah. 
 \q1
 \v 15 “In those days and at that time, 
 \q2 I will cause a Branch of righteousness to grow up to David. 
@@ -2254,57 +2254,57 @@
 \v 16 In those days Judah will be saved, 
 \q2 and Jerusalem will dwell safely. 
 \q1 This is the name by which she will be called: 
-\q2 Yahweh our righteousness.” 
+\q2 Yahuah our righteousness.” 
 \p
-\v 17 For Yahweh says: “David will never lack a man to sit on the throne of the house of Israel. 
+\v 17 For Yahuah says: “David will never lack a man to sit on the throne of the house of Israel. 
 \v 18 The Levitical priests won’t lack a man before me to offer burnt offerings, to burn meal offerings, and to do sacrifice continually.” 
 \p
-\v 19 Yahweh’s word came to Jeremiah, saying, 
-\v 20 “Yahweh says: ‘If you can break my covenant of the day and my covenant of the night, so that there will not be day and night in their time, 
+\v 19 Yahuah’s word came to Jeremiah, saying, 
+\v 20 “Yahuah says: ‘If you can break my covenant of the day and my covenant of the night, so that there will not be day and night in their time, 
 \v 21 then my covenant could also be broken with David my servant, that he won’t have a son to reign on his throne; and with the Levitical priests, my ministers. 
 \v 22 As the army of the sky can’t be counted, and the sand of the sea can’t be measured, so I will multiply the offspring of David my servant and the Levites who minister to me.’ ” 
 \p
-\v 23 Yahweh’s word came to Jeremiah, saying, 
-\v 24 “Don’t consider what this people has spoken, saying, ‘Has Yahweh cast off the two families which he chose?’ Thus they despise my people, that they should be no more a nation before them.” 
-\v 25 Yahweh says: “If my covenant of day and night fails, if I have not appointed the ordinances of heaven and earth, 
+\v 23 Yahuah’s word came to Jeremiah, saying, 
+\v 24 “Don’t consider what this people has spoken, saying, ‘Has Yahuah cast off the two families which he chose?’ Thus they despise my people, that they should be no more a nation before them.” 
+\v 25 Yahuah says: “If my covenant of day and night fails, if I have not appointed the ordinances of heaven and earth, 
 \v 26 then I will also cast away the offspring of Jacob, and of David my servant, so that I will not take of his offspring to be rulers over the offspring of Abraham, Isaac, and Jacob; for I will cause their captivity to be reversed and will have mercy on them.” 
 \c 34
 \p
-\v 1 The word which came to Jeremiah from Yahweh, when Nebuchadnezzar king of Babylon, with all his army, all the kingdoms of the earth that were under his dominion, and all the peoples, were fighting against Jerusalem and against all its cities, saying: 
-\v 2 “Yahweh, the Elohim of Israel, says, ‘Go, and speak to Zedekiah king of Judah, and tell him, Yahweh says, “Behold, I will give this city into the hand of the king of Babylon and he will burn it with fire. 
+\v 1 The word which came to Jeremiah from Yahuah, when Nebuchadnezzar king of Babylon, with all his army, all the kingdoms of the earth that were under his dominion, and all the peoples, were fighting against Jerusalem and against all its cities, saying: 
+\v 2 “Yahuah, the Elohim of Israel, says, ‘Go, and speak to Zedekiah king of Judah, and tell him, Yahuah says, “Behold, I will give this city into the hand of the king of Babylon and he will burn it with fire. 
 \v 3 You won’t escape out of his hand, but will surely be taken and delivered into his hand. Your eyes will see the eyes of the king of Babylon, and he will speak with you mouth to mouth. You will go to Babylon.” ’ 
 \p
-\v 4 “Yet hear Yahweh’s word, O Zedekiah king of Judah. Yahweh says concerning you, ‘You won’t die by the sword. 
-\v 5 You will die in peace; and with the burnings of your fathers, the former kings who were before you, so they will make a burning for you. They will lament you, saying, “Ah Lord!” for I have spoken the word,’ says Yahweh.” 
+\v 4 “Yet hear Yahuah’s word, O Zedekiah king of Judah. Yahuah says concerning you, ‘You won’t die by the sword. 
+\v 5 You will die in peace; and with the burnings of your fathers, the former kings who were before you, so they will make a burning for you. They will lament you, saying, “Ah Lord!” for I have spoken the word,’ says Yahuah.” 
 \p
 \v 6 Then Jeremiah the prophet spoke all these words to Zedekiah king of Judah in Jerusalem, 
 \v 7 when the king of Babylon’s army was fighting against Jerusalem and against all the cities of Judah that were left, against Lachish and against Azekah; for these alone remained of the cities of Judah as fortified cities. 
 \p
-\v 8 The word came to Jeremiah from Yahweh, after King Zedekiah had made a covenant with all the people who were at Jerusalem, to proclaim liberty to them, 
+\v 8 The word came to Jeremiah from Yahuah, after King Zedekiah had made a covenant with all the people who were at Jerusalem, to proclaim liberty to them, 
 \v 9 that every man should let his male servant, and every man his female servant, who is a Hebrew or a Hebrewess, go free, that no one should make bondservants of them, of a Jew his brother. 
 \v 10 All the princes and all the people obeyed who had entered into the covenant, that everyone should let his male servant and everyone his female servant go free, that no one should make bondservants of them any more. They obeyed and let them go, 
 \v 11 but afterwards they turned, and caused the servants and the handmaids whom they had let go free to return, and brought them into subjection for servants and for handmaids. 
 \p
-\v 12 Therefore Yahweh’s word came to Jeremiah from Yahweh, saying, 
-\v 13 “Yahweh, the Elohim of Israel, says: ‘I made a covenant with your fathers in the day that I brought them out of the land of Egypt, out of the house of bondage, saying: 
+\v 12 Therefore Yahuah’s word came to Jeremiah from Yahuah, saying, 
+\v 13 “Yahuah, the Elohim of Israel, says: ‘I made a covenant with your fathers in the day that I brought them out of the land of Egypt, out of the house of bondage, saying: 
 \v 14 At the end of seven years, every man of you shall release his brother who is a Hebrew, who has been sold to you, and has served you six years. You shall let him go free from you. But your fathers didn’t listen to me, and didn’t incline their ear. 
 \v 15 You had now turned, and had done that which is right in my eyes, in every man proclaiming liberty to his neighbor. You had made a covenant before me in the house which is called by my name; 
 \v 16 but you turned and profaned my name, and every man caused his servant and every man his handmaid, whom you had let go free at their pleasure, to return. You brought them into subjection, to be to you for servants and for handmaids.’ ” 
 \p
-\v 17 Therefore Yahweh says: “You have not listened to me, to proclaim liberty, every man to his brother, and every man to his neighbor. Behold, I proclaim to you a liberty,” says Yahweh, “to the sword, to the pestilence, and to the famine. I will make you be tossed back and forth among all the kingdoms of the earth. 
+\v 17 Therefore Yahuah says: “You have not listened to me, to proclaim liberty, every man to his brother, and every man to his neighbor. Behold, I proclaim to you a liberty,” says Yahuah, “to the sword, to the pestilence, and to the famine. I will make you be tossed back and forth among all the kingdoms of the earth. 
 \v 18 I will give the men who have transgressed my covenant, who have not performed the words of the covenant which they made before me when they cut the calf in two and passed between its parts: 
 \v 19 the princes of Judah, the princes of Jerusalem, the eunuchs, the priests, and all the people of the land, who passed between the parts of the calf. 
 \v 20 I will even give them into the hand of their enemies and into the hand of those who seek their life. Their dead bodies will be food for the birds of the sky and for the animals of the earth. 
 \p
 \v 21 “I will give Zedekiah king of Judah and his princes into the hands of their enemies, into the hands of those who seek their life and into the hands of the king of Babylon’s army, who has gone away from you. 
-\v 22 Behold, I will command,” says Yahweh, “and cause them to return to this city. They will fight against it, take it, and burn it with fire. I will make the cities of Judah a desolation, without inhabitant.” 
+\v 22 Behold, I will command,” says Yahuah, “and cause them to return to this city. They will fight against it, take it, and burn it with fire. I will make the cities of Judah a desolation, without inhabitant.” 
 \c 35
 \p
-\v 1 The word which came to Jeremiah from Yahweh in the days of Jehoiakim the son of Josiah, king of Judah, saying, 
-\v 2 “Go to the house of the Rechabites, and speak to them, and bring them into Yahweh’s house, into one of the rooms, and give them wine to drink.” 
+\v 1 The word which came to Jeremiah from Yahuah in the days of Jehoiakim the son of Josiah, king of Judah, saying, 
+\v 2 “Go to the house of the Rechabites, and speak to them, and bring them into Yahuah’s house, into one of the rooms, and give them wine to drink.” 
 \p
 \v 3 Then I took Jaazaniah the son of Jeremiah, the son of Habazziniah, with his brothers, all his sons, and the whole house of the Rechabites; 
-\v 4 and I brought them into Yahweh’s house, into the room of the sons of Hanan the son of Igdaliah, the man of Elohim, which was by the room of the princes, which was above the room of Maaseiah the son of Shallum, the keeper of the threshold. 
+\v 4 and I brought them into Yahuah’s house, into the room of the sons of Hanan the son of Igdaliah, the man of Elohim, which was by the room of the princes, which was above the room of Maaseiah the son of Shallum, the keeper of the threshold. 
 \v 5 I set before the sons of the house of the Rechabites bowls full of wine, and cups; and I said to them, “Drink wine!” 
 \p
 \v 6 But they said, “We will drink no wine; for Jonadab the son of Rechab, our father, commanded us, saying, ‘You shall drink no wine, neither you nor your children, forever. 
@@ -2314,32 +2314,32 @@
 \v 10 but we have lived in tents, and have obeyed, and done according to all that Jonadab our father commanded us. 
 \v 11 But when Nebuchadnezzar king of Babylon came up into the land, we said, ‘Come! Let’s go to Jerusalem for fear of the army of the Chaldeans, and for fear of the army of the Syrians; so we will dwell at Jerusalem.’ ” 
 \p
-\v 12 Then Yahweh’s word came to Jeremiah, saying, 
-\v 13 “Yahweh of Armies, the Elohim of Israel, says: ‘Go and tell the men of Judah and the inhabitants of Jerusalem, “Will you not receive instruction to listen to my words?” says Yahweh. 
+\v 12 Then Yahuah’s word came to Jeremiah, saying, 
+\v 13 “Yahuah of Armies, the Elohim of Israel, says: ‘Go and tell the men of Judah and the inhabitants of Jerusalem, “Will you not receive instruction to listen to my words?” says Yahuah. 
 \v 14 “The words of Jonadab the son of Rechab that he commanded his sons, not to drink wine, are performed; and to this day they drink none, for they obey their father’s commandment; but I have spoken to you, rising up early and speaking, and you have not listened to me. 
 \v 15 I have sent also to you all my servants the prophets, rising up early and sending them, saying, ‘Every one of you must return now from his evil way, amend your doings, and don’t go after other elohims to serve them. Then you will dwell in the land which I have given to you and to your fathers;’ but you have not inclined your ear, nor listened to me. 
 \v 16 The sons of Jonadab the son of Rechab have performed the commandment of their father which he commanded them, but this people has not listened to me.” ’ 
 \p
-\v 17 “Therefore Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘Behold, I will bring on Judah and on all the inhabitants of Jerusalem all the evil that I have pronounced against them, because I have spoken to them, but they have not heard; and I have called to them, but they have not answered.’ ” 
+\v 17 “Therefore Yahuah, the Elohim of Armies, the Elohim of Israel, says: ‘Behold, I will bring on Judah and on all the inhabitants of Jerusalem all the evil that I have pronounced against them, because I have spoken to them, but they have not heard; and I have called to them, but they have not answered.’ ” 
 \p
-\v 18 Jeremiah said to the house of the Rechabites, “Yahweh of Armies, the Elohim of Israel, says: ‘Because you have obeyed the commandment of Jonadab your father, and kept all his precepts, and done according to all that he commanded you,’ 
-\v 19 therefore Yahweh of Armies, the Elohim of Israel, says: ‘Jonadab the son of Rechab will not lack a man to stand before me forever.’ ” 
+\v 18 Jeremiah said to the house of the Rechabites, “Yahuah of Armies, the Elohim of Israel, says: ‘Because you have obeyed the commandment of Jonadab your father, and kept all his precepts, and done according to all that he commanded you,’ 
+\v 19 therefore Yahuah of Armies, the Elohim of Israel, says: ‘Jonadab the son of Rechab will not lack a man to stand before me forever.’ ” 
 \c 36
 \p
-\v 1 In the fourth year of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahweh, saying, 
+\v 1 In the fourth year of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahuah, saying, 
 \v 2 “Take a scroll of a book, and write in it all the words that I have spoken to you against Israel, against Judah, and against all the nations, from the day I spoke to you, from the days of Josiah even to this day. 
 \v 3 It may be that the house of Judah will hear all the evil which I intend to do to them, that they may each return from his evil way; that I may forgive their iniquity and their sin.” 
 \p
-\v 4 Then Jeremiah called Baruch the son of Neriah; and Baruch wrote from the mouth of Jeremiah all Yahweh’s words, which he had spoken to him, on a scroll of a book. 
-\v 5 Jeremiah commanded Baruch, saying, “I am restricted. I can’t go into Yahweh’s house. 
-\v 6 Therefore you go, and read from the scroll which you have written from my mouth, Yahweh’s words, in the ears of the people in Yahweh’s house on the fast day. Also you shall read them in the ears of all Judah who come out of their cities. 
-\v 7 It may be they will present their supplication before Yahweh, and will each return from his evil way; for Yahweh has pronounced great anger and wrath against this people.” 
+\v 4 Then Jeremiah called Baruch the son of Neriah; and Baruch wrote from the mouth of Jeremiah all Yahuah’s words, which he had spoken to him, on a scroll of a book. 
+\v 5 Jeremiah commanded Baruch, saying, “I am restricted. I can’t go into Yahuah’s house. 
+\v 6 Therefore you go, and read from the scroll which you have written from my mouth, Yahuah’s words, in the ears of the people in Yahuah’s house on the fast day. Also you shall read them in the ears of all Judah who come out of their cities. 
+\v 7 It may be they will present their supplication before Yahuah, and will each return from his evil way; for Yahuah has pronounced great anger and wrath against this people.” 
 \p
-\v 8 Baruch the son of Neriah did according to all that Jeremiah the prophet commanded him, reading in the book Yahweh’s words in Yahweh’s house. 
-\v 9 Now in the fifth year of Jehoiakim the son of Josiah, king of Judah, in the ninth month, all the people in Jerusalem and all the people who came from the cities of Judah to Jerusalem, proclaimed a fast before Yahweh. 
-\v 10 Then Baruch read the words of Jeremiah from the book in Yahweh’s house, in the room of Gemariah the son of Shaphan the scribe, in the upper court, at the entry of the new gate of Yahweh’s house, in the ears of all the people. 
+\v 8 Baruch the son of Neriah did according to all that Jeremiah the prophet commanded him, reading in the book Yahuah’s words in Yahuah’s house. 
+\v 9 Now in the fifth year of Jehoiakim the son of Josiah, king of Judah, in the ninth month, all the people in Jerusalem and all the people who came from the cities of Judah to Jerusalem, proclaimed a fast before Yahuah. 
+\v 10 Then Baruch read the words of Jeremiah from the book in Yahuah’s house, in the room of Gemariah the son of Shaphan the scribe, in the upper court, at the entry of the new gate of Yahuah’s house, in the ears of all the people. 
 \p
-\v 11 When Micaiah the son of Gemariah, the son of Shaphan, had heard out of the book all Yahweh’s words, 
+\v 11 When Micaiah the son of Gemariah, the son of Shaphan, had heard out of the book all Yahuah’s words, 
 \v 12 he went down into the king’s house, into the scribe’s room; and behold, all the princes were sitting there, Elishama the scribe, Delaiah the son of Shemaiah, Elnathan the son of Achbor, Gemariah the son of Shaphan, Zedekiah the son of Hananiah, and all the princes. 
 \v 13 Then Micaiah declared to them all the words that he had heard, when Baruch read the book in the ears of the people. 
 \v 14 Therefore all the princes sent Jehudi the son of Nethaniah, the son of Shelemiah, the son of Cushi, to Baruch, saying, “Take in your hand the scroll in which you have read in the ears of the people, and come.” 
@@ -2360,30 +2360,30 @@
 \v 23 When Jehudi had read three or four columns, the king cut it with the penknife, and cast it into the fire that was in the brazier, until all the scroll was consumed in the fire that was in the brazier. 
 \v 24 The king and his servants who heard all these words were not afraid, and didn’t tear their garments. 
 \v 25 Moreover Elnathan and Delaiah and Gemariah had made intercession to the king that he would not burn the scroll; but he would not listen to them. 
-\v 26 The king commanded Jerahmeel the king’s son, and Seraiah the son of Azriel, and Shelemiah the son of Abdeel, to arrest Baruch the scribe and Jeremiah the prophet; but Yahweh hid them. 
+\v 26 The king commanded Jerahmeel the king’s son, and Seraiah the son of Azriel, and Shelemiah the son of Abdeel, to arrest Baruch the scribe and Jeremiah the prophet; but Yahuah hid them. 
 \p
-\v 27 Then Yahweh’s word came to Jeremiah, after the king had burned the scroll, and the words which Baruch wrote at the mouth of Jeremiah, saying, 
+\v 27 Then Yahuah’s word came to Jeremiah, after the king had burned the scroll, and the words which Baruch wrote at the mouth of Jeremiah, saying, 
 \v 28 “Take again another scroll, and write in it all the former words that were in the first scroll, which Jehoiakim the king of Judah has burned. 
-\v 29 Concerning Jehoiakim king of Judah you shall say, ‘Yahweh says: “You have burned this scroll, saying, ‘Why have you written therein, saying, “The king of Babylon will certainly come and destroy this land, and will cause to cease from there man and animal”?’ ” 
-\v 30 Therefore Yahweh says concerning Jehoiakim king of Judah: “He will have no one to sit on David’s throne. His dead body will be cast out in the day to the heat, and in the night to the frost. 
+\v 29 Concerning Jehoiakim king of Judah you shall say, ‘Yahuah says: “You have burned this scroll, saying, ‘Why have you written therein, saying, “The king of Babylon will certainly come and destroy this land, and will cause to cease from there man and animal”?’ ” 
+\v 30 Therefore Yahuah says concerning Jehoiakim king of Judah: “He will have no one to sit on David’s throne. His dead body will be cast out in the day to the heat, and in the night to the frost. 
 \v 31 I will punish him, his offspring, and his servants for their iniquity. I will bring on them, on the inhabitants of Jerusalem, and on the men of Judah, all the evil that I have pronounced against them, but they didn’t listen.” ’ ” 
 \p
 \v 32 Then Jeremiah took another scroll, and gave it to Baruch the scribe, the son of Neriah, who wrote therein from the mouth of Jeremiah all the words of the book which Jehoiakim king of Judah had burned in the fire; and many similar words were added to them. 
 \c 37
 \p
 \v 1 Zedekiah the son of Josiah reigned as king instead of Coniah the son of Jehoiakim, whom Nebuchadnezzar king of Babylon made king in the land of Judah. 
-\v 2 But neither he, nor his servants, nor the people of the land, listened to Yahweh’s words, which he spoke by the prophet Jeremiah. 
+\v 2 But neither he, nor his servants, nor the people of the land, listened to Yahuah’s words, which he spoke by the prophet Jeremiah. 
 \p
-\v 3 Zedekiah the king sent Jehucal the son of Shelemiah and Zephaniah the son of Maaseiah, the priest, to the prophet Jeremiah, saying, “Pray now to Yahweh our Elohim for us.” 
+\v 3 Zedekiah the king sent Jehucal the son of Shelemiah and Zephaniah the son of Maaseiah, the priest, to the prophet Jeremiah, saying, “Pray now to Yahuah our Elohim for us.” 
 \p
 \v 4 Now Jeremiah came in and went out among the people, for they had not put him into prison. 
 \v 5 Pharaoh’s army had come out of Egypt; and when the Chaldeans who were besieging Jerusalem heard news of them, they withdrew from Jerusalem. 
 \p
-\v 6 Then Yahweh’s word came to the prophet Jeremiah, saying, 
-\v 7 “Yahweh, the Elohim of Israel, says, ‘You shall tell the king of Judah, who sent you to me to inquire of me: “Behold, Pharaoh’s army, which has come out to help you, will return to Egypt into their own land. 
+\v 6 Then Yahuah’s word came to the prophet Jeremiah, saying, 
+\v 7 “Yahuah, the Elohim of Israel, says, ‘You shall tell the king of Judah, who sent you to me to inquire of me: “Behold, Pharaoh’s army, which has come out to help you, will return to Egypt into their own land. 
 \v 8 The Chaldeans will come again, and fight against this city. They will take it and burn it with fire.” ’ 
 \p
-\v 9 “Yahweh says, ‘Don’t deceive yourselves, saying, “The Chaldeans will surely depart from us;” for they will not depart. 
+\v 9 “Yahuah says, ‘Don’t deceive yourselves, saying, “The Chaldeans will surely depart from us;” for they will not depart. 
 \v 10 For though you had struck the whole army of the Chaldeans who fight against you, and only wounded men remained among them, they would each rise up in his tent and burn this city with fire.’ ” 
 \p
 \v 11 When the army of the Chaldeans had withdrawn from Jerusalem for fear of Pharaoh’s army, 
@@ -2395,7 +2395,7 @@
 \v 15 The princes were angry with Jeremiah, and struck him, and put him in prison in the house of Jonathan the scribe; for they had made that the prison. 
 \p
 \v 16 When Jeremiah had come into the dungeon house and into the cells, and Jeremiah had remained there many days, 
-\v 17 then Zedekiah the king sent and had him brought out. The king asked him secretly in his house, “Is there any word from Yahweh?” 
+\v 17 then Zedekiah the king sent and had him brought out. The king asked him secretly in his house, “Is there any word from Yahuah?” 
 \p Jeremiah said, “There is.” He also said, “You will be delivered into the hand of the king of Babylon.” 
 \p
 \v 18 Moreover Jeremiah said to King Zedekiah, “How have I sinned against you, against your servants, or against this people, that you have put me in prison? 
@@ -2406,8 +2406,8 @@
 \c 38
 \p
 \v 1 Shephatiah the son of Mattan, Gedaliah the son of Pashhur, Jucal the son of Shelemiah, and Pashhur the son of Malchijah heard the words that Jeremiah spoke to all the people, saying, 
-\v 2 “Yahweh says, ‘He who remains in this city will die by the sword, by the famine, and by the pestilence, but he who goes out to the Chaldeans will live. He will escape with his life and he will live.’ 
-\v 3 Yahweh says, ‘This city will surely be given into the hand of the army of the king of Babylon, and he will take it.’ ” 
+\v 2 “Yahuah says, ‘He who remains in this city will die by the sword, by the famine, and by the pestilence, but he who goes out to the Chaldeans will live. He will escape with his life and he will live.’ 
+\v 3 Yahuah says, ‘This city will surely be given into the hand of the army of the king of Babylon, and he will take it.’ ” 
 \p
 \v 4 Then the princes said to the king, “Please let this man be put to death, because he weakens the hands of the men of war who remain in this city, and the hands of all the people, in speaking such words to them; for this man doesn’t seek the welfare of this people, but harm.” 
 \p
@@ -2426,19 +2426,19 @@
 \p Jeremiah did so. 
 \v 13 So they lifted Jeremiah up with the cords, and took him up out of the dungeon; and Jeremiah remained in the court of the guard. 
 \p
-\v 14 Then Zedekiah the king sent and took Jeremiah the prophet to himself into the third entry that is in Yahweh’s house. Then the king said to Jeremiah, “I will ask you something. Hide nothing from me.” 
+\v 14 Then Zedekiah the king sent and took Jeremiah the prophet to himself into the third entry that is in Yahuah’s house. Then the king said to Jeremiah, “I will ask you something. Hide nothing from me.” 
 \p
 \v 15 Then Jeremiah said to Zedekiah, “If I declare it to you, will you not surely put me to death? If I give you counsel, you will not listen to me.” 
 \p
-\v 16 So Zedekiah the king swore secretly to Jeremiah, saying, “As Yahweh lives, who made our souls, I will not put you to death, neither will I give you into the hand of these men who seek your life.” 
+\v 16 So Zedekiah the king swore secretly to Jeremiah, saying, “As Yahuah lives, who made our souls, I will not put you to death, neither will I give you into the hand of these men who seek your life.” 
 \p
-\v 17 Then Jeremiah said to Zedekiah, “Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘If you will go out to the king of Babylon’s princes, then your soul will live, and this city will not be burned with fire. You will live, along with your house. 
+\v 17 Then Jeremiah said to Zedekiah, “Yahuah, the Elohim of Armies, the Elohim of Israel, says: ‘If you will go out to the king of Babylon’s princes, then your soul will live, and this city will not be burned with fire. You will live, along with your house. 
 \v 18 But if you will not go out to the king of Babylon’s princes, then this city will be given into the hand of the Chaldeans, and they will burn it with fire, and you won’t escape out of their hand.’ ” 
 \p
 \v 19 Zedekiah the king said to Jeremiah, “I am afraid of the Jews who have defected to the Chaldeans, lest they deliver me into their hand, and they mock me.” 
 \p
-\v 20 But Jeremiah said, “They won’t deliver you. Obey, I beg you, Yahweh’s voice, in that which I speak to you; so it will be well with you, and your soul will live. 
-\v 21 But if you refuse to go out, this is the word that Yahweh has shown me: 
+\v 20 But Jeremiah said, “They won’t deliver you. Obey, I beg you, Yahuah’s voice, in that which I speak to you; so it will be well with you, and your soul will live. 
+\v 21 But if you refuse to go out, this is the word that Yahuah has shown me: 
 \v 22 ‘Behold, all the women who are left in the king of Judah’s house will be brought out to the king of Babylon’s princes, and those women will say, 
 \q1 “Your familiar friends have turned on you, 
 \q2 and have prevailed over you. 
@@ -2475,15 +2475,15 @@
 \v 13 So Nebuzaradan the captain of the guard, Nebushazban, Rabsaris, and Nergal Sharezer, Rabmag, and all the chief officers of the king of Babylon 
 \v 14 sent and took Jeremiah out of the court of the guard, and committed him to Gedaliah the son of Ahikam, the son of Shaphan, that he should bring him home. So he lived among the people. 
 \p
-\v 15 Now Yahweh’s word came to Jeremiah while he was shut up in the court of the guard, saying, 
-\v 16 “Go, and speak to Ebedmelech the Ethiopian, saying, ‘Yahweh of Armies, the Elohim of Israel, says: “Behold, I will bring my words on this city for evil, and not for good; and they will be accomplished before you in that day. 
-\v 17 But I will deliver you in that day,” says Yahweh; “and you will not be given into the hand of the men of whom you are afraid. 
-\v 18 For I will surely save you. You won’t fall by the sword, but you will escape with your life, because you have put your trust in me,” says Yahweh.’ ” 
+\v 15 Now Yahuah’s word came to Jeremiah while he was shut up in the court of the guard, saying, 
+\v 16 “Go, and speak to Ebedmelech the Ethiopian, saying, ‘Yahuah of Armies, the Elohim of Israel, says: “Behold, I will bring my words on this city for evil, and not for good; and they will be accomplished before you in that day. 
+\v 17 But I will deliver you in that day,” says Yahuah; “and you will not be given into the hand of the men of whom you are afraid. 
+\v 18 For I will surely save you. You won’t fall by the sword, but you will escape with your life, because you have put your trust in me,” says Yahuah.’ ” 
 \c 40
 \p
-\v 1 The word which came to Jeremiah from Yahweh, after Nebuzaradan the captain of the guard had let him go from Ramah, when he had taken him being bound in chains among all the captives of Jerusalem and Judah who were carried away captive to Babylon. 
-\v 2 The captain of the guard took Jeremiah and said to him, “Yahweh your Elohim pronounced this evil on this place; 
-\v 3 and Yahweh has brought it, and done according as he spoke. Because you have sinned against Yahweh, and have not obeyed his voice, therefore this thing has come on you. 
+\v 1 The word which came to Jeremiah from Yahuah, after Nebuzaradan the captain of the guard had let him go from Ramah, when he had taken him being bound in chains among all the captives of Jerusalem and Judah who were carried away captive to Babylon. 
+\v 2 The captain of the guard took Jeremiah and said to him, “Yahuah your Elohim pronounced this evil on this place; 
+\v 3 and Yahuah has brought it, and done according as he spoke. Because you have sinned against Yahuah, and have not obeyed his voice, therefore this thing has come on you. 
 \v 4 Now, behold, I release you today from the chains which are on your hand. If it seems good to you to come with me into Babylon, come, and I will take care of you; but if it seems bad to you to come with me into Babylon, don’t. Behold, all the land is before you. Where it seems good and right to you to go, go there.” 
 \v 5 Now while he had not yet gone back, “Go back then,” he said, “to Gedaliah the son of Ahikam, the son of Shaphan, whom the king of Babylon has made governor over the cities of Judah, and dwell with him among the people; or go wherever it seems right to you to go.” 
 \p So the captain of the guard gave him food and a present, and let him go. 
@@ -2511,7 +2511,7 @@
 \v 3 Ishmael also killed all the Jews who were with Gedaliah at Mizpah, and the Chaldean men of war who were found there. 
 \p
 \v 4 The second day after he had killed Gedaliah, and no man knew it, 
-\v 5 men came from Shechem, from Shiloh, and from Samaria, even eighty men, having their beards shaved and their clothes torn, and having cut themselves, with meal offerings and frankincense in their hand, to bring them to Yahweh’s house. 
+\v 5 men came from Shechem, from Shiloh, and from Samaria, even eighty men, having their beards shaved and their clothes torn, and having cut themselves, with meal offerings and frankincense in their hand, to bring them to Yahuah’s house. 
 \v 6 Ishmael the son of Nethaniah went out from Mizpah to meet them, weeping all along as he went, and as he met them, he said to them, “Come to Gedaliah the son of Ahikam.” 
 \v 7 It was so, when they came into the middle of the city, that Ishmael the son of Nethaniah killed them, and cast them into the middle of the pit, he, and the men who were with him. 
 \v 8 But ten men were found among those who said to Ishmael, “Don’t kill us; for we have stores hidden in the field, of wheat, and of barley, and of oil, and of honey.” 
@@ -2532,100 +2532,100 @@
 \c 42
 \p
 \v 1 Then all the captains of the forces, and Johanan the son of Kareah, and Jezaniah the son of Hoshaiah, and all the people from the least even to the greatest, came near, 
-\v 2 and said to Jeremiah the prophet, “Please let our supplication be presented before you, and pray for us to Yahweh your Elohim, even for all this remnant, for we are left but a few of many, as your eyes see us, 
-\v 3 that Yahweh your Elohim may show us the way in which we should walk, and the things that we should do.” 
+\v 2 and said to Jeremiah the prophet, “Please let our supplication be presented before you, and pray for us to Yahuah your Elohim, even for all this remnant, for we are left but a few of many, as your eyes see us, 
+\v 3 that Yahuah your Elohim may show us the way in which we should walk, and the things that we should do.” 
 \p
-\v 4 Then Jeremiah the prophet said to them, “I have heard you. Behold, I will pray to Yahweh your Elohim according to your words; and it will happen that whatever thing Yahweh answers you, I will declare it to you. I will keep nothing back from you.” 
+\v 4 Then Jeremiah the prophet said to them, “I have heard you. Behold, I will pray to Yahuah your Elohim according to your words; and it will happen that whatever thing Yahuah answers you, I will declare it to you. I will keep nothing back from you.” 
 \p
-\v 5 Then they said to Jeremiah, “May Yahweh be a true and faithful witness among us, if we don’t do according to all the word with which Yahweh your Elohim sends you to tell us. 
-\v 6 Whether it is good, or whether it is bad, we will obey the voice of Yahweh our Elohim, to whom we send you; that it may be well with us, when we obey the voice of Yahweh our Elohim.” 
+\v 5 Then they said to Jeremiah, “May Yahuah be a true and faithful witness among us, if we don’t do according to all the word with which Yahuah your Elohim sends you to tell us. 
+\v 6 Whether it is good, or whether it is bad, we will obey the voice of Yahuah our Elohim, to whom we send you; that it may be well with us, when we obey the voice of Yahuah our Elohim.” 
 \p
-\v 7 After ten days, Yahweh’s word came to Jeremiah. 
+\v 7 After ten days, Yahuah’s word came to Jeremiah. 
 \v 8 Then he called Johanan the son of Kareah, and all the captains of the forces who were with him, and all the people from the least even to the greatest, 
-\v 9 and said to them, “Yahweh, the Elohim of Israel, to whom you sent me to present your supplication before him, says: 
+\v 9 and said to them, “Yahuah, the Elohim of Israel, to whom you sent me to present your supplication before him, says: 
 \v 10 ‘If you will still live in this land, then I will build you, and not pull you down, and I will plant you, and not pluck you up; for I grieve over the distress that I have brought on you. 
-\v 11 Don’t be afraid of the king of Babylon, of whom you are afraid. Don’t be afraid of him,’ says Yahweh, ‘for I am with you to save you, and to deliver you from his hand. 
+\v 11 Don’t be afraid of the king of Babylon, of whom you are afraid. Don’t be afraid of him,’ says Yahuah, ‘for I am with you to save you, and to deliver you from his hand. 
 \v 12 I will grant you mercy, that he may have mercy on you, and cause you to return to your own land. 
 \p
-\v 13 “ ‘But if you say, “We will not dwell in this land,” so that you don’t obey Yahweh your Elohim’s voice, 
+\v 13 “ ‘But if you say, “We will not dwell in this land,” so that you don’t obey Yahuah your Elohim’s voice, 
 \v 14 saying, “No, but we will go into the land of Egypt, where we will see no war, nor hear the sound of the trumpet, nor have hunger of bread; and there we will dwell;” ’ 
-\v 15 now therefore hear Yahweh’s word, O remnant of Judah! Yahweh of Armies, the Elohim of Israel, says, ‘If you indeed set your faces to enter into Egypt, and go to live there, 
+\v 15 now therefore hear Yahuah’s word, O remnant of Judah! Yahuah of Armies, the Elohim of Israel, says, ‘If you indeed set your faces to enter into Egypt, and go to live there, 
 \v 16 then it will happen that the sword, which you fear, will overtake you there in the land of Egypt; and the famine, about which you are afraid, will follow close behind you there in Egypt; and you will die there. 
 \v 17 So will it be with all the men who set their faces to go into Egypt to live there. They will die by the sword, by the famine, and by the pestilence. None of them will remain or escape from the evil that I will bring on them.’ 
-\v 18 For Yahweh of Armies, the Elohim of Israel, says: ‘As my anger and my wrath has been poured out on the inhabitants of Jerusalem, so my wrath will be poured out on you, when you enter into Egypt; and you will be an object of horror, an astonishment, a curse, and a reproach; and you will see this place no more.’ 
+\v 18 For Yahuah of Armies, the Elohim of Israel, says: ‘As my anger and my wrath has been poured out on the inhabitants of Jerusalem, so my wrath will be poured out on you, when you enter into Egypt; and you will be an object of horror, an astonishment, a curse, and a reproach; and you will see this place no more.’ 
 \p
-\v 19 “Yahweh has spoken concerning you, remnant of Judah, ‘Don’t go into Egypt!’ Know certainly that I have testified to you today. 
-\v 20 For you have dealt deceitfully against your own souls; for you sent me to Yahweh your Elohim, saying, ‘Pray for us to Yahweh our Elohim; and according to all that Yahweh our Elohim says, so declare to us, and we will do it.’ 
-\v 21 I have declared it to you today; but you have not obeyed Yahweh your Elohim’s voice in anything for which he has sent me to you. 
+\v 19 “Yahuah has spoken concerning you, remnant of Judah, ‘Don’t go into Egypt!’ Know certainly that I have testified to you today. 
+\v 20 For you have dealt deceitfully against your own souls; for you sent me to Yahuah your Elohim, saying, ‘Pray for us to Yahuah our Elohim; and according to all that Yahuah our Elohim says, so declare to us, and we will do it.’ 
+\v 21 I have declared it to you today; but you have not obeyed Yahuah your Elohim’s voice in anything for which he has sent me to you. 
 \v 22 Now therefore know certainly that you will die by the sword, by the famine, and by the pestilence in the place where you desire to go to live.” 
 \c 43
 \p
-\v 1 When Jeremiah had finished speaking to all the people all the words of Yahweh their Elohim, with which Yahweh their Elohim had sent him to them, even all these words, 
-\v 2 then Azariah the son of Hoshaiah, Johanan the son of Kareah, and all the proud men spoke, saying to Jeremiah, “You speak falsely. Yahweh our Elohim has not sent you to say, ‘You shall not go into Egypt to live there;’ 
+\v 1 When Jeremiah had finished speaking to all the people all the words of Yahuah their Elohim, with which Yahuah their Elohim had sent him to them, even all these words, 
+\v 2 then Azariah the son of Hoshaiah, Johanan the son of Kareah, and all the proud men spoke, saying to Jeremiah, “You speak falsely. Yahuah our Elohim has not sent you to say, ‘You shall not go into Egypt to live there;’ 
 \v 3 but Baruch the son of Neriah has turned you against us, to deliver us into the hand of the Chaldeans, that they may put us to death or carry us away captive to Babylon.” 
 \p
-\v 4 So Johanan the son of Kareah, and all the captains of the forces, and all the people, didn’t obey Yahweh’s voice, to dwell in the land of Judah. 
+\v 4 So Johanan the son of Kareah, and all the captains of the forces, and all the people, didn’t obey Yahuah’s voice, to dwell in the land of Judah. 
 \v 5 But Johanan the son of Kareah and all the captains of the forces took all the remnant of Judah, who had returned from all the nations where they had been driven, to live in the land of Judah—\v 6 the men, the women, the children, the king’s daughters, and every person who Nebuzaradan the captain of the guard had left with Gedaliah the son of Ahikam, the son of Shaphan; and Jeremiah the prophet, and Baruch the son of Neriah. 
-\v 7 They came into the land of Egypt, for they didn’t obey Yahweh’s voice; and they came to Tahpanhes. 
+\v 7 They came into the land of Egypt, for they didn’t obey Yahuah’s voice; and they came to Tahpanhes. 
 \p
-\v 8 Then Yahweh’s word came to Jeremiah in Tahpanhes, saying, 
+\v 8 Then Yahuah’s word came to Jeremiah in Tahpanhes, saying, 
 \v 9 “Take great stones in your hand and hide them in mortar in the brick work which is at the entry of Pharaoh’s house in Tahpanhes, in the sight of the men of Judah. 
-\v 10 Tell them, Yahweh of Armies, the Elohim of Israel, says: ‘Behold, I will send and take Nebuchadnezzar the king of Babylon, my servant, and will set his throne on these stones that I have hidden; and he will spread his royal pavilion over them. 
+\v 10 Tell them, Yahuah of Armies, the Elohim of Israel, says: ‘Behold, I will send and take Nebuchadnezzar the king of Babylon, my servant, and will set his throne on these stones that I have hidden; and he will spread his royal pavilion over them. 
 \v 11 He will come, and will strike the land of Egypt; such as are for death will be put to death, and such as are for captivity to captivity, and such as are for the sword to the sword. 
 \v 12 I will kindle a fire in the houses of the elohims of Egypt. He will burn them, and carry them away captive. He will array himself with the land of Egypt, as a shepherd puts on his garment; and he will go out from there in peace. 
 \v 13 He will also break the pillars of Beth Shemesh that is in the land of Egypt; and he will burn the houses of the elohims of Egypt with fire.’ ” 
 \c 44
 \p
 \v 1 The word that came to Jeremiah concerning all the Jews who lived in the land of Egypt, who lived at Migdol, and at Tahpanhes, and at Memphis, and in the country of Pathros, saying, 
-\v 2 “Yahweh of Armies, the Elohim of Israel, says: ‘You have seen all the evil that I have brought on Jerusalem, and on all the cities of Judah. Behold, today they are a desolation, and no man dwells in them, 
+\v 2 “Yahuah of Armies, the Elohim of Israel, says: ‘You have seen all the evil that I have brought on Jerusalem, and on all the cities of Judah. Behold, today they are a desolation, and no man dwells in them, 
 \v 3 because of their wickedness which they have committed to provoke me to anger, in that they went to burn incense, to serve other elohims that they didn’t know, neither they, nor you, nor your fathers. 
 \v 4 However I sent to you all my servants the prophets, rising up early and sending them, saying, “Oh, don’t do this abominable thing that I hate.” 
 \v 5 But they didn’t listen and didn’t incline their ear. They didn’t turn from their wickedness, to stop burning incense to other elohims. 
 \v 6 Therefore my wrath and my anger was poured out, and was kindled in the cities of Judah and in the streets of Jerusalem; and they are wasted and desolate, as it is today.’ 
 \p
-\v 7 “Therefore now Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘Why do you commit great evil against your own souls, to cut off from yourselves man and woman, infant and nursing child out of the middle of Judah, to leave yourselves no one remaining, 
+\v 7 “Therefore now Yahuah, the Elohim of Armies, the Elohim of Israel, says: ‘Why do you commit great evil against your own souls, to cut off from yourselves man and woman, infant and nursing child out of the middle of Judah, to leave yourselves no one remaining, 
 \v 8 in that you provoke me to anger with the works of your hands, burning incense to other elohims in the land of Egypt where you have gone to live, that you may be cut off, and that you may be a curse and a reproach among all the nations of the earth? 
 \v 9 Have you forgotten the wickedness of your fathers, the wickedness of the kings of Judah, the wickedness of their women, your own wickedness, and the wickedness of your women which they committed in the land of Judah and in the streets of Jerusalem? 
 \v 10 They are not humbled even to this day, neither have they feared, nor walked in my law, nor in my statutes, that I set before you and before your fathers.’ 
 \p
-\v 11 “Therefore Yahweh of Armies, the Elohim of Israel, says: ‘Behold, I will set my face against you for evil, even to cut off all Judah. 
+\v 11 “Therefore Yahuah of Armies, the Elohim of Israel, says: ‘Behold, I will set my face against you for evil, even to cut off all Judah. 
 \v 12 I will take the remnant of Judah that have set their faces to go into the land of Egypt to live there, and they will all be consumed. They will fall in the land of Egypt. They will be consumed by the sword and by the famine. They will die, from the least even to the greatest, by the sword and by the famine. They will be an object of horror, an astonishment, a curse, and a reproach. 
 \v 13 For I will punish those who dwell in the land of Egypt, as I have punished Jerusalem, by the sword, by the famine, and by the pestilence; 
 \v 14 so that none of the remnant of Judah, who have gone into the land of Egypt to live there, will escape or be left to return into the land of Judah, to which they have a desire to return to dwell there; for no one will return except those who will escape.’ ” 
 \p
 \v 15 Then all the men who knew that their women burned incense to other elohims, and all the women who stood by, a great assembly, even all the people who lived in the land of Egypt, in Pathros, answered Jeremiah, saying, 
-\v 16 “As for the word that you have spoken to us in Yahweh’s name, we will not listen to you. 
+\v 16 “As for the word that you have spoken to us in Yahuah’s name, we will not listen to you. 
 \v 17 But we will certainly perform every word that has gone out of our mouth, to burn incense to the queen of the sky and to pour out drink offerings to her, as we have done, we and our fathers, our kings and our princes, in the cities of Judah and in the streets of Jerusalem; for then we had plenty of food, and were well, and saw no evil. 
 \v 18 But since we stopped burning incense to the queen of the sky, and pouring out drink offerings to her, we have lacked all things, and have been consumed by the sword and by the famine.” 
 \p
 \v 19 The women said, “When we burned incense to the queen of the sky and poured out drink offerings to her, did we make her cakes to worship her, and pour out drink offerings to her, without our men?” 
 \p
 \v 20 Then Jeremiah said to all the people—to the men and to the women, even to all the people who had given him an answer, saying, 
-\v 21 “The incense that you burned in the cities of Judah, and in the streets of Jerusalem, you and your fathers, your kings and your princes, and the people of the land, didn’t Yahweh remember them, and didn’t it come into his mind? 
-\v 22 Thus Yahweh could no longer bear it, because of the evil of your doings and because of the abominations which you have committed. Therefore your land has become a desolation, an astonishment, and a curse, without inhabitant, as it is today. 
-\v 23 Because you have burned incense and because you have sinned against Yahweh, and have not obeyed Yahweh’s voice, nor walked in his law, nor in his statutes, nor in his testimonies; therefore this evil has happened to you, as it is today.” 
+\v 21 “The incense that you burned in the cities of Judah, and in the streets of Jerusalem, you and your fathers, your kings and your princes, and the people of the land, didn’t Yahuah remember them, and didn’t it come into his mind? 
+\v 22 Thus Yahuah could no longer bear it, because of the evil of your doings and because of the abominations which you have committed. Therefore your land has become a desolation, an astonishment, and a curse, without inhabitant, as it is today. 
+\v 23 Because you have burned incense and because you have sinned against Yahuah, and have not obeyed Yahuah’s voice, nor walked in his law, nor in his statutes, nor in his testimonies; therefore this evil has happened to you, as it is today.” 
 \p
-\v 24 Moreover Jeremiah said to all the people, including all the women, “Hear Yahweh’s word, all Judah who are in the land of Egypt! 
-\v 25 Yahweh of Armies, the Elohim of Israel, says, ‘You and your women have both spoken with your mouths, and with your hands have fulfilled it, saying, “We will surely perform our vows that we have vowed, to burn incense to the queen of the sky, and to pour out drink offerings to her.” 
+\v 24 Moreover Jeremiah said to all the people, including all the women, “Hear Yahuah’s word, all Judah who are in the land of Egypt! 
+\v 25 Yahuah of Armies, the Elohim of Israel, says, ‘You and your women have both spoken with your mouths, and with your hands have fulfilled it, saying, “We will surely perform our vows that we have vowed, to burn incense to the queen of the sky, and to pour out drink offerings to her.” 
 \p “ ‘Establish then your vows, and perform your vows.’ 
 \p
-\v 26 “Therefore hear Yahweh’s word, all Judah who dwell in the land of Egypt: ‘Behold, I have sworn by my great name,’ says Yahweh, ‘that my name will no more be named in the mouth of any man of Judah in all the land of Egypt, saying, “As the Lord Yahweh lives.” 
+\v 26 “Therefore hear Yahuah’s word, all Judah who dwell in the land of Egypt: ‘Behold, I have sworn by my great name,’ says Yahuah, ‘that my name will no more be named in the mouth of any man of Judah in all the land of Egypt, saying, “As the Lord Yahuah lives.” 
 \v 27 Behold, I watch over them for evil, and not for good; and all the men of Judah who are in the land of Egypt will be consumed by the sword and by the famine, until they are all gone. 
 \v 28 Those who escape the sword will return out of the land of Egypt into the land of Judah few in number. All the remnant of Judah, who have gone into the land of Egypt to live there, will know whose word will stand, mine or theirs. 
 \p
-\v 29 “ ‘This will be the sign to you,’ says Yahweh, ‘that I will punish you in this place, that you may know that my words will surely stand against you for evil.’ 
-\v 30 Yahweh says, ‘Behold, I will give Pharaoh Hophra king of Egypt into the hand of his enemies and into the hand of those who seek his life, just as I gave Zedekiah king of Judah into the hand of Nebuchadnezzar king of Babylon, who was his enemy and sought his life.’ ” 
+\v 29 “ ‘This will be the sign to you,’ says Yahuah, ‘that I will punish you in this place, that you may know that my words will surely stand against you for evil.’ 
+\v 30 Yahuah says, ‘Behold, I will give Pharaoh Hophra king of Egypt into the hand of his enemies and into the hand of those who seek his life, just as I gave Zedekiah king of Judah into the hand of Nebuchadnezzar king of Babylon, who was his enemy and sought his life.’ ” 
 \c 45
 \p
 \v 1 The message that Jeremiah the prophet spoke to Baruch the son of Neriah, when he wrote these words in a book at the mouth of Jeremiah, in the fourth year of Jehoiakim the son of Josiah, king of Judah, saying, 
-\v 2 “Yahweh, the Elohim of Israel, says to you, Baruch: 
-\v 3 ‘You said, “Woe is me now! For Yahweh has added sorrow to my pain! I am weary with my groaning, and I find no rest.” ’ 
+\v 2 “Yahuah, the Elohim of Israel, says to you, Baruch: 
+\v 3 ‘You said, “Woe is me now! For Yahuah has added sorrow to my pain! I am weary with my groaning, and I find no rest.” ’ 
 \p
-\v 4 “You shall tell him, Yahweh says: ‘Behold, that which I have built, I will break down, and that which I have planted I will pluck up; and this in the whole land. 
-\v 5 Do you seek great things for yourself? Don’t seek them; for, behold, I will bring evil on all flesh,’ says Yahweh, ‘but I will let you escape with your life wherever you go.’ ” 
+\v 4 “You shall tell him, Yahuah says: ‘Behold, that which I have built, I will break down, and that which I have planted I will pluck up; and this in the whole land. 
+\v 5 Do you seek great things for yourself? Don’t seek them; for, behold, I will bring evil on all flesh,’ says Yahuah, ‘but I will let you escape with your life wherever you go.’ ” 
 \c 46
 \p
-\v 1 Yahweh’s word which came to Jeremiah the prophet concerning the nations. 
+\v 1 Yahuah’s word which came to Jeremiah the prophet concerning the nations. 
 \p
 \v 2 Of Egypt: concerning the army of Pharaoh Necoh king of Egypt, which was by the river Euphrates in Carchemish, which Nebuchadnezzar king of Babylon struck in the fourth year of Jehoiakim the son of Josiah, king of Judah. 
 \q1
@@ -2643,7 +2643,7 @@
 \q2 have fled in haste, 
 \q2 and don’t look back. 
 \q1 Terror is on every side,” 
-\q2 says Yahweh. 
+\q2 says Yahuah. 
 \q1
 \v 6 “Don’t let the swift flee away, 
 \q2 nor the mighty man escape. 
@@ -2665,12 +2665,12 @@
 \q2 Cush and Put, who handle the shield; 
 \q2 and the Ludim, who handle and bend the bow. 
 \q1
-\v 10 For that day is of the Lord, Yahweh of Armies, 
+\v 10 For that day is of the Lord, Yahuah of Armies, 
 \q2 a day of vengeance, 
 \q2 that he may avenge himself of his adversaries. 
 \q1 The sword will devour and be satiated, 
 \q2 and will drink its fill of their blood; 
-\q2 for the Lord, Yahweh of Armies, has a sacrifice in the north country by the river Euphrates. 
+\q2 for the Lord, Yahuah of Armies, has a sacrifice in the north country by the river Euphrates. 
 \q1
 \v 11 Go up into Gilead, and take balm, virgin daughter of Egypt. 
 \q2 You use many medicines in vain. 
@@ -2682,7 +2682,7 @@
 \q2 they both fall together.” 
 \b
 \p
-\v 13 The word that Yahweh spoke to Jeremiah the prophet, how that Nebuchadnezzar king of Babylon should come and strike the land of Egypt: 
+\v 13 The word that Yahuah spoke to Jeremiah the prophet, how that Nebuchadnezzar king of Babylon should come and strike the land of Egypt: 
 \q1
 \v 14 “Declare in Egypt, 
 \q2 publish in Migdol, 
@@ -2691,7 +2691,7 @@
 \q2 for the sword has devoured around you.’ 
 \q1
 \v 15 Why are your strong ones swept away? 
-\q2 They didn’t stand, because Yahweh pushed them. 
+\q2 They didn’t stand, because Yahuah pushed them. 
 \q1
 \v 16 He made many to stumble. 
 \q2 Yes, they fell on one another. 
@@ -2704,7 +2704,7 @@
 \b
 \q1
 \v 18 “As I live,” says the King, 
-\q2 whose name is Yahweh of Armies, 
+\q2 whose name is Yahuah of Armies, 
 \q1 “surely like Tabor among the mountains, 
 \q2 and like Carmel by the sea, 
 \q2 so he will come. 
@@ -2731,7 +2731,7 @@
 \q2 for they will march with an army, 
 \q2 and come against her with axes, as wood cutters. 
 \q1
-\v 23 They will cut down her forest,” says Yahweh, 
+\v 23 They will cut down her forest,” says Yahuah, 
 \q2 “though it can’t be searched; 
 \q1 because they are more than the locusts, 
 \q2 and are innumerable. 
@@ -2739,8 +2739,8 @@
 \v 24 The daughter of Egypt will be disappointed; 
 \q2 she will be delivered into the hand of the people of the north.” 
 \p
-\v 25 Yahweh of Armies, the Elohim of Israel, says: “Behold, I will punish Amon of No, and Pharaoh, and Egypt, with her elohims and her kings, even Pharaoh, and those who trust in him. 
-\v 26 I will deliver them into the hand of those who seek their lives, and into the hand of Nebuchadnezzar king of Babylon, and into the hand of his servants. Afterwards it will be inhabited, as in the days of old,” says Yahweh. 
+\v 25 Yahuah of Armies, the Elohim of Israel, says: “Behold, I will punish Amon of No, and Pharaoh, and Egypt, with her elohims and her kings, even Pharaoh, and those who trust in him. 
+\v 26 I will deliver them into the hand of those who seek their lives, and into the hand of Nebuchadnezzar king of Babylon, and into the hand of his servants. Afterwards it will be inhabited, as in the days of old,” says Yahuah. 
 \q1
 \v 27 “But don’t you be afraid, Jacob my servant. 
 \q2 Don’t be dismayed, Israel; 
@@ -2750,7 +2750,7 @@
 \q2 and will be quiet and at ease. 
 \q2 No one will make him afraid. 
 \q1
-\v 28 Don’t be afraid, O Jacob my servant,” says Yahweh, 
+\v 28 Don’t be afraid, O Jacob my servant,” says Yahuah, 
 \q2 “for I am with you; 
 \q2 for I will make a full end of all the nations where I have driven you, 
 \q1 but I will not make a full end of you, 
@@ -2758,9 +2758,9 @@
 \q2 and will in no way leave you unpunished.” 
 \c 47
 \p
-\v 1 Yahweh’s word that came to Jeremiah the prophet concerning the Philistines, before Pharaoh struck Gaza. 
+\v 1 Yahuah’s word that came to Jeremiah the prophet concerning the Philistines, before Pharaoh struck Gaza. 
 \p
-\v 2 Yahweh says: 
+\v 2 Yahuah says: 
 \q1 “Behold, waters rise up out of the north, 
 \q2 and will become an overflowing stream, 
 \q1 and will overflow the land and all that is therein, 
@@ -2776,7 +2776,7 @@
 \q1
 \v 4 because of the day that comes to destroy all the Philistines, 
 \q2 to cut off from Tyre and Sidon every helper who remains; 
-\q1 for Yahweh will destroy the Philistines, 
+\q1 for Yahuah will destroy the Philistines, 
 \q2 the remnant of the isle of Caphtor. 
 \q1
 \v 5 Baldness has come on Gaza; 
@@ -2785,18 +2785,18 @@
 \q2 how long will you cut yourself? 
 \b
 \q1
-\v 6 “ ‘You sword of Yahweh, how long will it be before you are quiet? 
+\v 6 “ ‘You sword of Yahuah, how long will it be before you are quiet? 
 \q2 Put yourself back into your scabbard; 
 \q2 rest, and be still.’ 
 \b
 \q1
 \v 7 “How can you be quiet, 
-\q2 since Yahweh has given you a command? 
+\q2 since Yahuah has given you a command? 
 \q1 Against Ashkelon, and against the seashore, 
 \q2 there he has appointed it.” 
 \c 48
 \p
-\v 1 Of Moab. Yahweh of Armies, the Elohim of Israel, says: 
+\v 1 Of Moab. Yahuah of Armies, the Elohim of Israel, says: 
 \q1 “Woe to Nebo! 
 \q2 For it is laid waste. 
 \q1 Kiriathaim is disappointed. 
@@ -2830,7 +2830,7 @@
 \v 8 The destroyer will come on every city, 
 \q2 and no city will escape; 
 \q1 the valley also will perish, 
-\q2 and the plain will be destroyed, as Yahweh has spoken. 
+\q2 and the plain will be destroyed, as Yahuah has spoken. 
 \q1
 \v 9 Give wings to Moab, 
 \q2 that she may fly and get herself away: 
@@ -2838,7 +2838,7 @@
 \q2 without anyone to dwell in them. 
 \b
 \q1
-\v 10 “Cursed is he who does the work of Yahweh negligently; 
+\v 10 “Cursed is he who does the work of Yahuah negligently; 
 \q2 and cursed is he who keeps back his sword from blood. 
 \b
 \q1
@@ -2849,7 +2849,7 @@
 \q1 therefore his taste remains in him, 
 \q2 and his scent is not changed. 
 \q1
-\v 12 Therefore behold, the days come,” says Yahweh, 
+\v 12 Therefore behold, the days come,” says Yahuah, 
 \q2 “that I will send to him those who pour off, 
 \q1 and they will pour him off; 
 \q2 and they will empty his vessels, 
@@ -2865,7 +2865,7 @@
 \v 15 Moab is laid waste, 
 \q2 and they have gone up into his cities, 
 \q2 and his chosen young men have gone down to the slaughter,” 
-\q2 says the King, whose name is Yahweh of Armies. 
+\q2 says the King, whose name is Yahuah of Armies. 
 \q1
 \v 16 “The calamity of Moab is near to come, 
 \q2 and his affliction hurries fast. 
@@ -2901,11 +2901,11 @@
 \q2 and on all the cities of the land of Moab, far or near. 
 \q1
 \v 25 The horn of Moab is cut off, 
-\q2 and his arm is broken,” says Yahweh. 
+\q2 and his arm is broken,” says Yahuah. 
 \b
 \q1
 \v 26 “Make him drunk, 
-\q2 for he magnified himself against Yahweh. 
+\q2 for he magnified himself against Yahuah. 
 \q1 Moab will wallow in his vomit, 
 \q2 and he also will be in derision. 
 \q1
@@ -2922,7 +2922,7 @@
 \q2 He is very proud in his loftiness, his pride, 
 \q2 his arrogance, and the arrogance of his heart. 
 \q1
-\v 30 I know his wrath,” says Yahweh, “that it is nothing; 
+\v 30 I know his wrath,” says Yahuah, “that it is nothing; 
 \q2 his boastings have done nothing. 
 \q1
 \v 31 Therefore I will wail for Moab. 
@@ -2947,7 +2947,7 @@
 \q2 from Zoar even to Horonaim, to Eglath Shelishiyah; 
 \q2 for the waters of Nimrim will also become desolate. 
 \q1
-\v 35 Moreover I will cause to cease in Moab,” says Yahweh, 
+\v 35 Moreover I will cause to cease in Moab,” says Yahuah, 
 \q2 “him who offers in the high place, 
 \q2 and him who burns incense to his elohims. 
 \q1
@@ -2962,7 +2962,7 @@
 \q1
 \v 38 On all the housetops of Moab, 
 \q2 and in its streets, there is lamentation everywhere; 
-\q2 for I have broken Moab like a vessel in which no one delights,” says Yahweh. 
+\q2 for I have broken Moab like a vessel in which no one delights,” says Yahuah. 
 \q1
 \v 39 “How it is broken down! 
 \q2 How they wail! 
@@ -2970,7 +2970,7 @@
 \q2 So will Moab become a derision 
 \q2 and a terror to all who are around him.” 
 \q1
-\v 40 For Yahweh says: “Behold, he will fly as an eagle, 
+\v 40 For Yahuah says: “Behold, he will fly as an eagle, 
 \q2 and will spread out his wings against Moab. 
 \q1
 \v 41 Kerioth is taken, 
@@ -2979,15 +2979,15 @@
 \q2 will be as the heart of a woman in her pangs. 
 \q1
 \v 42 Moab will be destroyed from being a people, 
-\q2 because he has magnified himself against Yahweh. 
+\q2 because he has magnified himself against Yahuah. 
 \q1
 \v 43 Terror, the pit, and the snare are on you, 
-\q2 inhabitant of Moab,” says Yahweh. 
+\q2 inhabitant of Moab,” says Yahuah. 
 \q1
 \v 44 “He who flees from the terror will fall into the pit; 
 \q2 and he who gets up out of the pit will be taken in the snare, 
 \q1 for I will bring on him, even on Moab, 
-\q2 the year of their visitation,” says Yahweh. 
+\q2 the year of their visitation,” says Yahuah. 
 \b
 \q1
 \v 45 “Those who fled stand without strength under the shadow of Heshbon; 
@@ -3003,23 +3003,23 @@
 \b
 \q1
 \v 47 “Yet I will reverse the captivity of Moab in the latter days,” 
-\q2 says Yahweh. 
+\q2 says Yahuah. 
 \p Thus far is the judgment of Moab. 
 \c 49
 \p
-\v 1 Of the children of Ammon. Yahweh says: 
+\v 1 Of the children of Ammon. Yahuah says: 
 \q1 “Has Israel no sons? 
 \q2 Has he no heir? 
 \q1 Why then does Malcam possess Gad, 
 \q2 and his people dwell in its cities? 
 \q1
 \v 2 Therefore behold, the days come,” 
-\q2 says Yahweh, 
+\q2 says Yahuah, 
 \q1 “that I will cause an alarm of war to be heard against Rabbah of the children of Ammon, 
 \q2 and it will become a desolate heap, 
 \q2 and her daughters will be burned with fire; 
 \q1 then Israel will possess those who possessed him,” 
-\q2 says Yahweh. 
+\q2 says Yahuah. 
 \q1
 \v 3 “Wail, Heshbon, for Ai is laid waste! 
 \q2 Cry, you daughters of Rabbah! 
@@ -3034,17 +3034,17 @@
 \q2 saying, ‘Who will come to me?’ 
 \q1
 \v 5 Behold, I will bring a terror on you,” 
-\q2 says the Lord, Yahweh of Armies, 
+\q2 says the Lord, Yahuah of Armies, 
 \q1 “from all who are around you. 
 \q2 All of you will be driven completely out, 
 \q2 and there will be no one to gather together the fugitives. 
 \b
 \q1
 \v 6 “But afterward I will reverse the captivity of the children of Ammon,” 
-\q2 says Yahweh. 
+\q2 says Yahuah. 
 \b
 \p
-\v 7 Of Edom, Yahweh of Armies says: 
+\v 7 Of Edom, Yahuah of Armies says: 
 \q1 “Is wisdom no more in Teman? 
 \q2 Has counsel perished from the prudent? 
 \q2 Has their wisdom vanished? 
@@ -3069,10 +3069,10 @@
 \q2 I will preserve them alive. 
 \q2 Let your widows trust in me.” 
 \p
-\v 12 For Yahweh says: “Behold, they to whom it didn’t pertain to drink of the cup will certainly drink; and are you he who will altogether go unpunished? You won’t go unpunished, but you will surely drink. 
-\v 13 For I have sworn by myself,” says Yahweh, “that Bozrah will become an astonishment, a reproach, a waste, and a curse. All its cities will be perpetual wastes.” 
+\v 12 For Yahuah says: “Behold, they to whom it didn’t pertain to drink of the cup will certainly drink; and are you he who will altogether go unpunished? You won’t go unpunished, but you will surely drink. 
+\v 13 For I have sworn by myself,” says Yahuah, “that Bozrah will become an astonishment, a reproach, a waste, and a curse. All its cities will be perpetual wastes.” 
 \q1
-\v 14 I have heard news from Yahweh, 
+\v 14 I have heard news from Yahuah, 
 \q2 and an ambassador is sent among the nations, 
 \q1 saying, “Gather yourselves together! 
 \q2 Come against her! 
@@ -3087,13 +3087,13 @@
 \q1 O you who dwell in the clefts of the rock, 
 \q2 who hold the height of the hill, 
 \q1 though you should make your nest as high as the eagle, 
-\q2 I will bring you down from there,” says Yahweh. 
+\q2 I will bring you down from there,” says Yahuah. 
 \q1
 \v 17 “Edom will become an astonishment. 
 \q2 Everyone who passes by it will be astonished, 
 \q2 and will hiss at all its plagues. 
 \q1
-\v 18 As in the overthrow of Sodom and Gomorrah and its neighbor cities,” says Yahweh, 
+\v 18 As in the overthrow of Sodom and Gomorrah and its neighbor cities,” says Yahuah, 
 \q2 “no man will dwell there, 
 \q2 neither will any son of man live therein. 
 \b
@@ -3106,7 +3106,7 @@
 \q2 Who will appoint me a time? 
 \q2 Who is the shepherd who will stand before me?” 
 \q1
-\v 20 Therefore hear the counsel of Yahweh, that he has taken against Edom, 
+\v 20 Therefore hear the counsel of Yahuah, that he has taken against Edom, 
 \q2 and his purposes that he has purposed against the inhabitants of Teman: 
 \q1 Surely they will drag them away, 
 \q2 the little ones of the flock. 
@@ -3138,13 +3138,13 @@
 \q1
 \v 26 Therefore her young men will fall in her streets, 
 \q2 and all the men of war will be brought to silence in that day,” 
-\q2 says Yahweh of Armies. 
+\q2 says Yahuah of Armies. 
 \q1
 \v 27 “I will kindle a fire in the wall of Damascus, 
 \q2 and it will devour the palaces of Ben Hadad.” 
 \b
 \q1
-\v 28 Of Kedar, and of the kingdoms of Hazor, which Nebuchadnezzar king of Babylon struck, Yahweh says: 
+\v 28 Of Kedar, and of the kingdoms of Hazor, which Nebuchadnezzar king of Babylon struck, Yahuah says: 
 \q1 “Arise, go up to Kedar, 
 \q2 and destroy the children of the east. 
 \q1
@@ -3155,12 +3155,12 @@
 \q1
 \v 30 Flee! 
 \q2 Wander far off! 
-\q1 Dwell in the depths, you inhabitants of Hazor,” says Yahweh; 
+\q1 Dwell in the depths, you inhabitants of Hazor,” says Yahuah; 
 \q2 “for Nebuchadnezzar king of Babylon has taken counsel against you, 
 \q2 and has conceived a purpose against you. 
 \q1
 \v 31 Arise! Go up to a nation that is at ease, 
-\q2 that dwells without care,” says Yahweh; 
+\q2 that dwells without care,” says Yahuah; 
 \q2 “that has neither gates nor bars, 
 \q2 that dwells alone. 
 \q1
@@ -3168,7 +3168,7 @@
 \q2 and the multitude of their livestock a plunder. 
 \q1 I will scatter to all winds those who have the corners of their beards cut off; 
 \q2 and I will bring their calamity from every side of them,” 
-\q2 says Yahweh. 
+\q2 says Yahuah. 
 \q1
 \v 33 Hazor will be a dwelling place of jackals, 
 \q2 a desolation forever. 
@@ -3176,8 +3176,8 @@
 \q2 neither will any son of man live therein.” 
 \b
 \p
-\v 34 Yahweh’s word that came to Jeremiah the prophet concerning Elam, in the beginning of the reign of Zedekiah king of Judah, saying, 
-\v 35 “Yahweh of Armies says: 
+\v 34 Yahuah’s word that came to Jeremiah the prophet concerning Elam, in the beginning of the reign of Zedekiah king of Judah, saying, 
+\v 35 “Yahuah of Armies says: 
 \q1 ‘Behold, I will break the bow of Elam, 
 \q2 the chief of their might. 
 \q1
@@ -3187,18 +3187,18 @@
 \q1
 \v 37 I will cause Elam to be dismayed before their enemies, 
 \q2 and before those who seek their life. 
-\q1 I will bring evil on them, even my fierce anger,’ says Yahweh; 
+\q1 I will bring evil on them, even my fierce anger,’ says Yahuah; 
 \q2 ‘and I will send the sword after them, 
 \q2 until I have consumed them. 
 \q1
 \v 38 I will set my throne in Elam, 
-\q2 and will destroy from there king and princes,’ says Yahweh. 
+\q2 and will destroy from there king and princes,’ says Yahuah. 
 \q1
 \v 39 ‘But it will happen in the latter days 
-\q2 that I will reverse the captivity of Elam,’ says Yahweh.” 
+\q2 that I will reverse the captivity of Elam,’ says Yahuah.” 
 \c 50
 \p
-\v 1 The word that Yahweh spoke concerning Babylon, concerning the land of the Chaldeans, by Jeremiah the prophet. 
+\v 1 The word that Yahuah spoke concerning Babylon, concerning the land of the Chaldeans, by Jeremiah the prophet. 
 \q1
 \v 2 “Declare among the nations and publish, 
 \q2 and set up a standard; 
@@ -3217,14 +3217,14 @@
 \q2 both man and animal. 
 \b
 \q1
-\v 4 “In those days, and in that time,” says Yahweh, 
+\v 4 “In those days, and in that time,” says Yahuah, 
 \q2 “the children of Israel will come, 
 \q2 they and the children of Judah together; 
 \q1 they will go on their way weeping, 
-\q2 and will seek Yahweh their Elohim. 
+\q2 and will seek Yahuah their Elohim. 
 \q1
 \v 5 They will inquire concerning Zion with their faces turned toward it, 
-\q2 saying, ‘Come, and join yourselves to Yahweh in an everlasting covenant 
+\q2 saying, ‘Come, and join yourselves to Yahuah in an everlasting covenant 
 \q2 that will not be forgotten.’ 
 \q1
 \v 6 My people have been lost sheep. 
@@ -3235,9 +3235,9 @@
 \q1
 \v 7 All who found them have devoured them. 
 \q2 Their adversaries said, ‘We are not guilty, 
-\q1 because they have sinned against Yahweh, 
+\q1 because they have sinned against Yahuah, 
 \q2 the habitation of righteousness, 
-\q2 even Yahweh, the hope of their fathers.’ 
+\q2 even Yahuah, the hope of their fathers.’ 
 \b
 \q1
 \v 8 “Flee out of the middle of Babylon! 
@@ -3252,7 +3252,7 @@
 \q2 None of them will return in vain. 
 \q1
 \v 10 Chaldea will be a prey. 
-\q2 All who prey on her will be satisfied,” says Yahweh. 
+\q2 All who prey on her will be satisfied,” says Yahuah. 
 \b
 \q1
 \v 11 “Because you are glad, 
@@ -3266,7 +3266,7 @@
 \q1 Behold, she will be the least of the nations, 
 \q2 a wilderness, a dry land, and a desert. 
 \q1
-\v 13 Because of Yahweh’s wrath she won’t be inhabited, 
+\v 13 Because of Yahuah’s wrath she won’t be inhabited, 
 \q2 but she will be wholly desolate. 
 \q1 Everyone who goes by Babylon will be astonished, 
 \q2 and hiss at all her plagues. 
@@ -3275,13 +3275,13 @@
 \q2 all you who bend the bow; 
 \q2 shoot at her. 
 \q1 Spare no arrows, 
-\q2 for she has sinned against Yahweh. 
+\q2 for she has sinned against Yahuah. 
 \q1
 \v 15 Shout against her all around. 
 \q2 She has submitted herself. 
 \q2 Her bulwarks have fallen. 
 \q1 Her walls have been thrown down, 
-\q2 for it is the vengeance of Yahweh. 
+\q2 for it is the vengeance of Yahuah. 
 \q1 Take vengeance on her. 
 \q2 As she has done, do to her. 
 \q1
@@ -3297,7 +3297,7 @@
 \q1 First, the king of Assyria devoured him, 
 \q2 and now at last Nebuchadnezzar king of Babylon has broken his bones.” 
 \p
-\v 18 Therefore Yahweh of Armies, the Elohim of Israel, says: 
+\v 18 Therefore Yahuah of Armies, the Elohim of Israel, says: 
 \q1 “Behold, I will punish the king of Babylon and his land, 
 \q2 as I have punished the king of Assyria. 
 \q1
@@ -3305,7 +3305,7 @@
 \q2 and he will feed on Carmel and Bashan. 
 \q2 His soul will be satisfied on the hills of Ephraim and in Gilead. 
 \q1
-\v 20 In those days, and in that time,” says Yahweh, 
+\v 20 In those days, and in that time,” says Yahuah, 
 \q2 “the iniquity of Israel will be sought for, 
 \q2 and there will be none, 
 \q1 also the sins of Judah, 
@@ -3315,7 +3315,7 @@
 \q1
 \v 21 “Go up against the land of Merathaim, 
 \q2 even against it, and against the inhabitants of Pekod. 
-\q1 Kill and utterly destroy after them,” says Yahweh, 
+\q1 Kill and utterly destroy after them,” says Yahuah, 
 \q2 “and do according to all that I have commanded you. 
 \q1
 \v 22 A sound of battle is in the land, 
@@ -3329,11 +3329,11 @@
 \q2 and you weren’t aware. 
 \q1 You are found, 
 \q2 and also caught, 
-\q2 because you have fought against Yahweh. 
+\q2 because you have fought against Yahuah. 
 \q1
-\v 25 Yahweh has opened his armory, 
+\v 25 Yahuah has opened his armory, 
 \q2 and has brought out the weapons of his indignation; 
-\q2 for the Lord, Yahweh of Armies, has a work to do in the land of the Chaldeans. 
+\q2 for the Lord, Yahuah of Armies, has a work to do in the land of the Chaldeans. 
 \q1
 \v 26 Come against her from the farthest border. 
 \q2 Open her storehouses. 
@@ -3347,7 +3347,7 @@
 \q2 the time of their visitation. 
 \q1
 \v 28 Listen to those who flee and escape out of the land of Babylon, 
-\q2 to declare in Zion the vengeance of Yahweh our Elohim, 
+\q2 to declare in Zion the vengeance of Yahuah our Elohim, 
 \q2 the vengeance of his temple. 
 \b
 \q1
@@ -3357,13 +3357,13 @@
 \q2 Let none of it escape. 
 \q1 Pay her back according to her work. 
 \q2 According to all that she has done, do to her; 
-\q1 for she has been proud against Yahweh, 
+\q1 for she has been proud against Yahuah, 
 \q2 against the Set-Apart One of Israel. 
 \q1
 \v 30 Therefore her young men will fall in her streets. 
-\q2 All her men of war will be brought to silence in that day,” says Yahweh. 
+\q2 All her men of war will be brought to silence in that day,” says Yahuah. 
 \q1
-\v 31 “Behold, I am against you, you proud one,” says the Lord, Yahweh of Armies; 
+\v 31 “Behold, I am against you, you proud one,” says the Lord, Yahuah of Armies; 
 \q2 “for your day has come, 
 \q2 the time that I will visit you. 
 \q1
@@ -3372,18 +3372,18 @@
 \q1 I will kindle a fire in his cities, 
 \q2 and it will devour all who are around him.” 
 \q1
-\v 33 Yahweh of Armies says: “The children of Israel and the children of Judah are oppressed together. 
+\v 33 Yahuah of Armies says: “The children of Israel and the children of Judah are oppressed together. 
 \q2 All who took them captive hold them fast. 
 \q2 They refuse to let them go. 
 \q1
 \v 34 Their Redeemer is strong. 
-\q2 Yahweh of Armies is his name. 
+\q2 Yahuah of Armies is his name. 
 \q1 He will thoroughly plead their cause, 
 \q2 that he may give rest to the earth, 
 \q2 and disquiet the inhabitants of Babylon. 
 \b
 \q1
-\v 35 “A sword is on the Chaldeans,” says Yahweh, 
+\v 35 “A sword is on the Chaldeans,” says Yahuah, 
 \q2 “and on the inhabitants of Babylon, 
 \q2 on her princes, 
 \q2 and on her wise men. 
@@ -3411,7 +3411,7 @@
 \q2 It will be inhabited no more forever, 
 \q2 neither will it be lived in from generation to generation. 
 \q1
-\v 40 As when Elohim overthrew Sodom and Gomorrah and its neighbor cities,” says Yahweh, 
+\v 40 As when Elohim overthrew Sodom and Gomorrah and its neighbor cities,” says Yahuah, 
 \q2 “so no man will dwell there, 
 \q2 neither will any son of man live therein. 
 \b
@@ -3441,7 +3441,7 @@
 \q1 Who will appoint me a time? 
 \q2 Who is the shepherd who can stand before me?” 
 \q1
-\v 45 Therefore hear the counsel of Yahweh 
+\v 45 Therefore hear the counsel of Yahuah 
 \q2 that he has taken against Babylon; 
 \q1 and his purposes 
 \q2 that he has purposed against the land of the Chaldeans: 
@@ -3453,7 +3453,7 @@
 \q2 The cry is heard among the nations. 
 \c 51
 \p
-\v 1 Yahweh says: 
+\v 1 Yahuah says: 
 \q1 “Behold, I will raise up against Babylon, 
 \q2 and against those who dwell in Lebkamai, a destroying wind. 
 \q1
@@ -3470,17 +3470,17 @@
 \q2 and thrust through in her streets. 
 \q1
 \v 5 For Israel is not forsaken, nor Judah, by his Elohim, 
-\q2 by Yahweh of Armies; 
+\q2 by Yahuah of Armies; 
 \q2 though their land is full of guilt against the Set-Apart One of Israel. 
 \b
 \q1
 \v 6 “Flee out of the middle of Babylon! 
 \q2 Everyone save his own life! 
 \q1 Don’t be cut off in her iniquity, 
-\q2 for it is the time of Yahweh’s vengeance. 
+\q2 for it is the time of Yahuah’s vengeance. 
 \q2 He will render to her a recompense. 
 \q1
-\v 7 Babylon has been a golden cup in Yahweh’s hand, 
+\v 7 Babylon has been a golden cup in Yahuah’s hand, 
 \q2 who made all the earth drunk. 
 \q1 The nations have drunk of her wine; 
 \q2 therefore the nations have gone mad. 
@@ -3498,28 +3498,28 @@
 \q1 for her judgment reaches to heaven, 
 \q2 and is lifted up even to the skies. 
 \q1
-\v 10 ‘Yahweh has produced our righteousness. 
-\q2 Come, and let’s declare in Zion the work of Yahweh our Elohim.’ 
+\v 10 ‘Yahuah has produced our righteousness. 
+\q2 Come, and let’s declare in Zion the work of Yahuah our Elohim.’ 
 \b
 \q1
 \v 11 “Make the arrows sharp! 
 \q2 Hold the shields firmly! 
-\q1 Yahweh has stirred up the spirit of the kings of the Medes, 
+\q1 Yahuah has stirred up the spirit of the kings of the Medes, 
 \q2 because his purpose is against Babylon, to destroy it; 
-\q1 for it is the vengeance of Yahweh, 
+\q1 for it is the vengeance of Yahuah, 
 \q2 the vengeance of his temple. 
 \q1
 \v 12 Set up a standard against the walls of Babylon! 
 \q2 Make the watch strong! 
 \q1 Set the watchmen, 
 \q2 and prepare the ambushes; 
-\q1 for Yahweh has both purposed and done 
+\q1 for Yahuah has both purposed and done 
 \q2 that which he spoke concerning the inhabitants of Babylon. 
 \q1
 \v 13 You who dwell on many waters, abundant in treasures, 
 \q2 your end has come, the measure of your desire. 
 \q1
-\v 14 Yahweh of Armies has sworn by himself, saying, 
+\v 14 Yahuah of Armies has sworn by himself, saying, 
 \q2 ‘Surely I will fill you with men, 
 \q2 as with locusts, 
 \q2 and they will lift up a shout against you.’ 
@@ -3548,7 +3548,7 @@
 \v 19 The portion of Jacob is not like these, 
 \q2 for he formed all things, 
 \q2 including the tribe of his inheritance. 
-\q2 Yahweh of Armies is his name. 
+\q2 Yahuah of Armies is his name. 
 \b
 \q1
 \v 20 “You are my battle ax and weapons of war. 
@@ -3574,9 +3574,9 @@
 \q1 With you I will break in pieces 
 \q2 governors and deputies. 
 \p
-\v 24 “I will render to Babylon and to all the inhabitants of Chaldea all their evil that they have done in Zion in your sight,” says Yahweh. 
+\v 24 “I will render to Babylon and to all the inhabitants of Chaldea all their evil that they have done in Zion in your sight,” says Yahuah. 
 \q1
-\v 25 “Behold, I am against you, destroying mountain,” says Yahweh, 
+\v 25 “Behold, I am against you, destroying mountain,” says Yahuah, 
 \q2 “which destroys all the earth. 
 \q1 I will stretch out my hand on you, 
 \q2 roll you down from the rocks, 
@@ -3584,7 +3584,7 @@
 \q1
 \v 26 They won’t take a cornerstone from you, 
 \q2 nor a stone for foundations; 
-\q2 but you will be desolate forever,” says Yahweh. 
+\q2 but you will be desolate forever,” says Yahuah. 
 \b
 \q1
 \v 27 “Set up a standard in the land! 
@@ -3598,7 +3598,7 @@
 \q2 the kings of the Medes, its governors, and all its deputies, and all the land of their dominion! 
 \q1
 \v 29 The land trembles and is in pain; 
-\q2 for the purposes of Yahweh against Babylon stand, 
+\q2 for the purposes of Yahuah against Babylon stand, 
 \q2 to make the land of Babylon a desolation, without inhabitant. 
 \q1
 \v 30 The mighty men of Babylon have stopped fighting, 
@@ -3616,7 +3616,7 @@
 \q2 They have burned the reeds with fire. 
 \q2 The men of war are frightened.” 
 \p
-\v 33 For Yahweh of Armies, the Elohim of Israel says: 
+\v 33 For Yahuah of Armies, the Elohim of Israel says: 
 \q1 “The daughter of Babylon is like a threshing floor at the time when it is trodden. 
 \q2 Yet a little while, and the time of harvest comes for her.” 
 \b
@@ -3634,7 +3634,7 @@
 \q2 will Jerusalem say. 
 \b
 \p
-\v 36 Therefore Yahweh says: 
+\v 36 Therefore Yahuah says: 
 \q1 “Behold, I will plead your cause, 
 \q2 and take vengeance for you. 
 \q1 I will dry up her sea, 
@@ -3652,7 +3652,7 @@
 \q2 and I will make them drunk, 
 \q1 that they may rejoice, 
 \q2 and sleep a perpetual sleep, 
-\q2 and not wake up,” says Yahweh. 
+\q2 and not wake up,” says Yahuah. 
 \b
 \q1
 \v 40 “I will bring them down like lambs to the slaughter, 
@@ -3678,7 +3678,7 @@
 \b
 \q1
 \v 45 “My people, go away from the middle of her, 
-\q2 and each of you save yourselves from Yahweh’s fierce anger. 
+\q2 and each of you save yourselves from Yahuah’s fierce anger. 
 \q1
 \v 46 Don’t let your heart faint. 
 \q2 Don’t fear for the news that will be heard in the land. 
@@ -3694,7 +3694,7 @@
 \v 48 Then the heavens and the earth, 
 \q2 and all that is therein, 
 \q1 will sing for joy over Babylon; 
-\q2 for the destroyers will come to her from the north,” says Yahweh. 
+\q2 for the destroyers will come to her from the north,” says Yahuah. 
 \b
 \q1
 \v 49 “As Babylon has caused the slain of Israel to fall, 
@@ -3702,29 +3702,29 @@
 \q1
 \v 50 You who have escaped the sword, go! 
 \q2 Don’t stand still! 
-\q1 Remember Yahweh from afar, 
+\q1 Remember Yahuah from afar, 
 \q2 and let Jerusalem come into your mind.” 
 \b
 \q1
 \v 51 “We are confounded 
 \q2 because we have heard reproach. 
 \q1 Confusion has covered our faces, 
-\q2 for strangers have come into the sanctuaries of Yahweh’s house.” 
+\q2 for strangers have come into the sanctuaries of Yahuah’s house.” 
 \b
 \q1
-\v 52 “Therefore behold, the days come,” says Yahweh, 
+\v 52 “Therefore behold, the days come,” says Yahuah, 
 \q2 “that I will execute judgment on her engraved images; 
 \q2 and through all her land the wounded will groan. 
 \q1
 \v 53 Though Babylon should mount up to the sky, 
 \q2 and though she should fortify the height of her strength, 
-\q2 yet destroyers will come to her from me,” says Yahweh. 
+\q2 yet destroyers will come to her from me,” says Yahuah. 
 \b
 \q1
 \v 54 “The sound of a cry comes from Babylon, 
 \q2 and of great destruction from the land of the Chaldeans! 
 \q1
-\v 55 For Yahweh lays Babylon waste, 
+\v 55 For Yahuah lays Babylon waste, 
 \q2 and destroys out of her the great voice! 
 \q1 Their waves roar like many waters. 
 \q2 The noise of their voice is uttered. 
@@ -3733,16 +3733,16 @@
 \q2 even on Babylon. 
 \q1 Her mighty men are taken. 
 \q2 Their bows are broken in pieces, 
-\q1 for Yahweh is an Elohim of retribution. 
+\q1 for Yahuah is an Elohim of retribution. 
 \q2 He will surely repay. 
 \q1
 \v 57 I will make her princes, her wise men, 
 \q2 her governors, her deputies, and her mighty men drunk. 
 \q1 They will sleep a perpetual sleep, 
 \q2 and not wake up,” 
-\q2 says the King, whose name is Yahweh of Armies. 
+\q2 says the King, whose name is Yahuah of Armies. 
 \p
-\v 58 Yahweh of Armies says: 
+\v 58 Yahuah of Armies says: 
 \q1 “The wide walls of Babylon will be utterly overthrown. 
 \q2 Her high gates will be burned with fire. 
 \q1 The peoples will labor for vanity, 
@@ -3752,15 +3752,15 @@
 \v 59 The word which Jeremiah the prophet commanded Seraiah the son of Neriah, the son of Mahseiah, when he went with Zedekiah the king of Judah to Babylon in the fourth year of his reign. Now Seraiah was chief quartermaster. 
 \v 60 Jeremiah wrote in a book all the evil that should come on Babylon, even all these words that are written concerning Babylon. 
 \v 61 Jeremiah said to Seraiah, “When you come to Babylon, then see that you read all these words, 
-\v 62 and say, ‘Yahweh, you have spoken concerning this place, to cut it off, that no one will dwell in it, neither man nor animal, but that it will be desolate forever.’ 
+\v 62 and say, ‘Yahuah, you have spoken concerning this place, to cut it off, that no one will dwell in it, neither man nor animal, but that it will be desolate forever.’ 
 \v 63 It will be, when you have finished reading this book, that you shall bind a stone to it, and cast it into the middle of the Euphrates. 
 \v 64 Then you shall say, ‘Thus will Babylon sink, and will not rise again because of the evil that I will bring on her; and they will be weary.’ ” 
 \p Thus far are the words of Jeremiah. 
 \c 52
 \p
 \v 1 Zedekiah was twenty-one years old when he began to reign. He reigned eleven years in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
-\v 2 He did that which was evil in Yahweh’s sight, according to all that Jehoiakim had done. 
-\v 3 For through Yahweh’s anger this happened in Jerusalem and Judah, until he had cast them out from his presence. 
+\v 2 He did that which was evil in Yahuah’s sight, according to all that Jehoiakim had done. 
+\v 3 For through Yahuah’s anger this happened in Jerusalem and Judah, until he had cast them out from his presence. 
 \p Zedekiah rebelled against the king of Babylon. 
 \v 4 In the ninth year of his reign, in the tenth month, in the tenth day of the month, Nebuchadnezzar king of Babylon came, he and all his army, against Jerusalem, and encamped against it; and they built forts against it round about. 
 \v 5 So the city was besieged to the eleventh year of King Zedekiah. 
@@ -3773,16 +3773,16 @@
 \v 11 He put out the eyes of Zedekiah; and the king of Babylon bound him in fetters, and carried him to Babylon, and put him in prison until the day of his death. 
 \p
 \v 12 Now in the fifth month, in the tenth day of the month, which was the nineteenth year of King Nebuchadnezzar, king of Babylon, Nebuzaradan the captain of the guard, who stood before the king of Babylon, came into Jerusalem. 
-\v 13 He burned Yahweh’s house, and the king’s house; and all the houses of Jerusalem, even every great house, he burned with fire. 
+\v 13 He burned Yahuah’s house, and the king’s house; and all the houses of Jerusalem, even every great house, he burned with fire. 
 \v 14 All the army of the Chaldeans, who were with the captain of the guard, broke down all the walls of Jerusalem all around. 
 \v 15 Then Nebuzaradan the captain of the guard carried away captive of the poorest of the people, and the rest of the people who were left in the city, and those who fell away, who defected to the king of Babylon, and the rest of the multitude. 
 \v 16 But Nebuzaradan the captain of the guard left of the poorest of the land to be vineyard keepers and farmers. 
 \p
-\v 17 The Chaldeans broke the pillars of bronze that were in Yahweh’s house and the bases and the bronze sea that were in Yahweh’s house in pieces, and carried all of their bronze to Babylon. 
+\v 17 The Chaldeans broke the pillars of bronze that were in Yahuah’s house and the bases and the bronze sea that were in Yahuah’s house in pieces, and carried all of their bronze to Babylon. 
 \v 18 They also took away the pots, the shovels, the snuffers, the basins, the spoons, and all the vessels of bronze with which they ministered. 
 \v 19 The captain of the guard took away the cups, the fire pans, the basins, the pots, the lamp stands, the spoons, and the bowls; that which was of gold, as gold, and that which was of silver, as silver. 
 \p
-\v 20 They took the two pillars, the one sea, and the twelve bronze bulls that were under the bases, which King Solomon had made for Yahweh’s house. The bronze of all these vessels was without weight. 
+\v 20 They took the two pillars, the one sea, and the twelve bronze bulls that were under the bases, which King Solomon had made for Yahuah’s house. The bronze of all these vessels was without weight. 
 \v 21 As for the pillars, the height of the one pillar was eighteen cubits; and a line of twelve cubits encircled it; and its thickness was four fingers. It was hollow. 
 \v 22 A capital of bronze was on it; and the height of the one capital was five cubits, with network and pomegranates on the capital all around, all of bronze. The second pillar also had the same, with pomegranates. 
 \v 23 There were ninety-six pomegranates on the sides; all the pomegranates were one hundred on the network all around. 

--- a/usfm/job.usfm
+++ b/usfm/job.usfm
@@ -9,18 +9,18 @@
 \v 4 His sons went and held a feast in the house of each one on his birthday; and they sent and called for their three sisters to eat and to drink with them. 
 \v 5 It was so, when the days of their feasting had run their course, that Job sent and sanctified them, and rose up early in the morning, and offered burnt offerings according to the number of them all. For Job said, “It may be that my sons have sinned, and renounced Elohim in their hearts.” Job did so continually. 
 \p
-\v 6 Now on the day when Elohim’s sons came to present themselves before Yahweh, Satan also came among them. 
-\v 7 Yahweh said to Satan, “Where have you come from?” 
-\p Then Satan answered Yahweh, and said, “From going back and forth in the earth, and from walking up and down in it.” 
+\v 6 Now on the day when Elohim’s sons came to present themselves before Yahuah, Satan also came among them. 
+\v 7 Yahuah said to Satan, “Where have you come from?” 
+\p Then Satan answered Yahuah, and said, “From going back and forth in the earth, and from walking up and down in it.” 
 \p
-\v 8 Yahweh said to Satan, “Have you considered my servant, Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil.” 
+\v 8 Yahuah said to Satan, “Have you considered my servant, Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil.” 
 \p
-\v 9 Then Satan answered Yahweh, and said, “Does Job fear Elohim for nothing? 
+\v 9 Then Satan answered Yahuah, and said, “Does Job fear Elohim for nothing? 
 \v 10 Haven’t you made a hedge around him, and around his house, and around all that he has, on every side? You have blessed the work of his hands, and his substance is increased in the land. 
 \v 11 But stretch out your hand now, and touch all that he has, and he will renounce you to your face.” 
 \p
-\v 12 Yahweh said to Satan, “Behold, all that he has is in your power. Only on himself don’t stretch out your hand.” 
-\p So Satan went out from the presence of Yahweh. 
+\v 12 Yahuah said to Satan, “Behold, all that he has is in your power. Only on himself don’t stretch out your hand.” 
+\p So Satan went out from the presence of Yahuah. 
 \v 13 It fell on a day when his sons and his daughters were eating and drinking wine in their oldest brother’s house, 
 \v 14 that a messenger came to Job, and said, “The oxen were plowing, and the donkeys feeding beside them, 
 \v 15 and the Sabeans attacked, and took them away. Yes, they have killed the servants with the edge of the sword, and I alone have escaped to tell you.” 
@@ -33,22 +33,22 @@
 \v 19 and behold, there came a great wind from the wilderness, and struck the four corners of the house, and it fell on the young men, and they are dead. I alone have escaped to tell you.” 
 \p
 \v 20 Then Job arose, and tore his robe, and shaved his head, and fell down on the ground, and worshiped. 
-\v 21 He said, “Naked I came out of my mother’s womb, and naked will I return there. Yahweh gave, and Yahweh has taken away. Blessed be Yahweh’s name.” 
+\v 21 He said, “Naked I came out of my mother’s womb, and naked will I return there. Yahuah gave, and Yahuah has taken away. Blessed be Yahuah’s name.” 
 \v 22 In all this, Job didn’t sin, nor charge Elohim with wrongdoing. 
 \c 2
 \p
-\v 1 Again, on the day when Elohim’s sons came to present themselves before Yahweh, Satan came also among them to present himself before Yahweh. 
-\v 2 Yahweh said to Satan, “Where have you come from?” 
-\p Satan answered Yahweh, and said, “From going back and forth in the earth, and from walking up and down in it.” 
+\v 1 Again, on the day when Elohim’s sons came to present themselves before Yahuah, Satan came also among them to present himself before Yahuah. 
+\v 2 Yahuah said to Satan, “Where have you come from?” 
+\p Satan answered Yahuah, and said, “From going back and forth in the earth, and from walking up and down in it.” 
 \p
-\v 3 Yahweh said to Satan, “Have you considered my servant Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil. He still maintains his integrity, although you incited me against him, to ruin him without cause.” 
+\v 3 Yahuah said to Satan, “Have you considered my servant Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil. He still maintains his integrity, although you incited me against him, to ruin him without cause.” 
 \p
-\v 4 Satan answered Yahweh, and said, “Skin for skin. Yes, all that a man has he will give for his life. 
+\v 4 Satan answered Yahuah, and said, “Skin for skin. Yes, all that a man has he will give for his life. 
 \v 5 But stretch out your hand now, and touch his bone and his flesh, and he will renounce you to your face.” 
 \p
-\v 6 Yahweh said to Satan, “Behold, he is in your hand. Only spare his life.” 
+\v 6 Yahuah said to Satan, “Behold, he is in your hand. Only spare his life.” 
 \p
-\v 7 So Satan went out from the presence of Yahweh, and struck Job with painful sores from the sole of his foot to his head. 
+\v 7 So Satan went out from the presence of Yahuah, and struck Job with painful sores from the sole of his foot to his head. 
 \v 8 He took for himself a potsherd to scrape himself with, and he sat among the ashes. 
 \v 9 Then his woman said to him, “Do you still maintain your integrity? Renounce Elohim, and die.” 
 \p
@@ -817,7 +817,7 @@
 \q2 The fish of the sea will declare to you. 
 \q1
 \v 9 Who doesn’t know that in all these, 
-\q2 Yahweh’s hand has done this, 
+\q2 Yahuah’s hand has done this, 
 \q1
 \v 10 in whose hand is the life of every living thing, 
 \q2 and the breath of all mankind? 
@@ -2947,7 +2947,7 @@
 \b
 \c 38
 \p
-\v 1 Then Yahweh answered Job out of the whirlwind, 
+\v 1 Then Yahuah answered Job out of the whirlwind, 
 \q1
 \v 2 “Who is this who darkens counsel 
 \q2 by words without knowledge? 
@@ -3180,13 +3180,13 @@
 \b
 \c 40
 \p
-\v 1 Moreover Yahweh answered Job, 
+\v 1 Moreover Yahuah answered Job, 
 \q1
 \v 2 “Shall he who argues contend with the Almighty? 
 \q2 He who argues with Elohim, let him answer it.” 
 \b
 \p
-\v 3 Then Job answered Yahweh, 
+\v 3 Then Job answered Yahuah, 
 \q1
 \v 4 “Behold, I am of small account. What will I answer you? 
 \q2 I lay my hand on my mouth. 
@@ -3195,7 +3195,7 @@
 \q2 Yes, twice, but I will proceed no further.” 
 \b
 \p
-\v 6 Then Yahweh answered Job out of the whirlwind: 
+\v 6 Then Yahuah answered Job out of the whirlwind: 
 \q1
 \v 7 “Now brace yourself like a man. 
 \q2 I will question you, and you will answer me. 
@@ -3365,7 +3365,7 @@
 \b
 \c 42
 \p
-\v 1 Then Job answered Yahweh: 
+\v 1 Then Job answered Yahuah: 
 \q1
 \v 2 “I know that you can do all things, 
 \q2 and that no purpose of yours can be restrained. 
@@ -3384,15 +3384,15 @@
 \q2 and repent in dust and ashes.” 
 \b
 \p
-\v 7 It was so, that after Yahweh had spoken these words to Job, Yahweh said to Eliphaz the Temanite, “My wrath is kindled against you, and against your two friends; for you have not spoken of me the thing that is right, as my servant Job has. 
+\v 7 It was so, that after Yahuah had spoken these words to Job, Yahuah said to Eliphaz the Temanite, “My wrath is kindled against you, and against your two friends; for you have not spoken of me the thing that is right, as my servant Job has. 
 \v 8 Now therefore, take to yourselves seven bulls and seven rams, and go to my servant Job, and offer up for yourselves a burnt offering; and my servant Job shall pray for you, for I will accept him, that I not deal with you according to your folly. For you have not spoken of me the thing that is right, as my servant Job has.” 
 \p
-\v 9 So Eliphaz the Temanite and Bildad the Shuhite and Zophar the Naamathite went and did what Yahweh commanded them, and Yahweh accepted Job. 
+\v 9 So Eliphaz the Temanite and Bildad the Shuhite and Zophar the Naamathite went and did what Yahuah commanded them, and Yahuah accepted Job. 
 \p
-\v 10 Yahweh restored Job’s prosperity when he prayed for his friends. Yahweh gave Job twice as much as he had before. 
-\v 11 Then all his brothers, all his sisters, and all those who had been of his acquaintance before, came to him and ate bread with him in his house. They comforted him, and consoled him concerning all the evil that Yahweh had brought on him. Everyone also gave him a piece of money, and everyone a ring of gold. 
+\v 10 Yahuah restored Job’s prosperity when he prayed for his friends. Yahuah gave Job twice as much as he had before. 
+\v 11 Then all his brothers, all his sisters, and all those who had been of his acquaintance before, came to him and ate bread with him in his house. They comforted him, and consoled him concerning all the evil that Yahuah had brought on him. Everyone also gave him a piece of money, and everyone a ring of gold. 
 \p
-\v 12 So Yahweh blessed the latter end of Job more than his beginning. He had fourteen thousand sheep, six thousand camels, one thousand yoke of oxen, and a thousand female donkeys. 
+\v 12 So Yahuah blessed the latter end of Job more than his beginning. He had fourteen thousand sheep, six thousand camels, one thousand yoke of oxen, and a thousand female donkeys. 
 \v 13 He had also seven sons and three daughters. 
 \v 14 He called the name of the first, Jemimah; and the name of the second, Keziah; and the name of the third, Keren Happuch. 
 \v 15 In all the land were no women found so beautiful as the daughters of Job. Their father gave them an inheritance among their brothers. 

--- a/usfm/joel.usfm
+++ b/usfm/joel.usfm
@@ -3,7 +3,7 @@
 \h Joel
 \c 1
 \p
-\v 1 Yahweh’s word that came to Joel, the son of Pethuel. 
+\v 1 Yahuah’s word that came to Joel, the son of Pethuel. 
 \q1
 \v 2 Hear this, you elders, 
 \q2 and listen, all you inhabitants of the land! 
@@ -34,8 +34,8 @@
 \v 8 Mourn like a virgin dressed in sackcloth 
 \q2 for the owner of her youth! 
 \q1
-\v 9 The meal offering and the drink offering are cut off from Yahweh’s house. 
-\q2 The priests, Yahweh’s ministers, mourn. 
+\v 9 The meal offering and the drink offering are cut off from Yahuah’s house. 
+\q2 The priests, Yahuah’s ministers, mourn. 
 \q1
 \v 10 The field is laid waste. 
 \q2 The land mourns, for the grain is destroyed, 
@@ -58,11 +58,11 @@
 \q1
 \v 14 Sanctify a fast. 
 \q2 Call a solemn assembly. 
-\q2 Gather the elders and all the inhabitants of the land to the house of Yahweh, your Elohim, 
-\q2 and cry to Yahweh. 
+\q2 Gather the elders and all the inhabitants of the land to the house of Yahuah, your Elohim, 
+\q2 and cry to Yahuah. 
 \q1
 \v 15 Alas for the day! 
-\q2 For the day of Yahweh is at hand, 
+\q2 For the day of Yahuah is at hand, 
 \q2 and it will come as destruction from the Almighty. 
 \q1
 \v 16 Isn’t the food cut off before our eyes, 
@@ -76,7 +76,7 @@
 \q2 The herds of livestock are perplexed, because they have no pasture. 
 \q2 Yes, the flocks of sheep are made desolate. 
 \q1
-\v 19 Yahweh, I cry to you, 
+\v 19 Yahuah, I cry to you, 
 \q2 for the fire has devoured the pastures of the wilderness, 
 \q2 and the flame has burned all the trees of the field. 
 \q1
@@ -89,7 +89,7 @@
 \v 1 Blow the trumpet in Zion, 
 \q2 and sound an alarm in my set-apart mountain! 
 \q1 Let all the inhabitants of the land tremble, 
-\q2 for the day of Yahweh comes, 
+\q2 for the day of Yahuah comes, 
 \q2 for it is close at hand: 
 \q1
 \v 2 A day of darkness and gloominess, 
@@ -135,24 +135,24 @@
 \q2 The sun and the moon are darkened, 
 \q2 and the stars withdraw their shining. 
 \q1
-\v 11 Yahweh thunders his voice before his army, 
+\v 11 Yahuah thunders his voice before his army, 
 \q2 for his forces are very great; 
 \q2 for he is strong who obeys his command; 
-\q2 for the day of Yahweh is great and very awesome, 
+\q2 for the day of Yahuah is great and very awesome, 
 \q2 and who can endure it? 
 \q1
-\v 12 “Yet even now,” says Yahweh, “turn to me with all your heart, 
+\v 12 “Yet even now,” says Yahuah, “turn to me with all your heart, 
 \q2 and with fasting, and with weeping, and with mourning.” 
 \q1
 \v 13 Tear your heart and not your garments, 
-\q2 and turn to Yahweh, your Elohim; 
+\q2 and turn to Yahuah, your Elohim; 
 \q2 for he is gracious and merciful, 
 \q2 slow to anger, and abundant in loving kindness, 
 \q2 and relents from sending calamity. 
 \q1
 \v 14 Who knows? He may turn and relent, 
 \q2 and leave a blessing behind him, 
-\q2 even a meal offering and a drink offering to Yahweh, your Elohim. 
+\q2 even a meal offering and a drink offering to Yahuah, your Elohim. 
 \q1
 \v 15 Blow the trumpet in Zion! 
 \q2 Sanctify a fast. 
@@ -165,17 +165,17 @@
 \q1 Let the bridegroom go out of his room, 
 \q2 and the bride out of her chamber. 
 \q1
-\v 17 Let the priests, the ministers of Yahweh, weep between the porch and the altar, 
-\q2 and let them say, “Spare your people, Yahweh, 
+\v 17 Let the priests, the ministers of Yahuah, weep between the porch and the altar, 
+\q2 and let them say, “Spare your people, Yahuah, 
 \q2 and don’t give your heritage to reproach, 
 \q2 that the nations should rule over them. 
 \q1 Why should they say among the peoples, 
 \q2 ‘Where is their Elohim?’ ” 
 \q1
-\v 18 Then Yahweh was jealous for his land, 
+\v 18 Then Yahuah was jealous for his land, 
 \q2 and had pity on his people. 
 \q1
-\v 19 Yahweh answered his people, 
+\v 19 Yahuah answered his people, 
 \q2 “Behold, I will send you grain, new wine, and oil, 
 \q2 and you will be satisfied with them; 
 \q2 and I will no more make you a reproach among the nations. 
@@ -189,7 +189,7 @@
 \q1 Surely he has done great things. 
 \q1
 \v 21 Land, don’t be afraid. 
-\q2 Be glad and rejoice, for Yahweh has done great things. 
+\q2 Be glad and rejoice, for Yahuah has done great things. 
 \q1
 \v 22 Don’t be afraid, you animals of the field; 
 \q2 for the pastures of the wilderness spring up, 
@@ -198,7 +198,7 @@
 \b
 \q1
 \v 23 “Be glad then, you children of Zion, 
-\q2 and rejoice in Yahweh, your Elohim; 
+\q2 and rejoice in Yahuah, your Elohim; 
 \q2 for he gives you the early rain in just measure, 
 \q2 and he causes the rain to come down for you, 
 \q2 the early rain and the latter rain, as before. 
@@ -211,12 +211,12 @@
 \q2 my great army, which I sent among you. 
 \q1
 \v 26 You will have plenty to eat and be satisfied, 
-\q2 and will praise the name of Yahweh, your Elohim, 
+\q2 and will praise the name of Yahuah, your Elohim, 
 \q2 who has dealt wondrously with you; 
 \q2 and my people will never again be disappointed. 
 \q1
 \v 27 You will know that I am among Israel, 
-\q2 and that I am Yahweh, your Elohim, and there is no one else; 
+\q2 and that I am Yahuah, your Elohim, and there is no one else; 
 \q2 and my people will never again be disappointed. 
 \b
 \q1
@@ -233,12 +233,12 @@
 \q1
 \v 31 The sun will be turned into darkness, 
 \q2 and the moon into blood, 
-\q2 before the great and terrible day of Yahweh comes. 
+\q2 before the great and terrible day of Yahuah comes. 
 \q1
-\v 32 It will happen that whoever will call on Yahweh’s name shall be saved; 
+\v 32 It will happen that whoever will call on Yahuah’s name shall be saved; 
 \q2 for in Mount Zion and in Jerusalem there will be those who escape, 
-\q2 as Yahweh has said, 
-\q2 and among the remnant, those whom Yahweh calls. 
+\q2 as Yahuah has said, 
+\q2 and among the remnant, those whom Yahuah calls. 
 \b
 \c 3
 \q1
@@ -275,7 +275,7 @@
 \v 8 and I will sell your sons and your daughters into the hands of the children of Judah, 
 \q2 and they will sell them to the men of Sheba, 
 \q2 to a faraway nation, 
-\q2 for Yahweh has spoken it.” 
+\q2 for Yahuah has spoken it.” 
 \b
 \q1
 \v 9 Proclaim this among the nations: 
@@ -289,7 +289,7 @@
 \q1
 \v 11 Hurry and come, all you surrounding nations, 
 \q2 and gather yourselves together.” 
-\q1 Cause your mighty ones to come down there, Yahweh. 
+\q1 Cause your mighty ones to come down there, Yahuah. 
 \q1
 \v 12 “Let the nations arouse themselves, 
 \q2 and come up to the valley of Jehoshaphat; 
@@ -301,18 +301,18 @@
 \q2 the vats overflow, for their wickedness is great.” 
 \q1
 \v 14 Multitudes, multitudes in the valley of decision! 
-\q2 For the day of Yahweh is near in the valley of decision. 
+\q2 For the day of Yahuah is near in the valley of decision. 
 \q1
 \v 15 The sun and the moon are darkened, 
 \q2 and the stars withdraw their shining. 
 \q1
-\v 16 Yahweh will roar from Zion, 
+\v 16 Yahuah will roar from Zion, 
 \q2 and thunder from Jerusalem; 
 \q2 and the heavens and the earth will shake; 
-\q2 but Yahweh will be a refuge to his people, 
+\q2 but Yahuah will be a refuge to his people, 
 \q2 and a stronghold to the children of Israel. 
 \q1
-\v 17 “So you will know that I am Yahweh, your Elohim, 
+\v 17 “So you will know that I am Yahuah, your Elohim, 
 \q2 dwelling in Zion, my set-apart mountain. 
 \q1 Then Jerusalem will be set-apart, 
 \q2 and no strangers will pass through her any more. 
@@ -321,7 +321,7 @@
 \q2 that the mountains will drop down sweet wine, 
 \q2 the hills will flow with milk, 
 \q2 all the brooks of Judah will flow with waters; 
-\q2 and a fountain will flow out from Yahweh’s house, 
+\q2 and a fountain will flow out from Yahuah’s house, 
 \q2 and will water the valley of Shittim. 
 \q1
 \v 19 Egypt will be a desolation 
@@ -334,4 +334,4 @@
 \q1
 \v 21 I will cleanse their blood 
 \q2 that I have not cleansed, 
-\q2 for Yahweh dwells in Zion.” 
+\q2 for Yahuah dwells in Zion.” 

--- a/usfm/jonah.usfm
+++ b/usfm/jonah.usfm
@@ -3,36 +3,36 @@
 \h Jonah
 \c 1
 \p
-\v 1 Now Yahweh’s word came to Jonah the son of Amittai, saying, 
+\v 1 Now Yahuah’s word came to Jonah the son of Amittai, saying, 
 \v 2 “Arise, go to Nineveh, that great city, and preach against it, for their wickedness has come up before me.” 
 \p
-\v 3 But Jonah rose up to flee to Tarshish from the presence of Yahweh. He went down to Joppa, and found a ship going to Tarshish; so he paid its fare, and went down into it, to go with them to Tarshish from the presence of Yahweh. 
+\v 3 But Jonah rose up to flee to Tarshish from the presence of Yahuah. He went down to Joppa, and found a ship going to Tarshish; so he paid its fare, and went down into it, to go with them to Tarshish from the presence of Yahuah. 
 \p
-\v 4 But Yahweh sent out a great wind on the sea, and there was a mighty storm on the sea, so that the ship was likely to break up. 
+\v 4 But Yahuah sent out a great wind on the sea, and there was a mighty storm on the sea, so that the ship was likely to break up. 
 \v 5 Then the mariners were afraid, and every man cried to his elohim. They threw the cargo that was in the ship into the sea to lighten the ship. But Jonah had gone down into the innermost parts of the ship and he was laying down, and was fast asleep. 
 \v 6 So the ship master came to him, and said to him, “What do you mean, sleeper? Arise, call on your Elohim! Maybe your Elohim will notice us, so that we won’t perish.” 
 \p
 \v 7 They all said to each other, “Come! Let’s cast lots, that we may know who is responsible for this evil that is on us.” So they cast lots, and the lot fell on Jonah. 
 \v 8 Then they asked him, “Tell us, please, for whose cause this evil is on us. What is your occupation? Where do you come from? What is your country? Of what people are you?” 
 \p
-\v 9 He said to them, “I am a Hebrew, and I fear Yahweh, the Elohim of heaven, who has made the sea and the dry land.” 
+\v 9 He said to them, “I am a Hebrew, and I fear Yahuah, the Elohim of heaven, who has made the sea and the dry land.” 
 \p
-\v 10 Then the men were exceedingly afraid, and said to him, “What have you done?” For the men knew that he was fleeing from the presence of Yahweh, because he had told them. 
+\v 10 Then the men were exceedingly afraid, and said to him, “What have you done?” For the men knew that he was fleeing from the presence of Yahuah, because he had told them. 
 \v 11 Then they said to him, “What shall we do to you, that the sea may be calm to us?” For the sea grew more and more stormy. 
 \p
 \v 12 He said to them, “Take me up, and throw me into the sea. Then the sea will be calm for you; for I know that because of me this great storm is on you.” 
 \p
 \v 13 Nevertheless the men rowed hard to get them back to the land; but they could not, for the sea grew more and more stormy against them. 
-\v 14 Therefore they cried to Yahweh, and said, “We beg you, Yahweh, we beg you, don’t let us die for this man’s life, and don’t lay on us innocent blood; for you, Yahweh, have done as it pleased you.” 
+\v 14 Therefore they cried to Yahuah, and said, “We beg you, Yahuah, we beg you, don’t let us die for this man’s life, and don’t lay on us innocent blood; for you, Yahuah, have done as it pleased you.” 
 \v 15 So they took up Jonah and threw him into the sea; and the sea ceased its raging. 
-\v 16 Then the men feared Yahweh exceedingly; and they offered a sacrifice to Yahweh and made vows. 
+\v 16 Then the men feared Yahuah exceedingly; and they offered a sacrifice to Yahuah and made vows. 
 \p
-\v 17 Yahweh prepared a huge fish to swallow up Jonah, and Jonah was in the belly of the fish three days and three nights. 
+\v 17 Yahuah prepared a huge fish to swallow up Jonah, and Jonah was in the belly of the fish three days and three nights. 
 \c 2
 \p
-\v 1 Then Jonah prayed to Yahweh, his Elohim, out of the fish’s belly. 
+\v 1 Then Jonah prayed to Yahuah, his Elohim, out of the fish’s belly. 
 \v 2 He said, 
-\q1 “I called because of my affliction to Yahweh. 
+\q1 “I called because of my affliction to Yahuah. 
 \q2 He answered me. 
 \q1 Out of the belly of Sheol I cried. 
 \q2 You heard my voice. 
@@ -52,25 +52,25 @@
 \q1
 \v 6 I went down to the bottoms of the mountains. 
 \q2 The earth barred me in forever; 
-\q2 yet you have brought my life up from the pit, Yahweh my Elohim. 
+\q2 yet you have brought my life up from the pit, Yahuah my Elohim. 
 \b
 \q1
-\v 7 “When my soul fainted within me, I remembered Yahweh. 
+\v 7 “When my soul fainted within me, I remembered Yahuah. 
 \q2 My prayer came in to you, into your set-apart temple. 
 \q1
 \v 8 Those who regard vain idols forsake their own mercy. 
 \q2
 \v 9 But I will sacrifice to you with the voice of thanksgiving. 
 \q2 I will pay that which I have vowed. 
-\q1 Salvation belongs to Yahweh.” 
+\q1 Salvation belongs to Yahuah.” 
 \p
-\v 10 Then Yahweh spoke to the fish, and it vomited out Jonah on the dry land. 
+\v 10 Then Yahuah spoke to the fish, and it vomited out Jonah on the dry land. 
 \c 3
 \p
-\v 1 Yahweh’s word came to Jonah the second time, saying, 
+\v 1 Yahuah’s word came to Jonah the second time, saying, 
 \v 2 “Arise, go to Nineveh, that great city, and preach to it the message that I give you.” 
 \p
-\v 3 So Jonah arose, and went to Nineveh, according to Yahweh’s word. Now Nineveh was an exceedingly great city, three days’ journey across. 
+\v 3 So Jonah arose, and went to Nineveh, according to Yahuah’s word. Now Nineveh was an exceedingly great city, three days’ journey across. 
 \v 4 Jonah began to enter into the city a day’s journey, and he cried out, and said, “In forty days, Nineveh will be overthrown!” 
 \p
 \v 5 The people of Nineveh believed Elohim; and they proclaimed a fast and put on sackcloth, from their greatest even to their least. 
@@ -83,18 +83,18 @@
 \c 4
 \p
 \v 1 But it displeased Jonah exceedingly, and he was angry. 
-\v 2 He prayed to Yahweh, and said, “Please, Yahweh, wasn’t this what I said when I was still in my own country? Therefore I hurried to flee to Tarshish, for I knew that you are a gracious Elohim and merciful, slow to anger, and abundant in loving kindness, and you relent of doing harm. 
-\v 3 Therefore now, Yahweh, take, I beg you, my life from me, for it is better for me to die than to live.” 
+\v 2 He prayed to Yahuah, and said, “Please, Yahuah, wasn’t this what I said when I was still in my own country? Therefore I hurried to flee to Tarshish, for I knew that you are a gracious Elohim and merciful, slow to anger, and abundant in loving kindness, and you relent of doing harm. 
+\v 3 Therefore now, Yahuah, take, I beg you, my life from me, for it is better for me to die than to live.” 
 \p
-\v 4 Yahweh said, “Is it right for you to be angry?” 
+\v 4 Yahuah said, “Is it right for you to be angry?” 
 \p
 \v 5 Then Jonah went out of the city and sat on the east side of the city, and there made himself a booth and sat under it in the shade, until he might see what would become of the city. 
-\v 6 Yahweh Elohim prepared a vine and made it to come up over Jonah, that it might be a shade over his head to deliver him from his discomfort. So Jonah was exceedingly glad because of the vine. 
+\v 6 Yahuah Elohim prepared a vine and made it to come up over Jonah, that it might be a shade over his head to deliver him from his discomfort. So Jonah was exceedingly glad because of the vine. 
 \v 7 But Elohim prepared a worm at dawn the next day, and it chewed on the vine so that it withered. 
 \v 8 When the sun arose, Elohim prepared a sultry east wind; and the sun beat on Jonah’s head, so that he was faint and requested for himself that he might die. He said, “It is better for me to die than to live.” 
 \p
 \v 9 Elohim said to Jonah, “Is it right for you to be angry about the vine?” 
 \p He said, “I am right to be angry, even to death.” 
 \p
-\v 10 Yahweh said, “You have been concerned for the vine, for which you have not labored, neither made it grow; which came up in a night and perished in a night. 
+\v 10 Yahuah said, “You have been concerned for the vine, for which you have not labored, neither made it grow; which came up in a night and perished in a night. 
 \v 11 Shouldn’t I be concerned for Nineveh, that great city, in which are more than one hundred twenty thousand persons who can’t discern between their right hand and their left hand, and also many animals?” 

--- a/usfm/joshua.usfm
+++ b/usfm/joshua.usfm
@@ -3,7 +3,7 @@
 \h Joshua
 \c 1
 \p
-\v 1 Now after the death of Moses the servant of Yahweh, Yahweh spoke to Joshua the son of Nun, Moses’ servant, saying, 
+\v 1 Now after the death of Moses the servant of Yahuah, Yahuah spoke to Joshua the son of Nun, Moses’ servant, saying, 
 \v 2 “Moses my servant is dead. Now therefore arise, go across this Jordan, you and all these people, to the land which I am giving to them, even to the children of Israel. 
 \v 3 I have given you every place that the sole of your foot will tread on, as I told Moses. 
 \v 4 From the wilderness and this Lebanon even to the great river, the river Euphrates, all the land of the Hittites, and to the great sea toward the going down of the sun, shall be your border. 
@@ -12,18 +12,18 @@
 \v 6 “Be strong and courageous; for you shall cause this people to inherit the land which I swore to their fathers to give them. 
 \v 7 Only be strong and very courageous. Be careful to observe to do according to all the law which Moses my servant commanded you. Don’t turn from it to the right hand or to the left, that you may have good success wherever you go. 
 \v 8 This book of the law shall not depart from your mouth, but you shall meditate on it day and night, that you may observe to do according to all that is written in it; for then you shall make your way prosperous, and then you shall have good success. 
-\v 9 Haven’t I commanded you? Be strong and courageous. Don’t be afraid. Don’t be dismayed, for Yahweh your Elohim is with you wherever you go.” 
+\v 9 Haven’t I commanded you? Be strong and courageous. Don’t be afraid. Don’t be dismayed, for Yahuah your Elohim is with you wherever you go.” 
 \p
 \v 10 Then Joshua commanded the officers of the people, saying, 
-\v 11 “Pass through the middle of the camp, and command the people, saying, ‘Prepare food; for within three days you are to pass over this Jordan, to go in to possess the land which Yahweh your Elohim gives you to possess.’ ” 
+\v 11 “Pass through the middle of the camp, and command the people, saying, ‘Prepare food; for within three days you are to pass over this Jordan, to go in to possess the land which Yahuah your Elohim gives you to possess.’ ” 
 \p
 \v 12 Joshua spoke to the Reubenites, and to the Gadites, and to the half-tribe of Manasseh, saying, 
-\v 13 “Remember the word which Moses the servant of Yahweh commanded you, saying, ‘Yahweh your Elohim gives you rest, and will give you this land. 
+\v 13 “Remember the word which Moses the servant of Yahuah commanded you, saying, ‘Yahuah your Elohim gives you rest, and will give you this land. 
 \v 14 Your women, your little ones, and your livestock shall live in the land which Moses gave you beyond the Jordan; but you shall pass over before your brothers armed, all the mighty men of valor, and shall help them 
-\v 15 until Yahweh has given your brothers rest, as he has given you, and they have also possessed the land which Yahweh your Elohim gives them. Then you shall return to the land of your possession and possess it, which Moses the servant of Yahweh gave you beyond the Jordan toward the sunrise.’ ” 
+\v 15 until Yahuah has given your brothers rest, as he has given you, and they have also possessed the land which Yahuah your Elohim gives them. Then you shall return to the land of your possession and possess it, which Moses the servant of Yahuah gave you beyond the Jordan toward the sunrise.’ ” 
 \p
 \v 16 They answered Joshua, saying, “All that you have commanded us we will do, and wherever you send us we will go. 
-\v 17 Just as we listened to Moses in all things, so will we listen to you. Only may Yahweh your Elohim be with you, as he was with Moses. 
+\v 17 Just as we listened to Moses in all things, so will we listen to you. Only may Yahuah your Elohim be with you, as he was with Moses. 
 \v 18 Whoever rebels against your commandment, and doesn’t listen to your words in all that you command him shall himself be put to death. Only be strong and courageous.” 
 \c 2
 \p
@@ -38,13 +38,13 @@
 \v 6 But she had brought them up to the roof, and hidden them under the stalks of flax which she had laid in order on the roof. 
 \v 7 The men pursued them along the way to the fords of the Jordan River. As soon as those who pursued them had gone out, they shut the gate. 
 \v 8 Before they had lain down, she came up to them on the roof. 
-\v 9 She said to the men, “I know that Yahweh has given you the land, and that the fear of you has fallen upon us, and that all the inhabitants of the land melt away before you. 
-\v 10 For we have heard how Yahweh dried up the water of the Red Sea before you, when you came out of Egypt; and what you did to the two kings of the Amorites, who were beyond the Jordan, to Sihon and to Og, whom you utterly destroyed. 
-\v 11 As soon as we had heard it, our hearts melted, and there wasn’t any more spirit in any man, because of you: for Yahweh your Elohim, he is Elohim in heaven above, and on earth beneath. 
-\v 12 Now therefore, please swear to me by Yahweh, since I have dealt kindly with you, that you also will deal kindly with my father’s house, and give me a true sign; 
+\v 9 She said to the men, “I know that Yahuah has given you the land, and that the fear of you has fallen upon us, and that all the inhabitants of the land melt away before you. 
+\v 10 For we have heard how Yahuah dried up the water of the Red Sea before you, when you came out of Egypt; and what you did to the two kings of the Amorites, who were beyond the Jordan, to Sihon and to Og, whom you utterly destroyed. 
+\v 11 As soon as we had heard it, our hearts melted, and there wasn’t any more spirit in any man, because of you: for Yahuah your Elohim, he is Elohim in heaven above, and on earth beneath. 
+\v 12 Now therefore, please swear to me by Yahuah, since I have dealt kindly with you, that you also will deal kindly with my father’s house, and give me a true sign; 
 \v 13 and that you will save alive my father, my mother, my brothers, and my sisters, and all that they have, and will deliver our lives from death.” 
 \p
-\v 14 The men said to her, “Our life for yours, if you don’t talk about this business of ours; and it shall be, when Yahweh gives us the land, that we will deal kindly and truly with you.” 
+\v 14 The men said to her, “Our life for yours, if you don’t talk about this business of ours; and it shall be, when Yahuah gives us the land, that we will deal kindly and truly with you.” 
 \p
 \v 15 Then she let them down by a cord through the window; for her house was on the side of the wall, and she lived on the wall. 
 \v 16 She said to them, “Go to the mountain, lest the pursuers find you. Hide yourselves there three days, until the pursuers have returned. Afterward, you may go your way.” 
@@ -58,165 +58,165 @@
 \p
 \v 22 They went and came to the mountain, and stayed there three days, until the pursuers had returned. The pursuers sought them all along the way, but didn’t find them. 
 \v 23 Then the two men returned, descended from the mountain, crossed the river, and came to Joshua the son of Nun. They told him all that had happened to them. 
-\v 24 They said to Joshua, “Truly Yahweh has delivered all the land into our hands. Moreover, all the inhabitants of the land melt away before us.” 
+\v 24 They said to Joshua, “Truly Yahuah has delivered all the land into our hands. Moreover, all the inhabitants of the land melt away before us.” 
 \c 3
 \p
 \v 1 Joshua got up early in the morning; and they moved from Shittim and came to the Jordan, he and all the children of Israel. They camped there before they crossed over. 
 \v 2 After three days, the officers went through the middle of the camp; 
-\v 3 and they commanded the people, saying, “When you see the ark of Yahweh your Elohim’s covenant, and the Levitical priests bearing it, then leave your place and follow it. 
+\v 3 and they commanded the people, saying, “When you see the ark of Yahuah your Elohim’s covenant, and the Levitical priests bearing it, then leave your place and follow it. 
 \v 4 Yet there shall be a space between you and it of about two thousand cubits by measure—don’t come closer to it—that you may know the way by which you must go; for you have not passed this way before.” 
 \p
-\v 5 Joshua said to the people, “Sanctify yourselves; for tomorrow Yahweh will do wonders among you.” 
+\v 5 Joshua said to the people, “Sanctify yourselves; for tomorrow Yahuah will do wonders among you.” 
 \p
 \v 6 Joshua spoke to the priests, saying, “Take up the ark of the covenant, and cross over before the people.” They took up the ark of the covenant, and went before the people. 
 \p
-\v 7 Yahweh said to Joshua, “Today I will begin to magnify you in the sight of all Israel, that they may know that as I was with Moses, so I will be with you. 
+\v 7 Yahuah said to Joshua, “Today I will begin to magnify you in the sight of all Israel, that they may know that as I was with Moses, so I will be with you. 
 \v 8 You shall command the priests who bear the ark of the covenant, saying, ‘When you come to the brink of the waters of the Jordan, you shall stand still in the Jordan.’ ” 
 \p
-\v 9 Joshua said to the children of Israel, “Come here, and hear the words of Yahweh your Elohim.” 
+\v 9 Joshua said to the children of Israel, “Come here, and hear the words of Yahuah your Elohim.” 
 \v 10 Joshua said, “By this you shall know that the living Elohim is among you, and that he will without fail drive the Canaanite, the Hittite, the Hivite, the Perizzite, the Girgashite, the Amorite, and the Jebusite out from before you. 
 \v 11 Behold, the ark of the covenant of the Lord of all the earth passes over before you into the Jordan. 
 \v 12 Now therefore take twelve men out of the tribes of Israel, for every tribe a man. 
-\v 13 It shall be that when the soles of the feet of the priests who bear the ark of Yahweh, the Lord of all the earth, rest in the waters of the Jordan, that the waters of the Jordan will be cut off. The waters that come down from above shall stand in one heap.” 
+\v 13 It shall be that when the soles of the feet of the priests who bear the ark of Yahuah, the Lord of all the earth, rest in the waters of the Jordan, that the waters of the Jordan will be cut off. The waters that come down from above shall stand in one heap.” 
 \p
 \v 14 When the people moved from their tents to pass over the Jordan, the priests who bore the ark of the covenant being before the people, 
 \v 15 and when those who bore the ark had come to the Jordan, and the feet of the priests who bore the ark had dipped in the edge of the water (for the Jordan overflows all its banks all the time of harvest), 
 \v 16 the waters which came down from above stood, and rose up in one heap a great way off, at Adam, the city that is beside Zarethan; and those that went down toward the sea of the Arabah, even the Salt Sea, were wholly cut off. Then the people passed over near Jericho. 
-\v 17 The priests who bore the ark of Yahweh’s covenant stood firm on dry ground in the middle of the Jordan; and all Israel crossed over on dry ground, until all the nation had passed completely over the Jordan. 
+\v 17 The priests who bore the ark of Yahuah’s covenant stood firm on dry ground in the middle of the Jordan; and all Israel crossed over on dry ground, until all the nation had passed completely over the Jordan. 
 \c 4
 \p
-\v 1 When all the nation had completely crossed over the Jordan, Yahweh spoke to Joshua, saying, 
+\v 1 When all the nation had completely crossed over the Jordan, Yahuah spoke to Joshua, saying, 
 \v 2 “Take twelve men out of the people, a man out of every tribe, 
 \v 3 and command them, saying, ‘Take from out of the middle of the Jordan, out of the place where the priests’ feet stood firm, twelve stones, carry them over with you, and lay them down in the place where you’ll camp tonight.’ ” 
 \p
 \v 4 Then Joshua called the twelve men whom he had prepared of the children of Israel, a man out of every tribe. 
-\v 5 Joshua said to them, “Cross before the ark of Yahweh your Elohim into the middle of the Jordan, and each of you pick up a stone and put it on your shoulder, according to the number of the tribes of the children of Israel; 
+\v 5 Joshua said to them, “Cross before the ark of Yahuah your Elohim into the middle of the Jordan, and each of you pick up a stone and put it on your shoulder, according to the number of the tribes of the children of Israel; 
 \v 6 that this may be a sign among you, that when your children ask in the future, saying, ‘What do you mean by these stones?’ 
-\v 7 then you shall tell them, ‘Because the waters of the Jordan were cut off before the ark of Yahweh’s covenant. When it crossed over the Jordan, the waters of the Jordan were cut off. These stones shall be for a memorial to the children of Israel forever.’ ” 
+\v 7 then you shall tell them, ‘Because the waters of the Jordan were cut off before the ark of Yahuah’s covenant. When it crossed over the Jordan, the waters of the Jordan were cut off. These stones shall be for a memorial to the children of Israel forever.’ ” 
 \p
-\v 8 The children of Israel did as Joshua commanded, and took up twelve stones out of the middle of the Jordan, as Yahweh spoke to Joshua, according to the number of the tribes of the children of Israel. They carried them over with them to the place where they camped, and laid them down there. 
+\v 8 The children of Israel did as Joshua commanded, and took up twelve stones out of the middle of the Jordan, as Yahuah spoke to Joshua, according to the number of the tribes of the children of Israel. They carried them over with them to the place where they camped, and laid them down there. 
 \v 9 Joshua set up twelve stones in the middle of the Jordan, in the place where the feet of the priests who bore the ark of the covenant stood; and they are there to this day. 
-\v 10 For the priests who bore the ark stood in the middle of the Jordan until everything was finished that Yahweh commanded Joshua to speak to the people, according to all that Moses commanded Joshua; and the people hurried and passed over. 
-\v 11 When all the people had completely crossed over, Yahweh’s ark crossed over with the priests in the presence of the people. 
+\v 10 For the priests who bore the ark stood in the middle of the Jordan until everything was finished that Yahuah commanded Joshua to speak to the people, according to all that Moses commanded Joshua; and the people hurried and passed over. 
+\v 11 When all the people had completely crossed over, Yahuah’s ark crossed over with the priests in the presence of the people. 
 \p
 \v 12 The children of Reuben, and the children of Gad, and the half-tribe of Manasseh crossed over armed before the children of Israel, as Moses spoke to them. 
-\v 13 About forty thousand men, ready and armed for war, passed over before Yahweh to battle, to the plains of Jericho. 
-\v 14 On that day, Yahweh magnified Joshua in the sight of all Israel; and they feared him, as they feared Moses, all the days of his life. 
+\v 13 About forty thousand men, ready and armed for war, passed over before Yahuah to battle, to the plains of Jericho. 
+\v 14 On that day, Yahuah magnified Joshua in the sight of all Israel; and they feared him, as they feared Moses, all the days of his life. 
 \p
-\v 15 Yahweh spoke to Joshua, saying, 
+\v 15 Yahuah spoke to Joshua, saying, 
 \v 16 “Command the priests who bear the ark of the covenant, that they come up out of the Jordan.” 
 \p
 \v 17 Joshua therefore commanded the priests, saying, “Come up out of the Jordan!” 
-\v 18 When the priests who bore the ark of Yahweh’s covenant had come up out of the middle of the Jordan, and the soles of the priests’ feet had been lifted up to the dry ground, the waters of the Jordan returned to their place, and went over all its banks, as before. 
+\v 18 When the priests who bore the ark of Yahuah’s covenant had come up out of the middle of the Jordan, and the soles of the priests’ feet had been lifted up to the dry ground, the waters of the Jordan returned to their place, and went over all its banks, as before. 
 \v 19 The people came up out of the Jordan on the tenth day of the first month, and encamped in Gilgal, on the east border of Jericho. 
 \p
 \v 20 Joshua set up those twelve stones, which they took out of the Jordan, in Gilgal. 
 \v 21 He spoke to the children of Israel, saying, “When your children ask their fathers in time to come, saying, ‘What do these stones mean?’ 
 \v 22 Then you shall let your children know, saying, ‘Israel came over this Jordan on dry land. 
-\v 23 For Yahweh your Elohim dried up the waters of the Jordan from before you until you had crossed over, as Yahweh your Elohim did to the Red Sea, which he dried up from before us, until we had crossed over, 
-\v 24 that all the peoples of the earth may know that Yahweh’s hand is mighty, and that you may fear Yahweh your Elohim forever.’ ” 
+\v 23 For Yahuah your Elohim dried up the waters of the Jordan from before you until you had crossed over, as Yahuah your Elohim did to the Red Sea, which he dried up from before us, until we had crossed over, 
+\v 24 that all the peoples of the earth may know that Yahuah’s hand is mighty, and that you may fear Yahuah your Elohim forever.’ ” 
 \c 5
 \p
-\v 1 When all the kings of the Amorites, who were beyond the Jordan westward, and all the kings of the Canaanites, who were by the sea, heard how Yahweh had dried up the waters of the Jordan from before the children of Israel until we had crossed over, their heart melted, and there was no more spirit in them, because of the children of Israel. 
-\v 2 At that time, Yahweh said to Joshua, “Make flint knives, and circumcise again the sons of Israel the second time.” 
+\v 1 When all the kings of the Amorites, who were beyond the Jordan westward, and all the kings of the Canaanites, who were by the sea, heard how Yahuah had dried up the waters of the Jordan from before the children of Israel until we had crossed over, their heart melted, and there was no more spirit in them, because of the children of Israel. 
+\v 2 At that time, Yahuah said to Joshua, “Make flint knives, and circumcise again the sons of Israel the second time.” 
 \v 3 Joshua made himself flint knives, and circumcised the sons of Israel at the hill of the foreskins. 
 \v 4 This is the reason Joshua circumcised them: all the people who came out of Egypt, who were males, even all the men of war, died in the wilderness along the way, after they came out of Egypt. 
 \v 5 For all the people who came out were circumcised; but all the people who were born in the wilderness along the way as they came out of Egypt had not been circumcised. 
-\v 6 For the children of Israel walked forty years in the wilderness until all the nation, even the men of war who came out of Egypt, were consumed, because they didn’t listen to Yahweh’s voice. Yahweh swore to them that he wouldn’t let them see the land which Yahweh swore to their fathers that he would give us, a land flowing with milk and honey. 
+\v 6 For the children of Israel walked forty years in the wilderness until all the nation, even the men of war who came out of Egypt, were consumed, because they didn’t listen to Yahuah’s voice. Yahuah swore to them that he wouldn’t let them see the land which Yahuah swore to their fathers that he would give us, a land flowing with milk and honey. 
 \v 7 Their children, whom he raised up in their place, were circumcised by Joshua, for they were uncircumcised, because they had not circumcised them on the way. 
 \v 8 When they were done circumcising the whole nation, they stayed in their places in the camp until they were healed. 
 \p
-\v 9 Yahweh said to Joshua, “Today I have rolled away the reproach of Egypt from you.” Therefore the name of that place was called Gilgal to this day. 
+\v 9 Yahuah said to Joshua, “Today I have rolled away the reproach of Egypt from you.” Therefore the name of that place was called Gilgal to this day. 
 \v 10 The children of Israel encamped in Gilgal. They kept the Passover on the fourteenth day of the month at evening in the plains of Jericho. 
 \v 11 They ate unleavened cakes and parched grain of the produce of the land on the next day after the Passover, in the same day. 
 \v 12 The manna ceased on the next day, after they had eaten of the produce of the land. The children of Israel didn’t have manna any more, but they ate of the fruit of the land of Canaan that year. 
 \p
 \v 13 When Joshua was by Jericho, he lifted up his eyes and looked, and behold, a man stood in front of him with his sword drawn in his hand. Joshua went to him and said to him, “Are you for us, or for our enemies?” 
 \p
-\v 14 He said, “No; but I have come now as commander of Yahweh’s army.” 
+\v 14 He said, “No; but I have come now as commander of Yahuah’s army.” 
 \p Joshua fell on his face to the earth, and worshiped, and asked him, “What does my lord say to his servant?” 
 \p
-\v 15 The prince of Yahweh’s army said to Joshua, “Take off your sandals, for the place on which you stand is set-apart.” Joshua did so. 
+\v 15 The prince of Yahuah’s army said to Joshua, “Take off your sandals, for the place on which you stand is set-apart.” Joshua did so. 
 \c 6
 \p
 \v 1 Now Jericho was tightly shut up because of the children of Israel. No one went out, and no one came in. 
-\v 2 Yahweh said to Joshua, “Behold, I have given Jericho into your hand, with its king and the mighty men of valor. 
+\v 2 Yahuah said to Joshua, “Behold, I have given Jericho into your hand, with its king and the mighty men of valor. 
 \v 3 All of your men of war shall march around the city, going around the city once. You shall do this six days. 
 \v 4 Seven priests shall bear seven trumpets of rams’ horns before the ark. On the seventh day, you shall march around the city seven times, and the priests shall blow the trumpets. 
 \v 5 It shall be that when they make a long blast with the ram’s horn, and when you hear the sound of the trumpet, all the people shall shout with a great shout; then the city wall will fall down flat, and the people shall go up, every man straight in front of him.” 
 \p
-\v 6 Joshua the son of Nun called the priests, and said to them, “Take up the ark of the covenant, and let seven priests bear seven trumpets of rams’ horns before Yahweh’s ark.” 
+\v 6 Joshua the son of Nun called the priests, and said to them, “Take up the ark of the covenant, and let seven priests bear seven trumpets of rams’ horns before Yahuah’s ark.” 
 \p
-\v 7 They said to the people, “Advance! March around the city, and let the armed men pass on before Yahweh’s ark.” 
+\v 7 They said to the people, “Advance! March around the city, and let the armed men pass on before Yahuah’s ark.” 
 \p
-\v 8 It was so, that when Joshua had spoken to the people, the seven priests bearing the seven trumpets of rams’ horns before Yahweh advanced and blew the trumpets, and the ark of Yahweh’s covenant followed them. 
+\v 8 It was so, that when Joshua had spoken to the people, the seven priests bearing the seven trumpets of rams’ horns before Yahuah advanced and blew the trumpets, and the ark of Yahuah’s covenant followed them. 
 \v 9 The armed men went before the priests who blew the trumpets, and the ark went after them. The trumpets sounded as they went. 
 \p
 \v 10 Joshua commanded the people, saying, “You shall not shout nor let your voice be heard, neither shall any word proceed out of your mouth until the day I tell you to shout. Then you shall shout.” 
-\v 11 So he caused Yahweh’s ark to go around the city, circling it once. Then they came into the camp, and stayed in the camp. 
-\v 12 Joshua rose early in the morning, and the priests took up Yahweh’s ark. 
-\v 13 The seven priests bearing the seven trumpets of rams’ horns in front of Yahweh’s ark went on continually, and blew the trumpets. The armed men went in front of them. The rear guard came after Yahweh’s ark. The trumpets sounded as they went. 
+\v 11 So he caused Yahuah’s ark to go around the city, circling it once. Then they came into the camp, and stayed in the camp. 
+\v 12 Joshua rose early in the morning, and the priests took up Yahuah’s ark. 
+\v 13 The seven priests bearing the seven trumpets of rams’ horns in front of Yahuah’s ark went on continually, and blew the trumpets. The armed men went in front of them. The rear guard came after Yahuah’s ark. The trumpets sounded as they went. 
 \v 14 The second day they marched around the city once, and returned into the camp. They did this six days. 
 \p
 \v 15 On the seventh day, they rose early at the dawning of the day, and marched around the city in the same way seven times. On this day only they marched around the city seven times. 
-\v 16 At the seventh time, when the priests blew the trumpets, Joshua said to the people, “Shout, for Yahweh has given you the city! 
-\v 17 The city shall be devoted, even it and all that is in it, to Yahweh. Only Rahab the prostitute shall live, she and all who are with her in the house, because she hid the messengers that we sent. 
+\v 16 At the seventh time, when the priests blew the trumpets, Joshua said to the people, “Shout, for Yahuah has given you the city! 
+\v 17 The city shall be devoted, even it and all that is in it, to Yahuah. Only Rahab the prostitute shall live, she and all who are with her in the house, because she hid the messengers that we sent. 
 \v 18 But as for you, only keep yourselves from what is devoted to destruction, lest when you have devoted it, you take of the devoted thing; so you would make the camp of Israel accursed and trouble it. 
-\v 19 But all the silver, gold, and vessels of bronze and iron are set-apart to Yahweh. They shall come into Yahweh’s treasury.” 
+\v 19 But all the silver, gold, and vessels of bronze and iron are set-apart to Yahuah. They shall come into Yahuah’s treasury.” 
 \p
 \v 20 So the people shouted and the priests blew the trumpets. When the people heard the sound of the trumpet, the people shouted with a great shout, and the wall fell down flat, so that the people went up into the city, every man straight in front of him, and they took the city. 
 \v 21 They utterly destroyed all that was in the city, both man and woman, both young and old, and ox, sheep, and donkey, with the edge of the sword. 
 \v 22 Joshua said to the two men who had spied out the land, “Go into the prostitute’s house, and bring the woman and all that she has out from there, as you swore to her.” 
 \v 23 The young men who were spies went in, and brought out Rahab with her father, her mother, her brothers, and all that she had. They also brought out all of her relatives, and they set them outside of the camp of Israel. 
-\v 24 They burned the city with fire, and all that was in it. Only they put the silver, the gold, and the vessels of bronze and of iron into the treasury of Yahweh’s house. 
+\v 24 They burned the city with fire, and all that was in it. Only they put the silver, the gold, and the vessels of bronze and of iron into the treasury of Yahuah’s house. 
 \v 25 But Rahab the prostitute, her father’s household, and all that she had, Joshua saved alive. She lives in the middle of Israel to this day, because she hid the messengers whom Joshua sent to spy out Jericho. 
 \p
-\v 26 Joshua commanded them with an oath at that time, saying, “Cursed is the man before Yahweh who rises up and builds this city Jericho. With the loss of his firstborn he will lay its foundation, and with the loss of his youngest son he will set up its gates.” 
-\v 27 So Yahweh was with Joshua; and his fame was in all the land. 
+\v 26 Joshua commanded them with an oath at that time, saying, “Cursed is the man before Yahuah who rises up and builds this city Jericho. With the loss of his firstborn he will lay its foundation, and with the loss of his youngest son he will set up its gates.” 
+\v 27 So Yahuah was with Joshua; and his fame was in all the land. 
 \c 7
 \p
-\v 1 But the children of Israel committed a trespass in the devoted things; for Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, took some of the devoted things. Therefore Yahweh’s anger burned against the children of Israel. 
+\v 1 But the children of Israel committed a trespass in the devoted things; for Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, took some of the devoted things. Therefore Yahuah’s anger burned against the children of Israel. 
 \v 2 Joshua sent men from Jericho to Ai, which is beside Beth Aven, on the east side of Bethel, and spoke to them, saying, “Go up and spy out the land.” 
 \p The men went up and spied out Ai. 
 \v 3 They returned to Joshua, and said to him, “Don’t let all the people go up, but let about two or three thousand men go up and strike Ai. Don’t make all the people to toil there, for there are only a few of them.” 
 \v 4 So about three thousand men of the people went up there, and they fled before the men of Ai. 
 \v 5 The men of Ai struck about thirty-six men of them. They chased them from before the gate even to Shebarim, and struck them at the descent. The hearts of the people melted, and became like water. 
-\v 6 Joshua tore his clothes, and fell to the earth on his face before Yahweh’s ark until the evening, he and the elders of Israel; and they put dust on their heads. 
-\v 7 Joshua said, “Alas, Lord Yahweh, why have you brought this people over the Jordan at all, to deliver us into the hand of the Amorites, to cause us to perish? I wish that we had been content and lived beyond the Jordan! 
+\v 6 Joshua tore his clothes, and fell to the earth on his face before Yahuah’s ark until the evening, he and the elders of Israel; and they put dust on their heads. 
+\v 7 Joshua said, “Alas, Lord Yahuah, why have you brought this people over the Jordan at all, to deliver us into the hand of the Amorites, to cause us to perish? I wish that we had been content and lived beyond the Jordan! 
 \v 8 Oh, Lord, what shall I say, after Israel has turned their backs before their enemies? 
 \v 9 For the Canaanites and all the inhabitants of the land will hear of it, and will surround us, and cut off our name from the earth. What will you do for your great name?” 
 \p
-\v 10 Yahweh said to Joshua, “Get up! Why have you fallen on your face like that? 
+\v 10 Yahuah said to Joshua, “Get up! Why have you fallen on your face like that? 
 \v 11 Israel has sinned. Yes, they have even transgressed my covenant which I commanded them. Yes, they have even taken some of the devoted things, and have also stolen, and also deceived. They have even put it among their own stuff. 
 \v 12 Therefore the children of Israel can’t stand before their enemies. They turn their backs before their enemies, because they have become devoted for destruction. I will not be with you any more, unless you destroy the devoted things from among you. 
-\v 13 Get up! Sanctify the people, and say, ‘Sanctify yourselves for tomorrow, for Yahweh, the Elohim of Israel, says, “There is a devoted thing among you, Israel. You cannot stand before your enemies until you take away the devoted thing from among you.” 
-\v 14 In the morning therefore you shall be brought near by your tribes. It shall be that the tribe which Yahweh selects shall come near by families. The family which Yahweh selects shall come near by households. The household which Yahweh selects shall come near man by man. 
-\v 15 It shall be, that he who is taken with the devoted thing shall be burned with fire, he and all that he has, because he has transgressed Yahweh’s covenant, and because he has done a disgraceful thing in Israel.’ ” 
+\v 13 Get up! Sanctify the people, and say, ‘Sanctify yourselves for tomorrow, for Yahuah, the Elohim of Israel, says, “There is a devoted thing among you, Israel. You cannot stand before your enemies until you take away the devoted thing from among you.” 
+\v 14 In the morning therefore you shall be brought near by your tribes. It shall be that the tribe which Yahuah selects shall come near by families. The family which Yahuah selects shall come near by households. The household which Yahuah selects shall come near man by man. 
+\v 15 It shall be, that he who is taken with the devoted thing shall be burned with fire, he and all that he has, because he has transgressed Yahuah’s covenant, and because he has done a disgraceful thing in Israel.’ ” 
 \p
 \v 16 So Joshua rose up early in the morning and brought Israel near by their tribes. The tribe of Judah was selected. 
 \v 17 He brought near the family of Judah, and he selected the family of the Zerahites. He brought near the family of the Zerahites man by man, and Zabdi was selected. 
 \v 18 He brought near his household man by man, and Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, was selected. 
-\v 19 Joshua said to Achan, “My son, please give glory to Yahweh, the Elohim of Israel, and make confession to him. Tell me now what you have done! Don’t hide it from me!” 
+\v 19 Joshua said to Achan, “My son, please give glory to Yahuah, the Elohim of Israel, and make confession to him. Tell me now what you have done! Don’t hide it from me!” 
 \p
-\v 20 Achan answered Joshua, and said, “I have truly sinned against Yahweh, the Elohim of Israel, and this is what I have done. 
+\v 20 Achan answered Joshua, and said, “I have truly sinned against Yahuah, the Elohim of Israel, and this is what I have done. 
 \v 21 When I saw among the plunder a beautiful Babylonian robe, two hundred shekels of silver, and a wedge of gold weighing fifty shekels, then I desired them and took them. Behold, they are hidden in the ground in the middle of my tent, with the silver under it.” 
 \p
 \v 22 So Joshua sent messengers, and they ran to the tent. Behold, it was hidden in his tent, with the silver under it. 
-\v 23 They took them from the middle of the tent, and brought them to Joshua and to all the children of Israel. They laid them down before Yahweh. 
+\v 23 They took them from the middle of the tent, and brought them to Joshua and to all the children of Israel. They laid them down before Yahuah. 
 \v 24 Joshua, and all Israel with him, took Achan the son of Zerah, the silver, the robe, the wedge of gold, his sons, his daughters, his cattle, his donkeys, his sheep, his tent, and all that he had; and they brought them up to the valley of Achor. 
-\v 25 Joshua said, “Why have you troubled us? Yahweh will trouble you today.” All Israel stoned him with stones, and they burned them with fire and stoned them with stones. 
-\v 26 They raised over him a great heap of stones that remains to this day. Yahweh turned from the fierceness of his anger. Therefore the name of that place was called “The valley of Achor” to this day. 
+\v 25 Joshua said, “Why have you troubled us? Yahuah will trouble you today.” All Israel stoned him with stones, and they burned them with fire and stoned them with stones. 
+\v 26 They raised over him a great heap of stones that remains to this day. Yahuah turned from the fierceness of his anger. Therefore the name of that place was called “The valley of Achor” to this day. 
 \c 8
 \p
-\v 1 Yahweh said to Joshua, “Don’t be afraid, and don’t be dismayed. Take all the warriors with you, and arise, go up to Ai. Behold, I have given into your hand the king of Ai, with his people, his city, and his land. 
+\v 1 Yahuah said to Joshua, “Don’t be afraid, and don’t be dismayed. Take all the warriors with you, and arise, go up to Ai. Behold, I have given into your hand the king of Ai, with his people, his city, and his land. 
 \v 2 You shall do to Ai and her king as you did to Jericho and her king, except you shall take its goods and its livestock for yourselves. Set an ambush for the city behind it.” 
 \p
 \v 3 So Joshua arose, with all the warriors, to go up to Ai. Joshua chose thirty thousand men, the mighty men of valor, and sent them out by night. 
 \v 4 He commanded them, saying, “Behold, you shall lie in ambush against the city, behind the city. Don’t go very far from the city, but all of you be ready. 
 \v 5 I and all the people who are with me will approach the city. It shall happen, when they come out against us, as at the first, that we will flee before them. 
 \v 6 They will come out after us until we have drawn them away from the city; for they will say, ‘They flee before us, like the first time.’ So we will flee before them, 
-\v 7 and you shall rise up from the ambush, and take possession of the city; for Yahweh your Elohim will deliver it into your hand. 
-\v 8 It shall be, when you have seized the city, that you shall set the city on fire. You shall do this according to Yahweh’s word. Behold, I have commanded you.” 
+\v 7 and you shall rise up from the ambush, and take possession of the city; for Yahuah your Elohim will deliver it into your hand. 
+\v 8 It shall be, when you have seized the city, that you shall set the city on fire. You shall do this according to Yahuah’s word. Behold, I have commanded you.” 
 \p
 \v 9 Joshua sent them out; and they went to set up the ambush, and stayed between Bethel and Ai on the west side of Ai; but Joshua stayed among the people that night. 
 \v 10 Joshua rose up early in the morning, mustered the people, and went up, he and the elders of Israel, before the people to Ai. 
@@ -228,7 +228,7 @@
 \v 16 All the people who were in the city were called together to pursue after them. They pursued Joshua, and were drawn away from the city. 
 \v 17 There was not a man left in Ai or Bethel who didn’t go out after Israel. They left the city open, and pursued Israel. 
 \p
-\v 18 Yahweh said to Joshua, “Stretch out the javelin that is in your hand toward Ai, for I will give it into your hand.” 
+\v 18 Yahuah said to Joshua, “Stretch out the javelin that is in your hand toward Ai, for I will give it into your hand.” 
 \p Joshua stretched out the javelin that was in his hand toward the city. 
 \v 19 The ambush arose quickly out of their place, and they ran as soon as he had stretched out his hand and entered into the city and took it. They hurried and set the city on fire. 
 \v 20 When the men of Ai looked behind them, they saw, and behold, the smoke of the city ascended up to heaven, and they had no power to flee this way or that way. The people who fled to the wilderness turned back on the pursuers. 
@@ -239,14 +239,14 @@
 \v 24 When Israel had finished killing all the inhabitants of Ai in the field, in the wilderness in which they pursued them, and they had all fallen by the edge of the sword until they were consumed, all Israel returned to Ai and struck it with the edge of the sword. 
 \v 25 All that fell that day, both of men and women, were twelve thousand, even all the people of Ai. 
 \v 26 For Joshua didn’t draw back his hand, with which he stretched out the javelin, until he had utterly destroyed all the inhabitants of Ai. 
-\v 27 Israel took for themselves only the livestock and the goods of that city, according to Yahweh’s word which he commanded Joshua. 
+\v 27 Israel took for themselves only the livestock and the goods of that city, according to Yahuah’s word which he commanded Joshua. 
 \v 28 So Joshua burned Ai and made it a heap forever, even a desolation, to this day. 
 \v 29 He hanged the king of Ai on a tree until the evening. At sundown, Joshua commanded, and they took his body down from the tree and threw it at the entrance of the gate of the city, and raised a great heap of stones on it that remains to this day. 
 \p
-\v 30 Then Joshua built an altar to Yahweh, the Elohim of Israel, on Mount Ebal, 
-\v 31 as Moses the servant of Yahweh commanded the children of Israel, as it is written in the book of the law of Moses: an altar of uncut stones, on which no one had lifted up any iron. They offered burnt offerings on it to Yahweh and sacrificed peace offerings. 
+\v 30 Then Joshua built an altar to Yahuah, the Elohim of Israel, on Mount Ebal, 
+\v 31 as Moses the servant of Yahuah commanded the children of Israel, as it is written in the book of the law of Moses: an altar of uncut stones, on which no one had lifted up any iron. They offered burnt offerings on it to Yahuah and sacrificed peace offerings. 
 \v 32 He wrote there on the stones a copy of Moses’ law, which he wrote in the presence of the children of Israel. 
-\v 33 All Israel, with their elders, officers, and judges, stood on both sides of the ark before the Levitical priests, who carried the ark of Yahweh’s covenant, the foreigner as well as the native; half of them in front of Mount Gerizim, and half of them in front of Mount Ebal, as Moses the servant of Yahweh had commanded at the first, that they should bless the people of Israel. 
+\v 33 All Israel, with their elders, officers, and judges, stood on both sides of the ark before the Levitical priests, who carried the ark of Yahuah’s covenant, the foreigner as well as the native; half of them in front of Mount Gerizim, and half of them in front of Mount Ebal, as Moses the servant of Yahuah had commanded at the first, that they should bless the people of Israel. 
 \v 34 Afterward he read all the words of the law, the blessing and the curse, according to all that is written in the book of the law. 
 \v 35 There was not a word of all that Moses commanded which Joshua didn’t read before all the assembly of Israel, with the women, the little ones, and the foreigners who were among them. 
 \c 9
@@ -263,29 +263,29 @@
 \v 8 They said to Joshua, “We are your servants.” 
 \p Joshua said to them, “Who are you? Where do you come from?” 
 \p
-\v 9 They said to him, “Your servants have come from a very far country because of the name of Yahweh your Elohim; for we have heard of his fame, all that he did in Egypt, 
+\v 9 They said to him, “Your servants have come from a very far country because of the name of Yahuah your Elohim; for we have heard of his fame, all that he did in Egypt, 
 \v 10 and all that he did to the two kings of the Amorites who were beyond the Jordan, to Sihon king of Heshbon and to Og king of Bashan, who was at Ashtaroth. 
 \v 11 Our elders and all the inhabitants of our country spoke to us, saying, ‘Take supplies in your hand for the journey, and go to meet them. Tell them, “We are your servants. Now make a covenant with us.” ’ 
 \v 12 This our bread we took hot for our supplies out of our houses on the day we went out to go to you; but now, behold, it is dry, and has become moldy. 
 \v 13 These wine skins, which we filled, were new; and behold, they are torn. These our garments and our sandals have become old because of the very long journey.” 
 \p
-\v 14 The men sampled their provisions, and didn’t ask counsel from Yahweh’s mouth. 
+\v 14 The men sampled their provisions, and didn’t ask counsel from Yahuah’s mouth. 
 \v 15 Joshua made peace with them, and made a covenant with them, to let them live. The princes of the congregation swore to them. 
 \v 16 At the end of three days after they had made a covenant with them, they heard that they were their neighbors, and that they lived among them. 
 \v 17 The children of Israel traveled and came to their cities on the third day. Now their cities were Gibeon, Chephirah, Beeroth, and Kiriath Jearim. 
-\v 18 The children of Israel didn’t strike them, because the princes of the congregation had sworn to them by Yahweh, the Elohim of Israel. All the congregation murmured against the princes. 
-\v 19 But all the princes said to all the congregation, “We have sworn to them by Yahweh, the Elohim of Israel. Now therefore we may not touch them. 
+\v 18 The children of Israel didn’t strike them, because the princes of the congregation had sworn to them by Yahuah, the Elohim of Israel. All the congregation murmured against the princes. 
+\v 19 But all the princes said to all the congregation, “We have sworn to them by Yahuah, the Elohim of Israel. Now therefore we may not touch them. 
 \v 20 We will do this to them, and let them live; lest wrath be on us, because of the oath which we swore to them.” 
 \v 21 The princes said to them, “Let them live.” So they became wood cutters and drawers of water for all the congregation, as the princes had spoken to them. 
 \p
 \v 22 Joshua called for them, and he spoke to them, saying, “Why have you deceived us, saying, ‘We are very far from you,’ when you live among us? 
 \v 23 Now therefore you are cursed, and some of you will never fail to be slaves, both wood cutters and drawers of water for the house of my Elohim.” 
 \p
-\v 24 They answered Joshua, and said, “Because your servants were certainly told how Yahweh your Elohim commanded his servant Moses to give you all the land, and to destroy all the inhabitants of the land from before you. Therefore we were very afraid for our lives because of you, and have done this thing. 
+\v 24 They answered Joshua, and said, “Because your servants were certainly told how Yahuah your Elohim commanded his servant Moses to give you all the land, and to destroy all the inhabitants of the land from before you. Therefore we were very afraid for our lives because of you, and have done this thing. 
 \v 25 Now, behold, we are in your hand. Do to us as it seems good and right to you to do.” 
 \p
 \v 26 He did so to them, and delivered them out of the hand of the children of Israel, so that they didn’t kill them. 
-\v 27 That day Joshua made them wood cutters and drawers of water for the congregation and for Yahweh’s altar to this day, in the place which he should choose. 
+\v 27 That day Joshua made them wood cutters and drawers of water for the congregation and for Yahuah’s altar to this day, in the place which he should choose. 
 \c 10
 \p
 \v 1 Now when Adoni-Zedek king of Jerusalem heard how Joshua had taken Ai, and had utterly destroyed it; as he had done to Jericho and her king, so he had done to Ai and her king; and how the inhabitants of Gibeon had made peace with Israel, and were among them, 
@@ -296,23 +296,23 @@
 \v 6 The men of Gibeon sent to Joshua at the camp at Gilgal, saying, “Don’t abandon your servants! Come up to us quickly and save us! Help us; for all the kings of the Amorites that dwell in the hill country have gathered together against us.” 
 \p
 \v 7 So Joshua went up from Gilgal, he and the whole army with him, including all the mighty men of valor. 
-\v 8 Yahweh said to Joshua, “Don’t fear them, for I have delivered them into your hands. Not a man of them will stand before you.” 
+\v 8 Yahuah said to Joshua, “Don’t fear them, for I have delivered them into your hands. Not a man of them will stand before you.” 
 \p
 \v 9 Joshua therefore came to them suddenly. He marched from Gilgal all night. 
-\v 10 Yahweh confused them before Israel. He killed them with a great slaughter at Gibeon, and chased them by the way of the ascent of Beth Horon, and struck them to Azekah and to Makkedah. 
-\v 11 As they fled from before Israel, while they were at the descent of Beth Horon, Yahweh hurled down great stones from the sky on them to Azekah, and they died. There were more who died from the hailstones than those whom the children of Israel killed with the sword. 
+\v 10 Yahuah confused them before Israel. He killed them with a great slaughter at Gibeon, and chased them by the way of the ascent of Beth Horon, and struck them to Azekah and to Makkedah. 
+\v 11 As they fled from before Israel, while they were at the descent of Beth Horon, Yahuah hurled down great stones from the sky on them to Azekah, and they died. There were more who died from the hailstones than those whom the children of Israel killed with the sword. 
 \p
-\v 12 Then Joshua spoke to Yahweh in the day when Yahweh delivered up the Amorites before the children of Israel. He said in the sight of Israel, “Sun, stand still on Gibeon! You, moon, stop in the valley of Aijalon!” 
+\v 12 Then Joshua spoke to Yahuah in the day when Yahuah delivered up the Amorites before the children of Israel. He said in the sight of Israel, “Sun, stand still on Gibeon! You, moon, stop in the valley of Aijalon!” 
 \p
 \v 13 The sun stood still, and the moon stayed, until the nation had avenged themselves of their enemies. Isn’t this written in the book of Jashar? The sun stayed in the middle of the sky, and didn’t hurry to go down about a whole day. 
-\v 14 There was no day like that before it or after it, that Yahweh listened to the voice of a man; for Yahweh fought for Israel. 
+\v 14 There was no day like that before it or after it, that Yahuah listened to the voice of a man; for Yahuah fought for Israel. 
 \p
 \v 15 Joshua returned, and all Israel with him, to the camp to Gilgal. 
 \v 16 These five kings fled, and hid themselves in the cave at Makkedah. 
 \v 17 Joshua was told, saying, “The five kings have been found, hidden in the cave at Makkedah.” 
 \p
 \v 18 Joshua said, “Roll large stones to cover the cave’s entrance, and set men by it to guard them; 
-\v 19 but don’t stay there. Pursue your enemies, and attack them from the rear. Don’t allow them to enter into their cities; for Yahweh your Elohim has delivered them into your hand.” 
+\v 19 but don’t stay there. Pursue your enemies, and attack them from the rear. Don’t allow them to enter into their cities; for Yahuah your Elohim has delivered them into your hand.” 
 \p
 \v 20 When Joshua and the children of Israel had finished killing them with a very great slaughter until they were consumed, and the remnant which remained of them had entered into the fortified cities, 
 \v 21 all the people returned to the camp to Joshua at Makkedah in peace. None moved his tongue against any of the children of Israel. 
@@ -322,7 +322,7 @@
 \v 24 When they brought those kings out to Joshua, Joshua called for all the men of Israel, and said to the chiefs of the men of war who went with him, “Come near. Put your feet on the necks of these kings.” 
 \p They came near, and put their feet on their necks. 
 \p
-\v 25 Joshua said to them, “Don’t be afraid, nor be dismayed. Be strong and courageous, for Yahweh will do this to all your enemies against whom you fight.” 
+\v 25 Joshua said to them, “Don’t be afraid, nor be dismayed. Be strong and courageous, for Yahuah will do this to all your enemies against whom you fight.” 
 \p
 \v 26 Afterward Joshua struck them, put them to death, and hanged them on five trees. They were hanging on the trees until the evening. 
 \v 27 At the time of the going down of the sun, Joshua commanded, and they took them down off the trees, and threw them into the cave in which they had hidden themselves, and laid great stones on the mouth of the cave, which remain to this very day. 
@@ -330,10 +330,10 @@
 \v 28 Joshua took Makkedah on that day, and struck it with the edge of the sword, with its king. He utterly destroyed it and all the souls who were in it. He left no one remaining. He did to the king of Makkedah as he had done to the king of Jericho. 
 \p
 \v 29 Joshua passed from Makkedah, and all Israel with him, to Libnah, and fought against Libnah. 
-\v 30 Yahweh delivered it also, with its king, into the hand of Israel. He struck it with the edge of the sword, and all the souls who were in it. He left no one remaining in it. He did to its king as he had done to the king of Jericho. 
+\v 30 Yahuah delivered it also, with its king, into the hand of Israel. He struck it with the edge of the sword, and all the souls who were in it. He left no one remaining in it. He did to its king as he had done to the king of Jericho. 
 \p
 \v 31 Joshua passed from Libnah, and all Israel with him, to Lachish, and encamped against it, and fought against it. 
-\v 32 Yahweh delivered Lachish into the hand of Israel. He took it on the second day, and struck it with the edge of the sword, with all the souls who were in it, according to all that he had done to Libnah. 
+\v 32 Yahuah delivered Lachish into the hand of Israel. He took it on the second day, and struck it with the edge of the sword, with all the souls who were in it, according to all that he had done to Libnah. 
 \v 33 Then Horam king of Gezer came up to help Lachish; and Joshua struck him and his people, until he had left him no one remaining. 
 \p
 \v 34 Joshua passed from Lachish, and all Israel with him, to Eglon; and they encamped against it and fought against it. 
@@ -344,9 +344,9 @@
 \p
 \v 38 Joshua returned, and all Israel with him, to Debir, and fought against it. 
 \v 39 He took it, with its king and all its cities. They struck them with the edge of the sword, and utterly destroyed all the souls who were in it. He left no one remaining. As he had done to Hebron, so he did to Debir, and to its king; as he had done also to Libnah, and to its king. 
-\v 40 So Joshua struck all the land, the hill country, the South, the lowland, the slopes, and all their kings. He left no one remaining, but he utterly destroyed all that breathed, as Yahweh, the Elohim of Israel, commanded. 
+\v 40 So Joshua struck all the land, the hill country, the South, the lowland, the slopes, and all their kings. He left no one remaining, but he utterly destroyed all that breathed, as Yahuah, the Elohim of Israel, commanded. 
 \v 41 Joshua struck them from Kadesh Barnea even to Gaza, and all the country of Goshen, even to Gibeon. 
-\v 42 Joshua took all these kings and their land at one time because Yahweh, the Elohim of Israel, fought for Israel. 
+\v 42 Joshua took all these kings and their land at one time because Yahuah, the Elohim of Israel, fought for Israel. 
 \v 43 Joshua returned, and all Israel with him, to the camp to Gilgal. 
 \c 11
 \p
@@ -356,26 +356,26 @@
 \v 4 They went out, they and all their armies with them, many people, even as the sand that is on the seashore in multitude, with very many horses and chariots. 
 \v 5 All these kings met together; and they came and encamped together at the waters of Merom, to fight with Israel. 
 \p
-\v 6 Yahweh said to Joshua, “Don’t be afraid because of them; for tomorrow at this time, I will deliver them up all slain before Israel. You shall hamstring their horses and burn their chariots with fire.” 
+\v 6 Yahuah said to Joshua, “Don’t be afraid because of them; for tomorrow at this time, I will deliver them up all slain before Israel. You shall hamstring their horses and burn their chariots with fire.” 
 \p
 \v 7 So Joshua came suddenly, with all the warriors, against them by the waters of Merom, and attacked them. 
-\v 8 Yahweh delivered them into the hand of Israel, and they struck them, and chased them to great Sidon, and to Misrephoth Maim, and to the valley of Mizpah eastward. They struck them until they left them no one remaining. 
-\v 9 Joshua did to them as Yahweh told him. He hamstrung their horses and burned their chariots with fire. 
+\v 8 Yahuah delivered them into the hand of Israel, and they struck them, and chased them to great Sidon, and to Misrephoth Maim, and to the valley of Mizpah eastward. They struck them until they left them no one remaining. 
+\v 9 Joshua did to them as Yahuah told him. He hamstrung their horses and burned their chariots with fire. 
 \v 10 Joshua turned back at that time, and took Hazor, and struck its king with the sword; for Hazor used to be the head of all those kingdoms. 
 \v 11 They struck all the souls who were in it with the edge of the sword, utterly destroying them. There was no one left who breathed. He burned Hazor with fire. 
-\v 12 Joshua captured all the cities of those kings, with their kings, and he struck them with the edge of the sword, and utterly destroyed them, as Moses the servant of Yahweh commanded. 
+\v 12 Joshua captured all the cities of those kings, with their kings, and he struck them with the edge of the sword, and utterly destroyed them, as Moses the servant of Yahuah commanded. 
 \v 13 But as for the cities that stood on their mounds, Israel burned none of them, except Hazor only. Joshua burned that. 
 \v 14 The children of Israel took all the plunder of these cities, with the livestock, as plunder for themselves; but every man they struck with the edge of the sword, until they had destroyed them. They didn’t leave any who breathed. 
 \p
-\v 15 As Yahweh commanded Moses his servant, so Moses commanded Joshua. Joshua did so. He left nothing undone of all that Yahweh commanded Moses. 
+\v 15 As Yahuah commanded Moses his servant, so Moses commanded Joshua. Joshua did so. He left nothing undone of all that Yahuah commanded Moses. 
 \v 16 So Joshua captured all that land, the hill country, all the South, all the land of Goshen, the lowland, the Arabah, the hill country of Israel, and the lowland of the same, 
 \v 17 from Mount Halak, that goes up to Seir, even to Baal Gad in the valley of Lebanon under Mount Hermon. He took all their kings, struck them, and put them to death. 
 \v 18 Joshua made war a long time with all those kings. 
 \v 19 There was not a city that made peace with the children of Israel, except the Hivites, the inhabitants of Gibeon. They took all in battle. 
-\v 20 For it was of Yahweh to harden their hearts, to come against Israel in battle, that he might utterly destroy them, that they might have no favor, but that he might destroy them, as Yahweh commanded Moses. 
+\v 20 For it was of Yahuah to harden their hearts, to come against Israel in battle, that he might utterly destroy them, that they might have no favor, but that he might destroy them, as Yahuah commanded Moses. 
 \v 21 Joshua came at that time, and cut off the Anakim from the hill country, from Hebron, from Debir, from Anab, and from all the hill country of Judah, and from all the hill country of Israel. Joshua utterly destroyed them with their cities. 
 \v 22 There were none of the Anakim left in the land of the children of Israel. Only in Gaza, in Gath, and in Ashdod, did some remain. 
-\v 23 So Joshua took the whole land, according to all that Yahweh spoke to Moses; and Joshua gave it for an inheritance to Israel according to their divisions by their tribes. Then the land had rest from war. 
+\v 23 So Joshua took the whole land, according to all that Yahuah spoke to Moses; and Joshua gave it for an inheritance to Israel according to their divisions by their tribes. Then the land had rest from war. 
 \c 12
 \p
 \v 1 Now these are the kings of the land, whom the children of Israel struck, and possessed their land beyond the Jordan toward the sunrise, from the valley of the Arnon to Mount Hermon, and all the Arabah eastward: 
@@ -383,7 +383,7 @@
 \v 3 and the Arabah to the sea of Chinneroth, eastward, and to the sea of the Arabah, even the Salt Sea, eastward, the way to Beth Jeshimoth; and on the south, under the slopes of Pisgah: 
 \v 4 and the border of Og king of Bashan, of the remnant of the Rephaim, who lived at Ashtaroth and at Edrei, 
 \v 5 and ruled in Mount Hermon, and in Salecah, and in all Bashan, to the border of the Geshurites and the Maacathites, and half Gilead, the border of Sihon king of Heshbon. 
-\v 6 Moses the servant of Yahweh and the children of Israel struck them. Moses the servant of Yahweh gave it for a possession to the Reubenites, and the Gadites, and the half-tribe of Manasseh. 
+\v 6 Moses the servant of Yahuah and the children of Israel struck them. Moses the servant of Yahuah gave it for a possession to the Reubenites, and the Gadites, and the half-tribe of Manasseh. 
 \p
 \v 7 These are the kings of the land whom Joshua and the children of Israel struck beyond the Jordan westward, from Baal Gad in the valley of Lebanon even to Mount Halak, that goes up to Seir. Joshua gave it to the tribes of Israel for a possession according to their divisions; 
 \v 8 in the hill country, and in the lowland, and in the Arabah, and in the slopes, and in the wilderness, and in the South; the Hittite, the Amorite, and the Canaanite, the Perizzite, the Hivite, and the Jebusite: 
@@ -437,7 +437,7 @@
 \m all the kings thirty-one. 
 \c 13
 \p
-\v 1 Now Joshua was old and well advanced in years. Yahweh said to him, “You are old and advanced in years, and there remains yet very much land to be possessed. 
+\v 1 Now Joshua was old and well advanced in years. Yahuah said to him, “You are old and advanced in years, and there remains yet very much land to be possessed. 
 \p
 \v 2 “This is the land that still remains: all the regions of the Philistines, and all the Geshurites; 
 \v 3 from the Shihor, which is before Egypt, even to the border of Ekron northward, which is counted as Canaanite; the five lords of the Philistines; the Gazites, and the Ashdodites, the Ashkelonites, the Gittites, and the Ekronites; also the Avvim, 
@@ -445,13 +445,13 @@
 \v 5 and the land of the Gebalites, and all Lebanon, toward the sunrise, from Baal Gad under Mount Hermon to the entrance of Hamath; 
 \v 6 all the inhabitants of the hill country from Lebanon to Misrephoth Maim, even all the Sidonians. I will drive them out from before the children of Israel. Just allocate it to Israel for an inheritance, as I have commanded you. 
 \v 7 Now therefore divide this land for an inheritance to the nine tribes and the half-tribe of Manasseh.” 
-\v 8 With him the Reubenites and the Gadites received their inheritance, which Moses gave them, beyond the Jordan eastward, even as Moses the servant of Yahweh gave them: 
+\v 8 With him the Reubenites and the Gadites received their inheritance, which Moses gave them, beyond the Jordan eastward, even as Moses the servant of Yahuah gave them: 
 \v 9 from Aroer, that is on the edge of the valley of the Arnon, and the city that is in the middle of the valley, and all the plain of Medeba to Dibon; 
 \v 10 and all the cities of Sihon king of the Amorites, who reigned in Heshbon, to the border of the children of Ammon; 
 \v 11 and Gilead, and the border of the Geshurites and Maacathites, and all Mount Hermon, and all Bashan to Salecah; 
 \v 12 all the kingdom of Og in Bashan, who reigned in Ashtaroth and in Edrei (who was left of the remnant of the Rephaim); for Moses attacked these, and drove them out. 
 \v 13 Nevertheless the children of Israel didn’t drive out the Geshurites, nor the Maacathites: but Geshur and Maacath live within Israel to this day. 
-\v 14 Only he gave no inheritance to the tribe of Levi. The offerings of Yahweh, the Elohim of Israel, made by fire are his inheritance, as he spoke to him. 
+\v 14 Only he gave no inheritance to the tribe of Levi. The offerings of Yahuah, the Elohim of Israel, made by fire are his inheritance, as he spoke to him. 
 \v 15 Moses gave to the tribe of the children of Reuben according to their families. 
 \v 16 Their border was from Aroer, that is on the edge of the valley of the Arnon, and the city that is in the middle of the valley, and all the plain by Medeba; 
 \v 17 Heshbon, and all its cities that are in the plain; Dibon, Bamoth Baal, Beth Baal Meon, 
@@ -474,26 +474,26 @@
 \v 31 Half Gilead, Ashtaroth, and Edrei, the cities of the kingdom of Og in Bashan, were for the children of Machir the son of Manasseh, even for the half of the children of Machir according to their families. 
 \p
 \v 32 These are the inheritances which Moses distributed in the plains of Moab, beyond the Jordan at Jericho, eastward. 
-\v 33 But Moses gave no inheritance to the tribe of Levi. Yahweh, the Elohim of Israel, is their inheritance, as he spoke to them. 
+\v 33 But Moses gave no inheritance to the tribe of Levi. Yahuah, the Elohim of Israel, is their inheritance, as he spoke to them. 
 \c 14
 \p
 \v 1 These are the inheritances which the children of Israel took in the land of Canaan, which Eleazar the priest, Joshua the son of Nun, and the heads of the fathers’ houses of the tribes of the children of Israel, distributed to them, 
-\v 2 by the lot of their inheritance, as Yahweh commanded by Moses, for the nine tribes, and for the half-tribe. 
+\v 2 by the lot of their inheritance, as Yahuah commanded by Moses, for the nine tribes, and for the half-tribe. 
 \v 3 For Moses had given the inheritance of the two tribes and the half-tribe beyond the Jordan; but to the Levites he gave no inheritance among them. 
 \v 4 For the children of Joseph were two tribes, Manasseh and Ephraim. They gave no portion to the Levites in the land, except cities to dwell in, with their pasture lands for their livestock and for their property. 
-\v 5 The children of Israel did as Yahweh commanded Moses, and they divided the land. 
+\v 5 The children of Israel did as Yahuah commanded Moses, and they divided the land. 
 \p
-\v 6 Then the children of Judah came near to Joshua in Gilgal. Caleb the son of Jephunneh the Kenizzite said to him, “You know the thing that Yahweh spoke to Moses the man of Elohim concerning me and concerning you in Kadesh Barnea. 
-\v 7 I was forty years old when Moses the servant of Yahweh sent me from Kadesh Barnea to spy out the land. I brought him word again as it was in my heart. 
-\v 8 Nevertheless, my brothers who went up with me made the heart of the people melt; but I wholly followed Yahweh my Elohim. 
-\v 9 Moses swore on that day, saying, ‘Surely the land where you walked shall be an inheritance to you and to your children forever, because you have wholly followed Yahweh my Elohim.’ 
+\v 6 Then the children of Judah came near to Joshua in Gilgal. Caleb the son of Jephunneh the Kenizzite said to him, “You know the thing that Yahuah spoke to Moses the man of Elohim concerning me and concerning you in Kadesh Barnea. 
+\v 7 I was forty years old when Moses the servant of Yahuah sent me from Kadesh Barnea to spy out the land. I brought him word again as it was in my heart. 
+\v 8 Nevertheless, my brothers who went up with me made the heart of the people melt; but I wholly followed Yahuah my Elohim. 
+\v 9 Moses swore on that day, saying, ‘Surely the land where you walked shall be an inheritance to you and to your children forever, because you have wholly followed Yahuah my Elohim.’ 
 \p
-\v 10 “Now, behold, Yahweh has kept me alive, as he spoke, these forty-five years, from the time that Yahweh spoke this word to Moses, while Israel walked in the wilderness. Now, behold, I am eighty-five years old, today. 
+\v 10 “Now, behold, Yahuah has kept me alive, as he spoke, these forty-five years, from the time that Yahuah spoke this word to Moses, while Israel walked in the wilderness. Now, behold, I am eighty-five years old, today. 
 \v 11 As yet I am as strong today as I was in the day that Moses sent me. As my strength was then, even so is my strength now for war, to go out and to come in. 
-\v 12 Now therefore give me this hill country, of which Yahweh spoke in that day; for you heard in that day how the Anakim were there, and great and fortified cities. It may be that Yahweh will be with me, and I shall drive them out, as Yahweh said.” 
+\v 12 Now therefore give me this hill country, of which Yahuah spoke in that day; for you heard in that day how the Anakim were there, and great and fortified cities. It may be that Yahuah will be with me, and I shall drive them out, as Yahuah said.” 
 \p
 \v 13 Joshua blessed him; and he gave Hebron to Caleb the son of Jephunneh for an inheritance. 
-\v 14 Therefore Hebron became the inheritance of Caleb the son of Jephunneh the Kenizzite to this day, because he followed Yahweh, the Elohim of Israel wholeheartedly. 
+\v 14 Therefore Hebron became the inheritance of Caleb the son of Jephunneh the Kenizzite to this day, because he followed Yahuah, the Elohim of Israel wholeheartedly. 
 \v 15 Now the name of Hebron before was Kiriath Arba, after the greatest man among the Anakim. Then the land had rest from war. 
 \c 15
 \p
@@ -510,7 +510,7 @@
 \v 11 and the border went out to the side of Ekron northward; and the border extended to Shikkeron, and passed along to Mount Baalah, and went out at Jabneel; and the goings out of the border were at the sea. 
 \v 12 The west border was to the shore of the great sea. This is the border of the children of Judah according to their families. 
 \p
-\v 13 He gave to Caleb the son of Jephunneh a portion among the children of Judah, according to the commandment of Yahweh to Joshua, even Kiriath Arba, named after the father of Anak (also called Hebron). 
+\v 13 He gave to Caleb the son of Jephunneh a portion among the children of Judah, according to the commandment of Yahuah to Joshua, even Kiriath Arba, named after the father of Anak (also called Hebron). 
 \v 14 Caleb drove out the three sons of Anak: Sheshai, and Ahiman, and Talmai, the children of Anak. 
 \v 15 He went up against the inhabitants of Debir: now the name of Debir before was Kiriath Sepher. 
 \v 16 Caleb said, “He who strikes Kiriath Sepher, and takes it, to him I will give Achsah my daughter as woman.” 
@@ -592,7 +592,7 @@
 \v 1 This was the lot for the tribe of Manasseh, for he was the firstborn of Joseph. As for Machir the firstborn of Manasseh, the father of Gilead, because he was a man of war, therefore he had Gilead and Bashan. 
 \v 2 So this was for the rest of the children of Manasseh according to their families: for the children of Abiezer, for the children of Helek, for the children of Asriel, for the children of Shechem, for the children of Hepher, and for the children of Shemida. These were the male children of Manasseh the son of Joseph according to their families. 
 \v 3 But Zelophehad, the son of Hepher, the son of Gilead, the son of Machir, the son of Manasseh, had no sons, but daughters. These are the names of his daughters: Mahlah, Noah, Hoglah, Milcah, and Tirzah. 
-\v 4 They came to Eleazar the priest, and to Joshua the son of Nun, and to the princes, saying, “Yahweh commanded Moses to give us an inheritance among our brothers.” Therefore according to the commandment of Yahweh he gave them an inheritance among the brothers of their father. 
+\v 4 They came to Eleazar the priest, and to Joshua the son of Nun, and to the princes, saying, “Yahuah commanded Moses to give us an inheritance among our brothers.” Therefore according to the commandment of Yahuah he gave them an inheritance among the brothers of their father. 
 \v 5 Ten parts fell to Manasseh, in addition to the land of Gilead and Bashan, which is beyond the Jordan; 
 \v 6 because the daughters of Manasseh had an inheritance among his sons. The land of Gilead belonged to the rest of the sons of Manasseh. 
 \v 7 The border of Manasseh was from Asher to Michmethath, which is before Shechem. The border went along to the right hand, to the inhabitants of En Tappuah. 
@@ -603,7 +603,7 @@
 \v 12 Yet the children of Manasseh couldn’t drive out the inhabitants of those cities; but the Canaanites would dwell in that land. 
 \p
 \v 13 When the children of Israel had grown strong, they put the Canaanites to forced labor, and didn’t utterly drive them out. 
-\v 14 The children of Joseph spoke to Joshua, saying, “Why have you given me just one lot and one part for an inheritance, since we are a numerous people, because Yahweh has blessed us so far?” 
+\v 14 The children of Joseph spoke to Joshua, saying, “Why have you given me just one lot and one part for an inheritance, since we are a numerous people, because Yahuah has blessed us so far?” 
 \p
 \v 15 Joshua said to them, “If you are a numerous people, go up to the forest, and clear land for yourself there in the land of the Perizzites and of the Rephaim, since the hill country of Ephraim is too narrow for you.” 
 \p
@@ -615,16 +615,16 @@
 \p
 \v 1 The whole congregation of the children of Israel assembled themselves together at Shiloh, and set up the Tent of Meeting there. The land was subdued before them. 
 \v 2 Seven tribes remained among the children of Israel, which had not yet divided their inheritance. 
-\v 3 Joshua said to the children of Israel, “How long will you neglect to go in to possess the land, which Yahweh, the Elohim of your fathers, has given you? 
+\v 3 Joshua said to the children of Israel, “How long will you neglect to go in to possess the land, which Yahuah, the Elohim of your fathers, has given you? 
 \v 4 Appoint for yourselves three men from each tribe. I will send them, and they shall arise, walk through the land, and describe it according to their inheritance; then they shall come to me. 
 \v 5 They shall divide it into seven portions. Judah shall live in his borders on the south, and the house of Joseph shall live in their borders on the north. 
-\v 6 You shall survey the land into seven parts, and bring the description here to me; and I will cast lots for you here before Yahweh our Elohim. 
-\v 7 However, the Levites have no portion among you; for the priesthood of Yahweh is their inheritance. Gad, Reuben, and the half-tribe of Manasseh have received their inheritance east of the Jordan, which Moses the servant of Yahweh gave them.” 
+\v 6 You shall survey the land into seven parts, and bring the description here to me; and I will cast lots for you here before Yahuah our Elohim. 
+\v 7 However, the Levites have no portion among you; for the priesthood of Yahuah is their inheritance. Gad, Reuben, and the half-tribe of Manasseh have received their inheritance east of the Jordan, which Moses the servant of Yahuah gave them.” 
 \p
-\v 8 The men arose and went. Joshua commanded those who went to survey the land, saying, “Go walk through the land, survey it, and come again to me. I will cast lots for you here before Yahweh in Shiloh.” 
+\v 8 The men arose and went. Joshua commanded those who went to survey the land, saying, “Go walk through the land, survey it, and come again to me. I will cast lots for you here before Yahuah in Shiloh.” 
 \p
 \v 9 The men went and passed through the land, and surveyed it by cities into seven portions in a book. They came to Joshua to the camp at Shiloh. 
-\v 10 Joshua cast lots for them in Shiloh before Yahweh. There Joshua divided the land to the children of Israel according to their divisions. 
+\v 10 Joshua cast lots for them in Shiloh before Yahuah. There Joshua divided the land to the children of Israel according to their divisions. 
 \p
 \v 11 The lot of the tribe of the children of Benjamin came up according to their families. The border of their lot went out between the children of Judah and the children of Joseph. 
 \v 12 Their border on the north quarter was from the Jordan. The border went up to the side of Jericho on the north, and went up through the hill country westward. It ended at the wilderness of Beth Aven. 
@@ -701,11 +701,11 @@
 \v 48 This is the inheritance of the tribe of the children of Dan according to their families, these cities with their villages. 
 \p
 \v 49 So they finished distributing the land for inheritance by its borders. The children of Israel gave an inheritance to Joshua the son of Nun among them. 
-\v 50 According to Yahweh’s commandment, they gave him the city which he asked, even Timnathserah in the hill country of Ephraim; and he built the city, and lived there. 
-\v 51 These are the inheritances, which Eleazar the priest, Joshua the son of Nun, and the heads of the fathers’ houses of the tribes of the children of Israel, distributed for inheritance by lot in Shiloh before Yahweh, at the door of the Tent of Meeting. So they finished dividing the land. 
+\v 50 According to Yahuah’s commandment, they gave him the city which he asked, even Timnathserah in the hill country of Ephraim; and he built the city, and lived there. 
+\v 51 These are the inheritances, which Eleazar the priest, Joshua the son of Nun, and the heads of the fathers’ houses of the tribes of the children of Israel, distributed for inheritance by lot in Shiloh before Yahuah, at the door of the Tent of Meeting. So they finished dividing the land. 
 \c 20
 \p
-\v 1 Yahweh spoke to Joshua, saying, 
+\v 1 Yahuah spoke to Joshua, saying, 
 \v 2 “Speak to the children of Israel, saying, ‘Assign the cities of refuge, of which I spoke to you by Moses, 
 \v 3 that the man slayer who kills any person accidentally or unintentionally may flee there. They shall be to you for a refuge from the avenger of blood. 
 \v 4 He shall flee to one of those cities, and shall stand at the entrance of the gate of the city, and declare his case in the ears of the elders of that city. They shall take him into the city with them, and give him a place, that he may live among them. 
@@ -718,14 +718,14 @@
 \c 21
 \p
 \v 1 Then the heads of fathers’ houses of the Levites came near to Eleazar the priest, and to Joshua the son of Nun, and to the heads of fathers’ houses of the tribes of the children of Israel. 
-\v 2 They spoke to them at Shiloh in the land of Canaan, saying, “Yahweh commanded through Moses to give us cities to dwell in, with their pasture lands for our livestock.” 
+\v 2 They spoke to them at Shiloh in the land of Canaan, saying, “Yahuah commanded through Moses to give us cities to dwell in, with their pasture lands for our livestock.” 
 \p
-\v 3 The children of Israel gave to the Levites out of their inheritance, according to the commandment of Yahweh, these cities with their pasture lands. 
+\v 3 The children of Israel gave to the Levites out of their inheritance, according to the commandment of Yahuah, these cities with their pasture lands. 
 \v 4 The lot came out for the families of the Kohathites. The children of Aaron the priest, who were of the Levites, had thirteen cities by lot out of the tribe of Judah, out of the tribe of the Simeonites, and out of the tribe of Benjamin. 
 \v 5 The rest of the children of Kohath had ten cities by lot out of the families of the tribe of Ephraim, out of the tribe of Dan, and out of the half-tribe of Manasseh. 
 \v 6 The children of Gershon had thirteen cities by lot out of the families of the tribe of Issachar, out of the tribe of Asher, out of the tribe of Naphtali, and out of the half-tribe of Manasseh in Bashan. 
 \v 7 The children of Merari according to their families had twelve cities out of the tribe of Reuben, out of the tribe of Gad, and out of the tribe of Zebulun. 
-\v 8 The children of Israel gave these cities with their pasture lands by lot to the Levites, as Yahweh commanded by Moses. 
+\v 8 The children of Israel gave these cities with their pasture lands by lot to the Levites, as Yahuah commanded by Moses. 
 \v 9 They gave out of the tribe of the children of Judah, and out of the tribe of the children of Simeon, these cities which are mentioned by name: 
 \v 10 and they were for the children of Aaron, of the families of the Kohathites, who were of the children of Levi; for theirs was the first lot. 
 \v 11 They gave them Kiriath Arba, named after the father of Anak (also called Hebron), in the hill country of Judah, with its pasture lands around it. 
@@ -765,85 +765,85 @@
 \v 41 All the cities of the Levites among the possessions of the children of Israel were forty-eight cities with their pasture lands. 
 \v 42 Each of these cities included their pasture lands around them. It was this way with all these cities. 
 \p
-\v 43 So Yahweh gave to Israel all the land which he swore to give to their fathers. They possessed it, and lived in it. 
-\v 44 Yahweh gave them rest all around, according to all that he swore to their fathers. Not a man of all their enemies stood before them. Yahweh delivered all their enemies into their hand. 
-\v 45 Nothing failed of any good thing which Yahweh had spoken to the house of Israel. All came to pass. 
+\v 43 So Yahuah gave to Israel all the land which he swore to give to their fathers. They possessed it, and lived in it. 
+\v 44 Yahuah gave them rest all around, according to all that he swore to their fathers. Not a man of all their enemies stood before them. Yahuah delivered all their enemies into their hand. 
+\v 45 Nothing failed of any good thing which Yahuah had spoken to the house of Israel. All came to pass. 
 \c 22
 \p
 \v 1 Then Joshua called the Reubenites, the Gadites, and the half-tribe of Manasseh, 
-\v 2 and said to them, “You have kept all that Moses the servant of Yahweh commanded you, and have listened to my voice in all that I commanded you. 
-\v 3 You have not left your brothers these many days to this day, but have performed the duty of the commandment of Yahweh your Elohim. 
-\v 4 Now Yahweh your Elohim has given rest to your brothers, as he spoke to them. Therefore now return and go to your tents, to the land of your possession, which Moses the servant of Yahweh gave you beyond the Jordan. 
-\v 5 Only take diligent heed to do the commandment and the law which Moses the servant of Yahweh commanded you, to love Yahweh your Elohim, to walk in all his ways, to keep his commandments, to hold fast to him, and to serve him with all your heart and with all your soul.” 
+\v 2 and said to them, “You have kept all that Moses the servant of Yahuah commanded you, and have listened to my voice in all that I commanded you. 
+\v 3 You have not left your brothers these many days to this day, but have performed the duty of the commandment of Yahuah your Elohim. 
+\v 4 Now Yahuah your Elohim has given rest to your brothers, as he spoke to them. Therefore now return and go to your tents, to the land of your possession, which Moses the servant of Yahuah gave you beyond the Jordan. 
+\v 5 Only take diligent heed to do the commandment and the law which Moses the servant of Yahuah commanded you, to love Yahuah your Elohim, to walk in all his ways, to keep his commandments, to hold fast to him, and to serve him with all your heart and with all your soul.” 
 \p
 \v 6 So Joshua blessed them, and sent them away; and they went to their tents. 
 \v 7 Now to the one half-tribe of Manasseh Moses had given inheritance in Bashan; but Joshua gave to the other half among their brothers beyond the Jordan westward. Moreover when Joshua sent them away to their tents, he blessed them, 
 \v 8 and spoke to them, saying, “Return with much wealth to your tents, with very much livestock, with silver, with gold, with bronze, with iron, and with very much clothing. Divide the plunder of your enemies with your brothers.” 
 \p
-\v 9 The children of Reuben and the children of Gad and the half-tribe of Manasseh returned, and departed from the children of Israel out of Shiloh, which is in the land of Canaan, to go to the land of Gilead, to the land of their possession, which they owned, according to the commandment of Yahweh by Moses. 
+\v 9 The children of Reuben and the children of Gad and the half-tribe of Manasseh returned, and departed from the children of Israel out of Shiloh, which is in the land of Canaan, to go to the land of Gilead, to the land of their possession, which they owned, according to the commandment of Yahuah by Moses. 
 \v 10 When they came to the region near the Jordan, that is in the land of Canaan, the children of Reuben and the children of Gad and the half-tribe of Manasseh built an altar there by the Jordan, a great altar to look at. 
 \v 11 The children of Israel heard this, “Behold, the children of Reuben and the children of Gad and the half-tribe of Manasseh have built an altar along the border of the land of Canaan, in the region around the Jordan, on the side that belongs to the children of Israel.” 
 \v 12 When the children of Israel heard of it, the whole congregation of the children of Israel gathered themselves together at Shiloh, to go up against them to war. 
 \v 13 The children of Israel sent to the children of Reuben, and to the children of Gad, and to the half-tribe of Manasseh, into the land of Gilead, Phinehas the son of Eleazar the priest. 
 \v 14 With him were ten princes, one prince of a fathers’ house for each of the tribes of Israel; and they were each head of their fathers’ houses among the thousands of Israel. 
 \v 15 They came to the children of Reuben, and to the children of Gad, and to the half-tribe of Manasseh, to the land of Gilead, and they spoke with them, saying, 
-\v 16 “The whole congregation of Yahweh says, ‘What trespass is this that you have committed against the Elohim of Israel, to turn away today from following Yahweh, in that you have built yourselves an altar, to rebel today against Yahweh? 
-\v 17 Is the iniquity of Peor too little for us, from which we have not cleansed ourselves to this day, although there came a plague on the congregation of Yahweh, 
-\v 18 that you must turn away today from following Yahweh? It will be, since you rebel today against Yahweh, that tomorrow he will be angry with the whole congregation of Israel. 
-\v 19 However, if the land of your possession is unclean, then pass over to the land of the possession of Yahweh, in which Yahweh’s tabernacle dwells, and take possession among us; but don’t rebel against Yahweh, nor rebel against us, in building an altar other than Yahweh our Elohim’s altar. 
+\v 16 “The whole congregation of Yahuah says, ‘What trespass is this that you have committed against the Elohim of Israel, to turn away today from following Yahuah, in that you have built yourselves an altar, to rebel today against Yahuah? 
+\v 17 Is the iniquity of Peor too little for us, from which we have not cleansed ourselves to this day, although there came a plague on the congregation of Yahuah, 
+\v 18 that you must turn away today from following Yahuah? It will be, since you rebel today against Yahuah, that tomorrow he will be angry with the whole congregation of Israel. 
+\v 19 However, if the land of your possession is unclean, then pass over to the land of the possession of Yahuah, in which Yahuah’s tabernacle dwells, and take possession among us; but don’t rebel against Yahuah, nor rebel against us, in building an altar other than Yahuah our Elohim’s altar. 
 \v 20 Didn’t Achan the son of Zerah commit a trespass in the devoted thing, and wrath fell on all the congregation of Israel? That man didn’t perish alone in his iniquity.’ ” 
 \p
 \v 21 Then the children of Reuben and the children of Gad and the half-tribe of Manasseh answered, and spoke to the heads of the thousands of Israel, 
-\v 22 “The Mighty One, Elohim, Yahweh, the Mighty One, Elohim, Yahweh, he knows; and Israel shall know: if it was in rebellion, or if in trespass against Yahweh (don’t save us today), 
-\v 23 that we have built us an altar to turn away from following Yahweh; or if to offer burnt offering or meal offering, or if to offer sacrifices of peace offerings, let Yahweh himself require it. 
+\v 22 “The Mighty One, Elohim, Yahuah, the Mighty One, Elohim, Yahuah, he knows; and Israel shall know: if it was in rebellion, or if in trespass against Yahuah (don’t save us today), 
+\v 23 that we have built us an altar to turn away from following Yahuah; or if to offer burnt offering or meal offering, or if to offer sacrifices of peace offerings, let Yahuah himself require it. 
 \p
-\v 24 “If we have not out of concern done this, and for a reason, saying, ‘In time to come your children might speak to our children, saying, “What have you to do with Yahweh, the Elohim of Israel? 
-\v 25 For Yahweh has made the Jordan a border between us and you, you children of Reuben and children of Gad. You have no portion in Yahweh.” ’ So your children might make our children cease from fearing Yahweh. 
+\v 24 “If we have not out of concern done this, and for a reason, saying, ‘In time to come your children might speak to our children, saying, “What have you to do with Yahuah, the Elohim of Israel? 
+\v 25 For Yahuah has made the Jordan a border between us and you, you children of Reuben and children of Gad. You have no portion in Yahuah.” ’ So your children might make our children cease from fearing Yahuah. 
 \p
 \v 26 “Therefore we said, ‘Let’s now prepare to build ourselves an altar, not for burnt offering, nor for sacrifice; 
-\v 27 but it will be a witness between us and you, and between our generations after us, that we may perform the service of Yahweh before him with our burnt offerings, with our sacrifices, and with our peace offerings;’ that your children may not tell our children in time to come, ‘You have no portion in Yahweh.’ 
+\v 27 but it will be a witness between us and you, and between our generations after us, that we may perform the service of Yahuah before him with our burnt offerings, with our sacrifices, and with our peace offerings;’ that your children may not tell our children in time to come, ‘You have no portion in Yahuah.’ 
 \p
-\v 28 “Therefore we said, ‘It shall be, when they tell us or our generations this in time to come, that we shall say, “Behold the pattern of Yahweh’s altar, which our fathers made, not for burnt offering, nor for sacrifice; but it is a witness between us and you.” ’ 
+\v 28 “Therefore we said, ‘It shall be, when they tell us or our generations this in time to come, that we shall say, “Behold the pattern of Yahuah’s altar, which our fathers made, not for burnt offering, nor for sacrifice; but it is a witness between us and you.” ’ 
 \p
-\v 29 “Far be it from us that we should rebel against Yahweh, and turn away today from following Yahweh, to build an altar for burnt offering, for meal offering, or for sacrifice, besides Yahweh our Elohim’s altar that is before his tabernacle!” 
+\v 29 “Far be it from us that we should rebel against Yahuah, and turn away today from following Yahuah, to build an altar for burnt offering, for meal offering, or for sacrifice, besides Yahuah our Elohim’s altar that is before his tabernacle!” 
 \p
 \v 30 When Phinehas the priest, and the princes of the congregation, even the heads of the thousands of Israel that were with him, heard the words that the children of Reuben and the children of Gad and the children of Manasseh spoke, it pleased them well. 
-\v 31 Phinehas the son of Eleazar the priest said to the children of Reuben, to the children of Gad, and to the children of Manasseh, “Today we know that Yahweh is among us, because you have not committed this trespass against Yahweh. Now you have delivered the children of Israel out of Yahweh’s hand.” 
+\v 31 Phinehas the son of Eleazar the priest said to the children of Reuben, to the children of Gad, and to the children of Manasseh, “Today we know that Yahuah is among us, because you have not committed this trespass against Yahuah. Now you have delivered the children of Israel out of Yahuah’s hand.” 
 \v 32 Phinehas the son of Eleazar the priest, and the princes, returned from the children of Reuben, and from the children of Gad, out of the land of Gilead, to the land of Canaan, to the children of Israel, and brought them word again. 
 \v 33 The thing pleased the children of Israel; and the children of Israel blessed Elohim, and spoke no more of going up against them to war, to destroy the land in which the children of Reuben and the children of Gad lived. 
-\v 34 The children of Reuben and the children of Gad named the altar “A Witness Between Us that Yahweh is Elohim.” 
+\v 34 The children of Reuben and the children of Gad named the altar “A Witness Between Us that Yahuah is Elohim.” 
 \c 23
 \p
-\v 1 After many days, when Yahweh had given rest to Israel from their enemies all around, and Joshua was old and well advanced in years, 
+\v 1 After many days, when Yahuah had given rest to Israel from their enemies all around, and Joshua was old and well advanced in years, 
 \v 2 Joshua called for all Israel, for their elders and for their heads, and for their judges and for their officers, and said to them, “I am old and well advanced in years. 
-\v 3 You have seen all that Yahweh your Elohim has done to all these nations because of you; for it is Yahweh your Elohim who has fought for you. 
+\v 3 You have seen all that Yahuah your Elohim has done to all these nations because of you; for it is Yahuah your Elohim who has fought for you. 
 \v 4 Behold, I have allotted to you these nations that remain, to be an inheritance for your tribes, from the Jordan, with all the nations that I have cut off, even to the great sea toward the going down of the sun. 
-\v 5 Yahweh your Elohim will thrust them out from before you, and drive them from out of your sight. You shall possess their land, as Yahweh your Elohim spoke to you. 
+\v 5 Yahuah your Elohim will thrust them out from before you, and drive them from out of your sight. You shall possess their land, as Yahuah your Elohim spoke to you. 
 \p
 \v 6 “Therefore be very courageous to keep and to do all that is written in the book of the law of Moses, that you not turn away from it to the right hand or to the left; 
 \v 7 that you not come among these nations, these that remain among you; neither make mention of the name of their elohims, nor cause to swear by them, neither serve them, nor bow down yourselves to them; 
-\v 8 but hold fast to Yahweh your Elohim, as you have done to this day. 
+\v 8 but hold fast to Yahuah your Elohim, as you have done to this day. 
 \p
-\v 9 “For Yahweh has driven great and strong nations out from before you. But as for you, no man has stood before you to this day. 
-\v 10 One man of you shall chase a thousand; for it is Yahweh your Elohim who fights for you, as he spoke to you. 
-\v 11 Take good heed therefore to yourselves, that you love Yahweh your Elohim. 
+\v 9 “For Yahuah has driven great and strong nations out from before you. But as for you, no man has stood before you to this day. 
+\v 10 One man of you shall chase a thousand; for it is Yahuah your Elohim who fights for you, as he spoke to you. 
+\v 11 Take good heed therefore to yourselves, that you love Yahuah your Elohim. 
 \p
 \v 12 “But if you do at all go back, and hold fast to the remnant of these nations, even these who remain among you, and you make yourselves relatives of them, and go in to them, and they to you; 
-\v 13 know for a certainty that Yahweh your Elohim will no longer drive these nations from out of your sight; but they shall be a snare and a trap to you, a scourge in your sides, and thorns in your eyes, until you perish from off this good land which Yahweh your Elohim has given you. 
+\v 13 know for a certainty that Yahuah your Elohim will no longer drive these nations from out of your sight; but they shall be a snare and a trap to you, a scourge in your sides, and thorns in your eyes, until you perish from off this good land which Yahuah your Elohim has given you. 
 \p
-\v 14 “Behold, today I am going the way of all the earth. You know in all your hearts and in all your souls that not one thing has failed of all the good things which Yahweh your Elohim spoke concerning you. All have happened to you. Not one thing has failed of it. 
-\v 15 It shall happen that as all the good things have come on you of which Yahweh your Elohim spoke to you, so Yahweh will bring on you all the evil things, until he has destroyed you from off this good land which Yahweh your Elohim has given you, 
-\v 16 when you disobey the covenant of Yahweh your Elohim, which he commanded you, and go and serve other elohims, and bow down yourselves to them. Then Yahweh’s anger will be kindled against you, and you will perish quickly from off the good land which he has given to you.” 
+\v 14 “Behold, today I am going the way of all the earth. You know in all your hearts and in all your souls that not one thing has failed of all the good things which Yahuah your Elohim spoke concerning you. All have happened to you. Not one thing has failed of it. 
+\v 15 It shall happen that as all the good things have come on you of which Yahuah your Elohim spoke to you, so Yahuah will bring on you all the evil things, until he has destroyed you from off this good land which Yahuah your Elohim has given you, 
+\v 16 when you disobey the covenant of Yahuah your Elohim, which he commanded you, and go and serve other elohims, and bow down yourselves to them. Then Yahuah’s anger will be kindled against you, and you will perish quickly from off the good land which he has given to you.” 
 \c 24
 \p
 \v 1 Joshua gathered all the tribes of Israel to Shechem, and called for the elders of Israel, for their heads, for their judges, and for their officers; and they presented themselves before Elohim. 
-\v 2 Joshua said to all the people, “Yahweh, the Elohim of Israel, says, ‘Your fathers lived of old time beyond the River, even Terah, the father of Abraham, and the father of Nahor. They served other elohims. 
+\v 2 Joshua said to all the people, “Yahuah, the Elohim of Israel, says, ‘Your fathers lived of old time beyond the River, even Terah, the father of Abraham, and the father of Nahor. They served other elohims. 
 \v 3 I took your father Abraham from beyond the River, and led him throughout all the land of Canaan, and multiplied his offspring, and gave him Isaac. 
 \v 4 I gave to Isaac Jacob and Esau: and I gave to Esau Mount Seir, to possess it. Jacob and his children went down into Egypt. 
 \p
 \v 5 “ ‘I sent Moses and Aaron, and I plagued Egypt, according to that which I did among them: and afterward I brought you out. 
 \v 6 I brought your fathers out of Egypt: and you came to the sea. The Egyptians pursued your fathers with chariots and with horsemen to the Red Sea. 
-\v 7 When they cried out to Yahweh, he put darkness between you and the Egyptians, and brought the sea on them, and covered them; and your eyes saw what I did in Egypt. You lived in the wilderness many days. 
+\v 7 When they cried out to Yahuah, he put darkness between you and the Egyptians, and brought the sea on them, and covered them; and your eyes saw what I did in Egypt. You lived in the wilderness many days. 
 \p
 \v 8 “ ‘I brought you into the land of the Amorites, that lived beyond the Jordan. They fought with you, and I gave them into your hand. You possessed their land, and I destroyed them from before you. 
 \v 9 Then Balak the son of Zippor, king of Moab, arose and fought against Israel. He sent and called Balaam the son of Beor to curse you, 
@@ -853,31 +853,31 @@
 \v 12 I sent the hornet before you, which drove them out from before you, even the two kings of the Amorites; not with your sword, nor with your bow. 
 \v 13 I gave you a land on which you had not labored, and cities which you didn’t build, and you live in them. You eat of vineyards and olive groves which you didn’t plant.’ 
 \p
-\v 14 “Now therefore fear Yahweh, and serve him in sincerity and in truth. Put away the elohims which your fathers served beyond the River, in Egypt; and serve Yahweh. 
-\v 15 If it seems evil to you to serve Yahweh, choose today whom you will serve; whether the elohims which your fathers served that were beyond the River, or the elohims of the Amorites, in whose land you dwell; but as for me and my house, we will serve Yahweh.” 
+\v 14 “Now therefore fear Yahuah, and serve him in sincerity and in truth. Put away the elohims which your fathers served beyond the River, in Egypt; and serve Yahuah. 
+\v 15 If it seems evil to you to serve Yahuah, choose today whom you will serve; whether the elohims which your fathers served that were beyond the River, or the elohims of the Amorites, in whose land you dwell; but as for me and my house, we will serve Yahuah.” 
 \p
-\v 16 The people answered, “Far be it from us that we should forsake Yahweh, to serve other elohims; 
-\v 17 for it is Yahweh our Elohim who brought us and our fathers up out of the land of Egypt, from the house of bondage, and who did those great signs in our sight, and preserved us in all the way in which we went, and among all the peoples through the middle of whom we passed. 
-\v 18 Yahweh drove out from before us all the peoples, even the Amorites who lived in the land. Therefore we also will serve Yahweh; for he is our Elohim.” 
+\v 16 The people answered, “Far be it from us that we should forsake Yahuah, to serve other elohims; 
+\v 17 for it is Yahuah our Elohim who brought us and our fathers up out of the land of Egypt, from the house of bondage, and who did those great signs in our sight, and preserved us in all the way in which we went, and among all the peoples through the middle of whom we passed. 
+\v 18 Yahuah drove out from before us all the peoples, even the Amorites who lived in the land. Therefore we also will serve Yahuah; for he is our Elohim.” 
 \p
-\v 19 Joshua said to the people, “You can’t serve Yahweh, for he is a set-apart Elohim. He is a jealous Elohim. He will not forgive your disobedience nor your sins. 
-\v 20 If you forsake Yahweh, and serve foreign elohims, then he will turn and do you evil, and consume you, after he has done you good.” 
+\v 19 Joshua said to the people, “You can’t serve Yahuah, for he is a set-apart Elohim. He is a jealous Elohim. He will not forgive your disobedience nor your sins. 
+\v 20 If you forsake Yahuah, and serve foreign elohims, then he will turn and do you evil, and consume you, after he has done you good.” 
 \p
-\v 21 The people said to Joshua, “No, but we will serve Yahweh.” 
-\v 22 Joshua said to the people, “You are witnesses against yourselves that you have chosen Yahweh yourselves, to serve him.” 
+\v 21 The people said to Joshua, “No, but we will serve Yahuah.” 
+\v 22 Joshua said to the people, “You are witnesses against yourselves that you have chosen Yahuah yourselves, to serve him.” 
 \p They said, “We are witnesses.” 
 \p
-\v 23 “Now therefore put away the foreign elohims which are among you, and incline your heart to Yahweh, the Elohim of Israel.” 
+\v 23 “Now therefore put away the foreign elohims which are among you, and incline your heart to Yahuah, the Elohim of Israel.” 
 \p
-\v 24 The people said to Joshua, “We will serve Yahweh our Elohim, and we will listen to his voice.” 
+\v 24 The people said to Joshua, “We will serve Yahuah our Elohim, and we will listen to his voice.” 
 \p
 \v 25 So Joshua made a covenant with the people that day, and made for them a statute and an ordinance in Shechem. 
-\v 26 Joshua wrote these words in the book of the law of Elohim; and he took a great stone, and set it up there under the oak that was by the sanctuary of Yahweh. 
-\v 27 Joshua said to all the people, “Behold, this stone shall be a witness against us, for it has heard all Yahweh’s words which he spoke to us. It shall be therefore a witness against you, lest you deny your Elohim.” 
+\v 26 Joshua wrote these words in the book of the law of Elohim; and he took a great stone, and set it up there under the oak that was by the sanctuary of Yahuah. 
+\v 27 Joshua said to all the people, “Behold, this stone shall be a witness against us, for it has heard all Yahuah’s words which he spoke to us. It shall be therefore a witness against you, lest you deny your Elohim.” 
 \v 28 So Joshua sent the people away, each to his own inheritance. 
 \p
-\v 29 After these things, Joshua the son of Nun, the servant of Yahweh, died, being one hundred ten years old. 
+\v 29 After these things, Joshua the son of Nun, the servant of Yahuah, died, being one hundred ten years old. 
 \v 30 They buried him in the border of his inheritance in Timnathserah, which is in the hill country of Ephraim, on the north of the mountain of Gaash. 
-\v 31 Israel served Yahweh all the days of Joshua, and all the days of the elders who outlived Joshua, and had known all the work of Yahweh, that he had worked for Israel. 
+\v 31 Israel served Yahuah all the days of Joshua, and all the days of the elders who outlived Joshua, and had known all the work of Yahuah, that he had worked for Israel. 
 \v 32 They buried the bones of Joseph, which the children of Israel brought up out of Egypt, in Shechem, in the parcel of ground which Jacob bought from the sons of Hamor the father of Shechem for a hundred pieces of silver. They became the inheritance of the children of Joseph. 
 \v 33 Eleazar the son of Aaron died. They buried him in the hill of Phinehas his son, which was given him in the hill country of Ephraim. 

--- a/usfm/judges.usfm
+++ b/usfm/judges.usfm
@@ -3,12 +3,12 @@
 \h Judges
 \c 1
 \p
-\v 1 After the death of Joshua, the children of Israel asked of Yahweh, saying, “Who should go up for us first against the Canaanites, to fight against them?” 
+\v 1 After the death of Joshua, the children of Israel asked of Yahuah, saying, “Who should go up for us first against the Canaanites, to fight against them?” 
 \p
-\v 2 Yahweh said, “Judah shall go up. Behold, I have delivered the land into his hand.” 
+\v 2 Yahuah said, “Judah shall go up. Behold, I have delivered the land into his hand.” 
 \p
 \v 3 Judah said to Simeon his brother, “Come up with me into my lot, that we may fight against the Canaanites; and I likewise will go with you into your lot.” So Simeon went with him. 
-\v 4 Judah went up, and Yahweh delivered the Canaanites and the Perizzites into their hand. They struck ten thousand men in Bezek. 
+\v 4 Judah went up, and Yahuah delivered the Canaanites and the Perizzites into their hand. They struck ten thousand men in Bezek. 
 \v 5 They found Adoni-Bezek in Bezek, and they fought against him. They struck the Canaanites and the Perizzites. 
 \v 6 But Adoni-Bezek fled. They pursued him, caught him, and cut off his thumbs and his big toes. 
 \v 7 Adoni-Bezek said, “Seventy kings, having their thumbs and their big toes cut off, scavenged under my table. As I have done, so Elohim has done to me.” They brought him to Jerusalem, and he died there. 
@@ -27,11 +27,11 @@
 \v 16 The children of the Kenite, Moses’ brother-in-law, went up out of the city of palm trees with the children of Judah into the wilderness of Judah, which is in the south of Arad; and they went and lived with the people. 
 \v 17 Judah went with Simeon his brother, and they struck the Canaanites who inhabited Zephath, and utterly destroyed it. The name of the city was called Hormah. 
 \v 18 Also Judah took Gaza with its border, and Ashkelon with its border, and Ekron with its border. 
-\v 19 Yahweh was with Judah, and drove out the inhabitants of the hill country; for he could not drive out the inhabitants of the valley, because they had chariots of iron. 
+\v 19 Yahuah was with Judah, and drove out the inhabitants of the hill country; for he could not drive out the inhabitants of the valley, because they had chariots of iron. 
 \v 20 They gave Hebron to Caleb, as Moses had said, and he drove the three sons of Anak out of there. 
 \v 21 The children of Benjamin didn’t drive out the Jebusites who inhabited Jerusalem, but the Jebusites dwell with the children of Benjamin in Jerusalem to this day. 
 \p
-\v 22 The house of Joseph also went up against Bethel, and Yahweh was with them. 
+\v 22 The house of Joseph also went up against Bethel, and Yahuah was with them. 
 \v 23 The house of Joseph sent to spy out Bethel. (The name of the city before that was Luz.) 
 \v 24 The watchers saw a man come out of the city, and they said to him, “Please show us the entrance into the city, and we will deal kindly with you.” 
 \v 25 He showed them the entrance into the city, and they struck the city with the edge of the sword; but they let the man and all his family go. 
@@ -49,48 +49,48 @@
 \v 36 The border of the Amorites was from the ascent of Akrabbim, from the rock, and upward. 
 \c 2
 \p
-\v 1 Yahweh’s angel came up from Gilgal to Bochim. He said, “I brought you out of Egypt, and have brought you to the land which I swore to give your fathers. I said, ‘I will never break my covenant with you. 
+\v 1 Yahuah’s angel came up from Gilgal to Bochim. He said, “I brought you out of Egypt, and have brought you to the land which I swore to give your fathers. I said, ‘I will never break my covenant with you. 
 \v 2 You shall make no covenant with the inhabitants of this land. You shall break down their altars.’ But you have not listened to my voice. Why have you done this? 
 \v 3 Therefore I also said, ‘I will not drive them out from before you; but they shall be in your sides, and their elohims will be a snare to you.’ ” 
 \p
-\v 4 When Yahweh’s angel spoke these words to all the children of Israel, the people lifted up their voice and wept. 
-\v 5 They called the name of that place Bochim, and they sacrificed there to Yahweh. 
+\v 4 When Yahuah’s angel spoke these words to all the children of Israel, the people lifted up their voice and wept. 
+\v 5 They called the name of that place Bochim, and they sacrificed there to Yahuah. 
 \v 6 Now when Joshua had sent the people away, the children of Israel each went to his inheritance to possess the land. 
-\v 7 The people served Yahweh all the days of Joshua, and all the days of the elders who outlived Joshua, who had seen all the great work of Yahweh that he had worked for Israel. 
-\v 8 Joshua the son of Nun, the servant of Yahweh, died, being one hundred ten years old. 
+\v 7 The people served Yahuah all the days of Joshua, and all the days of the elders who outlived Joshua, who had seen all the great work of Yahuah that he had worked for Israel. 
+\v 8 Joshua the son of Nun, the servant of Yahuah, died, being one hundred ten years old. 
 \v 9 They buried him in the border of his inheritance in Timnath Heres, in the hill country of Ephraim, on the north of the mountain of Gaash. 
-\v 10 After all that generation were gathered to their fathers, another generation arose after them who didn’t know Yahweh, nor the work which he had done for Israel. 
-\v 11 The children of Israel did that which was evil in Yahweh’s sight, and served the Baals. 
-\v 12 They abandoned Yahweh, the Elohim of their fathers, who brought them out of the land of Egypt, and followed other elohims, of the elohims of the peoples who were around them, and bowed themselves down to them; and they provoked Yahweh to anger. 
-\v 13 They abandoned Yahweh, and served Baal and the Ashtaroth. 
-\v 14 Yahweh’s anger burned against Israel, and he delivered them into the hands of raiders who plundered them. He sold them into the hands of their enemies all around, so that they could no longer stand before their enemies. 
-\v 15 Wherever they went out, Yahweh’s hand was against them for evil, as Yahweh had spoken, and as Yahweh had sworn to them; and they were very distressed. 
-\v 16 Yahweh raised up judges, who saved them out of the hand of those who plundered them. 
-\v 17 Yet they didn’t listen to their judges; for they prostituted themselves to other elohims, and bowed themselves down to them. They quickly turned away from the way in which their fathers walked, obeying Yahweh’s commandments. They didn’t do so. 
-\v 18 When Yahweh raised up judges for them, then Yahweh was with the judge, and saved them out of the hand of their enemies all the days of the judge; for it grieved Yahweh because of their groaning by reason of those who oppressed them and troubled them. 
+\v 10 After all that generation were gathered to their fathers, another generation arose after them who didn’t know Yahuah, nor the work which he had done for Israel. 
+\v 11 The children of Israel did that which was evil in Yahuah’s sight, and served the Baals. 
+\v 12 They abandoned Yahuah, the Elohim of their fathers, who brought them out of the land of Egypt, and followed other elohims, of the elohims of the peoples who were around them, and bowed themselves down to them; and they provoked Yahuah to anger. 
+\v 13 They abandoned Yahuah, and served Baal and the Ashtaroth. 
+\v 14 Yahuah’s anger burned against Israel, and he delivered them into the hands of raiders who plundered them. He sold them into the hands of their enemies all around, so that they could no longer stand before their enemies. 
+\v 15 Wherever they went out, Yahuah’s hand was against them for evil, as Yahuah had spoken, and as Yahuah had sworn to them; and they were very distressed. 
+\v 16 Yahuah raised up judges, who saved them out of the hand of those who plundered them. 
+\v 17 Yet they didn’t listen to their judges; for they prostituted themselves to other elohims, and bowed themselves down to them. They quickly turned away from the way in which their fathers walked, obeying Yahuah’s commandments. They didn’t do so. 
+\v 18 When Yahuah raised up judges for them, then Yahuah was with the judge, and saved them out of the hand of their enemies all the days of the judge; for it grieved Yahuah because of their groaning by reason of those who oppressed them and troubled them. 
 \v 19 But when the judge was dead, they turned back, and dealt more corruptly than their fathers in following other elohims to serve them and to bow down to them. They didn’t cease what they were doing, or give up their stubborn ways. 
-\v 20 Yahweh’s anger burned against Israel; and he said, “Because this nation transgressed my covenant which I commanded their fathers, and has not listened to my voice, 
+\v 20 Yahuah’s anger burned against Israel; and he said, “Because this nation transgressed my covenant which I commanded their fathers, and has not listened to my voice, 
 \v 21 I also will no longer drive out any of the nations that Joshua left when he died from before them; 
-\v 22 that by them I may test Israel, to see if they will keep Yahweh’s way to walk therein, as their fathers kept it, or not.” 
-\v 23 So Yahweh left those nations, without driving them out hastily. He didn’t deliver them into Joshua’s hand. 
+\v 22 that by them I may test Israel, to see if they will keep Yahuah’s way to walk therein, as their fathers kept it, or not.” 
+\v 23 So Yahuah left those nations, without driving them out hastily. He didn’t deliver them into Joshua’s hand. 
 \c 3
 \p
-\v 1 Now these are the nations which Yahweh left, to test Israel by them, even as many as had not known all the wars of Canaan; 
+\v 1 Now these are the nations which Yahuah left, to test Israel by them, even as many as had not known all the wars of Canaan; 
 \v 2 only that the generations of the children of Israel might know, to teach them war, at least those who knew nothing of it before: 
 \v 3 the five lords of the Philistines, all the Canaanites, the Sidonians, and the Hivites who lived on Mount Lebanon, from Mount Baal Hermon to the entrance of Hamath. 
-\v 4 They were left to test Israel by them, to know whether they would listen to Yahweh’s commandments, which he commanded their fathers by Moses. 
+\v 4 They were left to test Israel by them, to know whether they would listen to Yahuah’s commandments, which he commanded their fathers by Moses. 
 \v 5 The children of Israel lived among the Canaanites, the Hittites, the Amorites, the Perizzites, the Hivites, and the Jebusites. 
 \v 6 They took their daughters to be their women, and gave their own daughters to their sons and served their elohims. 
-\v 7 The children of Israel did that which was evil in Yahweh’s sight, and forgot Yahweh their Elohim, and served the Baals and the Asheroth. 
-\v 8 Therefore Yahweh’s anger burned against Israel, and he sold them into the hand of Cushan Rishathaim king of Mesopotamia; and the children of Israel served Cushan Rishathaim eight years. 
-\v 9 When the children of Israel cried to Yahweh, Yahweh raised up a savior to the children of Israel, who saved them, even Othniel the son of Kenaz, Caleb’s younger brother. 
-\v 10 Yahweh’s Spirit came on him, and he judged Israel; and he went out to war, and Yahweh delivered Cushan Rishathaim king of Mesopotamia into his hand. His hand prevailed against Cushan Rishathaim. 
+\v 7 The children of Israel did that which was evil in Yahuah’s sight, and forgot Yahuah their Elohim, and served the Baals and the Asheroth. 
+\v 8 Therefore Yahuah’s anger burned against Israel, and he sold them into the hand of Cushan Rishathaim king of Mesopotamia; and the children of Israel served Cushan Rishathaim eight years. 
+\v 9 When the children of Israel cried to Yahuah, Yahuah raised up a savior to the children of Israel, who saved them, even Othniel the son of Kenaz, Caleb’s younger brother. 
+\v 10 Yahuah’s Spirit came on him, and he judged Israel; and he went out to war, and Yahuah delivered Cushan Rishathaim king of Mesopotamia into his hand. His hand prevailed against Cushan Rishathaim. 
 \v 11 The land had rest forty years, then Othniel the son of Kenaz died. 
 \p
-\v 12 The children of Israel again did that which was evil in Yahweh’s sight, and Yahweh strengthened Eglon the king of Moab against Israel, because they had done that which was evil in Yahweh’s sight. 
+\v 12 The children of Israel again did that which was evil in Yahuah’s sight, and Yahuah strengthened Eglon the king of Moab against Israel, because they had done that which was evil in Yahuah’s sight. 
 \v 13 He gathered the children of Ammon and Amalek to himself; and he went and struck Israel, and they possessed the city of palm trees. 
 \v 14 The children of Israel served Eglon the king of Moab eighteen years. 
-\v 15 But when the children of Israel cried to Yahweh, Yahweh raised up a savior for them: Ehud the son of Gera, the Benjamite, a left-handed man. The children of Israel sent tribute by him to Eglon the king of Moab. 
+\v 15 But when the children of Israel cried to Yahuah, Yahuah raised up a savior for them: Ehud the son of Gera, the Benjamite, a left-handed man. The children of Israel sent tribute by him to Eglon the king of Moab. 
 \v 16 Ehud made himself a sword which had two edges, a cubit in length; and he wore it under his clothing on his right thigh. 
 \v 17 He offered the tribute to Eglon king of Moab. Now Eglon was a very fat man. 
 \v 18 When Ehud had finished offering the tribute, he sent away the people who carried the tribute. 
@@ -108,32 +108,32 @@
 \v 26 Ehud escaped while they waited, passed beyond the stone idols, and escaped to Seirah. 
 \v 27 When he had come, he blew a trumpet in the hill country of Ephraim; and the children of Israel went down with him from the hill country, and he led them. 
 \p
-\v 28 He said to them, “Follow me; for Yahweh has delivered your enemies the Moabites into your hand.” They followed him, and took the fords of the Jordan against the Moabites, and didn’t allow any man to pass over. 
+\v 28 He said to them, “Follow me; for Yahuah has delivered your enemies the Moabites into your hand.” They followed him, and took the fords of the Jordan against the Moabites, and didn’t allow any man to pass over. 
 \v 29 They struck at that time about ten thousand men of Moab, every strong man and every man of valor. No man escaped. 
 \v 30 So Moab was subdued that day under the hand of Israel. Then the land had rest eighty years. 
 \p
 \v 31 After him was Shamgar the son of Anath, who struck six hundred men of the Philistines with an ox goad. He also saved Israel. 
 \c 4
 \p
-\v 1 The children of Israel again did that which was evil in Yahweh’s sight, when Ehud was dead. 
-\v 2 Yahweh sold them into the hand of Jabin king of Canaan, who reigned in Hazor; the captain of whose army was Sisera, who lived in Harosheth of the Gentiles. 
-\v 3 The children of Israel cried to Yahweh, for he had nine hundred chariots of iron; and he mightily oppressed the children of Israel for twenty years. 
+\v 1 The children of Israel again did that which was evil in Yahuah’s sight, when Ehud was dead. 
+\v 2 Yahuah sold them into the hand of Jabin king of Canaan, who reigned in Hazor; the captain of whose army was Sisera, who lived in Harosheth of the Gentiles. 
+\v 3 The children of Israel cried to Yahuah, for he had nine hundred chariots of iron; and he mightily oppressed the children of Israel for twenty years. 
 \v 4 Now Deborah, a prophetess, the woman of Lappidoth, judged Israel at that time. 
 \v 5 She lived under Deborah’s palm tree between Ramah and Bethel in the hill country of Ephraim; and the children of Israel came up to her for judgment. 
-\v 6 She sent and called Barak the son of Abinoam out of Kedesh Naphtali, and said to him, “Hasn’t Yahweh, the Elohim of Israel, commanded, ‘Go and lead the way to Mount Tabor, and take with you ten thousand men of the children of Naphtali and of the children of Zebulun? 
+\v 6 She sent and called Barak the son of Abinoam out of Kedesh Naphtali, and said to him, “Hasn’t Yahuah, the Elohim of Israel, commanded, ‘Go and lead the way to Mount Tabor, and take with you ten thousand men of the children of Naphtali and of the children of Zebulun? 
 \v 7 I will draw to you, to the river Kishon, Sisera, the captain of Jabin’s army, with his chariots and his multitude; and I will deliver him into your hand.’ ” 
 \p
 \v 8 Barak said to her, “If you will go with me, then I will go; but if you will not go with me, I will not go.” 
 \p
-\v 9 She said, “I will surely go with you. Nevertheless, the journey that you take won’t be for your honor; for Yahweh will sell Sisera into a woman’s hand.” Deborah arose, and went with Barak to Kedesh. 
+\v 9 She said, “I will surely go with you. Nevertheless, the journey that you take won’t be for your honor; for Yahuah will sell Sisera into a woman’s hand.” Deborah arose, and went with Barak to Kedesh. 
 \p
 \v 10 Barak called Zebulun and Naphtali together to Kedesh. Ten thousand men followed him; and Deborah went up with him. 
 \v 11 Now Heber the Kenite had separated himself from the Kenites, even from the children of Hobab, Moses’ brother-in-law, and had pitched his tent as far as the oak in Zaanannim, which is by Kedesh. 
 \v 12 They told Sisera that Barak the son of Abinoam had gone up to Mount Tabor. 
 \v 13 Sisera gathered together all his chariots, even nine hundred chariots of iron, and all the people who were with him, from Harosheth of the Gentiles, to the river Kishon. 
 \p
-\v 14 Deborah said to Barak, “Go; for this is the day in which Yahweh has delivered Sisera into your hand. Hasn’t Yahweh gone out before you?” So Barak went down from Mount Tabor, and ten thousand men after him. 
-\v 15 Yahweh confused Sisera, all his chariots, and all his army, with the edge of the sword before Barak. Sisera abandoned his chariot and fled away on his feet. 
+\v 14 Deborah said to Barak, “Go; for this is the day in which Yahuah has delivered Sisera into your hand. Hasn’t Yahuah gone out before you?” So Barak went down from Mount Tabor, and ten thousand men after him. 
+\v 15 Yahuah confused Sisera, all his chariots, and all his army, with the edge of the sword before Barak. Sisera abandoned his chariot and fled away on his feet. 
 \v 16 But Barak pursued the chariots and the army to Harosheth of the Gentiles; and all the army of Sisera fell by the edge of the sword. There was not a man left. 
 \p
 \v 17 However Sisera fled away on his feet to the tent of Jael the woman of Heber the Kenite; for there was peace between Jabin the king of Hazor and the house of Heber the Kenite. 
@@ -154,22 +154,22 @@
 \q1
 \v 2 “Because the leaders took the lead in Israel, 
 \q2 because the people offered themselves willingly, 
-\q1 be blessed, Yahweh! 
+\q1 be blessed, Yahuah! 
 \b
 \q1
 \v 3 “Hear, you kings! 
 \q2 Give ear, you princes! 
-\q1 I, even I, will sing to Yahweh. 
-\q2 I will sing praise to Yahweh, the Elohim of Israel. 
+\q1 I, even I, will sing to Yahuah. 
+\q2 I will sing praise to Yahuah, the Elohim of Israel. 
 \b
 \q1
-\v 4 “Yahweh, when you went out of Seir, 
+\v 4 “Yahuah, when you went out of Seir, 
 \q2 when you marched out of the field of Edom, 
 \q1 the earth trembled, the sky also dropped. 
 \q2 Yes, the clouds dropped water. 
 \q1
-\v 5 The mountains quaked at Yahweh’s presence, 
-\q2 even Sinai at the presence of Yahweh, the Elohim of Israel. 
+\v 5 The mountains quaked at Yahuah’s presence, 
+\q2 even Sinai at the presence of Yahuah, the Elohim of Israel. 
 \b
 \q1
 \v 6 “In the days of Shamgar the son of Anath, 
@@ -186,7 +186,7 @@
 \q1
 \v 9 My heart is toward the governors of Israel, 
 \q2 who offered themselves willingly among the people. 
-\q2 Bless Yahweh! 
+\q2 Bless Yahuah! 
 \b
 \q1
 \v 10 “Speak, you who ride on white donkeys, 
@@ -194,10 +194,10 @@
 \q2 and you who walk by the way. 
 \q1
 \v 11 Far from the noise of archers, in the places of drawing water, 
-\q2 there they will rehearse Yahweh’s righteous acts, 
+\q2 there they will rehearse Yahuah’s righteous acts, 
 \q2 the righteous acts of his rule in Israel. 
 \b
-\q1 “Then Yahweh’s people went down to the gates. 
+\q1 “Then Yahuah’s people went down to the gates. 
 \q2
 \v 12 ‘Awake, awake, Deborah! 
 \q2 Awake, awake, utter a song! 
@@ -205,7 +205,7 @@
 \b
 \q1
 \v 13 “Then a remnant of the nobles and the people came down. 
-\q2 Yahweh came down for me against the mighty. 
+\q2 Yahuah came down for me against the mighty. 
 \q1
 \v 14 Those whose root is in Amalek came out of Ephraim, 
 \q2 after you, Benjamin, among your peoples. 
@@ -246,10 +246,10 @@
 \v 22 Then the horse hoofs stamped because of the prancing, 
 \q2 the prancing of their strong ones. 
 \q1
-\v 23 ‘Curse Meroz,’ said Yahweh’s angel. 
+\v 23 ‘Curse Meroz,’ said Yahuah’s angel. 
 \q2 ‘Curse bitterly its inhabitants, 
-\q2 because they didn’t come to help Yahweh, 
-\q2 to help Yahweh against the mighty.’ 
+\q2 because they didn’t come to help Yahuah, 
+\q2 to help Yahuah against the mighty.’ 
 \b
 \q1
 \v 24 “Jael shall be blessed above women, 
@@ -286,34 +286,34 @@
 \q2 of dyed garments embroidered on both sides, on the necks of the plunder?’ 
 \b
 \q1
-\v 31 “So let all your enemies perish, Yahweh, 
+\v 31 “So let all your enemies perish, Yahuah, 
 \q2 but let those who love him be as the sun when it rises in its strength.” 
 \b
 \p Then the land had rest forty years. 
 \c 6
 \p
-\v 1 The children of Israel did that which was evil in Yahweh’s sight, so Yahweh delivered them into the hand of Midian seven years. 
+\v 1 The children of Israel did that which was evil in Yahuah’s sight, so Yahuah delivered them into the hand of Midian seven years. 
 \v 2 The hand of Midian prevailed against Israel; and because of Midian the children of Israel made themselves the dens which are in the mountains, the caves, and the strongholds. 
 \v 3 So it was, when Israel had sown, that the Midianites, the Amalekites, and the children of the east came up against them. 
 \v 4 They encamped against them, and destroyed the increase of the earth, until you come to Gaza. They left no sustenance in Israel, and no sheep, ox, or donkey. 
 \v 5 For they came up with their livestock and their tents. They came in as locusts for multitude. Both they and their camels were without number; and they came into the land to destroy it. 
-\v 6 Israel was brought very low because of Midian; and the children of Israel cried to Yahweh. 
+\v 6 Israel was brought very low because of Midian; and the children of Israel cried to Yahuah. 
 \p
-\v 7 When the children of Israel cried to Yahweh because of Midian, 
-\v 8 Yahweh sent a prophet to the children of Israel; and he said to them, “Yahweh, the Elohim of Israel, says, ‘I brought you up from Egypt, and brought you out of the house of bondage. 
+\v 7 When the children of Israel cried to Yahuah because of Midian, 
+\v 8 Yahuah sent a prophet to the children of Israel; and he said to them, “Yahuah, the Elohim of Israel, says, ‘I brought you up from Egypt, and brought you out of the house of bondage. 
 \v 9 I delivered you out of the hand of the Egyptians and out of the hand of all who oppressed you, and drove them out from before you, and gave you their land. 
-\v 10 I said to you, “I am Yahweh your Elohim. You shall not fear the elohims of the Amorites, in whose land you dwell.” But you have not listened to my voice.’ ” 
+\v 10 I said to you, “I am Yahuah your Elohim. You shall not fear the elohims of the Amorites, in whose land you dwell.” But you have not listened to my voice.’ ” 
 \p
-\v 11 Yahweh’s angel came and sat under the oak which was in Ophrah, that belonged to Joash the Abiezrite. His son Gideon was beating out wheat in the wine press, to hide it from the Midianites. 
-\v 12 Yahweh’s angel appeared to him, and said to him, “Yahweh is with you, you mighty man of valor!” 
+\v 11 Yahuah’s angel came and sat under the oak which was in Ophrah, that belonged to Joash the Abiezrite. His son Gideon was beating out wheat in the wine press, to hide it from the Midianites. 
+\v 12 Yahuah’s angel appeared to him, and said to him, “Yahuah is with you, you mighty man of valor!” 
 \p
-\v 13 Gideon said to him, “Oh, my lord, if Yahweh is with us, why then has all this happened to us? Where are all his wondrous works which our fathers told us of, saying, ‘Didn’t Yahweh bring us up from Egypt?’ But now Yahweh has cast us off, and delivered us into the hand of Midian.” 
+\v 13 Gideon said to him, “Oh, my lord, if Yahuah is with us, why then has all this happened to us? Where are all his wondrous works which our fathers told us of, saying, ‘Didn’t Yahuah bring us up from Egypt?’ But now Yahuah has cast us off, and delivered us into the hand of Midian.” 
 \p
-\v 14 Yahweh looked at him, and said, “Go in this your might, and save Israel from the hand of Midian. Haven’t I sent you?” 
+\v 14 Yahuah looked at him, and said, “Go in this your might, and save Israel from the hand of Midian. Haven’t I sent you?” 
 \p
 \v 15 He said to him, “O Lord, how shall I save Israel? Behold, my family is the poorest in Manasseh, and I am the least in my father’s house.” 
 \p
-\v 16 Yahweh said to him, “Surely I will be with you, and you shall strike the Midianites as one man.” 
+\v 16 Yahuah said to him, “Surely I will be with you, and you shall strike the Midianites as one man.” 
 \p
 \v 17 He said to him, “If now I have found favor in your sight, then show me a sign that it is you who talk with me. 
 \v 18 Please don’t go away until I come to you, and bring out my present, and lay it before you.” 
@@ -323,18 +323,18 @@
 \p
 \v 20 The angel of Elohim said to him, “Take the meat and the unleavened cakes, and lay them on this rock, and pour out the broth.” 
 \p He did so. 
-\v 21 Then Yahweh’s angel stretched out the end of the staff that was in his hand, and touched the meat and the unleavened cakes; and fire went up out of the rock and consumed the meat and the unleavened cakes. Then Yahweh’s angel departed out of his sight. 
+\v 21 Then Yahuah’s angel stretched out the end of the staff that was in his hand, and touched the meat and the unleavened cakes; and fire went up out of the rock and consumed the meat and the unleavened cakes. Then Yahuah’s angel departed out of his sight. 
 \p
-\v 22 Gideon saw that he was Yahweh’s angel; and Gideon said, “Alas, Lord Yahweh! Because I have seen Yahweh’s angel face to face!” 
+\v 22 Gideon saw that he was Yahuah’s angel; and Gideon said, “Alas, Lord Yahuah! Because I have seen Yahuah’s angel face to face!” 
 \p
-\v 23 Yahweh said to him, “Peace be to you! Don’t be afraid. You shall not die.” 
+\v 23 Yahuah said to him, “Peace be to you! Don’t be afraid. You shall not die.” 
 \p
-\v 24 Then Gideon built an altar there to Yahweh, and called it “Yahweh is Peace.” To this day it is still in Ophrah of the Abiezrites. 
+\v 24 Then Gideon built an altar there to Yahuah, and called it “Yahuah is Peace.” To this day it is still in Ophrah of the Abiezrites. 
 \p
-\v 25 That same night, Yahweh said to him, “Take your father’s bull, even the second bull seven years old, and throw down the altar of Baal that your father has, and cut down the Asherah that is by it. 
-\v 26 Then build an altar to Yahweh your Elohim on the top of this stronghold, in an orderly way, and take the second bull, and offer a burnt offering with the wood of the Asherah which you shall cut down.” 
+\v 25 That same night, Yahuah said to him, “Take your father’s bull, even the second bull seven years old, and throw down the altar of Baal that your father has, and cut down the Asherah that is by it. 
+\v 26 Then build an altar to Yahuah your Elohim on the top of this stronghold, in an orderly way, and take the second bull, and offer a burnt offering with the wood of the Asherah which you shall cut down.” 
 \p
-\v 27 Then Gideon took ten men of his servants, and did as Yahweh had spoken to him. Because he feared his father’s household and the men of the city, he could not do it by day, but he did it by night. 
+\v 27 Then Gideon took ten men of his servants, and did as Yahuah had spoken to him. Because he feared his father’s household and the men of the city, he could not do it by day, but he did it by night. 
 \p
 \v 28 When the men of the city arose early in the morning, behold, the altar of Baal was broken down, and the Asherah was cut down that was by it, and the second bull was offered on the altar that was built. 
 \v 29 They said to one another, “Who has done this thing?” 
@@ -345,7 +345,7 @@
 \v 32 Therefore on that day he named him Jerub-Baal, saying, “Let Baal contend against him, because he has broken down his altar.” 
 \p
 \v 33 Then all the Midianites and the Amalekites and the children of the east assembled themselves together; and they passed over, and encamped in the valley of Jezreel. 
-\v 34 But Yahweh’s Spirit came on Gideon, and he blew a trumpet; and Abiezer was gathered together to follow him. 
+\v 34 But Yahuah’s Spirit came on Gideon, and he blew a trumpet; and Abiezer was gathered together to follow him. 
 \v 35 He sent messengers throughout all Manasseh, and they also were gathered together to follow him. He sent messengers to Asher, to Zebulun, and to Naphtali; and they came up to meet them. 
 \p
 \v 36 Gideon said to Elohim, “If you will save Israel by my hand, as you have spoken, 
@@ -359,16 +359,16 @@
 \c 7
 \p
 \v 1 Then Jerubbaal, who is Gideon, and all the people who were with him, rose up early and encamped beside the spring of Harod. Midian’s camp was on the north side of them, by the hill of Moreh, in the valley. 
-\v 2 Yahweh said to Gideon, “The people who are with you are too many for me to give the Midianites into their hand, lest Israel brag against me, saying, ‘My own hand has saved me.’ 
+\v 2 Yahuah said to Gideon, “The people who are with you are too many for me to give the Midianites into their hand, lest Israel brag against me, saying, ‘My own hand has saved me.’ 
 \v 3 Now therefore proclaim in the ears of the people, saying, ‘Whoever is fearful and trembling, let him return and depart from Mount Gilead.’ ” So twenty-two thousand of the people returned, and ten thousand remained. 
 \p
-\v 4 Yahweh said to Gideon, “There are still too many people. Bring them down to the water, and I will test them for you there. It shall be, that those whom I tell you, ‘This shall go with you,’ shall go with you; and whoever I tell you, ‘This shall not go with you,’ shall not go.” 
-\v 5 So he brought down the people to the water; and Yahweh said to Gideon, “Everyone who laps of the water with his tongue, like a dog laps, you shall set him by himself; likewise everyone who bows down on his knees to drink.” 
+\v 4 Yahuah said to Gideon, “There are still too many people. Bring them down to the water, and I will test them for you there. It shall be, that those whom I tell you, ‘This shall go with you,’ shall go with you; and whoever I tell you, ‘This shall not go with you,’ shall not go.” 
+\v 5 So he brought down the people to the water; and Yahuah said to Gideon, “Everyone who laps of the water with his tongue, like a dog laps, you shall set him by himself; likewise everyone who bows down on his knees to drink.” 
 \v 6 The number of those who lapped, putting their hand to their mouth, was three hundred men; but all the rest of the people bowed down on their knees to drink water. 
-\v 7 Yahweh said to Gideon, “I will save you by the three hundred men who lapped, and deliver the Midianites into your hand. Let all the other people go, each to his own place.” 
+\v 7 Yahuah said to Gideon, “I will save you by the three hundred men who lapped, and deliver the Midianites into your hand. Let all the other people go, each to his own place.” 
 \p
 \v 8 So the people took food in their hand, and their trumpets; and he sent all the rest of the men of Israel to their own tents, but retained the three hundred men; and the camp of Midian was beneath him in the valley. 
-\v 9 That same night, Yahweh said to him, “Arise, go down into the camp, for I have delivered it into your hand. 
+\v 9 That same night, Yahuah said to him, “Arise, go down into the camp, for I have delivered it into your hand. 
 \v 10 But if you are afraid to go down, go with Purah your servant down to the camp. 
 \v 11 You will hear what they say; and afterward your hands will be strengthened to go down into the camp.” Then went he down with Purah his servant to the outermost part of the armed men who were in the camp. 
 \p
@@ -378,17 +378,17 @@
 \p
 \v 14 His fellow answered, “This is nothing other than the sword of Gideon the son of Joash, a man of Israel. Elohim has delivered Midian into his hand, with all the army.” 
 \p
-\v 15 It was so, when Gideon heard the telling of the dream and its interpretation, that he worshiped. Then he returned into the camp of Israel and said, “Arise, for Yahweh has delivered the army of Midian into your hand!” 
+\v 15 It was so, when Gideon heard the telling of the dream and its interpretation, that he worshiped. Then he returned into the camp of Israel and said, “Arise, for Yahuah has delivered the army of Midian into your hand!” 
 \p
 \v 16 He divided the three hundred men into three companies, and he put into the hands of all of them trumpets and empty pitchers, with torches within the pitchers. 
 \p
 \v 17 He said to them, “Watch me, and do likewise. Behold, when I come to the outermost part of the camp, it shall be that, as I do, so you shall do. 
-\v 18 When I blow the trumpet, I and all who are with me, then blow the trumpets also on every side of all the camp, and shout, ‘For Yahweh and for Gideon!’ ” 
+\v 18 When I blow the trumpet, I and all who are with me, then blow the trumpets also on every side of all the camp, and shout, ‘For Yahuah and for Gideon!’ ” 
 \p
 \v 19 So Gideon and the hundred men who were with him came to the outermost part of the camp in the beginning of the middle watch, when they had but newly set the watch. Then they blew the trumpets and broke in pieces the pitchers that were in their hands. 
-\v 20 The three companies blew the trumpets, broke the pitchers, and held the torches in their left hands and the trumpets in their right hands with which to blow; and they shouted, “The sword of Yahweh and of Gideon!” 
+\v 20 The three companies blew the trumpets, broke the pitchers, and held the torches in their left hands and the trumpets in their right hands with which to blow; and they shouted, “The sword of Yahuah and of Gideon!” 
 \v 21 They each stood in his place around the camp, and all the army ran; and they shouted, and put them to flight. 
-\v 22 They blew the three hundred trumpets, and Yahweh set every man’s sword against his fellow and against all the army; and the army fled as far as Beth Shittah toward Zererah, as far as the border of Abel Meholah, by Tabbath. 
+\v 22 They blew the three hundred trumpets, and Yahuah set every man’s sword against his fellow and against all the army; and the army fled as far as Beth Shittah toward Zererah, as far as the border of Abel Meholah, by Tabbath. 
 \v 23 The men of Israel were gathered together out of Naphtali, out of Asher, and out of all Manasseh, and pursued Midian. 
 \v 24 Gideon sent messengers throughout all the hill country of Ephraim, saying, “Come down against Midian and take the waters before them as far as Beth Barah, even the Jordan!” So all the men of Ephraim were gathered together and took the waters as far as Beth Barah, even the Jordan. 
 \v 25 They took the two princes of Midian, Oreb and Zeeb. They killed Oreb at Oreb’s rock, and Zeeb they killed at Zeeb’s wine press, as they pursued Midian. Then they brought the heads of Oreb and Zeeb to Gideon beyond the Jordan. 
@@ -403,7 +403,7 @@
 \p
 \v 6 The princes of Succoth said, “Are the hands of Zebah and Zalmunna now in your hand, that we should give bread to your army?” 
 \p
-\v 7 Gideon said, “Therefore when Yahweh has delivered Zebah and Zalmunna into my hand, then I will tear your flesh with the thorns of the wilderness and with briers.” 
+\v 7 Gideon said, “Therefore when Yahuah has delivered Zebah and Zalmunna into my hand, then I will tear your flesh with the thorns of the wilderness and with briers.” 
 \p
 \v 8 He went up there to Penuel, and spoke to them in the same way; and the men of Penuel answered him as the men of Succoth had answered. 
 \v 9 He spoke also to the men of Penuel, saying, “When I come again in peace, I will break down this tower.” 
@@ -420,7 +420,7 @@
 \v 18 Then he said to Zebah and Zalmunna, “What kind of men were they whom you killed at Tabor?” 
 \p They answered, “They were like you. They all resembled the children of a king.” 
 \p
-\v 19 He said, “They were my brothers, the sons of my mother. As Yahweh lives, if you had saved them alive, I would not kill you.” 
+\v 19 He said, “They were my brothers, the sons of my mother. As Yahuah lives, if you had saved them alive, I would not kill you.” 
 \p
 \v 20 He said to Jether his firstborn, “Get up and kill them!” But the youth didn’t draw his sword; for he was afraid, because he was yet a youth. 
 \p
@@ -428,7 +428,7 @@
 \p
 \v 22 Then the men of Israel said to Gideon, “Rule over us, both you, your son, and your son’s son also; for you have saved us out of the hand of Midian.” 
 \p
-\v 23 Gideon said to them, “I will not rule over you, neither shall my son rule over you. Yahweh shall rule over you.” 
+\v 23 Gideon said to them, “I will not rule over you, neither shall my son rule over you. Yahuah shall rule over you.” 
 \v 24 Gideon said to them, “I do have a request: that you would each give me the earrings of his plunder.” (For they had golden earrings, because they were Ishmaelites.) 
 \p
 \v 25 They answered, “We will willingly give them.” They spread a garment, and every man threw the earrings of his plunder into it. 
@@ -442,7 +442,7 @@
 \v 32 Gideon the son of Joash died in a good old age, and was buried in the tomb of Joash his father, in Ophrah of the Abiezrites. 
 \p
 \v 33 As soon as Gideon was dead, the children of Israel turned again and played the prostitute following the Baals, and made Baal Berith their elohim. 
-\v 34 The children of Israel didn’t remember Yahweh their Elohim, who had delivered them out of the hand of all their enemies on every side; 
+\v 34 The children of Israel didn’t remember Yahuah their Elohim, who had delivered them out of the hand of all their enemies on every side; 
 \v 35 neither did they show kindness to the house of Jerubbaal, that is, Gideon, according to all the goodness which he had shown to Israel. 
 \c 9
 \p
@@ -534,19 +534,19 @@
 \v 4 He had thirty sons who rode on thirty donkey colts. They had thirty cities, which are called Havvoth Jair to this day, which are in the land of Gilead. 
 \v 5 Jair died, and was buried in Kamon. 
 \p
-\v 6 The children of Israel again did that which was evil in Yahweh’s sight, and served the Baals, the Ashtaroth, the elohims of Syria, the elohims of Sidon, the elohims of Moab, the elohims of the children of Ammon, and the elohims of the Philistines. They abandoned Yahweh, and didn’t serve him. 
-\v 7 Yahweh’s anger burned against Israel, and he sold them into the hand of the Philistines and into the hand of the children of Ammon. 
+\v 6 The children of Israel again did that which was evil in Yahuah’s sight, and served the Baals, the Ashtaroth, the elohims of Syria, the elohims of Sidon, the elohims of Moab, the elohims of the children of Ammon, and the elohims of the Philistines. They abandoned Yahuah, and didn’t serve him. 
+\v 7 Yahuah’s anger burned against Israel, and he sold them into the hand of the Philistines and into the hand of the children of Ammon. 
 \v 8 They troubled and oppressed the children of Israel that year. For eighteen years they oppressed all the children of Israel that were beyond the Jordan in the land of the Amorites, which is in Gilead. 
 \v 9 The children of Ammon passed over the Jordan to fight also against Judah, and against Benjamin, and against the house of Ephraim, so that Israel was very distressed. 
-\v 10 The children of Israel cried to Yahweh, saying, “We have sinned against you, even because we have forsaken our Elohim, and have served the Baals.” 
+\v 10 The children of Israel cried to Yahuah, saying, “We have sinned against you, even because we have forsaken our Elohim, and have served the Baals.” 
 \p
-\v 11 Yahweh said to the children of Israel, “Didn’t I save you from the Egyptians, and from the Amorites, from the children of Ammon, and from the Philistines? 
+\v 11 Yahuah said to the children of Israel, “Didn’t I save you from the Egyptians, and from the Amorites, from the children of Ammon, and from the Philistines? 
 \v 12 The Sidonians also, and the Amalekites, and the Maonites, oppressed you; and you cried to me, and I saved you out of their hand. 
 \v 13 Yet you have forsaken me and served other elohims. Therefore I will save you no more. 
 \v 14 Go and cry to the elohims which you have chosen. Let them save you in the time of your distress!” 
 \p
-\v 15 The children of Israel said to Yahweh, “We have sinned! Do to us whatever seems good to you; only deliver us, please, today.” 
-\v 16 They put away the foreign elohims from among them and served Yahweh; and his soul was grieved for the misery of Israel. 
+\v 15 The children of Israel said to Yahuah, “We have sinned! Do to us whatever seems good to you; only deliver us, please, today.” 
+\v 16 They put away the foreign elohims from among them and served Yahuah; and his soul was grieved for the misery of Israel. 
 \p
 \v 17 Then the children of Ammon were gathered together and encamped in Gilead. The children of Israel assembled themselves together and encamped in Mizpah. 
 \v 18 The people, the princes of Gilead, said to one another, “Who is the man who will begin to fight against the children of Ammon? He shall be head over all the inhabitants of Gilead.” 
@@ -564,11 +564,11 @@
 \p
 \v 8 The elders of Gilead said to Jephthah, “Therefore we have turned again to you now, that you may go with us and fight with the children of Ammon. You will be our head over all the inhabitants of Gilead.” 
 \p
-\v 9 Jephthah said to the elders of Gilead, “If you bring me home again to fight with the children of Ammon, and Yahweh delivers them before me, will I be your head?” 
+\v 9 Jephthah said to the elders of Gilead, “If you bring me home again to fight with the children of Ammon, and Yahuah delivers them before me, will I be your head?” 
 \p
-\v 10 The elders of Gilead said to Jephthah, “Yahweh will be witness between us. Surely we will do what you say.” 
+\v 10 The elders of Gilead said to Jephthah, “Yahuah will be witness between us. Surely we will do what you say.” 
 \p
-\v 11 Then Jephthah went with the elders of Gilead, and the people made him head and chief over them. Jephthah spoke all his words before Yahweh in Mizpah. 
+\v 11 Then Jephthah went with the elders of Gilead, and the people made him head and chief over them. Jephthah spoke all his words before Yahuah in Mizpah. 
 \p
 \v 12 Jephthah sent messengers to the king of the children of Ammon, saying, “What do you have to do with me, that you have come to me to fight against my land?” 
 \p
@@ -581,27 +581,27 @@
 \v 18 Then they went through the wilderness, and went around the land of Edom, and the land of Moab, and came by the east side of the land of Moab, and they encamped on the other side of the Arnon; but they didn’t come within the border of Moab, for the Arnon was the border of Moab. 
 \v 19 Israel sent messengers to Sihon king of the Amorites, the king of Heshbon; and Israel said to him, ‘Please let us pass through your land to my place.’ 
 \v 20 But Sihon didn’t trust Israel to pass through his border; but Sihon gathered all his people together, and encamped in Jahaz, and fought against Israel. 
-\v 21 Yahweh, the Elohim of Israel, delivered Sihon and all his people into the hand of Israel, and they struck them. So Israel possessed all the land of the Amorites, the inhabitants of that country. 
+\v 21 Yahuah, the Elohim of Israel, delivered Sihon and all his people into the hand of Israel, and they struck them. So Israel possessed all the land of the Amorites, the inhabitants of that country. 
 \v 22 They possessed all the border of the Amorites, from the Arnon even to the Jabbok, and from the wilderness even to the Jordan. 
-\v 23 So now Yahweh, the Elohim of Israel, has dispossessed the Amorites from before his people Israel, and should you possess them? 
-\v 24 Won’t you possess that which Chemosh your elohim gives you to possess? So whoever Yahweh our Elohim has dispossessed from before us, them will we possess. 
+\v 23 So now Yahuah, the Elohim of Israel, has dispossessed the Amorites from before his people Israel, and should you possess them? 
+\v 24 Won’t you possess that which Chemosh your elohim gives you to possess? So whoever Yahuah our Elohim has dispossessed from before us, them will we possess. 
 \v 25 Now are you anything better than Balak the son of Zippor, king of Moab? Did he ever strive against Israel, or did he ever fight against them? 
 \v 26 Israel lived in Heshbon and its towns, and in Aroer and its towns, and in all the cities that are along the side of the Arnon for three hundred years! Why didn’t you recover them within that time? 
-\v 27 Therefore I have not sinned against you, but you do me wrong to war against me. May Yahweh the Judge be judge today between the children of Israel and the children of Ammon.” 
+\v 27 Therefore I have not sinned against you, but you do me wrong to war against me. May Yahuah the Judge be judge today between the children of Israel and the children of Ammon.” 
 \p
 \v 28 However, the king of the children of Ammon didn’t listen to the words of Jephthah which he sent him. 
-\v 29 Then Yahweh’s Spirit came on Jephthah, and he passed over Gilead and Manasseh, and passed over Mizpah of Gilead, and from Mizpah of Gilead he passed over to the children of Ammon. 
+\v 29 Then Yahuah’s Spirit came on Jephthah, and he passed over Gilead and Manasseh, and passed over Mizpah of Gilead, and from Mizpah of Gilead he passed over to the children of Ammon. 
 \p
-\v 30 Jephthah vowed a vow to Yahweh, and said, “If you will indeed deliver the children of Ammon into my hand, 
-\v 31 then it shall be, that whatever comes out of the doors of my house to meet me when I return in peace from the children of Ammon, it shall be Yahweh’s, and I will offer it up for a burnt offering.” 
+\v 30 Jephthah vowed a vow to Yahuah, and said, “If you will indeed deliver the children of Ammon into my hand, 
+\v 31 then it shall be, that whatever comes out of the doors of my house to meet me when I return in peace from the children of Ammon, it shall be Yahuah’s, and I will offer it up for a burnt offering.” 
 \p
-\v 32 So Jephthah passed over to the children of Ammon to fight against them; and Yahweh delivered them into his hand. 
+\v 32 So Jephthah passed over to the children of Ammon to fight against them; and Yahuah delivered them into his hand. 
 \v 33 He struck them from Aroer until you come to Minnith, even twenty cities, and to Abelcheramim, with a very great slaughter. So the children of Ammon were subdued before the children of Israel. 
 \p
 \v 34 Jephthah came to Mizpah to his house; and behold, his daughter came out to meet him with tambourines and with dances. She was his only child. Besides her he had neither son nor daughter. 
-\v 35 When he saw her, he tore his clothes, and said, “Alas, my daughter! You have brought me very low, and you are one of those who trouble me; for I have opened my mouth to Yahweh, and I can’t go back.” 
+\v 35 When he saw her, he tore his clothes, and said, “Alas, my daughter! You have brought me very low, and you are one of those who trouble me; for I have opened my mouth to Yahuah, and I can’t go back.” 
 \p
-\v 36 She said to him, “My father, you have opened your mouth to Yahweh; do to me according to that which has proceeded out of your mouth, because Yahweh has taken vengeance for you on your enemies, even on the children of Ammon.” 
+\v 36 She said to him, “My father, you have opened your mouth to Yahuah; do to me according to that which has proceeded out of your mouth, because Yahuah has taken vengeance for you on your enemies, even on the children of Ammon.” 
 \v 37 Then she said to her father, “Let this thing be done for me. Leave me alone two months, that I may depart and go down on the mountains, and bewail my virginity, I and my companions.” 
 \p
 \v 38 He said, “Go.” He sent her away for two months; and she departed, she and her companions, and mourned her virginity on the mountains. 
@@ -612,7 +612,7 @@
 \v 1 The men of Ephraim were gathered together, and passed northward; and they said to Jephthah, “Why did you pass over to fight against the children of Ammon, and didn’t call us to go with you? We will burn your house around you with fire!” 
 \p
 \v 2 Jephthah said to them, “I and my people were at great strife with the children of Ammon; and when I called you, you didn’t save me out of their hand. 
-\v 3 When I saw that you didn’t save me, I put my life in my hand, and passed over against the children of Ammon, and Yahweh delivered them into my hand. Why then have you come up to me today, to fight against me?” 
+\v 3 When I saw that you didn’t save me, I put my life in my hand, and passed over against the children of Ammon, and Yahuah delivered them into my hand. Why then have you come up to me today, to fight against me?” 
 \p
 \v 4 Then Jephthah gathered together all the men of Gilead, and fought with Ephraim. The men of Gilead struck Ephraim, because they said, “You are fugitives of Ephraim, you Gileadites, in the middle of Ephraim, and in the middle of Manasseh.” 
 \v 5 The Gileadites took the fords of the Jordan against the Ephraimites. Whenever a fugitive of Ephraim said, “Let me go over,” the men of Gilead said to him, “Are you an Ephraimite?” If he said, “No;” 
@@ -632,17 +632,17 @@
 \v 15 Abdon the son of Hillel the Pirathonite died, and was buried in Pirathon in the land of Ephraim, in the hill country of the Amalekites. 
 \c 13
 \p
-\v 1 The children of Israel again did that which was evil in Yahweh’s sight; and Yahweh delivered them into the hand of the Philistines forty years. 
+\v 1 The children of Israel again did that which was evil in Yahuah’s sight; and Yahuah delivered them into the hand of the Philistines forty years. 
 \p
 \v 2 There was a certain man of Zorah, of the family of the Danites, whose name was Manoah; and his woman was barren, and childless. 
-\v 3 Yahweh’s angel appeared to the woman, and said to her, “See now, you are barren and childless; but you shall conceive and bear a son. 
+\v 3 Yahuah’s angel appeared to the woman, and said to her, “See now, you are barren and childless; but you shall conceive and bear a son. 
 \v 4 Now therefore please beware and drink no wine nor strong drink, and don’t eat any unclean thing; 
 \v 5 for, behold, you shall conceive and give birth to a son. No razor shall come on his head, for the child shall be a Nazirite to Elohim from the womb. He shall begin to save Israel out of the hand of the Philistines.” 
 \p
 \v 6 Then the woman came and told her man, saying, “A man of Elohim came to me, and his face was like the face of the angel of Elohim, very awesome. I didn’t ask him where he was from, neither did he tell me his name; 
 \v 7 but he said to me, ‘Behold, you shall conceive and bear a son; and now drink no wine nor strong drink. Don’t eat any unclean thing, for the child shall be a Nazirite to Elohim from the womb to the day of his death.’ ” 
 \p
-\v 8 Then Manoah entreated Yahweh, and said, “Oh, Lord, please let the man of Elohim whom you sent come again to us, and teach us what we should do to the child who shall be born.” 
+\v 8 Then Manoah entreated Yahuah, and said, “Oh, Lord, please let the man of Elohim whom you sent come again to us, and teach us what we should do to the child who shall be born.” 
 \p
 \v 9 Elohim listened to the voice of Manoah, and the angel of Elohim came again to the woman as she sat in the field; but Manoah, her man, wasn’t with her. 
 \v 10 The woman hurried and ran, and told her man, saying to him, “Behold, the man who came to me that day has appeared to me.” 
@@ -652,25 +652,25 @@
 \p
 \v 12 Manoah said, “Now let your words happen. What shall the child’s way of life and mission be?” 
 \p
-\v 13 Yahweh’s angel said to Manoah, “Of all that I said to the woman let her beware. 
+\v 13 Yahuah’s angel said to Manoah, “Of all that I said to the woman let her beware. 
 \v 14 She may not eat of anything that comes of the vine, neither let her drink wine or strong drink, nor eat any unclean thing. Let her observe all that I commanded her.” 
 \p
-\v 15 Manoah said to Yahweh’s angel, “Please stay with us, that we may make a young goat ready for you.” 
+\v 15 Manoah said to Yahuah’s angel, “Please stay with us, that we may make a young goat ready for you.” 
 \p
-\v 16 Yahweh’s angel said to Manoah, “Though you detain me, I won’t eat your bread. If you will prepare a burnt offering, you must offer it to Yahweh.” For Manoah didn’t know that he was Yahweh’s angel. 
+\v 16 Yahuah’s angel said to Manoah, “Though you detain me, I won’t eat your bread. If you will prepare a burnt offering, you must offer it to Yahuah.” For Manoah didn’t know that he was Yahuah’s angel. 
 \p
-\v 17 Manoah said to Yahweh’s angel, “What is your name, that when your words happen, we may honor you?” 
+\v 17 Manoah said to Yahuah’s angel, “What is your name, that when your words happen, we may honor you?” 
 \p
-\v 18 Yahweh’s angel said to him, “Why do you ask about my name, since it is incomprehensible?” 
+\v 18 Yahuah’s angel said to him, “Why do you ask about my name, since it is incomprehensible?” 
 \p
-\v 19 So Manoah took the young goat with the meal offering, and offered it on the rock to Yahweh. Then the angel did an amazing thing as Manoah and his woman watched. 
-\v 20 For when the flame went up toward the sky from off the altar, Yahweh’s angel ascended in the flame of the altar. Manoah and his woman watched; and they fell on their faces to the ground. 
-\v 21 But Yahweh’s angel didn’t appear to Manoah or to his woman any more. Then Manoah knew that he was Yahweh’s angel. 
+\v 19 So Manoah took the young goat with the meal offering, and offered it on the rock to Yahuah. Then the angel did an amazing thing as Manoah and his woman watched. 
+\v 20 For when the flame went up toward the sky from off the altar, Yahuah’s angel ascended in the flame of the altar. Manoah and his woman watched; and they fell on their faces to the ground. 
+\v 21 But Yahuah’s angel didn’t appear to Manoah or to his woman any more. Then Manoah knew that he was Yahuah’s angel. 
 \v 22 Manoah said to his woman, “We shall surely die, because we have seen Elohim.” 
 \p
-\v 23 But his woman said to him, “If Yahweh were pleased to kill us, he wouldn’t have received a burnt offering and a meal offering at our hand, and he wouldn’t have shown us all these things, nor would he have told us such things as these at this time.” 
-\v 24 The woman bore a son and named him Samson. The child grew, and Yahweh blessed him. 
-\v 25 Yahweh’s Spirit began to move him in Mahaneh Dan, between Zorah and Eshtaol. 
+\v 23 But his woman said to him, “If Yahuah were pleased to kill us, he wouldn’t have received a burnt offering and a meal offering at our hand, and he wouldn’t have shown us all these things, nor would he have told us such things as these at this time.” 
+\v 24 The woman bore a son and named him Samson. The child grew, and Yahuah blessed him. 
+\v 25 Yahuah’s Spirit began to move him in Mahaneh Dan, between Zorah and Eshtaol. 
 \c 14
 \p
 \v 1 Samson went down to Timnah, and saw a woman in Timnah of the daughters of the Philistines. 
@@ -679,10 +679,10 @@
 \v 3 Then his father and his mother said to him, “Isn’t there a woman among your brothers’ daughters, or among all my people, that you go to take a woman of the uncircumcised Philistines?” 
 \p Samson said to his father, “Get her for me, for she pleases me well.” 
 \p
-\v 4 But his father and his mother didn’t know that it was of Yahweh; for he sought an occasion against the Philistines. Now at that time the Philistines ruled over Israel. 
+\v 4 But his father and his mother didn’t know that it was of Yahuah; for he sought an occasion against the Philistines. Now at that time the Philistines ruled over Israel. 
 \p
 \v 5 Then Samson went down to Timnah with his father and his mother, and came to the vineyards of Timnah; and behold, a young lion roared at him. 
-\v 6 Yahweh’s Spirit came mightily on him, and he tore him as he would have torn a young goat with his bare hands, but he didn’t tell his father or his mother what he had done. 
+\v 6 Yahuah’s Spirit came mightily on him, and he tore him as he would have torn a young goat with his bare hands, but he didn’t tell his father or his mother what he had done. 
 \v 7 He went down and talked with the woman, and she pleased Samson well. 
 \v 8 After a while he returned to take her, and he went over to see the carcass of the lion; and behold, there was a swarm of bees in the body of the lion, and honey. 
 \v 9 He took it into his hands, and went on, eating as he went. He came to his father and mother and gave to them, and they ate, but he didn’t tell them that he had taken the honey out of the lion’s body. 
@@ -708,7 +708,7 @@
 \q1 “If you hadn’t plowed with my heifer, 
 \q2 you wouldn’t have found out my riddle.” 
 \p
-\v 19 Yahweh’s Spirit came mightily on him, and he went down to Ashkelon and struck thirty men of them. He took their plunder, then gave the changes of clothing to those who declared the riddle. His anger burned, and he went up to his father’s house. 
+\v 19 Yahuah’s Spirit came mightily on him, and he went down to Ashkelon and struck thirty men of them. He took their plunder, then gave the changes of clothing to those who declared the riddle. His anger burned, and he went up to his father’s house. 
 \v 20 But Samson’s woman was given to his companion, who had been his friend. 
 \c 15
 \p
@@ -738,12 +738,12 @@
 \p
 \v 13 They spoke to him, saying, “No, but we will bind you securely and deliver you into their hands; but surely we will not kill you.” They bound him with two new ropes, and brought him up from the rock. 
 \p
-\v 14 When he came to Lehi, the Philistines shouted as they met him. Then Yahweh’s Spirit came mightily on him, and the ropes that were on his arms became as flax that was burned with fire; and his bands dropped from off his hands. 
+\v 14 When he came to Lehi, the Philistines shouted as they met him. Then Yahuah’s Spirit came mightily on him, and the ropes that were on his arms became as flax that was burned with fire; and his bands dropped from off his hands. 
 \v 15 He found a fresh jawbone of a donkey, put out his hand, took it, and struck a thousand men with it. 
 \v 16 Samson said, “With the jawbone of a donkey, heaps on heaps; with the jawbone of a donkey I have struck a thousand men.” 
 \v 17 When he had finished speaking, he threw the jawbone out of his hand; and that place was called Ramath Lehi. 
 \p
-\v 18 He was very thirsty, and called on Yahweh and said, “You have given this great deliverance by the hand of your servant; and now shall I die of thirst, and fall into the hands of the uncircumcised?” 
+\v 18 He was very thirsty, and called on Yahuah and said, “You have given this great deliverance by the hand of your servant; and now shall I die of thirst, and fall into the hands of the uncircumcised?” 
 \p
 \v 19 But Elohim split the hollow place that is in Lehi, and water came out of it. When he had drunk, his spirit came again, and he revived. Therefore its name was called En Hakkore, which is in Lehi, to this day. 
 \v 20 He judged Israel twenty years in the days of the Philistines. 
@@ -782,7 +782,7 @@
 \v 18 When Delilah saw that he had told her all his heart, she sent and called for the lords of the Philistines, saying, “Come up this once, for he has told me all his heart.” Then the lords of the Philistines came up to her and brought the money in their hand. 
 \v 19 She made him sleep on her knees; and she called for a man and shaved off the seven locks of his head; and she began to afflict him, and his strength went from him. 
 \v 20 She said, “The Philistines are upon you, Samson!” 
-\p He awoke out of his sleep, and said, “I will go out as at other times, and shake myself free.” But he didn’t know that Yahweh had departed from him. 
+\p He awoke out of his sleep, and said, “I will go out as at other times, and shake myself free.” But he didn’t know that Yahuah had departed from him. 
 \v 21 The Philistines laid hold on him and put out his eyes; and they brought him down to Gaza and bound him with fetters of bronze; and he ground at the mill in the prison. 
 \v 22 However, the hair of his head began to grow again after he was shaved. 
 \p
@@ -792,7 +792,7 @@
 \v 25 When their hearts were merry, they said, “Call for Samson, that he may entertain us.” They called for Samson out of the prison; and he performed before them. They set him between the pillars; 
 \v 26 and Samson said to the boy who held him by the hand, “Allow me to feel the pillars on which the house rests, that I may lean on them.” 
 \v 27 Now the house was full of men and women; and all the lords of the Philistines were there; and there were on the roof about three thousand men and women, who saw while Samson performed. 
-\v 28 Samson called to Yahweh, and said, “Lord Yahweh, remember me, please, and strengthen me, please, only this once, Elohim, that I may be at once avenged of the Philistines for my two eyes.” 
+\v 28 Samson called to Yahuah, and said, “Lord Yahuah, remember me, please, and strengthen me, please, only this once, Elohim, that I may be at once avenged of the Philistines for my two eyes.” 
 \v 29 Samson took hold of the two middle pillars on which the house rested and leaned on them, the one with his right hand and the other with his left. 
 \v 30 Samson said, “Let me die with the Philistines!” He bowed himself with all his might; and the house fell on the lords, and on all the people who were in it. So the dead that he killed at his death were more than those who he killed in his life. 
 \p
@@ -801,9 +801,9 @@
 \p
 \v 1 There was a man of the hill country of Ephraim, whose name was Micah. 
 \v 2 He said to his mother, “The eleven hundred pieces of silver that were taken from you, about which you uttered a curse, and also spoke it in my ears—behold, the silver is with me. I took it.” 
-\p His mother said, “May Yahweh bless my son!” 
+\p His mother said, “May Yahuah bless my son!” 
 \p
-\v 3 He restored the eleven hundred pieces of silver to his mother, then his mother said, “I most certainly dedicate the silver to Yahweh from my hand for my son, to make a carved image and a molten image. Now therefore I will restore it to you.” 
+\v 3 He restored the eleven hundred pieces of silver to his mother, then his mother said, “I most certainly dedicate the silver to Yahuah from my hand for my son, to make a carved image and a molten image. Now therefore I will restore it to you.” 
 \p
 \v 4 When he restored the money to his mother, his mother took two hundred pieces of silver, and gave them to a silversmith, who made a carved image and a molten image out of it. It was in the house of Micah. 
 \p
@@ -817,7 +817,7 @@
 \v 10 Micah said to him, “Dwell with me, and be to me a father and a priest, and I will give you ten pieces of silver per year, a suit of clothing, and your food.” So the Levite went in. 
 \v 11 The Levite was content to dwell with the man; and the young man was to him as one of his sons. 
 \v 12 Micah consecrated the Levite, and the young man became his priest, and was in the house of Micah. 
-\v 13 Then Micah said, “Now I know that Yahweh will do good to me, since I have a Levite as my priest.” 
+\v 13 Then Micah said, “Now I know that Yahuah will do good to me, since I have a Levite as my priest.” 
 \c 18
 \p
 \v 1 In those days there was no king in Israel. In those days the tribe of the Danites sought an inheritance to dwell in; for to that day, their inheritance had not fallen to them among the tribes of Israel. 
@@ -829,7 +829,7 @@
 \p
 \v 5 They said to him, “Please ask counsel of Elohim, that we may know whether our way which we go shall be prosperous.” 
 \p
-\v 6 The priest said to them, “Go in peace. Your way in which you go is before Yahweh.” 
+\v 6 The priest said to them, “Go in peace. Your way in which you go is before Yahuah.” 
 \p
 \v 7 Then the five men departed and came to Laish and saw the people who were there, how they lived in safety, in the way of the Sidonians, quiet and secure; for there was no one in the land possessing authority, that might put them to shame in anything, and they were far from the Sidonians, and had no dealings with anyone else. 
 \v 8 They came to their brothers at Zorah and Eshtaol; and their brothers asked them, “What do you say?” 
@@ -890,7 +890,7 @@
 \v 16 Behold, an old man came from his work out of the field at evening. Now the man was from the hill country of Ephraim, and he lived in Gibeah; but the men of the place were Benjamites. 
 \v 17 He lifted up his eyes, and saw the wayfaring man in the street of the city; and the old man said, “Where are you going? Where did you come from?” 
 \p
-\v 18 He said to him, “We are passing from Bethlehem Judah to the farther side of the hill country of Ephraim. I am from there, and I went to Bethlehem Judah. I am going to Yahweh’s house; and there is no one who has taken me into his house. 
+\v 18 He said to him, “We are passing from Bethlehem Judah to the farther side of the hill country of Ephraim. I am from there, and I went to Bethlehem Judah. I am going to Yahuah’s house; and there is no one who has taken me into his house. 
 \v 19 Yet there is both straw and feed for our donkeys; and there is bread and wine also for me, and for your servant, and for the young man who is with your servants. There is no lack of anything.” 
 \p
 \v 20 The old man said, “Peace be to you! Just let me supply all your needs, but don’t sleep in the street.” 
@@ -910,7 +910,7 @@
 \v 30 It was so, that all who saw it said, “Such a deed has not been done or seen from the day that the children of Israel came up out of the land of Egypt to this day! Consider it, take counsel, and speak.” 
 \c 20
 \p
-\v 1 Then all the children of Israel went out, and the congregation was assembled as one man, from Dan even to Beersheba, with the land of Gilead, to Yahweh at Mizpah. 
+\v 1 Then all the children of Israel went out, and the congregation was assembled as one man, from Dan even to Beersheba, with the land of Gilead, to Yahuah at Mizpah. 
 \v 2 The chiefs of all the people, even of all the tribes of Israel, presented themselves in the assembly of the people of Elohim, four hundred thousand footmen who drew sword. 
 \v 3 (Now the children of Benjamin heard that the children of Israel had gone up to Mizpah.) The children of Israel said, “Tell us, how did this wickedness happen?” 
 \p
@@ -933,22 +933,22 @@
 \v 17 The men of Israel, besides Benjamin, were counted four hundred thousand men who drew sword. All these were men of war. 
 \p
 \v 18 The children of Israel arose, went up to Bethel, and asked counsel of Elohim. They asked, “Who shall go up for us first to battle against the children of Benjamin?” 
-\p Yahweh said, “Judah first.” 
+\p Yahuah said, “Judah first.” 
 \p
 \v 19 The children of Israel rose up in the morning and encamped against Gibeah. 
 \v 20 The men of Israel went out to battle against Benjamin; and the men of Israel set the battle in array against them at Gibeah. 
 \v 21 The children of Benjamin came out of Gibeah, and on that day destroyed twenty-two thousand of the Israelite men down to the ground. 
 \v 22 The people, the men of Israel, encouraged themselves, and set the battle again in array in the place where they set themselves in array the first day. 
-\v 23 The children of Israel went up and wept before Yahweh until evening; and they asked of Yahweh, saying, “Shall I again draw near to battle against the children of Benjamin my brother?” 
-\p Yahweh said, “Go up against him.” 
+\v 23 The children of Israel went up and wept before Yahuah until evening; and they asked of Yahuah, saying, “Shall I again draw near to battle against the children of Benjamin my brother?” 
+\p Yahuah said, “Go up against him.” 
 \p
 \v 24 The children of Israel came near against the children of Benjamin the second day. 
 \v 25 Benjamin went out against them out of Gibeah the second day, and destroyed down to the ground of the children of Israel again eighteen thousand men. All these drew the sword. 
 \p
-\v 26 Then all the children of Israel and all the people went up, and came to Bethel, and wept, and sat there before Yahweh, and fasted that day until evening; then they offered burnt offerings and peace offerings before Yahweh. 
-\v 27 The children of Israel asked Yahweh (for the ark of the covenant of Elohim was there in those days, 
+\v 26 Then all the children of Israel and all the people went up, and came to Bethel, and wept, and sat there before Yahuah, and fasted that day until evening; then they offered burnt offerings and peace offerings before Yahuah. 
+\v 27 The children of Israel asked Yahuah (for the ark of the covenant of Elohim was there in those days, 
 \v 28 and Phinehas, the son of Eleazar, the son of Aaron, stood before it in those days), saying, “Shall I yet again go out to battle against the children of Benjamin my brother, or shall I cease?” 
-\p Yahweh said, “Go up; for tomorrow I will deliver him into your hand.” 
+\p Yahuah said, “Go up; for tomorrow I will deliver him into your hand.” 
 \p
 \v 29 Israel set ambushes all around Gibeah. 
 \v 30 The children of Israel went up against the children of Benjamin on the third day, and set themselves in array against Gibeah, as at other times. 
@@ -958,7 +958,7 @@
 \p
 \v 33 All the men of Israel rose up out of their place and set themselves in array at Baal Tamar. Then the ambushers of Israel broke out of their place, even out of Maareh Geba. 
 \v 34 Ten thousand chosen men out of all Israel came over against Gibeah, and the battle was severe; but they didn’t know that disaster was close to them. 
-\v 35 Yahweh struck Benjamin before Israel; and the children of Israel destroyed of Benjamin that day twenty-five thousand one hundred men. All these drew the sword. 
+\v 35 Yahuah struck Benjamin before Israel; and the children of Israel destroyed of Benjamin that day twenty-five thousand one hundred men. All these drew the sword. 
 \v 36 So the children of Benjamin saw that they were struck, for the men of Israel yielded to Benjamin because they trusted the ambushers whom they had set against Gibeah. 
 \v 37 The ambushers hurried, and rushed on Gibeah; then the ambushers spread out, and struck all the city with the edge of the sword. 
 \v 38 Now the appointed sign between the men of Israel and the ambushers was that they should make a great cloud of smoke rise up out of the city. 
@@ -976,13 +976,13 @@
 \p
 \v 1 Now the men of Israel had sworn in Mizpah, saying, “None of us will give his daughter to Benjamin as a woman.” 
 \v 2 The people came to Bethel and sat there until evening before Elohim, and lifted up their voices, and wept severely. 
-\v 3 They said, “Yahweh, the Elohim of Israel, why has this happened in Israel, that there should be one tribe lacking in Israel today?” 
+\v 3 They said, “Yahuah, the Elohim of Israel, why has this happened in Israel, that there should be one tribe lacking in Israel today?” 
 \p
 \v 4 On the next day, the people rose early and built an altar there, and offered burnt offerings and peace offerings. 
-\v 5 The children of Israel said, “Who is there among all the tribes of Israel who didn’t come up in the assembly to Yahweh?” For they had made a great oath concerning him who didn’t come up to Yahweh to Mizpah, saying, “He shall surely be put to death.” 
+\v 5 The children of Israel said, “Who is there among all the tribes of Israel who didn’t come up in the assembly to Yahuah?” For they had made a great oath concerning him who didn’t come up to Yahuah to Mizpah, saying, “He shall surely be put to death.” 
 \v 6 The children of Israel grieved for Benjamin their brother, and said, “There is one tribe cut off from Israel today. 
-\v 7 How shall we provide women for those who remain, since we have sworn by Yahweh that we will not give them of our daughters to women?” 
-\v 8 They said, “What one is there of the tribes of Israel who didn’t come up to Yahweh to Mizpah?” Behold, no one came from Jabesh Gilead to the camp to the assembly. 
+\v 7 How shall we provide women for those who remain, since we have sworn by Yahuah that we will not give them of our daughters to women?” 
+\v 8 They said, “What one is there of the tribes of Israel who didn’t come up to Yahuah to Mizpah?” Behold, no one came from Jabesh Gilead to the camp to the assembly. 
 \v 9 For when the people were counted, behold, there were none of the inhabitants of Jabesh Gilead there. 
 \v 10 The congregation sent twelve thousand of the most valiant men there, and commanded them, saying, “Go and strike the inhabitants of Jabesh Gilead with the edge of the sword, with the women and the little ones. 
 \v 11 This is the thing that you shall do: you shall utterly destroy every male, and every woman who has lain with a man.” 
@@ -990,11 +990,11 @@
 \p
 \v 13 The whole congregation sent and spoke to the children of Benjamin who were in the rock of Rimmon, and proclaimed peace to them. 
 \v 14 Benjamin returned at that time; and they gave them the women whom they had saved alive of the women of Jabesh Gilead. There still weren’t enough for them. 
-\v 15 The people grieved for Benjamin, because Yahweh had made a breach in the tribes of Israel. 
+\v 15 The people grieved for Benjamin, because Yahuah had made a breach in the tribes of Israel. 
 \v 16 Then the elders of the congregation said, “How shall we provide women for those who remain, since the women are destroyed out of Benjamin?” 
 \v 17 They said, “There must be an inheritance for those who are escaped of Benjamin, that a tribe not be blotted out from Israel. 
 \v 18 However, we may not give them women of our daughters, for the children of Israel had sworn, saying, ‘Cursed is he who gives a woman to Benjamin.’ ” 
-\v 19 They said, “Behold, there is a feast of Yahweh from year to year in Shiloh, which is on the north of Bethel, on the east side of the highway that goes up from Bethel to Shechem, and on the south of Lebonah.” 
+\v 19 They said, “Behold, there is a feast of Yahuah from year to year in Shiloh, which is on the north of Bethel, on the east side of the highway that goes up from Bethel to Shechem, and on the south of Lebonah.” 
 \v 20 They commanded the children of Benjamin, saying, “Go and lie in wait in the vineyards, 
 \v 21 and see, and behold, if the daughters of Shiloh come out to dance in the dances, then come out of the vineyards, and each man catch his woman of the daughters of Shiloh, and go to the land of Benjamin. 
 \v 22 It shall be, when their fathers or their brothers come to complain to us, that we will say to them, ‘Grant them graciously to us, because we didn’t take for each man his woman in battle, neither did you give them to them; otherwise you would now be guilty.’ ” 

--- a/usfm/lamentations.usfm
+++ b/usfm/lamentations.usfm
@@ -36,7 +36,7 @@
 \q1
 \v 5 Her adversaries have become the head. 
 \q2 Her enemies prosper; 
-\q1 for Yahweh has afflicted her for the multitude of her transgressions. 
+\q1 for Yahuah has afflicted her for the multitude of her transgressions. 
 \q2 Her young children have gone into captivity before the adversary. 
 \b
 \q1
@@ -64,7 +64,7 @@
 \q2 She didn’t remember her latter end. 
 \q1 Therefore she has come down astoundingly. 
 \q2 She has no comforter. 
-\q1 “See, Yahweh, my affliction; 
+\q1 “See, Yahuah, my affliction; 
 \q2 for the enemy has magnified himself.” 
 \b
 \q1
@@ -76,14 +76,14 @@
 \v 11 All her people sigh. 
 \q2 They seek bread. 
 \q2 They have given their pleasant things for food to refresh their soul. 
-\q1 “Look, Yahweh, and see, 
+\q1 “Look, Yahuah, and see, 
 \q2 for I have become despised.” 
 \b
 \q1
 \v 12 “Is it nothing to you, all you who pass by? 
 \q2 Look, and see if there is any sorrow like my sorrow, 
 \q2 which is brought on me, 
-\q2 with which Yahweh has afflicted me in the day of his fierce anger. 
+\q2 with which Yahuah has afflicted me in the day of his fierce anger. 
 \b
 \q1
 \v 13 “From on high has he sent fire into my bones, 
@@ -115,12 +115,12 @@
 \q1
 \v 17 Zion spreads out her hands. 
 \q2 There is no one to comfort her. 
-\q1 Yahweh has commanded concerning Jacob, 
+\q1 Yahuah has commanded concerning Jacob, 
 \q2 that those who are around him should be his adversaries. 
 \q2 Jerusalem is among them as an unclean thing. 
 \b
 \q1
-\v 18 “Yahweh is righteous, 
+\v 18 “Yahuah is righteous, 
 \q2 for I have rebelled against his commandment. 
 \q1 Please hear all you peoples, 
 \q2 and see my sorrow. 
@@ -133,7 +133,7 @@
 \q2 while they sought food for themselves to refresh their souls. 
 \b
 \q1
-\v 20 “Look, Yahweh; for I am in distress. 
+\v 20 “Look, Yahuah; for I am in distress. 
 \q2 My heart is troubled. 
 \q1 My heart turns over within me, 
 \q2 for I have grievously rebelled. 
@@ -189,18 +189,18 @@
 \v 6 He has violently taken away his tabernacle, 
 \q2 as if it were a garden. 
 \q1 He has destroyed his place of assembly. 
-\q2 Yahweh has caused solemn assembly and Sabbath to be forgotten in Zion. 
+\q2 Yahuah has caused solemn assembly and Sabbath to be forgotten in Zion. 
 \q2 In the indignation of his anger, he has despised the king and the priest. 
 \b
 \q1
 \v 7 The Lord has cast off his altar. 
 \q2 He has abhorred his sanctuary. 
 \q1 He has given the walls of her palaces into the hand of the enemy. 
-\q2 They have made a noise in Yahweh’s house, 
+\q2 They have made a noise in Yahuah’s house, 
 \q2 as in the day of a solemn assembly. 
 \b
 \q1
-\v 8 Yahweh has purposed to destroy the wall of the daughter of Zion. 
+\v 8 Yahuah has purposed to destroy the wall of the daughter of Zion. 
 \q2 He has stretched out the line. 
 \q2 He has not withdrawn his hand from destroying; 
 \q1 He has made the rampart and wall lament. 
@@ -210,7 +210,7 @@
 \v 9 Her gates have sunk into the ground. 
 \q2 He has destroyed and broken her bars. 
 \q1 Her king and her princes are among the nations where the law is not. 
-\q2 Yes, her prophets find no vision from Yahweh. 
+\q2 Yes, her prophets find no vision from Yahuah. 
 \b
 \q1
 \v 10 The elders of the daughter of Zion sit on the ground. 
@@ -261,7 +261,7 @@
 \q2 We have seen it.” 
 \b
 \q1
-\v 17 Yahweh has done that which he planned. 
+\v 17 Yahuah has done that which he planned. 
 \q2 He has fulfilled his word that he commanded in the days of old. 
 \q1 He has thrown down, 
 \q2 and has not pitied. 
@@ -283,7 +283,7 @@
 \q2 who faint for hunger at the head of every street. 
 \b
 \q1
-\v 20 “Look, Yahweh, and see to whom you have done thus! 
+\v 20 “Look, Yahuah, and see to whom you have done thus! 
 \q2 Should the women eat their offspring, 
 \q2 the children that they held and bounced on their knees? 
 \q2 Should the priest and the prophet be killed in the sanctuary of the Lord? 
@@ -296,7 +296,7 @@
 \b
 \q1
 \v 22 “You have called, as in the day of a solemn assembly, my terrors on every side. 
-\q2 There was no one that escaped or remained in the day of Yahweh’s anger. 
+\q2 There was no one that escaped or remained in the day of Yahuah’s anger. 
 \q2 My enemy has consumed those whom I have cared for and brought up. 
 \c 3
 \q1
@@ -357,7 +357,7 @@
 \q2 I forgot prosperity. 
 \q1
 \v 18 I said, “My strength has perished, 
-\q2 along with my expectation from Yahweh.” 
+\q2 along with my expectation from Yahuah.” 
 \b
 \q1
 \v 19 Remember my affliction and my misery, 
@@ -370,21 +370,21 @@
 \q2 therefore I have hope. 
 \b
 \q1
-\v 22 It is because of Yahweh’s loving kindnesses that we are not consumed, 
+\v 22 It is because of Yahuah’s loving kindnesses that we are not consumed, 
 \q2 because his mercies don’t fail. 
 \q1
 \v 23 They are new every morning. 
 \q2 Great is your faithfulness. 
 \q1
-\v 24 “Yahweh is my portion,” says my soul. 
+\v 24 “Yahuah is my portion,” says my soul. 
 \q2 “Therefore I will hope in him.” 
 \b
 \q1
-\v 25 Yahweh is good to those who wait for him, 
+\v 25 Yahuah is good to those who wait for him, 
 \q2 to the soul who seeks him. 
 \q1
 \v 26 It is good that a man should hope 
-\q2 and quietly wait for the salvation of Yahweh. 
+\q2 and quietly wait for the salvation of Yahuah. 
 \q2
 \v 27 It is good for a man that he bear the yoke in his youth. 
 \b
@@ -425,7 +425,7 @@
 \b
 \q1
 \v 40 Let us search and try our ways, 
-\q2 and turn again to Yahweh. 
+\q2 and turn again to Yahuah. 
 \q1
 \v 41 Let’s lift up our heart with our hands to Elohim in the heavens. 
 \q2
@@ -457,7 +457,7 @@
 \q2 and doesn’t cease, 
 \q2 without any intermission, 
 \q1
-\v 50 until Yahweh looks down, 
+\v 50 until Yahuah looks down, 
 \q2 and sees from heaven. 
 \q1
 \v 51 My eye affects my soul, 
@@ -474,7 +474,7 @@
 \q2 I said, “I am cut off.” 
 \b
 \q1
-\v 55 I called on your name, Yahweh, 
+\v 55 I called on your name, Yahuah, 
 \q2 out of the lowest dungeon. 
 \q1
 \v 56 You heard my voice: 
@@ -489,14 +489,14 @@
 \v 58 Lord, you have pleaded the causes of my soul. 
 \q2 You have redeemed my life. 
 \q1
-\v 59 Yahweh, you have seen my wrong. 
+\v 59 Yahuah, you have seen my wrong. 
 \q2 Judge my cause. 
 \q1
 \v 60 You have seen all their vengeance 
 \q2 and all their plans against me. 
 \b
 \q1
-\v 61 You have heard their reproach, Yahweh, 
+\v 61 You have heard their reproach, Yahuah, 
 \q2 and all their plans against me, 
 \q1
 \v 62 the lips of those that rose up against me, 
@@ -506,14 +506,14 @@
 \q2 I am their song. 
 \b
 \q1
-\v 64 You will pay them back, Yahweh, 
+\v 64 You will pay them back, Yahuah, 
 \q2 according to the work of their hands. 
 \q1
 \v 65 You will give them hardness of heart, 
 \q2 your curse to them. 
 \q1
 \v 66 You will pursue them in anger, 
-\q2 and destroy them from under the heavens of Yahweh. 
+\q2 and destroy them from under the heavens of Yahuah. 
 \c 4
 \q1
 \v 1 How the gold has become dim! 
@@ -570,7 +570,7 @@
 \q2 They were their food in the destruction of the daughter of my people. 
 \b
 \q1
-\v 11 Yahweh has accomplished his wrath. 
+\v 11 Yahuah has accomplished his wrath. 
 \q2 He has poured out his fierce anger. 
 \q1 He has kindled a fire in Zion, 
 \q2 which has devoured its foundations. 
@@ -597,7 +597,7 @@
 \q2 “They can’t live here any more.” 
 \b
 \q1
-\v 16 Yahweh’s anger has scattered them. 
+\v 16 Yahuah’s anger has scattered them. 
 \q2 He will not pay attention to them any more. 
 \q1 They didn’t respect the persons of the priests. 
 \q2 They didn’t favor the elders. 
@@ -621,7 +621,7 @@
 \b
 \q1
 \v 20 The breath of our nostrils, 
-\q2 the anointed of Yahweh, 
+\q2 the anointed of Yahuah, 
 \q2 was taken in their pits; 
 \q1 of whom we said, 
 \q2 under his shadow we will live among the nations. 
@@ -640,7 +640,7 @@
 \q2 He will uncover your sins. 
 \c 5
 \q1
-\v 1 Remember, Yahweh, what has come on us. 
+\v 1 Remember, Yahuah, what has come on us. 
 \q2 Look, and see our reproach. 
 \q1
 \v 2 Our inheritance has been turned over to strangers, 
@@ -695,13 +695,13 @@
 \q2 The foxes walk on it. 
 \b
 \q1
-\v 19 You, Yahweh, remain forever. 
+\v 19 You, Yahuah, remain forever. 
 \q2 Your throne is from generation to generation. 
 \q1
 \v 20 Why do you forget us forever, 
 \q2 and forsake us for so long a time? 
 \q1
-\v 21 Turn us to yourself, Yahweh, and we will be turned. 
+\v 21 Turn us to yourself, Yahuah, and we will be turned. 
 \q2 Renew our days as of old. 
 \q1
 \v 22 But you have utterly rejected us. 

--- a/usfm/leviticus.usfm
+++ b/usfm/leviticus.usfm
@@ -3,109 +3,109 @@
 \h Leviticus
 \c 1
 \p
-\v 1 Yahweh called to Moses, and spoke to him from the Tent of Meeting, saying, 
-\v 2 “Speak to the children of Israel, and tell them, ‘When anyone of you offers an offering to Yahweh, you shall offer your offering of the livestock, from the herd and from the flock. 
+\v 1 Yahuah called to Moses, and spoke to him from the Tent of Meeting, saying, 
+\v 2 “Speak to the children of Israel, and tell them, ‘When anyone of you offers an offering to Yahuah, you shall offer your offering of the livestock, from the herd and from the flock. 
 \p
-\v 3 “ ‘If his offering is a burnt offering from the herd, he shall offer a male without defect. He shall offer it at the door of the Tent of Meeting, that he may be accepted before Yahweh. 
+\v 3 “ ‘If his offering is a burnt offering from the herd, he shall offer a male without defect. He shall offer it at the door of the Tent of Meeting, that he may be accepted before Yahuah. 
 \v 4 He shall lay his hand on the head of the burnt offering, and it shall be accepted for him to make atonement for him. 
-\v 5 He shall kill the bull before Yahweh. Aaron’s sons, the priests, shall present the blood and sprinkle the blood around on the altar that is at the door of the Tent of Meeting. 
+\v 5 He shall kill the bull before Yahuah. Aaron’s sons, the priests, shall present the blood and sprinkle the blood around on the altar that is at the door of the Tent of Meeting. 
 \v 6 He shall skin the burnt offering and cut it into pieces. 
 \v 7 The sons of Aaron the priest shall put fire on the altar, and lay wood in order on the fire; 
 \v 8 and Aaron’s sons, the priests, shall lay the pieces, the head, and the fat in order on the wood that is on the fire which is on the altar; 
-\v 9 but he shall wash its innards and its legs with water. The priest shall burn all of it on the altar, for a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
+\v 9 but he shall wash its innards and its legs with water. The priest shall burn all of it on the altar, for a burnt offering, an offering made by fire, of a pleasant aroma to Yahuah. 
 \p
 \v 10 “ ‘If his offering is from the flock, from the sheep or from the goats, for a burnt offering, he shall offer a male without defect. 
-\v 11 He shall kill it on the north side of the altar before Yahweh. Aaron’s sons, the priests, shall sprinkle its blood around on the altar. 
+\v 11 He shall kill it on the north side of the altar before Yahuah. Aaron’s sons, the priests, shall sprinkle its blood around on the altar. 
 \v 12 He shall cut it into its pieces, with its head and its fat. The priest shall lay them in order on the wood that is on the fire which is on the altar, 
-\v 13 but the innards and the legs he shall wash with water. The priest shall offer the whole, and burn it on the altar. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
+\v 13 but the innards and the legs he shall wash with water. The priest shall offer the whole, and burn it on the altar. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahuah. 
 \p
-\v 14 “ ‘If his offering to Yahweh is a burnt offering of birds, then he shall offer his offering from turtledoves or of young pigeons. 
+\v 14 “ ‘If his offering to Yahuah is a burnt offering of birds, then he shall offer his offering from turtledoves or of young pigeons. 
 \v 15 The priest shall bring it to the altar, and wring off its head, and burn it on the altar; and its blood shall be drained out on the side of the altar; 
 \v 16 and he shall take away its crop and its feathers, and cast it beside the altar on the east part, in the place of the ashes. 
-\v 17 He shall tear it by its wings, but shall not divide it apart. The priest shall burn it on the altar, on the wood that is on the fire. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
+\v 17 He shall tear it by its wings, but shall not divide it apart. The priest shall burn it on the altar, on the wood that is on the fire. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahuah. 
 \c 2
 \p
-\v 1 “ ‘When anyone offers an offering of a meal offering to Yahweh, his offering shall be of fine flour. He shall pour oil on it, and put frankincense on it. 
-\v 2 He shall bring it to Aaron’s sons, the priests. He shall take his handful of its fine flour, and of its oil, with all its frankincense, and the priest shall burn its memorial on the altar, an offering made by fire, of a pleasant aroma to Yahweh. 
-\v 3 That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahweh made by fire. 
+\v 1 “ ‘When anyone offers an offering of a meal offering to Yahuah, his offering shall be of fine flour. He shall pour oil on it, and put frankincense on it. 
+\v 2 He shall bring it to Aaron’s sons, the priests. He shall take his handful of its fine flour, and of its oil, with all its frankincense, and the priest shall burn its memorial on the altar, an offering made by fire, of a pleasant aroma to Yahuah. 
+\v 3 That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahuah made by fire. 
 \p
 \v 4 “ ‘When you offer an offering of a meal offering baked in the oven, it shall be unleavened cakes of fine flour mixed with oil, or unleavened wafers anointed with oil. 
 \v 5 If your offering is a meal offering made on a griddle, it shall be of unleavened fine flour, mixed with oil. 
 \v 6 You shall cut it in pieces, and pour oil on it. It is a meal offering. 
 \v 7 If your offering is a meal offering of the pan, it shall be made of fine flour with oil. 
-\v 8 You shall bring the meal offering that is made of these things to Yahweh. It shall be presented to the priest, and he shall bring it to the altar. 
-\v 9 The priest shall take from the meal offering its memorial, and shall burn it on the altar, an offering made by fire, of a pleasant aroma to Yahweh. 
-\v 10 That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahweh made by fire. 
+\v 8 You shall bring the meal offering that is made of these things to Yahuah. It shall be presented to the priest, and he shall bring it to the altar. 
+\v 9 The priest shall take from the meal offering its memorial, and shall burn it on the altar, an offering made by fire, of a pleasant aroma to Yahuah. 
+\v 10 That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahuah made by fire. 
 \p
-\v 11 “ ‘No meal offering which you shall offer to Yahweh shall be made with yeast; for you shall burn no yeast, nor any honey, as an offering made by fire to Yahweh. 
-\v 12 As an offering of first fruits you shall offer them to Yahweh, but they shall not rise up as a pleasant aroma on the altar. 
+\v 11 “ ‘No meal offering which you shall offer to Yahuah shall be made with yeast; for you shall burn no yeast, nor any honey, as an offering made by fire to Yahuah. 
+\v 12 As an offering of first fruits you shall offer them to Yahuah, but they shall not rise up as a pleasant aroma on the altar. 
 \v 13 Every offering of your meal offering you shall season with salt. You shall not allow the salt of the covenant of your Elohim to be lacking from your meal offering. With all your offerings you shall offer salt. 
 \p
-\v 14 “ ‘If you offer a meal offering of first fruits to Yahweh, you shall offer for the meal offering of your first fruits fresh heads of grain parched with fire and crushed. 
+\v 14 “ ‘If you offer a meal offering of first fruits to Yahuah, you shall offer for the meal offering of your first fruits fresh heads of grain parched with fire and crushed. 
 \v 15 You shall put oil on it and lay frankincense on it. It is a meal offering. 
-\v 16 The priest shall burn as its memorial part of its crushed grain and part of its oil, along with all its frankincense. It is an offering made by fire to Yahweh. 
+\v 16 The priest shall burn as its memorial part of its crushed grain and part of its oil, along with all its frankincense. It is an offering made by fire to Yahuah. 
 \c 3
 \p
-\v 1 “ ‘If his offering is a sacrifice of peace offerings, if he offers it from the herd, whether male or female, he shall offer it without defect before Yahweh. 
+\v 1 “ ‘If his offering is a sacrifice of peace offerings, if he offers it from the herd, whether male or female, he shall offer it without defect before Yahuah. 
 \v 2 He shall lay his hand on the head of his offering, and kill it at the door of the Tent of Meeting. Aaron’s sons, the priests, shall sprinkle the blood around on the altar. 
-\v 3 He shall offer of the sacrifice of peace offerings an offering made by fire to Yahweh. The fat that covers the innards, and all the fat that is on the innards, 
+\v 3 He shall offer of the sacrifice of peace offerings an offering made by fire to Yahuah. The fat that covers the innards, and all the fat that is on the innards, 
 \v 4 and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
-\v 5 Aaron’s sons shall burn it on the altar on the burnt offering, which is on the wood that is on the fire: it is an offering made by fire, of a pleasant aroma to Yahweh. 
+\v 5 Aaron’s sons shall burn it on the altar on the burnt offering, which is on the wood that is on the fire: it is an offering made by fire, of a pleasant aroma to Yahuah. 
 \p
-\v 6 “ ‘If his offering for a sacrifice of peace offerings to Yahweh is from the flock, either male or female, he shall offer it without defect. 
-\v 7 If he offers a lamb for his offering, then he shall offer it before Yahweh; 
+\v 6 “ ‘If his offering for a sacrifice of peace offerings to Yahuah is from the flock, either male or female, he shall offer it without defect. 
+\v 7 If he offers a lamb for his offering, then he shall offer it before Yahuah; 
 \v 8 and he shall lay his hand on the head of his offering, and kill it before the Tent of Meeting. Aaron’s sons shall sprinkle its blood around on the altar. 
-\v 9 He shall offer from the sacrifice of peace offerings an offering made by fire to Yahweh; its fat, the entire tail fat, he shall take away close to the backbone; and the fat that covers the entrails, and all the fat that is on the entrails, 
+\v 9 He shall offer from the sacrifice of peace offerings an offering made by fire to Yahuah; its fat, the entire tail fat, he shall take away close to the backbone; and the fat that covers the entrails, and all the fat that is on the entrails, 
 \v 10 and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
-\v 11 The priest shall burn it on the altar: it is the food of the offering made by fire to Yahweh. 
+\v 11 The priest shall burn it on the altar: it is the food of the offering made by fire to Yahuah. 
 \p
-\v 12 “ ‘If his offering is a goat, then he shall offer it before Yahweh. 
+\v 12 “ ‘If his offering is a goat, then he shall offer it before Yahuah. 
 \v 13 He shall lay his hand on its head, and kill it before the Tent of Meeting; and the sons of Aaron shall sprinkle its blood around on the altar. 
-\v 14 He shall offer from it as his offering, an offering made by fire to Yahweh; the fat that covers the innards, and all the fat that is on the innards, 
+\v 14 He shall offer from it as his offering, an offering made by fire to Yahuah; the fat that covers the innards, and all the fat that is on the innards, 
 \v 15 and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
-\v 16 The priest shall burn them on the altar: it is the food of the offering made by fire, for a pleasant aroma; all the fat is Yahweh’s. 
+\v 16 The priest shall burn them on the altar: it is the food of the offering made by fire, for a pleasant aroma; all the fat is Yahuah’s. 
 \p
 \v 17 “ ‘It shall be a perpetual statute throughout your generations in all your dwellings, that you shall eat neither fat nor blood.’ ” 
 \c 4
 \p
-\v 1 Yahweh spoke to Moses, saying, 
-\v 2 “Speak to the children of Israel, saying, ‘If anyone sins unintentionally, in any of the things which Yahweh has commanded not to be done, and does any one of them, 
-\v 3 if the anointed priest sins so as to bring guilt on the people, then let him offer for his sin which he has sinned a young bull without defect to Yahweh for a sin offering. 
-\v 4 He shall bring the bull to the door of the Tent of Meeting before Yahweh; and he shall lay his hand on the head of the bull, and kill the bull before Yahweh. 
+\v 1 Yahuah spoke to Moses, saying, 
+\v 2 “Speak to the children of Israel, saying, ‘If anyone sins unintentionally, in any of the things which Yahuah has commanded not to be done, and does any one of them, 
+\v 3 if the anointed priest sins so as to bring guilt on the people, then let him offer for his sin which he has sinned a young bull without defect to Yahuah for a sin offering. 
+\v 4 He shall bring the bull to the door of the Tent of Meeting before Yahuah; and he shall lay his hand on the head of the bull, and kill the bull before Yahuah. 
 \v 5 The anointed priest shall take some of the blood of the bull, and bring it to the Tent of Meeting. 
-\v 6 The priest shall dip his finger in the blood, and sprinkle some of the blood seven times before Yahweh, before the veil of the sanctuary. 
-\v 7 The priest shall put some of the blood on the horns of the altar of sweet incense before Yahweh, which is in the Tent of Meeting; and he shall pour out the rest of the blood of the bull at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
+\v 6 The priest shall dip his finger in the blood, and sprinkle some of the blood seven times before Yahuah, before the veil of the sanctuary. 
+\v 7 The priest shall put some of the blood on the horns of the altar of sweet incense before Yahuah, which is in the Tent of Meeting; and he shall pour out the rest of the blood of the bull at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
 \v 8 He shall take all the fat of the bull of the sin offering from it: the fat that covers the innards, and all the fat that is on the innards, 
 \v 9 and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall remove, 
 \v 10 as it is removed from the bull of the sacrifice of peace offerings. The priest shall burn them on the altar of burnt offering. 
 \v 11 He shall carry the bull’s skin, all its meat, with its head, and with its legs, its innards, and its dung\v 12 —all the rest of the bull—outside of the camp to a clean place where the ashes are poured out, and burn it on wood with fire. It shall be burned where the ashes are poured out. 
 \p
-\v 13 “ ‘If the whole congregation of Israel sins, and the thing is hidden from the eyes of the assembly, and they have done any of the things which Yahweh has commanded not to be done, and are guilty; 
+\v 13 “ ‘If the whole congregation of Israel sins, and the thing is hidden from the eyes of the assembly, and they have done any of the things which Yahuah has commanded not to be done, and are guilty; 
 \v 14 when the sin in which they have sinned is known, then the assembly shall offer a young bull for a sin offering, and bring it before the Tent of Meeting. 
-\v 15 The elders of the congregation shall lay their hands on the head of the bull before Yahweh; and the bull shall be killed before Yahweh. 
+\v 15 The elders of the congregation shall lay their hands on the head of the bull before Yahuah; and the bull shall be killed before Yahuah. 
 \v 16 The anointed priest shall bring some of the blood of the bull to the Tent of Meeting. 
-\v 17 The priest shall dip his finger in the blood and sprinkle it seven times before Yahweh, before the veil. 
-\v 18 He shall put some of the blood on the horns of the altar which is before Yahweh, that is in the Tent of Meeting; and the rest of the blood he shall pour out at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
+\v 17 The priest shall dip his finger in the blood and sprinkle it seven times before Yahuah, before the veil. 
+\v 18 He shall put some of the blood on the horns of the altar which is before Yahuah, that is in the Tent of Meeting; and the rest of the blood he shall pour out at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
 \v 19 All its fat he shall take from it, and burn it on the altar. 
 \v 20 He shall do this with the bull; as he did with the bull of the sin offering, so he shall do with this; and the priest shall make atonement for them, and they shall be forgiven. 
 \v 21 He shall carry the bull outside the camp, and burn it as he burned the first bull. It is the sin offering for the assembly. 
 \p
-\v 22 “ ‘When a ruler sins, and unwittingly does any one of all the things which Yahweh his Elohim has commanded not to be done, and is guilty, 
+\v 22 “ ‘When a ruler sins, and unwittingly does any one of all the things which Yahuah his Elohim has commanded not to be done, and is guilty, 
 \v 23 if his sin in which he has sinned is made known to him, he shall bring as his offering a goat, a male without defect. 
-\v 24 He shall lay his hand on the head of the goat, and kill it in the place where they kill the burnt offering before Yahweh. It is a sin offering. 
+\v 24 He shall lay his hand on the head of the goat, and kill it in the place where they kill the burnt offering before Yahuah. It is a sin offering. 
 \v 25 The priest shall take some of the blood of the sin offering with his finger, and put it on the horns of the altar of burnt offering. He shall pour out the rest of its blood at the base of the altar of burnt offering. 
 \v 26 All its fat he shall burn on the altar, like the fat of the sacrifice of peace offerings; and the priest shall make atonement for him concerning his sin, and he will be forgiven. 
 \p
-\v 27 “ ‘If anyone of the common people sins unwittingly, in doing any of the things which Yahweh has commanded not to be done, and is guilty, 
+\v 27 “ ‘If anyone of the common people sins unwittingly, in doing any of the things which Yahuah has commanded not to be done, and is guilty, 
 \v 28 if his sin which he has sinned is made known to him, then he shall bring for his offering a goat, a female without defect, for his sin which he has sinned. 
 \v 29 He shall lay his hand on the head of the sin offering, and kill the sin offering in the place of burnt offering. 
 \v 30 The priest shall take some of its blood with his finger, and put it on the horns of the altar of burnt offering; and the rest of its blood he shall pour out at the base of the altar. 
-\v 31 All its fat he shall take away, like the fat is taken away from the sacrifice of peace offerings; and the priest shall burn it on the altar for a pleasant aroma to Yahweh; and the priest shall make atonement for him, and he will be forgiven. 
+\v 31 All its fat he shall take away, like the fat is taken away from the sacrifice of peace offerings; and the priest shall burn it on the altar for a pleasant aroma to Yahuah; and the priest shall make atonement for him, and he will be forgiven. 
 \p
 \v 32 “ ‘If he brings a lamb as his offering for a sin offering, he shall bring a female without defect. 
 \v 33 He shall lay his hand on the head of the sin offering, and kill it for a sin offering in the place where they kill the burnt offering. 
 \v 34 The priest shall take some of the blood of the sin offering with his finger, and put it on the horns of the altar of burnt offering; and all the rest of its blood he shall pour out at the base of the altar. 
-\v 35 He shall remove all its fat, like the fat of the lamb is removed from the sacrifice of peace offerings. The priest shall burn them on the altar, on the offerings of Yahweh made by fire. The priest shall make atonement for him concerning his sin that he has sinned, and he will be forgiven. 
+\v 35 He shall remove all its fat, like the fat of the lamb is removed from the sacrifice of peace offerings. The priest shall burn them on the altar, on the offerings of Yahuah made by fire. The priest shall make atonement for him concerning his sin that he has sinned, and he will be forgiven. 
 \c 5
 \p
 \v 1 “ ‘If anyone sins, in that he hears a public adjuration to testify, he being a witness, whether he has seen or known, if he doesn’t report it, then he shall bear his iniquity. 
@@ -116,54 +116,54 @@
 \p
 \v 4 “ ‘Or if anyone swears rashly with his lips to do evil or to do good—whatever it is that a man might utter rashly with an oath, and it is hidden from him—when he knows of it, then he will be guilty of one of these. 
 \v 5 It shall be, when he is guilty of one of these, he shall confess that in which he has sinned; 
-\v 6 and he shall bring his trespass offering to Yahweh for his sin which he has sinned: a female from the flock, a lamb or a goat, for a sin offering; and the priest shall make atonement for him concerning his sin. 
+\v 6 and he shall bring his trespass offering to Yahuah for his sin which he has sinned: a female from the flock, a lamb or a goat, for a sin offering; and the priest shall make atonement for him concerning his sin. 
 \p
-\v 7 “ ‘If he can’t afford a lamb, then he shall bring his trespass offering for that in which he has sinned, two turtledoves, or two young pigeons, to Yahweh; one for a sin offering, and the other for a burnt offering. 
+\v 7 “ ‘If he can’t afford a lamb, then he shall bring his trespass offering for that in which he has sinned, two turtledoves, or two young pigeons, to Yahuah; one for a sin offering, and the other for a burnt offering. 
 \v 8 He shall bring them to the priest, who shall first offer the one which is for the sin offering. He shall wring off its head from its neck, but shall not sever it completely. 
 \v 9 He shall sprinkle some of the blood of the sin offering on the side of the altar; and the rest of the blood shall be drained out at the base of the altar. It is a sin offering. 
 \v 10 He shall offer the second for a burnt offering, according to the ordinance; and the priest shall make atonement for him concerning his sin which he has sinned, and he shall be forgiven. 
 \p
 \v 11 “ ‘But if he can’t afford two turtledoves or two young pigeons, then he shall bring as his offering for that in which he has sinned, one tenth of an ephah of fine flour for a sin offering. He shall put no oil on it, and he shall not put any frankincense on it, for it is a sin offering. 
-\v 12 He shall bring it to the priest, and the priest shall take his handful of it as the memorial portion, and burn it on the altar, on the offerings of Yahweh made by fire. It is a sin offering. 
+\v 12 He shall bring it to the priest, and the priest shall take his handful of it as the memorial portion, and burn it on the altar, on the offerings of Yahuah made by fire. It is a sin offering. 
 \v 13 The priest shall make atonement for him concerning his sin that he has sinned in any of these things, and he will be forgiven; and the rest shall be the priest’s, as the meal offering.’ ” 
 \p
-\v 14 Yahweh spoke to Moses, saying, 
-\v 15 “If anyone commits a trespass, and sins unwittingly regarding Yahweh’s set-apart things, then he shall bring his trespass offering to Yahweh: a ram without defect from the flock, according to your estimation in silver by shekels, according to the shekel of the sanctuary, for a trespass offering. 
+\v 14 Yahuah spoke to Moses, saying, 
+\v 15 “If anyone commits a trespass, and sins unwittingly regarding Yahuah’s set-apart things, then he shall bring his trespass offering to Yahuah: a ram without defect from the flock, according to your estimation in silver by shekels, according to the shekel of the sanctuary, for a trespass offering. 
 \v 16 He shall make restitution for that which he has done wrong regarding the set-apart thing, and shall add a fifth part to it, and give it to the priest; and the priest shall make atonement for him with the ram of the trespass offering, and he will be forgiven. 
 \p
-\v 17 “If anyone sins, doing any of the things which Yahweh has commanded not to be done, though he didn’t know it, he is still guilty, and shall bear his iniquity. 
+\v 17 “If anyone sins, doing any of the things which Yahuah has commanded not to be done, though he didn’t know it, he is still guilty, and shall bear his iniquity. 
 \v 18 He shall bring a ram without defect from of the flock, according to your estimation, for a trespass offering, to the priest; and the priest shall make atonement for him concerning the thing in which he sinned and didn’t know it, and he will be forgiven. 
-\v 19 It is a trespass offering. He is certainly guilty before Yahweh.” 
+\v 19 It is a trespass offering. He is certainly guilty before Yahuah.” 
 \c 6
 \p
-\v 1 Yahweh spoke to Moses, saying, 
-\v 2 “If anyone sins, and commits a trespass against Yahweh, and deals falsely with his neighbor in a matter of deposit, or of bargain, or of robbery, or has oppressed his neighbor, 
+\v 1 Yahuah spoke to Moses, saying, 
+\v 2 “If anyone sins, and commits a trespass against Yahuah, and deals falsely with his neighbor in a matter of deposit, or of bargain, or of robbery, or has oppressed his neighbor, 
 \v 3 or has found that which was lost, and lied about it, and swearing to a lie—in any of these things that a man sins in his actions—\v 4 then it shall be, if he has sinned, and is guilty, he shall restore that which he took by robbery, or the thing which he has gotten by oppression, or the deposit which was committed to him, or the lost thing which he found, 
 \v 5 or any thing about which he has sworn falsely: he shall restore it in full, and shall add a fifth part more to it. He shall return it to him to whom it belongs in the day of his being found guilty. 
-\v 6 He shall bring his trespass offering to Yahweh: a ram without defect from the flock, according to your estimation, for a trespass offering, to the priest. 
-\v 7 The priest shall make atonement for him before Yahweh, and he will be forgiven concerning whatever he does to become guilty.” 
+\v 6 He shall bring his trespass offering to Yahuah: a ram without defect from the flock, according to your estimation, for a trespass offering, to the priest. 
+\v 7 The priest shall make atonement for him before Yahuah, and he will be forgiven concerning whatever he does to become guilty.” 
 \p
-\v 8 Yahweh spoke to Moses, saying, 
+\v 8 Yahuah spoke to Moses, saying, 
 \v 9 “Command Aaron and his sons, saying, ‘This is the law of the burnt offering: the burnt offering shall be on the hearth on the altar all night until the morning; and the fire of the altar shall be kept burning on it. 
 \v 10 The priest shall put on his linen garment, and he shall put on his linen trousers upon his body; and he shall remove the ashes from where the fire has consumed the burnt offering on the altar, and he shall put them beside the altar. 
 \v 11 He shall take off his garments, and put on other garments, and carry the ashes outside the camp to a clean place. 
 \v 12 The fire on the altar shall be kept burning on it, it shall not go out; and the priest shall burn wood on it every morning. He shall lay the burnt offering in order upon it, and shall burn on it the fat of the peace offerings. 
 \v 13 Fire shall be kept burning on the altar continually; it shall not go out. 
 \p
-\v 14 “ ‘This is the law of the meal offering: the sons of Aaron shall offer it before Yahweh, before the altar. 
-\v 15 He shall take from there his handful of the fine flour of the meal offering, and of its oil, and all the frankincense which is on the meal offering, and shall burn it on the altar for a pleasant aroma, as its memorial portion, to Yahweh. 
+\v 14 “ ‘This is the law of the meal offering: the sons of Aaron shall offer it before Yahuah, before the altar. 
+\v 15 He shall take from there his handful of the fine flour of the meal offering, and of its oil, and all the frankincense which is on the meal offering, and shall burn it on the altar for a pleasant aroma, as its memorial portion, to Yahuah. 
 \v 16 That which is left of it Aaron and his sons shall eat. It shall be eaten without yeast in a set-apart place. They shall eat it in the court of the Tent of Meeting. 
 \v 17 It shall not be baked with yeast. I have given it as their portion of my offerings made by fire. It is most set-apart, as are the sin offering and the trespass offering. 
-\v 18 Every male among the children of Aaron shall eat of it, as their portion forever throughout your generations, from the offerings of Yahweh made by fire. Whoever touches them shall be set-apart.’ ” 
+\v 18 Every male among the children of Aaron shall eat of it, as their portion forever throughout your generations, from the offerings of Yahuah made by fire. Whoever touches them shall be set-apart.’ ” 
 \p
-\v 19 Yahweh spoke to Moses, saying, 
-\v 20 “This is the offering of Aaron and of his sons, which they shall offer to Yahweh in the day when he is anointed: one tenth of an ephah of fine flour for a meal offering perpetually, half of it in the morning, and half of it in the evening. 
-\v 21 It shall be made with oil in a griddle. When it is soaked, you shall bring it in. You shall offer the meal offering in baked pieces for a pleasant aroma to Yahweh. 
-\v 22 The anointed priest that will be in his place from among his sons shall offer it. By a statute forever, it shall be wholly burned to Yahweh. 
+\v 19 Yahuah spoke to Moses, saying, 
+\v 20 “This is the offering of Aaron and of his sons, which they shall offer to Yahuah in the day when he is anointed: one tenth of an ephah of fine flour for a meal offering perpetually, half of it in the morning, and half of it in the evening. 
+\v 21 It shall be made with oil in a griddle. When it is soaked, you shall bring it in. You shall offer the meal offering in baked pieces for a pleasant aroma to Yahuah. 
+\v 22 The anointed priest that will be in his place from among his sons shall offer it. By a statute forever, it shall be wholly burned to Yahuah. 
 \v 23 Every meal offering of a priest shall be wholly burned. It shall not be eaten.” 
 \p
-\v 24 Yahweh spoke to Moses, saying, 
-\v 25 “Speak to Aaron and to his sons, saying, ‘This is the law of the sin offering: in the place where the burnt offering is killed, the sin offering shall be killed before Yahweh. It is most set-apart. 
+\v 24 Yahuah spoke to Moses, saying, 
+\v 25 “Speak to Aaron and to his sons, saying, ‘This is the law of the sin offering: in the place where the burnt offering is killed, the sin offering shall be killed before Yahuah. It is most set-apart. 
 \v 26 The priest who offers it for sin shall eat it. It shall be eaten in a set-apart place, in the court of the Tent of Meeting. 
 \v 27 Whatever shall touch its flesh shall be set-apart. When there is any of its blood sprinkled on a garment, you shall wash that on which it was sprinkled in a set-apart place. 
 \v 28 But the earthen vessel in which it is boiled shall be broken; and if it is boiled in a bronze vessel, it shall be scoured, and rinsed in water. 
@@ -175,7 +175,7 @@
 \v 2 In the place where they kill the burnt offering, he shall kill the trespass offering; and its blood he shall sprinkle around on the altar. 
 \v 3 He shall offer all of its fat: the fat tail, and the fat that covers the innards, 
 \v 4 and he shall take away the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys; 
-\v 5 and the priest shall burn them on the altar for an offering made by fire to Yahweh: it is a trespass offering. 
+\v 5 and the priest shall burn them on the altar for an offering made by fire to Yahuah: it is a trespass offering. 
 \v 6 Every male among the priests may eat of it. It shall be eaten in a set-apart place. It is most set-apart. 
 \p
 \v 7 “ ‘As is the sin offering, so is the trespass offering; there is one law for them. The priest who makes atonement with them shall have it. 
@@ -183,10 +183,10 @@
 \v 9 Every meal offering that is baked in the oven, and all that is prepared in the pan and on the griddle, shall be the priest’s who offers it. 
 \v 10 Every meal offering, mixed with oil or dry, belongs to all the sons of Aaron, one as well as another. 
 \p
-\v 11 “ ‘This is the law of the sacrifice of peace offerings, which one shall offer to Yahweh: 
+\v 11 “ ‘This is the law of the sacrifice of peace offerings, which one shall offer to Yahuah: 
 \v 12 If he offers it for a thanksgiving, then he shall offer with the sacrifice of thanksgiving unleavened cakes mixed with oil, and unleavened wafers anointed with oil, and cakes mixed with oil. 
 \v 13 He shall offer his offering with the sacrifice of his peace offerings for thanksgiving with cakes of leavened bread. 
-\v 14 Of it he shall offer one out of each offering for a heave offering to Yahweh. It shall be the priest’s who sprinkles the blood of the peace offerings. 
+\v 14 Of it he shall offer one out of each offering for a heave offering to Yahuah. It shall be the priest’s who sprinkles the blood of the peace offerings. 
 \v 15 The flesh of the sacrifice of his peace offerings for thanksgiving shall be eaten on the day of his offering. He shall not leave any of it until the morning. 
 \p
 \v 16 “ ‘But if the sacrifice of his offering is a vow, or a free will offering, it shall be eaten on the day that he offers his sacrifice. On the next day what remains of it shall be eaten, 
@@ -194,83 +194,83 @@
 \v 18 If any of the meat of the sacrifice of his peace offerings is eaten on the third day, it will not be accepted, and it shall not be credited to him who offers it. It will be an abomination, and the soul who eats any of it will bear his iniquity. 
 \p
 \v 19 “ ‘The meat that touches any unclean thing shall not be eaten. It shall be burned with fire. As for the meat, everyone who is clean may eat it; 
-\v 20 but the soul who eats of the meat of the sacrifice of peace offerings that belongs to Yahweh, having his uncleanness on him, that soul shall be cut off from his people. 
-\v 21 When anyone touches any unclean thing, the uncleanness of man, or an unclean animal, or any unclean abomination, and eats some of the meat of the sacrifice of peace offerings which belong to Yahweh, that soul shall be cut off from his people.’ ” 
+\v 20 but the soul who eats of the meat of the sacrifice of peace offerings that belongs to Yahuah, having his uncleanness on him, that soul shall be cut off from his people. 
+\v 21 When anyone touches any unclean thing, the uncleanness of man, or an unclean animal, or any unclean abomination, and eats some of the meat of the sacrifice of peace offerings which belong to Yahuah, that soul shall be cut off from his people.’ ” 
 \p
-\v 22 Yahweh spoke to Moses, saying, 
+\v 22 Yahuah spoke to Moses, saying, 
 \v 23 “Speak to the children of Israel, saying, ‘You shall eat no fat, of bull, or sheep, or goat. 
 \v 24 The fat of that which dies of itself, and the fat of that which is torn of animals, may be used for any other service, but you shall in no way eat of it. 
-\v 25 For whoever eats the fat of the animal which men offer as an offering made by fire to Yahweh, even the soul who eats it shall be cut off from his people. 
+\v 25 For whoever eats the fat of the animal which men offer as an offering made by fire to Yahuah, even the soul who eats it shall be cut off from his people. 
 \v 26 You shall not eat any blood, whether it is of bird or of animal, in any of your dwellings. 
 \v 27 Whoever it is who eats any blood, that soul shall be cut off from his people.’ ” 
 \p
-\v 28 Yahweh spoke to Moses, saying, 
-\v 29 “Speak to the children of Israel, saying, ‘He who offers the sacrifice of his peace offerings to Yahweh shall bring his offering to Yahweh out of the sacrifice of his peace offerings. 
-\v 30 With his own hands he shall bring the offerings of Yahweh made by fire. He shall bring the fat with the breast, that the breast may be waved for a wave offering before Yahweh. 
+\v 28 Yahuah spoke to Moses, saying, 
+\v 29 “Speak to the children of Israel, saying, ‘He who offers the sacrifice of his peace offerings to Yahuah shall bring his offering to Yahuah out of the sacrifice of his peace offerings. 
+\v 30 With his own hands he shall bring the offerings of Yahuah made by fire. He shall bring the fat with the breast, that the breast may be waved for a wave offering before Yahuah. 
 \v 31 The priest shall burn the fat on the altar, but the breast shall be Aaron’s and his sons’. 
 \v 32 The right thigh you shall give to the priest for a heave offering out of the sacrifices of your peace offerings. 
 \v 33 He among the sons of Aaron who offers the blood of the peace offerings, and the fat, shall have the right thigh for a portion. 
 \v 34 For the waved breast and the heaved thigh I have taken from the children of Israel out of the sacrifices of their peace offerings, and have given them to Aaron the priest and to his sons as their portion forever from the children of Israel.’ ” 
 \p
-\v 35 This is the consecrated portion of Aaron, and the consecrated portion of his sons, out of the offerings of Yahweh made by fire, in the day when he presented them to minister to Yahweh in the priest’s office; 
-\v 36 which Yahweh commanded to be given them of the children of Israel, in the day that he anointed them. It is their portion forever throughout their generations. 
+\v 35 This is the consecrated portion of Aaron, and the consecrated portion of his sons, out of the offerings of Yahuah made by fire, in the day when he presented them to minister to Yahuah in the priest’s office; 
+\v 36 which Yahuah commanded to be given them of the children of Israel, in the day that he anointed them. It is their portion forever throughout their generations. 
 \v 37 This is the law of the burnt offering, the meal offering, the sin offering, the trespass offering, the consecration, and the sacrifice of peace offerings 
-\v 38 which Yahweh commanded Moses in Mount Sinai in the day that he commanded the children of Israel to offer their offerings to Yahweh, in the wilderness of Sinai. 
+\v 38 which Yahuah commanded Moses in Mount Sinai in the day that he commanded the children of Israel to offer their offerings to Yahuah, in the wilderness of Sinai. 
 \c 8
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Take Aaron and his sons with him, and the garments, and the anointing oil, and the bull of the sin offering, and the two rams, and the basket of unleavened bread; 
 \v 3 and assemble all the congregation at the door of the Tent of Meeting.” 
 \p
-\v 4 Moses did as Yahweh commanded him; and the congregation was assembled at the door of the Tent of Meeting. 
-\v 5 Moses said to the congregation, “This is the thing which Yahweh has commanded to be done.” 
+\v 4 Moses did as Yahuah commanded him; and the congregation was assembled at the door of the Tent of Meeting. 
+\v 5 Moses said to the congregation, “This is the thing which Yahuah has commanded to be done.” 
 \v 6 Moses brought Aaron and his sons, and washed them with water. 
 \v 7 He put the tunic on him, tied the sash on him, clothed him with the robe, put the ephod on him, and he tied the skillfully woven band of the ephod on him and fastened it to him with it. 
 \v 8 He placed the breastplate on him. He put the Urim and Thummim in the breastplate. 
-\v 9 He set the turban on his head. He set the golden plate, the set-apart crown, on the front of the turban, as Yahweh commanded Moses. 
+\v 9 He set the turban on his head. He set the golden plate, the set-apart crown, on the front of the turban, as Yahuah commanded Moses. 
 \v 10 Moses took the anointing oil, and anointed the tabernacle and all that was in it, and sanctified them. 
 \v 11 He sprinkled it on the altar seven times, and anointed the altar and all its vessels, and the basin and its base, to sanctify them. 
 \v 12 He poured some of the anointing oil on Aaron’s head, and anointed him, to sanctify him. 
-\v 13 Moses brought Aaron’s sons, and clothed them with tunics, and tied sashes on them, and put headbands on them, as Yahweh commanded Moses. 
+\v 13 Moses brought Aaron’s sons, and clothed them with tunics, and tied sashes on them, and put headbands on them, as Yahuah commanded Moses. 
 \p
 \v 14 He brought the bull of the sin offering, and Aaron and his sons laid their hands on the head of the bull of the sin offering. 
 \v 15 He killed it; and Moses took the blood, and put it around on the horns of the altar with his finger, and purified the altar, and poured out the blood at the base of the altar, and sanctified it, to make atonement for it. 
 \v 16 He took all the fat that was on the innards, and the cover of the liver, and the two kidneys, and their fat; and Moses burned it on the altar. 
-\v 17 But the bull, and its skin, and its meat, and its dung, he burned with fire outside the camp, as Yahweh commanded Moses. 
+\v 17 But the bull, and its skin, and its meat, and its dung, he burned with fire outside the camp, as Yahuah commanded Moses. 
 \v 18 He presented the ram of the burnt offering. Aaron and his sons laid their hands on the head of the ram. 
 \v 19 He killed it; and Moses sprinkled the blood around on the altar. 
 \v 20 He cut the ram into its pieces; and Moses burned the head, and the pieces, and the fat. 
-\v 21 He washed the innards and the legs with water; and Moses burned the whole ram on the altar. It was a burnt offering for a pleasant aroma. It was an offering made by fire to Yahweh, as Yahweh commanded Moses. 
+\v 21 He washed the innards and the legs with water; and Moses burned the whole ram on the altar. It was a burnt offering for a pleasant aroma. It was an offering made by fire to Yahuah, as Yahuah commanded Moses. 
 \v 22 He presented the other ram, the ram of consecration. Aaron and his sons laid their hands on the head of the ram. 
 \v 23 He killed it; and Moses took some of its blood, and put it on the tip of Aaron’s right ear, and on the thumb of his right hand, and on the great toe of his right foot. 
 \v 24 He brought Aaron’s sons; and Moses put some of the blood on the tip of their right ear, and on the thumb of their right hand, and on the great toe of their right foot; and Moses sprinkled the blood around on the altar. 
 \v 25 He took the fat, the fat tail, all the fat that was on the innards, the cover of the liver, the two kidneys and their fat, and the right thigh; 
-\v 26 and out of the basket of unleavened bread that was before Yahweh, he took one unleavened cake, one cake of oiled bread, and one wafer, and placed them on the fat and on the right thigh. 
-\v 27 He put all these in Aaron’s hands and in his sons’ hands, and waved them for a wave offering before Yahweh. 
-\v 28 Moses took them from their hands, and burned them on the altar on the burnt offering. They were a consecration offering for a pleasant aroma. It was an offering made by fire to Yahweh. 
-\v 29 Moses took the breast, and waved it for a wave offering before Yahweh. It was Moses’ portion of the ram of consecration, as Yahweh commanded Moses. 
+\v 26 and out of the basket of unleavened bread that was before Yahuah, he took one unleavened cake, one cake of oiled bread, and one wafer, and placed them on the fat and on the right thigh. 
+\v 27 He put all these in Aaron’s hands and in his sons’ hands, and waved them for a wave offering before Yahuah. 
+\v 28 Moses took them from their hands, and burned them on the altar on the burnt offering. They were a consecration offering for a pleasant aroma. It was an offering made by fire to Yahuah. 
+\v 29 Moses took the breast, and waved it for a wave offering before Yahuah. It was Moses’ portion of the ram of consecration, as Yahuah commanded Moses. 
 \v 30 Moses took some of the anointing oil, and some of the blood which was on the altar, and sprinkled it on Aaron, on his garments, and on his sons, and on his sons’ garments with him, and sanctified Aaron, his garments, and his sons, and his sons’ garments with him. 
 \p
 \v 31 Moses said to Aaron and to his sons, “Boil the meat at the door of the Tent of Meeting, and there eat it and the bread that is in the basket of consecration, as I commanded, saying, ‘Aaron and his sons shall eat it.’ 
 \v 32 What remains of the meat and of the bread you shall burn with fire. 
 \v 33 You shall not go out from the door of the Tent of Meeting for seven days, until the days of your consecration are fulfilled: for he shall consecrate you seven days. 
-\v 34 What has been done today, so Yahweh has commanded to do, to make atonement for you. 
-\v 35 You shall stay at the door of the Tent of Meeting day and night seven days, and keep Yahweh’s command, that you don’t die: for so I am commanded.” 
-\v 36 Aaron and his sons did all the things which Yahweh commanded by Moses. 
+\v 34 What has been done today, so Yahuah has commanded to do, to make atonement for you. 
+\v 35 You shall stay at the door of the Tent of Meeting day and night seven days, and keep Yahuah’s command, that you don’t die: for so I am commanded.” 
+\v 36 Aaron and his sons did all the things which Yahuah commanded by Moses. 
 \c 9
 \p
 \v 1 On the eighth day, Moses called Aaron and his sons, and the elders of Israel; 
-\v 2 and he said to Aaron, “Take a calf from the herd for a sin offering, and a ram for a burnt offering, without defect, and offer them before Yahweh. 
+\v 2 and he said to Aaron, “Take a calf from the herd for a sin offering, and a ram for a burnt offering, without defect, and offer them before Yahuah. 
 \v 3 You shall speak to the children of Israel, saying, ‘Take a male goat for a sin offering; and a calf and a lamb, both a year old, without defect, for a burnt offering; 
-\v 4 and a bull and a ram for peace offerings, to sacrifice before Yahweh; and a meal offering mixed with oil: for today Yahweh appears to you.’ ” 
+\v 4 and a bull and a ram for peace offerings, to sacrifice before Yahuah; and a meal offering mixed with oil: for today Yahuah appears to you.’ ” 
 \p
-\v 5 They brought what Moses commanded before the Tent of Meeting. All the congregation came near and stood before Yahweh. 
-\v 6 Moses said, “This is the thing which Yahweh commanded that you should do; and Yahweh’s glory shall appear to you.” 
-\v 7 Moses said to Aaron, “Draw near to the altar, and offer your sin offering, and your burnt offering, and make atonement for yourself, and for the people; and offer the offering of the people, and make atonement for them, as Yahweh commanded.” 
+\v 5 They brought what Moses commanded before the Tent of Meeting. All the congregation came near and stood before Yahuah. 
+\v 6 Moses said, “This is the thing which Yahuah commanded that you should do; and Yahuah’s glory shall appear to you.” 
+\v 7 Moses said to Aaron, “Draw near to the altar, and offer your sin offering, and your burnt offering, and make atonement for yourself, and for the people; and offer the offering of the people, and make atonement for them, as Yahuah commanded.” 
 \p
 \v 8 So Aaron came near to the altar, and killed the calf of the sin offering, which was for himself. 
 \v 9 The sons of Aaron presented the blood to him; and he dipped his finger in the blood, and put it on the horns of the altar, and poured out the blood at the base of the altar; 
-\v 10 but the fat, and the kidneys, and the cover from the liver of the sin offering, he burned upon the altar, as Yahweh commanded Moses. 
+\v 10 but the fat, and the kidneys, and the cover from the liver of the sin offering, he burned upon the altar, as Yahuah commanded Moses. 
 \v 11 The meat and the skin he burned with fire outside the camp. 
 \v 12 He killed the burnt offering; and Aaron’s sons delivered the blood to him, and he sprinkled it around on the altar. 
 \v 13 They delivered the burnt offering to him, piece by piece, and the head. He burned them upon the altar. 
@@ -281,45 +281,45 @@
 \v 18 He also killed the bull and the ram, the sacrifice of peace offerings, which was for the people. Aaron’s sons delivered to him the blood, which he sprinkled around on the altar; 
 \v 19 and the fat of the bull and of the ram, the fat tail, and that which covers the innards, and the kidneys, and the cover of the liver; 
 \v 20 and they put the fat upon the breasts, and he burned the fat on the altar. 
-\v 21 Aaron waved the breasts and the right thigh for a wave offering before Yahweh, as Moses commanded. 
+\v 21 Aaron waved the breasts and the right thigh for a wave offering before Yahuah, as Moses commanded. 
 \v 22 Aaron lifted up his hands toward the people, and blessed them; and he came down from offering the sin offering, and the burnt offering, and the peace offerings. 
 \p
-\v 23 Moses and Aaron went into the Tent of Meeting, and came out, and blessed the people; and Yahweh’s glory appeared to all the people. 
-\v 24 Fire came out from before Yahweh, and consumed the burnt offering and the fat upon the altar. When all the people saw it, they shouted, and fell on their faces. 
+\v 23 Moses and Aaron went into the Tent of Meeting, and came out, and blessed the people; and Yahuah’s glory appeared to all the people. 
+\v 24 Fire came out from before Yahuah, and consumed the burnt offering and the fat upon the altar. When all the people saw it, they shouted, and fell on their faces. 
 \c 10
 \p
-\v 1 Nadab and Abihu, the sons of Aaron, each took his censer, and put fire in it, and laid incense on it, and offered strange fire before Yahweh, which he had not commanded them. 
-\v 2 Fire came out from before Yahweh, and devoured them, and they died before Yahweh. 
+\v 1 Nadab and Abihu, the sons of Aaron, each took his censer, and put fire in it, and laid incense on it, and offered strange fire before Yahuah, which he had not commanded them. 
+\v 2 Fire came out from before Yahuah, and devoured them, and they died before Yahuah. 
 \p
-\v 3 Then Moses said to Aaron, “This is what Yahweh spoke of, saying, 
+\v 3 Then Moses said to Aaron, “This is what Yahuah spoke of, saying, 
 \q1 ‘I will show myself set-apart to those who come near me, 
 \q2 and before all the people I will be glorified.’ ” 
 \p Aaron held his peace. 
 \v 4 Moses called Mishael and Elzaphan, the sons of Uzziel the uncle of Aaron, and said to them, “Draw near, carry your brothers from before the sanctuary out of the camp.” 
 \v 5 So they came near, and carried them in their tunics out of the camp, as Moses had said. 
 \p
-\v 6 Moses said to Aaron, and to Eleazar and to Ithamar, his sons, “Don’t let the hair of your heads go loose, and don’t tear your clothes, so that you don’t die, and so that he will not be angry with all the congregation; but let your brothers, the whole house of Israel, bewail the burning which Yahweh has kindled. 
-\v 7 You shall not go out from the door of the Tent of Meeting, lest you die; for the anointing oil of Yahweh is on you.” They did according to the word of Moses. 
-\v 8 Then Yahweh said to Aaron, 
+\v 6 Moses said to Aaron, and to Eleazar and to Ithamar, his sons, “Don’t let the hair of your heads go loose, and don’t tear your clothes, so that you don’t die, and so that he will not be angry with all the congregation; but let your brothers, the whole house of Israel, bewail the burning which Yahuah has kindled. 
+\v 7 You shall not go out from the door of the Tent of Meeting, lest you die; for the anointing oil of Yahuah is on you.” They did according to the word of Moses. 
+\v 8 Then Yahuah said to Aaron, 
 \v 9 “You and your sons are not to drink wine or strong drink whenever you go into the Tent of Meeting, or you will die. This shall be a statute forever throughout your generations. 
 \v 10 You are to make a distinction between the set-apart and the common, and between the unclean and the clean. 
-\v 11 You are to teach the children of Israel all the statutes which Yahweh has spoken to them by Moses.” 
+\v 11 You are to teach the children of Israel all the statutes which Yahuah has spoken to them by Moses.” 
 \p
-\v 12 Moses spoke to Aaron, and to Eleazar and to Ithamar, his sons who were left, “Take the meal offering that remains of the offerings of Yahweh made by fire, and eat it without yeast beside the altar; for it is most set-apart; 
-\v 13 and you shall eat it in a set-apart place, because it is your portion, and your sons’ portion, of the offerings of Yahweh made by fire; for so I am commanded. 
+\v 12 Moses spoke to Aaron, and to Eleazar and to Ithamar, his sons who were left, “Take the meal offering that remains of the offerings of Yahuah made by fire, and eat it without yeast beside the altar; for it is most set-apart; 
+\v 13 and you shall eat it in a set-apart place, because it is your portion, and your sons’ portion, of the offerings of Yahuah made by fire; for so I am commanded. 
 \v 14 The waved breast and the heaved thigh you shall eat in a clean place, you, and your sons, and your daughters with you: for they are given as your portion, and your sons’ portion, out of the sacrifices of the peace offerings of the children of Israel. 
-\v 15 They shall bring the heaved thigh and the waved breast with the offerings made by fire of the fat, to wave it for a wave offering before Yahweh. It shall be yours, and your sons’ with you, as a portion forever, as Yahweh has commanded.” 
+\v 15 They shall bring the heaved thigh and the waved breast with the offerings made by fire of the fat, to wave it for a wave offering before Yahuah. It shall be yours, and your sons’ with you, as a portion forever, as Yahuah has commanded.” 
 \p
 \v 16 Moses diligently inquired about the goat of the sin offering, and, behold, it was burned. He was angry with Eleazar and with Ithamar, the sons of Aaron who were left, saying, 
-\v 17 “Why haven’t you eaten the sin offering in the place of the sanctuary, since it is most set-apart, and he has given it to you to bear the iniquity of the congregation, to make atonement for them before Yahweh? 
+\v 17 “Why haven’t you eaten the sin offering in the place of the sanctuary, since it is most set-apart, and he has given it to you to bear the iniquity of the congregation, to make atonement for them before Yahuah? 
 \v 18 Behold, its blood was not brought into the inner part of the sanctuary. You certainly should have eaten it in the sanctuary, as I commanded.” 
 \p
-\v 19 Aaron spoke to Moses, “Behold, today they have offered their sin offering and their burnt offering before Yahweh; and such things as these have happened to me. If I had eaten the sin offering today, would it have been pleasing in Yahweh’s sight?” 
+\v 19 Aaron spoke to Moses, “Behold, today they have offered their sin offering and their burnt offering before Yahuah; and such things as these have happened to me. If I had eaten the sin offering today, would it have been pleasing in Yahuah’s sight?” 
 \p
 \v 20 When Moses heard that, it was pleasing in his sight. 
 \c 11
 \p
-\v 1 Yahweh spoke to Moses and to Aaron, saying to them, 
+\v 1 Yahuah spoke to Moses and to Aaron, saying to them, 
 \v 2 “Speak to the children of Israel, saying, ‘These are the living things which you may eat among all the animals that are on the earth. 
 \v 3 Whatever parts the hoof, and is cloven-footed, and chews the cud among the animals, that you may eat. 
 \p
@@ -371,26 +371,26 @@
 \v 41 “ ‘Every creeping thing that creeps on the earth is an abomination. It shall not be eaten. 
 \v 42 Whatever goes on its belly, and whatever goes on all fours, or whatever has many feet, even all creeping things that creep on the earth, them you shall not eat; for they are an abomination. 
 \v 43 You shall not make yourselves abominable with any creeping thing that creeps. You shall not make yourselves unclean with them, that you should be defiled by them. 
-\v 44 For I am Yahweh your Elohim. Sanctify yourselves therefore, and be set-apart; for I am set-apart. You shall not defile yourselves with any kind of creeping thing that moves on the earth. 
-\v 45 For I am Yahweh who brought you up out of the land of Egypt, to be your Elohim. You shall therefore be set-apart, for I am set-apart. 
+\v 44 For I am Yahuah your Elohim. Sanctify yourselves therefore, and be set-apart; for I am set-apart. You shall not defile yourselves with any kind of creeping thing that moves on the earth. 
+\v 45 For I am Yahuah who brought you up out of the land of Egypt, to be your Elohim. You shall therefore be set-apart, for I am set-apart. 
 \p
 \v 46 “ ‘This is the law of the animal, and of the bird, and of every living creature that moves in the waters, and of every creature that creeps on the earth, 
 \v 47 to make a distinction between the unclean and the clean, and between the living thing that may be eaten and the living thing that may not be eaten.’ ” 
 \c 12
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Speak to the children of Israel, saying, ‘If a woman conceives, and bears a male child, then she shall be unclean seven days; as in the days of her monthly period she shall be unclean. 
 \v 3 In the eighth day the flesh of his foreskin shall be circumcised. 
 \v 4 She shall continue in the blood of purification thirty-three days. She shall not touch any set-apart thing, nor come into the sanctuary, until the days of her purifying are completed. 
 \v 5 But if she bears a female child, then she shall be unclean two weeks, as in her period; and she shall continue in the blood of purification sixty-six days. 
 \p
 \v 6 “ ‘When the days of her purification are completed for a son or for a daughter, she shall bring to the priest at the door of the Tent of Meeting, a year old lamb for a burnt offering, and a young pigeon or a turtledove, for a sin offering. 
-\v 7 He shall offer it before Yahweh, and make atonement for her; then she shall be cleansed from the fountain of her blood. 
+\v 7 He shall offer it before Yahuah, and make atonement for her; then she shall be cleansed from the fountain of her blood. 
 \p “ ‘This is the law for her who bears, whether a male or a female. 
 \v 8 If she cannot afford a lamb, then she shall take two turtledoves or two young pigeons: the one for a burnt offering, and the other for a sin offering. The priest shall make atonement for her, and she shall be clean.’ ” 
 \c 13
 \p
-\v 1 Yahweh spoke to Moses and to Aaron, saying, 
+\v 1 Yahuah spoke to Moses and to Aaron, saying, 
 \v 2 “When a man shall have a swelling in his body’s skin, or a scab, or a bright spot, and it becomes in the skin of his body the plague of leprosy, then he shall be brought to Aaron the priest or to one of his sons, the priests. 
 \v 3 The priest shall examine the plague in the skin of the body. If the hair in the plague has turned white, and the appearance of the plague is deeper than the body’s skin, it is the plague of leprosy; so the priest shall examine him and pronounce him unclean. 
 \v 4 If the bright spot is white in the skin of his body, and its appearance isn’t deeper than the skin, and its hair hasn’t turned white, then the priest shall isolate the infected person for seven days. 
@@ -462,7 +462,7 @@
 \v 59 This is the law of the plague of mildew in a garment of wool or linen, either in the warp, or the woof, or in anything of skin, to pronounce it clean, or to pronounce it unclean. 
 \c 14
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \p
 \v 2 “This shall be the law of the leper in the day of his cleansing: He shall be brought to the priest, 
 \v 3 and the priest shall go out of the camp. The priest shall examine him. Behold, if the plague of leprosy is healed in the leper, 
@@ -475,15 +475,15 @@
 \v 9 It shall be on the seventh day, that he shall shave all his hair off his head and his beard and his eyebrows. He shall shave off all his hair. He shall wash his clothes, and he shall bathe his body in water. Then he shall be clean. 
 \p
 \v 10 “On the eighth day he shall take two male lambs without defect, one ewe lamb a year old without defect, three tenths of an ephah of fine flour for a meal offering, mixed with oil, and one log of oil. 
-\v 11 The priest who cleanses him shall set the man who is to be cleansed, and those things, before Yahweh, at the door of the Tent of Meeting. 
+\v 11 The priest who cleanses him shall set the man who is to be cleansed, and those things, before Yahuah, at the door of the Tent of Meeting. 
 \p
-\v 12 “The priest shall take one of the male lambs, and offer him for a trespass offering, with the log of oil, and wave them for a wave offering before Yahweh. 
+\v 12 “The priest shall take one of the male lambs, and offer him for a trespass offering, with the log of oil, and wave them for a wave offering before Yahuah. 
 \v 13 He shall kill the male lamb in the place where they kill the sin offering and the burnt offering, in the place of the sanctuary; for as the sin offering is the priest’s, so is the trespass offering. It is most set-apart. 
 \v 14 The priest shall take some of the blood of the trespass offering, and the priest shall put it on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot. 
 \v 15 The priest shall take some of the log of oil, and pour it into the palm of his own left hand. 
-\v 16 The priest shall dip his right finger in the oil that is in his left hand, and shall sprinkle some of the oil with his finger seven times before Yahweh. 
+\v 16 The priest shall dip his right finger in the oil that is in his left hand, and shall sprinkle some of the oil with his finger seven times before Yahuah. 
 \v 17 The priest shall put some of the rest of the oil that is in his hand on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot, upon the blood of the trespass offering. 
-\v 18 The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, and the priest shall make atonement for him before Yahweh. 
+\v 18 The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, and the priest shall make atonement for him before Yahuah. 
 \p
 \v 19 “The priest shall offer the sin offering, and make atonement for him who is to be cleansed because of his uncleanness. Afterward he shall kill the burnt offering; 
 \v 20 then the priest shall offer the burnt offering and the meal offering on the altar. The priest shall make atonement for him, and he shall be clean. 
@@ -491,19 +491,19 @@
 \v 21 “If he is poor, and can’t afford so much, then he shall take one male lamb for a trespass offering to be waved, to make atonement for him, and one tenth of an ephah of fine flour mixed with oil for a meal offering, and a log of oil; 
 \v 22 and two turtledoves, or two young pigeons, such as he is able to afford; and the one shall be a sin offering, and the other a burnt offering. 
 \p
-\v 23 “On the eighth day he shall bring them for his cleansing to the priest, to the door of the Tent of Meeting, before Yahweh. 
-\v 24 The priest shall take the lamb of the trespass offering, and the log of oil, and the priest shall wave them for a wave offering before Yahweh. 
+\v 23 “On the eighth day he shall bring them for his cleansing to the priest, to the door of the Tent of Meeting, before Yahuah. 
+\v 24 The priest shall take the lamb of the trespass offering, and the log of oil, and the priest shall wave them for a wave offering before Yahuah. 
 \v 25 He shall kill the lamb of the trespass offering. The priest shall take some of the blood of the trespass offering and put it on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot. 
 \v 26 The priest shall pour some of the oil into the palm of his own left hand; 
-\v 27 and the priest shall sprinkle with his right finger some of the oil that is in his left hand seven times before Yahweh. 
+\v 27 and the priest shall sprinkle with his right finger some of the oil that is in his left hand seven times before Yahuah. 
 \v 28 Then the priest shall put some of the oil that is in his hand on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot, on the place of the blood of the trespass offering. 
-\v 29 The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, to make atonement for him before Yahweh. 
+\v 29 The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, to make atonement for him before Yahuah. 
 \v 30 He shall offer one of the turtledoves, or of the young pigeons, which ever he is able to afford, 
-\v 31 of the kind he is able to afford, the one for a sin offering, and the other for a burnt offering, with the meal offering. The priest shall make atonement for him who is to be cleansed before Yahweh.” 
+\v 31 of the kind he is able to afford, the one for a sin offering, and the other for a burnt offering, with the meal offering. The priest shall make atonement for him who is to be cleansed before Yahuah.” 
 \p
 \v 32 This is the law for him in whom is the plague of leprosy, who is not able to afford the sacrifice for his cleansing. 
 \p
-\v 33 Yahweh spoke to Moses and to Aaron, saying, 
+\v 33 Yahuah spoke to Moses and to Aaron, saying, 
 \v 34 “When you have come into the land of Canaan, which I give to you for a possession, and I put a spreading mildew in a house in the land of your possession, 
 \v 35 then he who owns the house shall come and tell the priest, saying, ‘There seems to me to be some sort of plague in the house.’ 
 \v 36 The priest shall command that they empty the house, before the priest goes in to examine the plague, that all that is in the house not be made unclean. Afterward the priest shall go in to inspect the house. 
@@ -535,7 +535,7 @@
 \p This is the law of leprosy. 
 \c 15
 \p
-\v 1 Yahweh spoke to Moses and to Aaron, saying, 
+\v 1 Yahuah spoke to Moses and to Aaron, saying, 
 \v 2 “Speak to the children of Israel, and tell them, ‘When any man has a discharge from his body, because of his discharge he is unclean. 
 \v 3 This shall be his uncleanness in his discharge: whether his body runs with his discharge, or his body has stopped from his discharge, it is his uncleanness. 
 \p
@@ -556,8 +556,8 @@
 \p
 \v 13 “ ‘When he who has a discharge is cleansed of his discharge, then he shall count to himself seven days for his cleansing, and wash his clothes; and he shall bathe his flesh in running water, and shall be clean. 
 \p
-\v 14 “ ‘On the eighth day he shall take two turtledoves, or two young pigeons, and come before Yahweh to the door of the Tent of Meeting, and give them to the priest. 
-\v 15 The priest shall offer them, the one for a sin offering, and the other for a burnt offering. The priest shall make atonement for him before Yahweh for his discharge. 
+\v 14 “ ‘On the eighth day he shall take two turtledoves, or two young pigeons, and come before Yahuah to the door of the Tent of Meeting, and give them to the priest. 
+\v 15 The priest shall offer them, the one for a sin offering, and the other for a burnt offering. The priest shall make atonement for him before Yahuah for his discharge. 
 \p
 \v 16 “ ‘If any man has an emission of semen, then he shall bathe all his flesh in water, and be unclean until the evening. 
 \v 17 Every garment and every skin which the semen is on shall be washed with water, and be unclean until the evening. 
@@ -578,7 +578,7 @@
 \p
 \v 28 “ ‘But if she is cleansed of her discharge, then she shall count to herself seven days, and after that she shall be clean. 
 \v 29 On the eighth day she shall take two turtledoves, or two young pigeons, and bring them to the priest, to the door of the Tent of Meeting. 
-\v 30 The priest shall offer the one for a sin offering, and the other for a burnt offering; and the priest shall make atonement for her before Yahweh for the uncleanness of her discharge. 
+\v 30 The priest shall offer the one for a sin offering, and the other for a burnt offering; and the priest shall make atonement for her before Yahuah for the uncleanness of her discharge. 
 \p
 \v 31 “ ‘Thus you shall separate the children of Israel from their uncleanness, so they will not die in their uncleanness when they defile my tabernacle that is among them.’ ” 
 \p
@@ -586,29 +586,29 @@
 \v 33 and of her who has her period, and of a man or woman who has a discharge, and of him who lies with her who is unclean. 
 \c 16
 \p
-\v 1 Yahweh spoke to Moses after the death of the two sons of Aaron, when they came near before Yahweh, and died; 
-\v 2 and Yahweh said to Moses, “Tell Aaron your brother not to come at just any time into the Most Set-Apart Place within the veil, before the mercy seat which is on the ark; lest he die; for I will appear in the cloud on the mercy seat. 
+\v 1 Yahuah spoke to Moses after the death of the two sons of Aaron, when they came near before Yahuah, and died; 
+\v 2 and Yahuah said to Moses, “Tell Aaron your brother not to come at just any time into the Most Set-Apart Place within the veil, before the mercy seat which is on the ark; lest he die; for I will appear in the cloud on the mercy seat. 
 \p
 \v 3 “Aaron shall come into the sanctuary with a young bull for a sin offering, and a ram for a burnt offering. 
 \v 4 He shall put on the set-apart linen tunic. He shall have the linen trousers on his body, and shall put on the linen sash, and he shall be clothed with the linen turban. They are the set-apart garments. He shall bathe his body in water, and put them on. 
 \v 5 He shall take from the congregation of the children of Israel two male goats for a sin offering, and one ram for a burnt offering. 
 \p
 \v 6 “Aaron shall offer the bull of the sin offering, which is for himself, and make atonement for himself and for his house. 
-\v 7 He shall take the two goats, and set them before Yahweh at the door of the Tent of Meeting. 
-\v 8 Aaron shall cast lots for the two goats: one lot for Yahweh, and the other lot for the scapegoat. 
-\v 9 Aaron shall present the goat on which the lot fell for Yahweh, and offer him for a sin offering. 
-\v 10 But the goat on which the lot fell for the scapegoat shall be presented alive before Yahweh, to make atonement for him, to send him away as the scapegoat into the wilderness. 
+\v 7 He shall take the two goats, and set them before Yahuah at the door of the Tent of Meeting. 
+\v 8 Aaron shall cast lots for the two goats: one lot for Yahuah, and the other lot for the scapegoat. 
+\v 9 Aaron shall present the goat on which the lot fell for Yahuah, and offer him for a sin offering. 
+\v 10 But the goat on which the lot fell for the scapegoat shall be presented alive before Yahuah, to make atonement for him, to send him away as the scapegoat into the wilderness. 
 \p
 \v 11 “Aaron shall present the bull of the sin offering, which is for himself, and shall make atonement for himself and for his house, and shall kill the bull of the sin offering which is for himself. 
-\v 12 He shall take a censer full of coals of fire from off the altar before Yahweh, and two handfuls of sweet incense beaten small, and bring it within the veil. 
-\v 13 He shall put the incense on the fire before Yahweh, that the cloud of the incense may cover the mercy seat that is on the covenant, so that he will not die. 
+\v 12 He shall take a censer full of coals of fire from off the altar before Yahuah, and two handfuls of sweet incense beaten small, and bring it within the veil. 
+\v 13 He shall put the incense on the fire before Yahuah, that the cloud of the incense may cover the mercy seat that is on the covenant, so that he will not die. 
 \v 14 He shall take some of the blood of the bull, and sprinkle it with his finger on the mercy seat on the east; and before the mercy seat he shall sprinkle some of the blood with his finger seven times. 
 \p
 \v 15 “Then he shall kill the goat of the sin offering that is for the people, and bring his blood within the veil, and do with his blood as he did with the blood of the bull, and sprinkle it on the mercy seat and before the mercy seat. 
 \v 16 He shall make atonement for the Set-Apart Place, because of the uncleanness of the children of Israel, and because of their transgressions, even all their sins; and so he shall do for the Tent of Meeting that dwells with them in the middle of their uncleanness. 
 \v 17 No one shall be in the Tent of Meeting when he enters to make atonement in the Set-Apart Place, until he comes out, and has made atonement for himself and for his household, and for all the assembly of Israel. 
 \p
-\v 18 “He shall go out to the altar that is before Yahweh and make atonement for it, and shall take some of the bull’s blood, and some of the goat’s blood, and put it around on the horns of the altar. 
+\v 18 “He shall go out to the altar that is before Yahuah and make atonement for it, and shall take some of the bull’s blood, and some of the goat’s blood, and put it around on the horns of the altar. 
 \v 19 He shall sprinkle some of the blood on it with his finger seven times, and cleanse it, and make it set-apart from the uncleanness of the children of Israel. 
 \p
 \v 20 “When he has finished atoning for the Set-Apart Place, the Tent of Meeting, and the altar, he shall present the live goat. 
@@ -624,25 +624,25 @@
 \v 28 He who burns them shall wash his clothes, and bathe his flesh in water, and afterward he shall come into the camp. 
 \p
 \v 29 “It shall be a statute to you forever: in the seventh month, on the tenth day of the month, you shall afflict your souls, and shall do no kind of work, whether native-born or a stranger who lives as a foreigner among you; 
-\v 30 for on this day shall atonement be made for you, to cleanse you. You shall be clean from all your sins before Yahweh. 
+\v 30 for on this day shall atonement be made for you, to cleanse you. You shall be clean from all your sins before Yahuah. 
 \v 31 It is a Sabbath of solemn rest to you, and you shall afflict your souls. It is a statute forever. 
 \v 32 The priest, who is anointed and who is consecrated to be priest in his father’s place, shall make the atonement, and shall put on the linen garments, even the set-apart garments. 
 \v 33 Then he shall make atonement for the Set-Apart Sanctuary; and he shall make atonement for the Tent of Meeting and for the altar; and he shall make atonement for the priests and for all the people of the assembly. 
 \p
 \v 34 “This shall be an everlasting statute for you, to make atonement for the children of Israel once in the year because of all their sins.” 
-\p It was done as Yahweh commanded Moses. 
+\p It was done as Yahuah commanded Moses. 
 \c 17
 \p
-\v 1 Yahweh spoke to Moses, saying, 
-\v 2 “Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘This is the thing which Yahweh has commanded: 
+\v 1 Yahuah spoke to Moses, saying, 
+\v 2 “Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘This is the thing which Yahuah has commanded: 
 \v 3 Whatever man there is of the house of Israel who kills a bull, or lamb, or goat in the camp, or who kills it outside the camp, 
-\v 4 and hasn’t brought it to the door of the Tent of Meeting to offer it as an offering to Yahweh before Yahweh’s tabernacle: blood shall be imputed to that man. He has shed blood. That man shall be cut off from among his people. 
-\v 5 This is to the end that the children of Israel may bring their sacrifices, which they sacrifice in the open field, that they may bring them to Yahweh, to the door of the Tent of Meeting, to the priest, and sacrifice them for sacrifices of peace offerings to Yahweh. 
-\v 6 The priest shall sprinkle the blood on Yahweh’s altar at the door of the Tent of Meeting, and burn the fat for a pleasant aroma to Yahweh. 
+\v 4 and hasn’t brought it to the door of the Tent of Meeting to offer it as an offering to Yahuah before Yahuah’s tabernacle: blood shall be imputed to that man. He has shed blood. That man shall be cut off from among his people. 
+\v 5 This is to the end that the children of Israel may bring their sacrifices, which they sacrifice in the open field, that they may bring them to Yahuah, to the door of the Tent of Meeting, to the priest, and sacrifice them for sacrifices of peace offerings to Yahuah. 
+\v 6 The priest shall sprinkle the blood on Yahuah’s altar at the door of the Tent of Meeting, and burn the fat for a pleasant aroma to Yahuah. 
 \v 7 They shall no more sacrifice their sacrifices to the goat idols, after which they play the prostitute. This shall be a statute forever to them throughout their generations.’ 
 \p
 \v 8 “You shall say to them, ‘Any man there is of the house of Israel, or of the strangers who live as foreigners among them, who offers a burnt offering or sacrifice, 
-\v 9 and doesn’t bring it to the door of the Tent of Meeting to sacrifice it to Yahweh, that man shall be cut off from his people. 
+\v 9 and doesn’t bring it to the door of the Tent of Meeting to sacrifice it to Yahuah, that man shall be cut off from his people. 
 \p
 \v 10 “ ‘Any man of the house of Israel, or of the strangers who live as foreigners among them, who eats any kind of blood, I will set my face against that soul who eats blood, and will cut him off from among his people. 
 \v 11 For the life of the flesh is in the blood. I have given it to you on the altar to make atonement for your souls; for it is the blood that makes atonement by reason of the life. 
@@ -655,13 +655,13 @@
 \v 16 But if he doesn’t wash them, or bathe his flesh, then he shall bear his iniquity.’ ” 
 \c 18
 \p
-\v 1 Yahweh said to Moses, 
-\v 2 “Speak to the children of Israel, and say to them, ‘I am Yahweh your Elohim. 
+\v 1 Yahuah said to Moses, 
+\v 2 “Speak to the children of Israel, and say to them, ‘I am Yahuah your Elohim. 
 \v 3 You shall not do as they do in the land of Egypt, where you lived. You shall not do as they do in the land of Canaan, where I am bringing you. You shall not follow their statutes. 
-\v 4 You shall do my ordinances. You shall keep my statutes and walk in them. I am Yahweh your Elohim. 
-\v 5 You shall therefore keep my statutes and my ordinances, which if a man does, he shall live in them. I am Yahweh. 
+\v 4 You shall do my ordinances. You shall keep my statutes and walk in them. I am Yahuah your Elohim. 
+\v 5 You shall therefore keep my statutes and my ordinances, which if a man does, he shall live in them. I am Yahuah. 
 \p
-\v 6 “ ‘None of you shall approach any close relatives, to uncover their nakedness: I am Yahweh. 
+\v 6 “ ‘None of you shall approach any close relatives, to uncover their nakedness: I am Yahuah. 
 \p
 \v 7 “ ‘You shall not uncover the nakedness of your father, nor the nakedness of your mother: she is your mother. You shall not uncover her nakedness. 
 \p
@@ -691,7 +691,7 @@
 \p
 \v 20 “ ‘You shall not lie carnally with your neighbor’s woman, and defile yourself with her. 
 \p
-\v 21 “ ‘You shall not give any of your children as a sacrifice to Molech. You shall not profane the name of your Elohim. I am Yahweh. 
+\v 21 “ ‘You shall not give any of your children as a sacrifice to Molech. You shall not profane the name of your Elohim. I am Yahuah. 
 \p
 \v 22 “ ‘You shall not lie with a man as with a woman. That is detestable. 
 \p
@@ -704,43 +704,43 @@
 \v 28 that the land not vomit you out also, when you defile it, as it vomited out the nation that was before you. 
 \p
 \v 29 “ ‘For whoever shall do any of these abominations, even the souls that do them shall be cut off from among their people. 
-\v 30 Therefore you shall keep my requirements, that you do not practice any of these abominable customs which were practiced before you, and that you do not defile yourselves with them. I am Yahweh your Elohim.’ ” 
+\v 30 Therefore you shall keep my requirements, that you do not practice any of these abominable customs which were practiced before you, and that you do not defile yourselves with them. I am Yahuah your Elohim.’ ” 
 \c 19
 \p
-\v 1 Yahweh spoke to Moses, saying, 
-\v 2 “Speak to all the congregation of the children of Israel, and tell them, ‘You shall be set-apart; for I, Yahweh your Elohim, am set-apart. 
+\v 1 Yahuah spoke to Moses, saying, 
+\v 2 “Speak to all the congregation of the children of Israel, and tell them, ‘You shall be set-apart; for I, Yahuah your Elohim, am set-apart. 
 \p
-\v 3 “ ‘Each one of you shall respect his mother and his father. You shall keep my Sabbaths. I am Yahweh your Elohim. 
+\v 3 “ ‘Each one of you shall respect his mother and his father. You shall keep my Sabbaths. I am Yahuah your Elohim. 
 \p
-\v 4 “ ‘Don’t turn to idols, nor make molten elohims for yourselves. I am Yahweh your Elohim. 
+\v 4 “ ‘Don’t turn to idols, nor make molten elohims for yourselves. I am Yahuah your Elohim. 
 \p
-\v 5 “ ‘When you offer a sacrifice of peace offerings to Yahweh, you shall offer it so that you may be accepted. 
+\v 5 “ ‘When you offer a sacrifice of peace offerings to Yahuah, you shall offer it so that you may be accepted. 
 \v 6 It shall be eaten the same day you offer it, and on the next day. If anything remains until the third day, it shall be burned with fire. 
 \v 7 If it is eaten at all on the third day, it is an abomination. It will not be accepted; 
-\v 8 but everyone who eats it shall bear his iniquity, because he has profaned the set-apart thing of Yahweh, and that soul shall be cut off from his people. 
+\v 8 but everyone who eats it shall bear his iniquity, because he has profaned the set-apart thing of Yahuah, and that soul shall be cut off from his people. 
 \p
 \v 9 “ ‘When you reap the harvest of your land, you shall not wholly reap the corners of your field, neither shall you gather the gleanings of your harvest. 
-\v 10 You shall not glean your vineyard, neither shall you gather the fallen grapes of your vineyard. You shall leave them for the poor and for the foreigner. I am Yahweh your Elohim. 
+\v 10 You shall not glean your vineyard, neither shall you gather the fallen grapes of your vineyard. You shall leave them for the poor and for the foreigner. I am Yahuah your Elohim. 
 \p
 \v 11 “ ‘You shall not steal. 
 \p “ ‘You shall not lie. 
 \p “ ‘You shall not deceive one another. 
 \p
-\v 12 “ ‘You shall not swear by my name falsely, and profane the name of your Elohim. I am Yahweh. 
+\v 12 “ ‘You shall not swear by my name falsely, and profane the name of your Elohim. I am Yahuah. 
 \p
 \v 13 “ ‘You shall not oppress your neighbor, nor rob him. 
 \p “ ‘The wages of a hired servant shall not remain with you all night until the morning. 
 \p
-\v 14 “ ‘You shall not curse the deaf, nor put a stumbling block before the blind; but you shall fear your Elohim. I am Yahweh. 
+\v 14 “ ‘You shall not curse the deaf, nor put a stumbling block before the blind; but you shall fear your Elohim. I am Yahuah. 
 \p
 \v 15 “ ‘You shall do no injustice in judgment. You shall not be partial to the poor, nor show favoritism to the great; but you shall judge your neighbor in righteousness. 
 \p
 \v 16 “ ‘You shall not go around as a slanderer among your people. 
-\p “ ‘You shall not endanger the life of your neighbor. I am Yahweh. 
+\p “ ‘You shall not endanger the life of your neighbor. I am Yahuah. 
 \p
 \v 17 “ ‘You shall not hate your brother in your heart. You shall surely rebuke your neighbor, and not bear sin because of him. 
 \p
-\v 18 “ ‘You shall not take vengeance, nor bear any grudge against the children of your people; but you shall love your neighbor as yourself. I am Yahweh. 
+\v 18 “ ‘You shall not take vengeance, nor bear any grudge against the children of your people; but you shall love your neighbor as yourself. I am Yahuah. 
 \p
 \v 19 “ ‘You shall keep my statutes. 
 \p “ ‘You shall not cross-breed different kinds of animals. 
@@ -748,37 +748,37 @@
 \p “ ‘Don’t wear a garment made of two kinds of material. 
 \p
 \v 20 “ ‘If a man lies carnally with a woman who is a slave girl, pierced to another man, and not ransomed or given her freedom; they shall be punished. They shall not be put to death, because she was not free. 
-\v 21 He shall bring his trespass offering to Yahweh, to the door of the Tent of Meeting, even a ram for a trespass offering. 
-\v 22 The priest shall make atonement for him with the ram of the trespass offering before Yahweh for his sin which he has committed; and the sin which he has committed shall be forgiven him. 
+\v 21 He shall bring his trespass offering to Yahuah, to the door of the Tent of Meeting, even a ram for a trespass offering. 
+\v 22 The priest shall make atonement for him with the ram of the trespass offering before Yahuah for his sin which he has committed; and the sin which he has committed shall be forgiven him. 
 \p
 \v 23 “ ‘When you come into the land, and have planted all kinds of trees for food, then you shall count their fruit as forbidden. For three years it shall be forbidden to you. It shall not be eaten. 
-\v 24 But in the fourth year all its fruit shall be set-apart, for giving praise to Yahweh. 
-\v 25 In the fifth year you shall eat its fruit, that it may yield its increase to you. I am Yahweh your Elohim. 
+\v 24 But in the fourth year all its fruit shall be set-apart, for giving praise to Yahuah. 
+\v 25 In the fifth year you shall eat its fruit, that it may yield its increase to you. I am Yahuah your Elohim. 
 \p
 \v 26 “ ‘You shall not eat any meat with the blood still in it. You shall not use enchantments, nor practice sorcery. 
 \p
 \v 27 “ ‘You shall not cut the hair on the sides of your head or clip off the edge of your beard. 
 \p
-\v 28 “ ‘You shall not make any cuttings in your flesh for the dead, nor tattoo any marks on you. I am Yahweh. 
+\v 28 “ ‘You shall not make any cuttings in your flesh for the dead, nor tattoo any marks on you. I am Yahuah. 
 \p
 \v 29 “ ‘Don’t profane your daughter, to make her a prostitute; lest the land fall to prostitution, and the land become full of wickedness. 
 \p
-\v 30 “ ‘You shall keep my Sabbaths, and reverence my sanctuary; I am Yahweh. 
+\v 30 “ ‘You shall keep my Sabbaths, and reverence my sanctuary; I am Yahuah. 
 \p
-\v 31 “ ‘Don’t turn to those who are mediums, nor to the wizards. Don’t seek them out, to be defiled by them. I am Yahweh your Elohim. 
+\v 31 “ ‘Don’t turn to those who are mediums, nor to the wizards. Don’t seek them out, to be defiled by them. I am Yahuah your Elohim. 
 \p
-\v 32 “ ‘You shall rise up before the gray head and honor the face of the elderly; and you shall fear your Elohim. I am Yahweh. 
+\v 32 “ ‘You shall rise up before the gray head and honor the face of the elderly; and you shall fear your Elohim. I am Yahuah. 
 \p
 \v 33 “ ‘If a stranger lives as a foreigner with you in your land, you shall not do him wrong. 
-\v 34 The stranger who lives as a foreigner with you shall be to you as the native-born among you, and you shall love him as yourself; for you lived as foreigners in the land of Egypt. I am Yahweh your Elohim. 
+\v 34 The stranger who lives as a foreigner with you shall be to you as the native-born among you, and you shall love him as yourself; for you lived as foreigners in the land of Egypt. I am Yahuah your Elohim. 
 \p
 \v 35 “ ‘You shall do no unrighteousness in judgment, in measures of length, of weight, or of quantity. 
-\v 36 You shall have just balances, just weights, a just ephah, and a just hin. I am Yahweh your Elohim, who brought you out of the land of Egypt. 
+\v 36 You shall have just balances, just weights, a just ephah, and a just hin. I am Yahuah your Elohim, who brought you out of the land of Egypt. 
 \p
-\v 37 “ ‘You shall observe all my statutes and all my ordinances, and do them. I am Yahweh.’ ” 
+\v 37 “ ‘You shall observe all my statutes and all my ordinances, and do them. I am Yahuah.’ ” 
 \c 20
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Moreover, you shall tell the children of Israel, ‘Anyone of the children of Israel, or of the strangers who live as foreigners in Israel, who gives any of his offspring to Molech shall surely be put to death. The people of the land shall stone that person with stones. 
 \v 3 I also will set my face against that person, and will cut him off from among his people, because he has given of his offspring to Molech, to defile my sanctuary, and to profane my set-apart name. 
 \v 4 If the people of the land all hide their eyes from that person when he gives of his offspring to Molech, and don’t put him to death, 
@@ -786,8 +786,8 @@
 \p
 \v 6 “ ‘The person that turns to those who are mediums and wizards, to play the prostitute after them, I will even set my face against that person, and will cut him off from among his people. 
 \p
-\v 7 “ ‘Sanctify yourselves therefore, and be set-apart; for I am Yahweh your Elohim. 
-\v 8 You shall keep my statutes, and do them. I am Yahweh who sanctifies you. 
+\v 7 “ ‘Sanctify yourselves therefore, and be set-apart; for I am Yahuah your Elohim. 
+\v 8 You shall keep my statutes, and do them. I am Yahuah who sanctifies you. 
 \p
 \v 9 “ ‘For everyone who curses his father or his mother shall surely be put to death. He has cursed his father or his mother. His blood shall be upon himself. 
 \p
@@ -816,58 +816,58 @@
 \p
 \v 22 “ ‘You shall therefore keep all my statutes and all my ordinances, and do them, that the land where I am bringing you to dwell may not vomit you out. 
 \v 23 You shall not walk in the customs of the nation which I am casting out before you; for they did all these things, and therefore I abhorred them. 
-\v 24 But I have said to you, “You shall inherit their land, and I will give it to you to possess it, a land flowing with milk and honey.” I am Yahweh your Elohim, who has separated you from the peoples. 
+\v 24 But I have said to you, “You shall inherit their land, and I will give it to you to possess it, a land flowing with milk and honey.” I am Yahuah your Elohim, who has separated you from the peoples. 
 \p
 \v 25 “ ‘You shall therefore make a distinction between the clean animal and the unclean, and between the unclean fowl and the clean. You shall not make yourselves abominable by animal, or by bird, or by anything with which the ground teems, which I have separated from you as unclean for you. 
-\v 26 You shall be set-apart to me, for I, Yahweh, am set-apart, and have set you apart from the peoples, that you should be mine. 
+\v 26 You shall be set-apart to me, for I, Yahuah, am set-apart, and have set you apart from the peoples, that you should be mine. 
 \p
 \v 27 “ ‘A man or a woman that is a medium or is a wizard shall surely be put to death. They shall be stoned with stones. Their blood shall be upon themselves.’ ” 
 \c 21
 \p
-\v 1 Yahweh said to Moses, “Speak to the priests, the sons of Aaron, and say to them, ‘A priest shall not defile himself for the dead among his people, 
+\v 1 Yahuah said to Moses, “Speak to the priests, the sons of Aaron, and say to them, ‘A priest shall not defile himself for the dead among his people, 
 \v 2 except for his relatives that are near to him: for his mother, for his father, for his son, for his daughter, for his brother, 
 \v 3 and for his virgin sister who is near to him, who has had no man; for her he may defile himself. 
 \v 4 He shall not defile himself, being an owner among his people, to profane himself. 
 \p
 \v 5 “ ‘They shall not shave their heads or shave off the corners of their beards or make any cuttings in their flesh. 
-\v 6 They shall be set-apart to their Elohim, and not profane the name of their Elohim, for they offer the offerings of Yahweh made by fire, the bread of their Elohim. Therefore they shall be set-apart. 
+\v 6 They shall be set-apart to their Elohim, and not profane the name of their Elohim, for they offer the offerings of Yahuah made by fire, the bread of their Elohim. Therefore they shall be set-apart. 
 \p
 \v 7 “ ‘They shall not take a woman who is a whore, or pierced. A priest shall not take a woman divorced from her man; for he is set-apart to his Elohim. 
-\v 8 Therefore you shall sanctify him, for he offers the bread of your Elohim. He shall be set-apart to you, for I Yahweh, who sanctify you, am set-apart. 
+\v 8 Therefore you shall sanctify him, for he offers the bread of your Elohim. He shall be set-apart to you, for I Yahuah, who sanctify you, am set-apart. 
 \p
 \v 9 “ ‘The daughter of any priest, if she profanes herself by playing the prostitute, she profanes her father. She shall be burned with fire. 
 \p
 \v 10 “ ‘He who is the high priest among his brothers, upon whose head the anointing oil is poured, and who is consecrated to put on the garments, shall not let the hair of his head hang loose, or tear his clothes. 
 \v 11 He must not go in to any dead body, or defile himself for his father or for his mother. 
-\v 12 He shall not go out of the sanctuary, nor profane the sanctuary of his Elohim; for the crown of the anointing oil of his Elohim is upon him. I am Yahweh. 
+\v 12 He shall not go out of the sanctuary, nor profane the sanctuary of his Elohim; for the crown of the anointing oil of his Elohim is upon him. I am Yahuah. 
 \p
 \v 13 “ ‘He shall take a woman in her virginity. 
 \v 14 He shall not take a widow, or one divorced, or a woman who has been pierced, or a whore. He shall take a virgin of his own people as a woman. 
-\v 15 He shall not profane his offspring among his people, for I am Yahweh who sanctifies him.’ ” 
+\v 15 He shall not profane his offspring among his people, for I am Yahuah who sanctifies him.’ ” 
 \p
-\v 16 Yahweh spoke to Moses, saying, 
+\v 16 Yahuah spoke to Moses, saying, 
 \v 17 “Say to Aaron, ‘None of your offspring throughout their generations who has a defect may approach to offer the bread of his Elohim. 
 \v 18 For whatever man he is that has a defect, he shall not draw near: a blind man, or a lame, or he who has a flat nose, or any deformity, 
 \v 19 or a man who has an injured foot, or an injured hand, 
 \v 20 or hunchbacked, or a dwarf, or one who has a defect in his eye, or an itching disease, or scabs, or who has damaged testicles. 
-\v 21 No man of the offspring of Aaron the priest who has a defect shall come near to offer the offerings of Yahweh made by fire. Since he has a defect, he shall not come near to offer the bread of his Elohim. 
+\v 21 No man of the offspring of Aaron the priest who has a defect shall come near to offer the offerings of Yahuah made by fire. Since he has a defect, he shall not come near to offer the bread of his Elohim. 
 \v 22 He shall eat the bread of his Elohim, both of the most set-apart, and of the set-apart. 
-\v 23 He shall not come near to the veil, nor come near to the altar, because he has a defect; that he may not profane my sanctuaries, for I am Yahweh who sanctifies them.’ ” 
+\v 23 He shall not come near to the veil, nor come near to the altar, because he has a defect; that he may not profane my sanctuaries, for I am Yahuah who sanctifies them.’ ” 
 \p
 \v 24 So Moses spoke to Aaron, and to his sons, and to all the children of Israel. 
 \c 22
 \p
-\v 1 Yahweh spoke to Moses, saying, 
-\v 2 “Tell Aaron and his sons to separate themselves from the set-apart things of the children of Israel, which they make set-apart to me, and that they not profane my set-apart name. I am Yahweh. 
+\v 1 Yahuah spoke to Moses, saying, 
+\v 2 “Tell Aaron and his sons to separate themselves from the set-apart things of the children of Israel, which they make set-apart to me, and that they not profane my set-apart name. I am Yahuah. 
 \p
-\v 3 “Tell them, ‘If anyone of all your offspring throughout your generations approaches the set-apart things which the children of Israel make set-apart to Yahweh, having his uncleanness on him, that soul shall be cut off from before me. I am Yahweh. 
+\v 3 “Tell them, ‘If anyone of all your offspring throughout your generations approaches the set-apart things which the children of Israel make set-apart to Yahuah, having his uncleanness on him, that soul shall be cut off from before me. I am Yahuah. 
 \p
 \v 4 “ ‘Whoever of the offspring of Aaron is a leper or has a discharge shall not eat of the set-apart things until he is clean. Whoever touches anything that is unclean by the dead, or a man who has a seminal emission, 
 \v 5 or whoever touches any creeping thing by which he may be made unclean, or a man from whom he may become unclean, whatever uncleanness he has—\v 6 the person that touches any such shall be unclean until the evening, and shall not eat of the set-apart things unless he bathes his body in water. 
 \v 7 When the sun is down, he shall be clean; and afterward he shall eat of the set-apart things, because it is his bread. 
-\v 8 He shall not eat that which dies of itself or is torn by animals, defiling himself by it. I am Yahweh. 
+\v 8 He shall not eat that which dies of itself or is torn by animals, defiling himself by it. I am Yahuah. 
 \p
-\v 9 “ ‘They shall therefore follow my commandment, lest they bear sin for it and die in it, if they profane it. I am Yahweh who sanctifies them. 
+\v 9 “ ‘They shall therefore follow my commandment, lest they bear sin for it and die in it, if they profane it. I am Yahuah who sanctifies them. 
 \p
 \v 10 “ ‘No stranger shall eat of the set-apart thing: a foreigner living with the priests, or a hired servant, shall not eat of the set-apart thing. 
 \v 11 But if a priest buys a slave, purchased by his money, he shall eat of it; and those who are born in his house shall eat of his bread. 
@@ -875,120 +875,120 @@
 \v 13 But if a priest’s daughter is a widow, or divorced, and has no child, and has returned to her father’s house as in her youth, she may eat of her father’s bread; but no stranger shall eat any of it. 
 \p
 \v 14 “ ‘If a man eats something set-apart unwittingly, then he shall add the fifth part of its value to it, and shall give the set-apart thing to the priest. 
-\v 15 The priests shall not profane the set-apart things of the children of Israel, which they offer to Yahweh, 
-\v 16 and so cause them to bear the iniquity that brings guilt when they eat their set-apart things; for I am Yahweh who sanctifies them.’ ” 
+\v 15 The priests shall not profane the set-apart things of the children of Israel, which they offer to Yahuah, 
+\v 16 and so cause them to bear the iniquity that brings guilt when they eat their set-apart things; for I am Yahuah who sanctifies them.’ ” 
 \p
-\v 17 Yahweh spoke to Moses, saying, 
-\v 18 “Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘Whoever is of the house of Israel, or of the foreigners in Israel, who offers his offering, whether it is any of their vows or any of their free will offerings, which they offer to Yahweh for a burnt offering: 
+\v 17 Yahuah spoke to Moses, saying, 
+\v 18 “Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘Whoever is of the house of Israel, or of the foreigners in Israel, who offers his offering, whether it is any of their vows or any of their free will offerings, which they offer to Yahuah for a burnt offering: 
 \v 19 that you may be accepted, you shall offer a male without defect, of the bulls, of the sheep, or of the goats. 
 \v 20 But you shall not offer whatever has a defect, for it shall not be acceptable for you. 
-\v 21 Whoever offers a sacrifice of peace offerings to Yahweh to accomplish a vow, or for a free will offering of the herd or of the flock, it shall be perfect to be accepted. It shall have no defect. 
-\v 22 You shall not offer what is blind, is injured, is maimed, has a wart, is festering, or has a running sore to Yahweh, nor make an offering by fire of them on the altar to Yahweh. 
+\v 21 Whoever offers a sacrifice of peace offerings to Yahuah to accomplish a vow, or for a free will offering of the herd or of the flock, it shall be perfect to be accepted. It shall have no defect. 
+\v 22 You shall not offer what is blind, is injured, is maimed, has a wart, is festering, or has a running sore to Yahuah, nor make an offering by fire of them on the altar to Yahuah. 
 \v 23 Either a bull or a lamb that has any deformity or lacking in his parts, that you may offer for a free will offering; but for a vow it shall not be accepted. 
-\v 24 You must not offer to Yahweh that which has its testicles bruised, crushed, broken, or cut. You must not do this in your land. 
+\v 24 You must not offer to Yahuah that which has its testicles bruised, crushed, broken, or cut. You must not do this in your land. 
 \v 25 You must not offer any of these as the bread of your Elohim from the hand of a foreigner, because their corruption is in them. There is a defect in them. They shall not be accepted for you.’ ” 
 \p
-\v 26 Yahweh spoke to Moses, saying, 
-\v 27 “When a bull, a sheep, or a goat is born, it shall remain seven days with its mother. From the eighth day on it shall be accepted for the offering of an offering made by fire to Yahweh. 
+\v 26 Yahuah spoke to Moses, saying, 
+\v 27 “When a bull, a sheep, or a goat is born, it shall remain seven days with its mother. From the eighth day on it shall be accepted for the offering of an offering made by fire to Yahuah. 
 \v 28 Whether it is a cow or ewe, you shall not kill it and its young both in one day. 
 \p
-\v 29 “When you sacrifice a sacrifice of thanksgiving to Yahweh, you shall sacrifice it so that you may be accepted. 
-\v 30 It shall be eaten on the same day; you shall leave none of it until the morning. I am Yahweh. 
+\v 29 “When you sacrifice a sacrifice of thanksgiving to Yahuah, you shall sacrifice it so that you may be accepted. 
+\v 30 It shall be eaten on the same day; you shall leave none of it until the morning. I am Yahuah. 
 \p
-\v 31 “Therefore you shall keep my commandments, and do them. I am Yahweh. 
-\v 32 You shall not profane my set-apart name, but I will be made set-apart among the children of Israel. I am Yahweh who makes you set-apart, 
-\v 33 who brought you out of the land of Egypt, to be your Elohim. I am Yahweh.” 
+\v 31 “Therefore you shall keep my commandments, and do them. I am Yahuah. 
+\v 32 You shall not profane my set-apart name, but I will be made set-apart among the children of Israel. I am Yahuah who makes you set-apart, 
+\v 33 who brought you out of the land of Egypt, to be your Elohim. I am Yahuah.” 
 \c 23
 \p
-\v 1 Yahweh spoke to Moses, saying, 
-\v 2 “Speak to the children of Israel, and tell them, ‘The set feasts of Yahweh, which you shall proclaim to be set-apart convocations, even these are my set feasts. 
+\v 1 Yahuah spoke to Moses, saying, 
+\v 2 “Speak to the children of Israel, and tell them, ‘The set feasts of Yahuah, which you shall proclaim to be set-apart convocations, even these are my set feasts. 
 \p
-\v 3 “ ‘Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, a set-apart convocation; you shall do no kind of work. It is a Sabbath to Yahweh in all your dwellings. 
+\v 3 “ ‘Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, a set-apart convocation; you shall do no kind of work. It is a Sabbath to Yahuah in all your dwellings. 
 \p
-\v 4 “ ‘These are the set feasts of Yahweh, even set-apart convocations, which you shall proclaim in their appointed season. 
-\v 5 In the first month, on the fourteenth day of the month in the evening, is Yahweh’s Passover. 
-\v 6 On the fifteenth day of the same month is the feast of unleavened bread to Yahweh. Seven days you shall eat unleavened bread. 
+\v 4 “ ‘These are the set feasts of Yahuah, even set-apart convocations, which you shall proclaim in their appointed season. 
+\v 5 In the first month, on the fourteenth day of the month in the evening, is Yahuah’s Passover. 
+\v 6 On the fifteenth day of the same month is the feast of unleavened bread to Yahuah. Seven days you shall eat unleavened bread. 
 \v 7 In the first day you shall have a set-apart convocation. You shall do no regular work. 
-\v 8 But you shall offer an offering made by fire to Yahweh seven days. In the seventh day is a set-apart convocation. You shall do no regular work.’ ” 
+\v 8 But you shall offer an offering made by fire to Yahuah seven days. In the seventh day is a set-apart convocation. You shall do no regular work.’ ” 
 \p
-\v 9 Yahweh spoke to Moses, saying, 
+\v 9 Yahuah spoke to Moses, saying, 
 \v 10 “Speak to the children of Israel, and tell them, ‘When you have come into the land which I give to you, and shall reap its harvest, then you shall bring the sheaf of the first fruits of your harvest to the priest. 
-\v 11 He shall wave the sheaf before Yahweh, to be accepted for you. On the next day after the Sabbath the priest shall wave it. 
-\v 12 On the day when you wave the sheaf, you shall offer a male lamb without defect a year old for a burnt offering to Yahweh. 
-\v 13 The meal offering with it shall be two tenths of an ephah of fine flour mixed with oil, an offering made by fire to Yahweh for a pleasant aroma; and the drink offering with it shall be of wine, the fourth part of a hin. 
+\v 11 He shall wave the sheaf before Yahuah, to be accepted for you. On the next day after the Sabbath the priest shall wave it. 
+\v 12 On the day when you wave the sheaf, you shall offer a male lamb without defect a year old for a burnt offering to Yahuah. 
+\v 13 The meal offering with it shall be two tenths of an ephah of fine flour mixed with oil, an offering made by fire to Yahuah for a pleasant aroma; and the drink offering with it shall be of wine, the fourth part of a hin. 
 \v 14 You must not eat bread, or roasted grain, or fresh grain, until this same day, until you have brought the offering of your Elohim. This is a statute forever throughout your generations in all your dwellings. 
 \p
 \v 15 “ ‘You shall count from the next day after the Sabbath, from the day that you brought the sheaf of the wave offering: seven Sabbaths shall be completed. 
-\v 16 The next day after the seventh Sabbath you shall count fifty days; and you shall offer a new meal offering to Yahweh. 
-\v 17 You shall bring out of your habitations two loaves of bread for a wave offering made of two tenths of an ephah of fine flour. They shall be baked with yeast, for first fruits to Yahweh. 
-\v 18 You shall present with the bread seven lambs without defect a year old, one young bull, and two rams. They shall be a burnt offering to Yahweh, with their meal offering and their drink offerings, even an offering made by fire, of a sweet aroma to Yahweh. 
+\v 16 The next day after the seventh Sabbath you shall count fifty days; and you shall offer a new meal offering to Yahuah. 
+\v 17 You shall bring out of your habitations two loaves of bread for a wave offering made of two tenths of an ephah of fine flour. They shall be baked with yeast, for first fruits to Yahuah. 
+\v 18 You shall present with the bread seven lambs without defect a year old, one young bull, and two rams. They shall be a burnt offering to Yahuah, with their meal offering and their drink offerings, even an offering made by fire, of a sweet aroma to Yahuah. 
 \v 19 You shall offer one male goat for a sin offering, and two male lambs a year old for a sacrifice of peace offerings. 
-\v 20 The priest shall wave them with the bread of the first fruits for a wave offering before Yahweh, with the two lambs. They shall be set-apart to Yahweh for the priest. 
+\v 20 The priest shall wave them with the bread of the first fruits for a wave offering before Yahuah, with the two lambs. They shall be set-apart to Yahuah for the priest. 
 \v 21 You shall make proclamation on the same day that there shall be a set-apart convocation to you. You shall do no regular work. This is a statute forever in all your dwellings throughout your generations. 
 \p
-\v 22 “ ‘When you reap the harvest of your land, you must not wholly reap into the corners of your field. You must not gather the gleanings of your harvest. You must leave them for the poor and for the foreigner. I am Yahweh your Elohim.’ ” 
+\v 22 “ ‘When you reap the harvest of your land, you must not wholly reap into the corners of your field. You must not gather the gleanings of your harvest. You must leave them for the poor and for the foreigner. I am Yahuah your Elohim.’ ” 
 \p
-\v 23 Yahweh spoke to Moses, saying, 
+\v 23 Yahuah spoke to Moses, saying, 
 \v 24 “Speak to the children of Israel, saying, ‘In the seventh month, on the first day of the month, there shall be a solemn rest for you, a memorial of blowing of trumpets, a set-apart convocation. 
-\v 25 You shall do no regular work. You shall offer an offering made by fire to Yahweh.’ ” 
+\v 25 You shall do no regular work. You shall offer an offering made by fire to Yahuah.’ ” 
 \p
-\v 26 Yahweh spoke to Moses, saying, 
-\v 27 “However on the tenth day of this seventh month is the day of atonement. It shall be a set-apart convocation to you. You shall afflict yourselves and you shall offer an offering made by fire to Yahweh. 
-\v 28 You shall do no kind of work in that same day, for it is a day of atonement, to make atonement for you before Yahweh your Elohim. 
+\v 26 Yahuah spoke to Moses, saying, 
+\v 27 “However on the tenth day of this seventh month is the day of atonement. It shall be a set-apart convocation to you. You shall afflict yourselves and you shall offer an offering made by fire to Yahuah. 
+\v 28 You shall do no kind of work in that same day, for it is a day of atonement, to make atonement for you before Yahuah your Elohim. 
 \v 29 For whoever it is who shall not deny himself in that same day shall be cut off from his people. 
 \v 30 Whoever does any kind of work in that same day, I will destroy that person from among his people. 
 \v 31 You shall do no kind of work: it is a statute forever throughout your generations in all your dwellings. 
 \v 32 It shall be a Sabbath of solemn rest for you, and you shall deny yourselves. In the ninth day of the month at evening, from evening to evening, you shall keep your Sabbath.” 
 \p
-\v 33 Yahweh spoke to Moses, saying, 
-\v 34 “Speak to the children of Israel, and say, ‘On the fifteenth day of this seventh month is the feast of booths for seven days to Yahweh. 
+\v 33 Yahuah spoke to Moses, saying, 
+\v 34 “Speak to the children of Israel, and say, ‘On the fifteenth day of this seventh month is the feast of booths for seven days to Yahuah. 
 \v 35 On the first day shall be a set-apart convocation. You shall do no regular work. 
-\v 36 Seven days you shall offer an offering made by fire to Yahweh. On the eighth day shall be a set-apart convocation to you. You shall offer an offering made by fire to Yahweh. It is a solemn assembly; you shall do no regular work. 
+\v 36 Seven days you shall offer an offering made by fire to Yahuah. On the eighth day shall be a set-apart convocation to you. You shall offer an offering made by fire to Yahuah. It is a solemn assembly; you shall do no regular work. 
 \p
-\v 37 “ ‘These are the appointed feasts of Yahweh which you shall proclaim to be set-apart convocations, to offer an offering made by fire to Yahweh, a burnt offering, a meal offering, a sacrifice, and drink offerings, each on its own day—\v 38 in addition to the Sabbaths of Yahweh, and in addition to your gifts, and in addition to all your vows, and in addition to all your free will offerings, which you give to Yahweh. 
+\v 37 “ ‘These are the appointed feasts of Yahuah which you shall proclaim to be set-apart convocations, to offer an offering made by fire to Yahuah, a burnt offering, a meal offering, a sacrifice, and drink offerings, each on its own day—\v 38 in addition to the Sabbaths of Yahuah, and in addition to your gifts, and in addition to all your vows, and in addition to all your free will offerings, which you give to Yahuah. 
 \p
-\v 39 “ ‘So on the fifteenth day of the seventh month, when you have gathered in the fruits of the land, you shall keep the feast of Yahweh seven days. On the first day shall be a solemn rest, and on the eighth day shall be a solemn rest. 
-\v 40 You shall take on the first day the fruit of majestic trees, branches of palm trees, and boughs of thick trees, and willows of the brook; and you shall rejoice before Yahweh your Elohim seven days. 
-\v 41 You shall keep it as a feast to Yahweh seven days in the year. It is a statute forever throughout your generations. You shall keep it in the seventh month. 
+\v 39 “ ‘So on the fifteenth day of the seventh month, when you have gathered in the fruits of the land, you shall keep the feast of Yahuah seven days. On the first day shall be a solemn rest, and on the eighth day shall be a solemn rest. 
+\v 40 You shall take on the first day the fruit of majestic trees, branches of palm trees, and boughs of thick trees, and willows of the brook; and you shall rejoice before Yahuah your Elohim seven days. 
+\v 41 You shall keep it as a feast to Yahuah seven days in the year. It is a statute forever throughout your generations. You shall keep it in the seventh month. 
 \v 42 You shall dwell in temporary shelters for seven days. All who are native-born in Israel shall dwell in temporary shelters, 
-\v 43 that your generations may know that I made the children of Israel to dwell in temporary shelters when I brought them out of the land of Egypt. I am Yahweh your Elohim.’ ” 
+\v 43 that your generations may know that I made the children of Israel to dwell in temporary shelters when I brought them out of the land of Egypt. I am Yahuah your Elohim.’ ” 
 \p
-\v 44 So Moses declared to the children of Israel the appointed feasts of Yahweh. 
+\v 44 So Moses declared to the children of Israel the appointed feasts of Yahuah. 
 \c 24
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Command the children of Israel, that they bring to you pure olive oil beaten for the light, to cause a lamp to burn continually. 
-\v 3 Outside of the veil of the Testimony, in the Tent of Meeting, Aaron shall keep it in order from evening to morning before Yahweh continually. It shall be a statute forever throughout your generations. 
-\v 4 He shall keep in order the lamps on the pure gold lamp stand before Yahweh continually. 
+\v 3 Outside of the veil of the Testimony, in the Tent of Meeting, Aaron shall keep it in order from evening to morning before Yahuah continually. It shall be a statute forever throughout your generations. 
+\v 4 He shall keep in order the lamps on the pure gold lamp stand before Yahuah continually. 
 \p
 \v 5 “You shall take fine flour, and bake twelve cakes of it: two tenths of an ephah shall be in one cake. 
-\v 6 You shall set them in two rows, six on a row, on the pure gold table before Yahweh. 
-\v 7 You shall put pure frankincense on each row, that it may be to the bread for a memorial, even an offering made by fire to Yahweh. 
-\v 8 Every Sabbath day he shall set it in order before Yahweh continually. It is an everlasting covenant on the behalf of the children of Israel. 
-\v 9 It shall be for Aaron and his sons. They shall eat it in a set-apart place; for it is most set-apart to him of the offerings of Yahweh made by fire by a perpetual statute.” 
+\v 6 You shall set them in two rows, six on a row, on the pure gold table before Yahuah. 
+\v 7 You shall put pure frankincense on each row, that it may be to the bread for a memorial, even an offering made by fire to Yahuah. 
+\v 8 Every Sabbath day he shall set it in order before Yahuah continually. It is an everlasting covenant on the behalf of the children of Israel. 
+\v 9 It shall be for Aaron and his sons. They shall eat it in a set-apart place; for it is most set-apart to him of the offerings of Yahuah made by fire by a perpetual statute.” 
 \p
 \v 10 The son of an Israelite woman, whose father was an Egyptian, went out among the children of Israel; and the son of the Israelite woman and a man of Israel strove together in the camp. 
 \v 11 The son of the Israelite woman blasphemed the Name, and cursed; and they brought him to Moses. His mother’s name was Shelomith, the daughter of Dibri, of the tribe of Dan. 
-\v 12 They put him in custody until Yahweh’s will should be declared to them. 
-\v 13 Yahweh spoke to Moses, saying, 
+\v 12 They put him in custody until Yahuah’s will should be declared to them. 
+\v 13 Yahuah spoke to Moses, saying, 
 \v 14 “Bring him who cursed out of the camp; and let all who heard him lay their hands on his head, and let all the congregation stone him. 
 \v 15 You shall speak to the children of Israel, saying, ‘Whoever curses his Elohim shall bear his sin. 
-\v 16 He who blasphemes Yahweh’s name, he shall surely be put to death. All the congregation shall certainly stone him. The foreigner as well as the native-born shall be put to death when he blasphemes the Name. 
+\v 16 He who blasphemes Yahuah’s name, he shall surely be put to death. All the congregation shall certainly stone him. The foreigner as well as the native-born shall be put to death when he blasphemes the Name. 
 \p
 \v 17 “ ‘He who strikes any man mortally shall surely be put to death. 
 \v 18 He who strikes an animal mortally shall make it good, life for life. 
 \v 19 If anyone injures his neighbor, it shall be done to him as he has done: 
 \v 20 fracture for fracture, eye for eye, tooth for tooth. It shall be done to him as he has injured someone. 
 \v 21 He who kills an animal shall make it good; and he who kills a man shall be put to death. 
-\v 22 You shall have one kind of law for the foreigner as well as the native-born; for I am Yahweh your Elohim.’ ” 
+\v 22 You shall have one kind of law for the foreigner as well as the native-born; for I am Yahuah your Elohim.’ ” 
 \p
-\v 23 Moses spoke to the children of Israel; and they brought him who had cursed out of the camp, and stoned him with stones. The children of Israel did as Yahweh commanded Moses. 
+\v 23 Moses spoke to the children of Israel; and they brought him who had cursed out of the camp, and stoned him with stones. The children of Israel did as Yahuah commanded Moses. 
 \c 25
 \p
-\v 1 Yahweh said to Moses on Mount Sinai, 
-\v 2 “Speak to the children of Israel, and tell them, ‘When you come into the land which I give you, then the land shall keep a Sabbath to Yahweh. 
+\v 1 Yahuah said to Moses on Mount Sinai, 
+\v 2 “Speak to the children of Israel, and tell them, ‘When you come into the land which I give you, then the land shall keep a Sabbath to Yahuah. 
 \v 3 You shall sow your field six years, and you shall prune your vineyard six years, and gather in its fruits; 
-\v 4 but in the seventh year there shall be a Sabbath of solemn rest for the land, a Sabbath to Yahweh. You shall not sow your field or prune your vineyard. 
+\v 4 but in the seventh year there shall be a Sabbath of solemn rest for the land, a Sabbath to Yahuah. You shall not sow your field or prune your vineyard. 
 \v 5 What grows of itself in your harvest you shall not reap, and you shall not gather the grapes of your undressed vine. It shall be a year of solemn rest for the land. 
 \v 6 The Sabbath of the land shall be for food for you; for yourself, for your servant, for your maid, for your hired servant, and for your stranger, who lives as a foreigner with you. 
 \v 7 For your livestock also, and for the animals that are in your land, shall all its increase be for food. 
@@ -1004,7 +1004,7 @@
 \v 14 “ ‘If you sell anything to your neighbor, or buy from your neighbor, you shall not wrong one another. 
 \v 15 According to the number of years after the Jubilee you shall buy from your neighbor. According to the number of years of the crops he shall sell to you. 
 \v 16 According to the length of the years you shall increase its price, and according to the shortness of the years you shall diminish its price; for he is selling the number of the crops to you. 
-\v 17 You shall not wrong one another, but you shall fear your Elohim; for I am Yahweh your Elohim. 
+\v 17 You shall not wrong one another, but you shall fear your Elohim; for I am Yahuah your Elohim. 
 \p
 \v 18 “ ‘Therefore you shall do my statutes, and keep my ordinances and do them; and you shall dwell in the land in safety. 
 \v 19 The land shall yield its fruit, and you shall eat your fill, and dwell therein in safety. 
@@ -1031,7 +1031,7 @@
 \v 35 “ ‘If your brother has become poor, and his hand can’t support himself among you, then you shall uphold him. He shall live with you like an alien and a temporary resident. 
 \v 36 Take no interest from him or profit; but fear your Elohim, that your brother may live among you. 
 \v 37 You shall not lend him your money at interest, nor give him your food for profit. 
-\v 38 I am Yahweh your Elohim, who brought you out of the land of Egypt, to give you the land of Canaan, and to be your Elohim. 
+\v 38 I am Yahuah your Elohim, who brought you out of the land of Egypt, to give you the land of Canaan, and to be your Elohim. 
 \p
 \v 39 “ ‘If your brother has grown poor among you, and sells himself to you, you shall not make him to serve as a slave. 
 \v 40 As a hired servant, and as a temporary resident, he shall be with you; he shall serve with you until the Year of Jubilee. 
@@ -1051,12 +1051,12 @@
 \v 52 If there remain but a few years to the year of jubilee, then he shall reckon with him; according to his years of service he shall give back the price of his redemption. 
 \v 53 As a servant hired year by year shall he be with him. He shall not rule with harshness over him in your sight. 
 \v 54 If he isn’t redeemed by these means, then he shall be released in the Year of Jubilee: he and his children with him. 
-\v 55 For to me the children of Israel are servants; they are my servants whom I brought out of the land of Egypt. I am Yahweh your Elohim. 
+\v 55 For to me the children of Israel are servants; they are my servants whom I brought out of the land of Egypt. I am Yahuah your Elohim. 
 \c 26
 \p
-\v 1 “ ‘You shall make for yourselves no idols, and you shall not raise up a carved image or a pillar, and you shall not place any figured stone in your land, to bow down to it; for I am Yahweh your Elohim. 
+\v 1 “ ‘You shall make for yourselves no idols, and you shall not raise up a carved image or a pillar, and you shall not place any figured stone in your land, to bow down to it; for I am Yahuah your Elohim. 
 \p
-\v 2 “ ‘You shall keep my Sabbaths, and have reverence for my sanctuary. I am Yahweh. 
+\v 2 “ ‘You shall keep my Sabbaths, and have reverence for my sanctuary. I am Yahuah. 
 \p
 \v 3 “ ‘If you walk in my statutes and keep my commandments, and do them, 
 \v 4 then I will give you your rains in their season, and the land shall yield its increase, and the trees of the field shall yield their fruit. 
@@ -1070,7 +1070,7 @@
 \v 10 You shall eat old supplies long kept, and you shall move out the old because of the new. 
 \v 11 I will set my tent among you, and my soul won’t abhor you. 
 \v 12 I will walk among you, and will be your Elohim, and you will be my people. 
-\v 13 I am Yahweh your Elohim, who brought you out of the land of Egypt, that you should not be their slaves. I have broken the bars of your yoke, and made you walk upright. 
+\v 13 I am Yahuah your Elohim, who brought you out of the land of Egypt, that you should not be their slaves. I have broken the bars of your yoke, and made you walk upright. 
 \p
 \v 14 “ ‘But if you will not listen to me, and will not do all these commandments, 
 \v 15 and if you shall reject my statutes, and if your soul abhors my ordinances, so that you will not do all my commandments, but break my covenant, 
@@ -1108,14 +1108,14 @@
 \v 41 I also walked contrary to them, and brought them into the land of their enemies; if then their uncircumcised heart is humbled, and they then accept the punishment of their iniquity, 
 \v 42 then I will remember my covenant with Jacob, my covenant with Isaac, and also my covenant with Abraham; and I will remember the land. 
 \v 43 The land also will be left by them, and will enjoy its Sabbaths while it lies desolate without them; and they will accept the punishment of their iniquity because they rejected my ordinances, and their soul abhorred my statutes. 
-\v 44 Yet for all that, when they are in the land of their enemies, I will not reject them, neither will I abhor them, to destroy them utterly and to break my covenant with them; for I am Yahweh their Elohim. 
-\v 45 But I will for their sake remember the covenant of their ancestors, whom I brought out of the land of Egypt in the sight of the nations, that I might be their Elohim. I am Yahweh.’ ” 
+\v 44 Yet for all that, when they are in the land of their enemies, I will not reject them, neither will I abhor them, to destroy them utterly and to break my covenant with them; for I am Yahuah their Elohim. 
+\v 45 But I will for their sake remember the covenant of their ancestors, whom I brought out of the land of Egypt in the sight of the nations, that I might be their Elohim. I am Yahuah.’ ” 
 \p
-\v 46 These are the statutes, ordinances, and laws, which Yahweh made between him and the children of Israel in Mount Sinai by Moses. 
+\v 46 These are the statutes, ordinances, and laws, which Yahuah made between him and the children of Israel in Mount Sinai by Moses. 
 \c 27
 \p
-\v 1 Yahweh spoke to Moses, saying, 
-\v 2 “Speak to the children of Israel, and say to them, ‘When a man consecrates a person to Yahweh in a vow, according to your valuation, 
+\v 1 Yahuah spoke to Moses, saying, 
+\v 2 “Speak to the children of Israel, and say to them, ‘When a man consecrates a person to Yahuah in a vow, according to your valuation, 
 \v 3 your valuation of a male from twenty years old to sixty years old shall be fifty shekels of silver, according to the shekel of the sanctuary. 
 \v 4 If she is a female, then your valuation shall be thirty shekels. 
 \v 5 If the person is from five years old to twenty years old, then your valuation shall be for a male twenty shekels, and for a female ten shekels. 
@@ -1123,37 +1123,37 @@
 \v 7 If the person is from sixty years old and upward; if he is a male, then your valuation shall be fifteen shekels, and for a female ten shekels. 
 \v 8 But if he is poorer than your valuation, then he shall be set before the priest, and the priest shall assign a value to him. The priest shall assign a value according to his ability to pay. 
 \p
-\v 9 “ ‘If it is an animal of which men offer an offering to Yahweh, all that any man gives of such to Yahweh becomes set-apart. 
+\v 9 “ ‘If it is an animal of which men offer an offering to Yahuah, all that any man gives of such to Yahuah becomes set-apart. 
 \v 10 He shall not alter it, nor exchange it, a good for a bad, or a bad for a good. If he shall at all exchange animal for animal, then both it and that for which it is exchanged shall be set-apart. 
-\v 11 If it is any unclean animal, of which they do not offer as an offering to Yahweh, then he shall set the animal before the priest; 
+\v 11 If it is any unclean animal, of which they do not offer as an offering to Yahuah, then he shall set the animal before the priest; 
 \v 12 and the priest shall evaluate it, whether it is good or bad. As the priest evaluates it, so it shall be. 
 \v 13 But if he will indeed redeem it, then he shall add the fifth part of it to its valuation. 
 \p
-\v 14 “ ‘When a man dedicates his house to be set-apart to Yahweh, then the priest shall evaluate it, whether it is good or bad. As the priest evaluates it, so it shall stand. 
+\v 14 “ ‘When a man dedicates his house to be set-apart to Yahuah, then the priest shall evaluate it, whether it is good or bad. As the priest evaluates it, so it shall stand. 
 \v 15 If he who dedicates it will redeem his house, then he shall add the fifth part of the money of your valuation to it, and it shall be his. 
 \p
-\v 16 “ ‘If a man dedicates to Yahweh part of the field of his possession, then your valuation shall be according to the seed for it. The sowing of a homer of barley shall be valued at fifty shekels of silver. 
+\v 16 “ ‘If a man dedicates to Yahuah part of the field of his possession, then your valuation shall be according to the seed for it. The sowing of a homer of barley shall be valued at fifty shekels of silver. 
 \v 17 If he dedicates his field from the Year of Jubilee, according to your valuation it shall stand. 
 \v 18 But if he dedicates his field after the Jubilee, then the priest shall reckon to him the money according to the years that remain to the Year of Jubilee; and an abatement shall be made from your valuation. 
 \v 19 If he who dedicated the field will indeed redeem it, then he shall add the fifth part of the money of your valuation to it, and it shall remain his. 
 \v 20 If he will not redeem the field, or if he has sold the field to another man, it shall not be redeemed any more; 
-\v 21 but the field, when it goes out in the Jubilee, shall be set-apart to Yahweh, as a devoted field. It shall be owned by the priests. 
+\v 21 but the field, when it goes out in the Jubilee, shall be set-apart to Yahuah, as a devoted field. It shall be owned by the priests. 
 \p
-\v 22 “ ‘If he dedicates a field to Yahweh which he has bought, which is not of the field of his possession, 
-\v 23 then the priest shall reckon to him the worth of your valuation up to the Year of Jubilee; and he shall give your valuation on that day, as a set-apart thing to Yahweh. 
+\v 22 “ ‘If he dedicates a field to Yahuah which he has bought, which is not of the field of his possession, 
+\v 23 then the priest shall reckon to him the worth of your valuation up to the Year of Jubilee; and he shall give your valuation on that day, as a set-apart thing to Yahuah. 
 \v 24 In the Year of Jubilee the field shall return to him from whom it was bought, even to him to whom the possession of the land belongs. 
 \v 25 All your valuations shall be according to the shekel of the sanctuary: twenty gerahs to the shekel. 
 \p
-\v 26 “ ‘However the firstborn among animals, which belongs to Yahweh as a firstborn, no man may dedicate, whether an ox or a sheep. It is Yahweh’s. 
+\v 26 “ ‘However the firstborn among animals, which belongs to Yahuah as a firstborn, no man may dedicate, whether an ox or a sheep. It is Yahuah’s. 
 \v 27 If it is an unclean animal, then he shall buy it back according to your valuation, and shall add to it the fifth part of it; or if it isn’t redeemed, then it shall be sold according to your valuation. 
 \p
-\v 28 “ ‘Notwithstanding, no devoted thing that a man devotes to Yahweh of all that he has, whether of man or animal, or of the field of his possession, shall be sold or redeemed. Everything that is permanently devoted is most set-apart to Yahweh. 
+\v 28 “ ‘Notwithstanding, no devoted thing that a man devotes to Yahuah of all that he has, whether of man or animal, or of the field of his possession, shall be sold or redeemed. Everything that is permanently devoted is most set-apart to Yahuah. 
 \p
 \v 29 “ ‘No one devoted to destruction, who shall be devoted from among men, shall be ransomed. He shall surely be put to death. 
 \p
-\v 30 “ ‘All the tithe of the land, whether of the seed of the land or of the fruit of the trees, is Yahweh’s. It is set-apart to Yahweh. 
+\v 30 “ ‘All the tithe of the land, whether of the seed of the land or of the fruit of the trees, is Yahuah’s. It is set-apart to Yahuah. 
 \v 31 If a man redeems anything of his tithe, he shall add a fifth part to it. 
-\v 32 All the tithe of the herds or the flocks, whatever passes under the rod, the tenth shall be set-apart to Yahweh. 
+\v 32 All the tithe of the herds or the flocks, whatever passes under the rod, the tenth shall be set-apart to Yahuah. 
 \v 33 He shall not examine whether it is good or bad, neither shall he exchange it. If he exchanges it at all, then both it and that for which it is exchanged shall be set-apart. It shall not be redeemed.’ ” 
 \p
-\v 34 These are the commandments which Yahweh commanded Moses for the children of Israel on Mount Sinai. 
+\v 34 These are the commandments which Yahuah commanded Moses for the children of Israel on Mount Sinai. 

--- a/usfm/malachi.usfm
+++ b/usfm/malachi.usfm
@@ -3,81 +3,81 @@
 \h Malachi
 \c 1
 \p
-\v 1 A revelation, Yahweh’s word to Israel by Malachi. 
+\v 1 A revelation, Yahuah’s word to Israel by Malachi. 
 \p
-\v 2 “I have loved you,” says Yahweh. 
+\v 2 “I have loved you,” says Yahuah. 
 \p Yet you say, “How have you loved us?” 
-\p “Wasn’t Esau Jacob’s brother?” says Yahweh, “Yet I loved Jacob; 
+\p “Wasn’t Esau Jacob’s brother?” says Yahuah, “Yet I loved Jacob; 
 \v 3 but Esau I hated, and made his mountains a desolation, and gave his heritage to the jackals of the wilderness.” 
-\v 4 Whereas Edom says, “We are beaten down, but we will return and build the waste places,” Yahweh of Armies says, “They shall build, but I will throw down; and men will call them ‘The Wicked Land,’ even the people against whom Yahweh shows wrath forever.” 
+\v 4 Whereas Edom says, “We are beaten down, but we will return and build the waste places,” Yahuah of Armies says, “They shall build, but I will throw down; and men will call them ‘The Wicked Land,’ even the people against whom Yahuah shows wrath forever.” 
 \p
-\v 5 Your eyes will see, and you will say, “Yahweh is great—even beyond the border of Israel!” 
+\v 5 Your eyes will see, and you will say, “Yahuah is great—even beyond the border of Israel!” 
 \p
-\v 6 “A son honors his father, and a servant his master. If I am a father, then where is my honor? And if I am a master, where is the respect due me?” says Yahweh of Armies to you priests who despise my name. “You say, ‘How have we despised your name?’ 
-\v 7 You offer polluted bread on my altar. You say, ‘How have we polluted you?’ In that you say, ‘Yahweh’s table is contemptible.’ 
-\v 8 When you offer the blind for sacrifice, isn’t that evil? And when you offer the lame and sick, isn’t that evil? Present it now to your governor! Will he be pleased with you? Or will he accept your person?” says Yahweh of Armies. 
+\v 6 “A son honors his father, and a servant his master. If I am a father, then where is my honor? And if I am a master, where is the respect due me?” says Yahuah of Armies to you priests who despise my name. “You say, ‘How have we despised your name?’ 
+\v 7 You offer polluted bread on my altar. You say, ‘How have we polluted you?’ In that you say, ‘Yahuah’s table is contemptible.’ 
+\v 8 When you offer the blind for sacrifice, isn’t that evil? And when you offer the lame and sick, isn’t that evil? Present it now to your governor! Will he be pleased with you? Or will he accept your person?” says Yahuah of Armies. 
 \p
-\v 9 “Now, please entreat the favor of Elohim, that he may be gracious to us. With this, will he accept any of you?” says Yahweh of Armies. 
+\v 9 “Now, please entreat the favor of Elohim, that he may be gracious to us. With this, will he accept any of you?” says Yahuah of Armies. 
 \p
-\v 10 “Oh that there were one among you who would shut the doors, that you might not kindle fire on my altar in vain! I have no pleasure in you,” says Yahweh of Armies, “neither will I accept an offering at your hand. 
-\v 11 For from the rising of the sun even to its going down, my name is great among the nations, and in every place incense will be offered to my name, and a pure offering; for my name is great among the nations,” says Yahweh of Armies. 
-\v 12 “But you profane it when you say, ‘Yahweh’s table is polluted, and its fruit, even its food, is contemptible.’ 
-\v 13 You say also, ‘Behold, what a weariness it is!’ And you have sniffed at it”, says Yahweh of Armies; “and you have brought that which was taken by violence, the lame, and the sick; thus you bring the offering. Should I accept this at your hand?” says Yahweh. 
+\v 10 “Oh that there were one among you who would shut the doors, that you might not kindle fire on my altar in vain! I have no pleasure in you,” says Yahuah of Armies, “neither will I accept an offering at your hand. 
+\v 11 For from the rising of the sun even to its going down, my name is great among the nations, and in every place incense will be offered to my name, and a pure offering; for my name is great among the nations,” says Yahuah of Armies. 
+\v 12 “But you profane it when you say, ‘Yahuah’s table is polluted, and its fruit, even its food, is contemptible.’ 
+\v 13 You say also, ‘Behold, what a weariness it is!’ And you have sniffed at it”, says Yahuah of Armies; “and you have brought that which was taken by violence, the lame, and the sick; thus you bring the offering. Should I accept this at your hand?” says Yahuah. 
 \p
-\v 14 “But the deceiver is cursed who has in his flock a male, and vows and sacrifices to the Lord a defective thing; for I am a great King,” says Yahweh of Armies, “and my name is awesome among the nations.” 
+\v 14 “But the deceiver is cursed who has in his flock a male, and vows and sacrifices to the Lord a defective thing; for I am a great King,” says Yahuah of Armies, “and my name is awesome among the nations.” 
 \c 2
 \p
 \v 1 “Now, you priests, this commandment is for you. 
-\v 2 If you will not listen, and if you will not take it to heart, to give glory to my name,” says Yahweh of Armies, “then I will send the curse on you, and I will curse your blessings. Indeed, I have cursed them already, because you do not take it to heart. 
+\v 2 If you will not listen, and if you will not take it to heart, to give glory to my name,” says Yahuah of Armies, “then I will send the curse on you, and I will curse your blessings. Indeed, I have cursed them already, because you do not take it to heart. 
 \v 3 Behold, I will rebuke your offspring, and will spread dung on your faces, even the dung of your feasts; and you will be taken away with it. 
-\v 4 You will know that I have sent this commandment to you, that my covenant may be with Levi,” says Yahweh of Armies. 
+\v 4 You will know that I have sent this commandment to you, that my covenant may be with Levi,” says Yahuah of Armies. 
 \v 5 “My covenant was with him of life and peace; and I gave them to him that he might be reverent toward me; and he was reverent toward me, and stood in awe of my name. 
 \v 6 The law of truth was in his mouth, and unrighteousness was not found in his lips. He walked with me in peace and uprightness, and turned many away from iniquity. 
-\v 7 For the priest’s lips should keep knowledge, and they should seek the law at his mouth; for he is the messenger of Yahweh of Armies. 
-\v 8 But you have turned away from the path. You have caused many to stumble in the law. You have corrupted the covenant of Levi,” says Yahweh of Armies. 
+\v 7 For the priest’s lips should keep knowledge, and they should seek the law at his mouth; for he is the messenger of Yahuah of Armies. 
+\v 8 But you have turned away from the path. You have caused many to stumble in the law. You have corrupted the covenant of Levi,” says Yahuah of Armies. 
 \v 9 “Therefore I have also made you contemptible and wicked before all the people, according to the way you have not kept my ways, but have had respect for persons in the law. 
 \v 10 Don’t we all have one father? Hasn’t one Elohim created us? Why do we deal treacherously every man against his brother, profaning the covenant of our fathers? 
-\v 11 Judah has dealt treacherously, and an abomination is committed in Israel and in Jerusalem; for Judah has profaned the set-apartness of Yahweh which he loves, and has owned the daughter of a foreign elohim. 
-\v 12 Yahweh will cut off the man who does this, him who wakes and him who answers, out of the tents of Jacob and him who offers an offering to Yahweh of Armies. 
+\v 11 Judah has dealt treacherously, and an abomination is committed in Israel and in Jerusalem; for Judah has profaned the set-apartness of Yahuah which he loves, and has owned the daughter of a foreign elohim. 
+\v 12 Yahuah will cut off the man who does this, him who wakes and him who answers, out of the tents of Jacob and him who offers an offering to Yahuah of Armies. 
 \p
-\v 13 “This again you do: you cover Yahweh’s altar with tears, with weeping, and with sighing, because he doesn’t regard the offering any more, neither receives it with good will at your hand. 
-\v 14 Yet you say, ‘Why?’ Because Yahweh has been witness between you and the woman of your youth, against whom you have dealt treacherously, though she is your companion and the woman of your covenant. 
+\v 13 “This again you do: you cover Yahuah’s altar with tears, with weeping, and with sighing, because he doesn’t regard the offering any more, neither receives it with good will at your hand. 
+\v 14 Yet you say, ‘Why?’ Because Yahuah has been witness between you and the woman of your youth, against whom you have dealt treacherously, though she is your companion and the woman of your covenant. 
 \v 15 Did he not make you one, although he had the residue of the Spirit? Why one? He sought elohimly offspring. Therefore take heed to your spirit, and let no one deal treacherously against the woman of his youth. 
-\v 16 One who hates and divorces”, says Yahweh, the Elohim of Israel, “covers his garment with violence!” says Yahweh of Armies. “Therefore pay attention to your spirit, that you don’t be unfaithful. 
+\v 16 One who hates and divorces”, says Yahuah, the Elohim of Israel, “covers his garment with violence!” says Yahuah of Armies. “Therefore pay attention to your spirit, that you don’t be unfaithful. 
 \p
-\v 17 You have wearied Yahweh with your words. Yet you say, ‘How have we wearied him?’ In that you say, ‘Everyone who does evil is good in Yahweh’s sight, and he delights in them;’ or ‘Where is the Elohim of justice?’ 
+\v 17 You have wearied Yahuah with your words. Yet you say, ‘How have we wearied him?’ In that you say, ‘Everyone who does evil is good in Yahuah’s sight, and he delights in them;’ or ‘Where is the Elohim of justice?’ 
 \c 3
 \p
-\v 1 “Behold, I send my messenger, and he will prepare the way before me! The Lord, whom you seek, will suddenly come to his temple. Behold, the messenger of the covenant, whom you desire, is coming!” says Yahweh of Armies. 
+\v 1 “Behold, I send my messenger, and he will prepare the way before me! The Lord, whom you seek, will suddenly come to his temple. Behold, the messenger of the covenant, whom you desire, is coming!” says Yahuah of Armies. 
 \v 2 “But who can endure the day of his coming? And who will stand when he appears? For he is like a refiner’s fire, and like launderers’ soap; 
-\v 3 and he will sit as a refiner and purifier of silver, and he will purify the sons of Levi, and refine them as gold and silver; and they shall offer to Yahweh offerings in righteousness. 
-\v 4 Then the offering of Judah and Jerusalem will be pleasant to Yahweh as in the days of old and as in ancient years. 
+\v 3 and he will sit as a refiner and purifier of silver, and he will purify the sons of Levi, and refine them as gold and silver; and they shall offer to Yahuah offerings in righteousness. 
+\v 4 Then the offering of Judah and Jerusalem will be pleasant to Yahuah as in the days of old and as in ancient years. 
 \p
-\v 5 I will come near to you to judgment. I will be a swift witness against the sorcerers, against the adulterers, against the perjurers, and against those who oppress the hireling in his wages, the widow, and the fatherless, and who deprive the foreigner of justice, and don’t fear me,” says Yahweh of Armies. 
+\v 5 I will come near to you to judgment. I will be a swift witness against the sorcerers, against the adulterers, against the perjurers, and against those who oppress the hireling in his wages, the widow, and the fatherless, and who deprive the foreigner of justice, and don’t fear me,” says Yahuah of Armies. 
 \p
-\v 6 “For I, Yahweh, don’t change; therefore you, sons of Jacob, are not consumed. 
-\v 7 From the days of your fathers you have turned away from my ordinances and have not kept them. Return to me, and I will return to you,” says Yahweh of Armies. “But you say, ‘How shall we return?’ 
+\v 6 “For I, Yahuah, don’t change; therefore you, sons of Jacob, are not consumed. 
+\v 7 From the days of your fathers you have turned away from my ordinances and have not kept them. Return to me, and I will return to you,” says Yahuah of Armies. “But you say, ‘How shall we return?’ 
 \p
 \v 8 Will a man rob Elohim? Yet you rob me! But you say, ‘How have we robbed you?’ In tithes and offerings. 
 \v 9 You are cursed with the curse; for you rob me, even this whole nation. 
-\v 10 Bring the whole tithe into the storehouse, that there may be food in my house, and test me now in this,” says Yahweh of Armies, “if I will not open you the windows of heaven, and pour you out a blessing, that there will not be enough room for. 
-\v 11 I will rebuke the devourer for your sakes, and he shall not destroy the fruits of your ground; neither shall your vine cast its fruit before its time in the field,” says Yahweh of Armies. 
-\v 12 “All nations shall call you blessed, for you will be a delightful land,” says Yahweh of Armies. 
+\v 10 Bring the whole tithe into the storehouse, that there may be food in my house, and test me now in this,” says Yahuah of Armies, “if I will not open you the windows of heaven, and pour you out a blessing, that there will not be enough room for. 
+\v 11 I will rebuke the devourer for your sakes, and he shall not destroy the fruits of your ground; neither shall your vine cast its fruit before its time in the field,” says Yahuah of Armies. 
+\v 12 “All nations shall call you blessed, for you will be a delightful land,” says Yahuah of Armies. 
 \p
-\v 13 “Your words have been harsh against me,” says Yahweh. “Yet you say, ‘What have we spoken against you?’ 
-\v 14 You have said, ‘It is vain to serve Elohim,’ and ‘What profit is it that we have followed his instructions and that we have walked mournfully before Yahweh of Armies? 
+\v 13 “Your words have been harsh against me,” says Yahuah. “Yet you say, ‘What have we spoken against you?’ 
+\v 14 You have said, ‘It is vain to serve Elohim,’ and ‘What profit is it that we have followed his instructions and that we have walked mournfully before Yahuah of Armies? 
 \v 15 Now we call the proud happy; yes, those who work wickedness are built up; yes, they tempt Elohim, and escape.’ 
 \p
-\v 16 Then those who feared Yahweh spoke one with another; and Yahweh listened and heard, and a book of memory was written before him for those who feared Yahweh and who honored his name. 
-\v 17 They shall be mine,” says Yahweh of Armies, “my own possession in the day that I make. I will spare them, as a man spares his own son who serves him. 
+\v 16 Then those who feared Yahuah spoke one with another; and Yahuah listened and heard, and a book of memory was written before him for those who feared Yahuah and who honored his name. 
+\v 17 They shall be mine,” says Yahuah of Armies, “my own possession in the day that I make. I will spare them, as a man spares his own son who serves him. 
 \v 18 Then you shall return and discern between the righteous and the wicked, between him who serves Elohim and him who doesn’t serve him. 
 \c 4
 \p
-\v 1 “For behold, the day comes, burning like a furnace, when all the proud and all who work wickedness will be stubble. The day that comes will burn them up,” says Yahweh of Armies, “so that it will leave them neither root nor branch. 
+\v 1 “For behold, the day comes, burning like a furnace, when all the proud and all who work wickedness will be stubble. The day that comes will burn them up,” says Yahuah of Armies, “so that it will leave them neither root nor branch. 
 \v 2 But to you who fear my name shall the sun of righteousness arise with healing in its wings. You will go out and leap like calves of the stall. 
-\v 3 You shall tread down the wicked; for they will be ashes under the soles of your feet in the day that I make,” says Yahweh of Armies. 
+\v 3 You shall tread down the wicked; for they will be ashes under the soles of your feet in the day that I make,” says Yahuah of Armies. 
 \p
 \v 4 “Remember the law of Moses my servant, which I commanded to him in Horeb for all Israel, even statutes and ordinances. 
 \p
-\v 5 Behold, I will send you Elijah the prophet before the great and terrible day of Yahweh comes. 
+\v 5 Behold, I will send you Elijah the prophet before the great and terrible day of Yahuah comes. 
 \v 6 He will turn the hearts of the fathers to the children and the hearts of the children to their fathers, lest I come and strike the earth with a curse.” 

--- a/usfm/matthew.usfm
+++ b/usfm/matthew.usfm
@@ -1447,7 +1447,7 @@
 \v 62 The high priest stood up and said to him, “Have you no answer? What is this that these testify against you?” 
 \v 63 But Yahushua stayed silent. The high priest answered him, “I adjure you by the living Elohim that you tell us whether you are the Christ, the Son of Elohim.” 
 \p
-\v 64 Yahushua said to him, “You have said so. Nevertheless, I tell you, after this you will see the Son of Man sitting at the right hand of Yahweh, and coming on the clouds of the sky.” 
+\v 64 Yahushua said to him, “You have said so. Nevertheless, I tell you, after this you will see the Son of Man sitting at the right hand of Yahuah, and coming on the clouds of the sky.” 
 \p
 \v 65 Then the high priest tore his clothing, saying, “He has spoken blasphemy! Why do we need any more witnesses? Behold, now you have heard his blasphemy. 
 \v 66 What do you think?” 

--- a/usfm/micah.usfm
+++ b/usfm/micah.usfm
@@ -3,14 +3,14 @@
 \h Micah
 \c 1
 \p
-\v 1 Yahweh’s word that came to Micah of Morasheth in the days of Jotham, Ahaz, and Hezekiah, kings of Judah, which he saw concerning Samaria and Jerusalem. 
+\v 1 Yahuah’s word that came to Micah of Morasheth in the days of Jotham, Ahaz, and Hezekiah, kings of Judah, which he saw concerning Samaria and Jerusalem. 
 \q1
 \v 2 Hear, you peoples, all of you! 
 \q2 Listen, O earth, and all that is therein. 
-\q1 Let the Lord Yahweh be witness against you, 
+\q1 Let the Lord Yahuah be witness against you, 
 \q2 the Lord from his set-apart temple. 
 \q1
-\v 3 For behold, Yahweh comes out of his place, 
+\v 3 For behold, Yahuah comes out of his place, 
 \q2 and will come down and tread on the high places of the earth. 
 \q1
 \v 4 The mountains melt under him, 
@@ -56,7 +56,7 @@
 \q2 The wailing of Beth Ezel will take from you his protection. 
 \q1
 \v 12 For the inhabitant of Maroth waits anxiously for good, 
-\q2 because evil has come down from Yahweh to the gate of Jerusalem. 
+\q2 because evil has come down from Yahuah to the gate of Jerusalem. 
 \q1
 \v 13 Harness the chariot to the swift steed, inhabitant of Lachish. 
 \q2 She was the beginning of sin to the daughter of Zion; 
@@ -85,7 +85,7 @@
 \q1 They oppress a man and his house, 
 \q2 even a man and his heritage. 
 \q1
-\v 3 Therefore Yahweh says: 
+\v 3 Therefore Yahuah says: 
 \q1 “Behold, I am planning against these people a disaster, 
 \q2 from which you will not remove your necks, 
 \q2 neither will you walk haughtily, 
@@ -97,13 +97,13 @@
 \q2 My people’s possession is divided up. 
 \q2 Indeed he takes it from me and assigns our fields to traitors!’ ” 
 \q1
-\v 5 Therefore you will have no one who divides the land by lot in Yahweh’s assembly. 
+\v 5 Therefore you will have no one who divides the land by lot in Yahuah’s assembly. 
 \q1
 \v 6 “Don’t prophesy!”—they prophesy—\q2 “Don’t prophesy about these things. 
 \q2 Disgrace won’t overtake us.” 
 \q1
 \v 7 Shall it be said, O house of Jacob, 
-\q2 “Is Yahweh’s Spirit angry? 
+\q2 “Is Yahuah’s Spirit angry? 
 \q2 Are these his doings? 
 \q2 Don’t my words do good to him who walks blamelessly?” 
 \q1
@@ -131,7 +131,7 @@
 \v 13 He who breaks open the way goes up before them. 
 \q2 They break through the gate, and go out. 
 \q2 Their king passes on before them, 
-\q2 with Yahweh at their head. 
+\q2 with Yahuah at their head. 
 \c 3
 \p
 \v 1 I said, 
@@ -150,12 +150,12 @@
 \q2 and chop them in pieces, as for the pot, 
 \q2 and as meat within the cauldron. 
 \q1
-\v 4 Then they will cry to Yahweh, 
+\v 4 Then they will cry to Yahuah, 
 \q2 but he will not answer them. 
 \q1 Yes, he will hide his face from them at that time, 
 \q2 because they made their deeds evil.” 
 \p
-\v 5 Yahweh says concerning the prophets who lead my people astray—for those who feed their teeth, they proclaim, “Peace!” and whoever doesn’t provide for their mouths, they prepare war against him: 
+\v 5 Yahuah says concerning the prophets who lead my people astray—for those who feed their teeth, they proclaim, “Peace!” and whoever doesn’t provide for their mouths, they prepare war against him: 
 \q1
 \v 6 “Therefore night is over you, with no vision, 
 \q2 and it is dark to you, that you may not divine; 
@@ -167,7 +167,7 @@
 \q1 Yes, they shall all cover their lips, 
 \q2 for there is no answer from Elohim.” 
 \q1
-\v 8 But as for me, I am full of power by Yahweh’s Spirit, 
+\v 8 But as for me, I am full of power by Yahuah’s Spirit, 
 \q2 and of judgment, and of might, 
 \q2 to declare to Jacob his disobedience, 
 \q2 and to Israel his sin. 
@@ -183,8 +183,8 @@
 \v 11 Her leaders judge for bribes, 
 \q2 and her priests teach for a price, 
 \q2 and her prophets of it tell fortunes for money; 
-\q1 yet they lean on Yahweh, and say, 
-\q2 “Isn’t Yahweh among us? 
+\q1 yet they lean on Yahuah, and say, 
+\q2 “Isn’t Yahuah among us? 
 \q2 No disaster will come on us.” 
 \q1
 \v 12 Therefore Zion for your sake will be plowed like a field, 
@@ -194,17 +194,17 @@
 \c 4
 \q1
 \v 1 But in the latter days, 
-\q2 it will happen that the mountain of Yahweh’s temple will be established on the top of the mountains, 
+\q2 it will happen that the mountain of Yahuah’s temple will be established on the top of the mountains, 
 \q2 and it will be exalted above the hills; 
 \q2 and peoples will stream to it. 
 \q1
 \v 2 Many nations will go and say, 
-\q2 “Come! Let’s go up to the mountain of Yahweh, 
+\q2 “Come! Let’s go up to the mountain of Yahuah, 
 \q2 and to the house of the Elohim of Jacob; 
 \q2 and he will teach us of his ways, 
 \q2 and we will walk in his paths.” 
 \q1 For the law will go out of Zion, 
-\q2 and Yahweh’s word from Jerusalem; 
+\q2 and Yahuah’s word from Jerusalem; 
 \q1
 \v 3 and he will judge between many peoples, 
 \q2 and will decide concerning strong nations afar off. 
@@ -215,18 +215,18 @@
 \q1
 \v 4 But every man will sit under his vine and under his fig tree. 
 \q2 No one will make them afraid, 
-\q2 for the mouth of Yahweh of Armies has spoken. 
+\q2 for the mouth of Yahuah of Armies has spoken. 
 \v 5 Indeed all the nations may walk in the name of their elohims, 
-\q2 but we will walk in the name of Yahweh our Elohim forever and ever. 
+\q2 but we will walk in the name of Yahuah our Elohim forever and ever. 
 \q1
-\v 6 “In that day,” says Yahweh, 
+\v 6 “In that day,” says Yahuah, 
 \q2 “I will assemble that which is lame, 
 \q2 and I will gather that which is driven away, 
 \q2 and that which I have afflicted; 
 \q2
 \v 7 and I will make that which was lame a remnant, 
 \q2 and that which was cast far off a strong nation: 
-\q2 and Yahweh will reign over them on Mount Zion from then on, even forever.” 
+\q2 and Yahuah will reign over them on Mount Zion from then on, even forever.” 
 \q1
 \v 8 You, tower of the flock, the hill of the daughter of Zion, 
 \q2 to you it will come. 
@@ -245,14 +245,14 @@
 \q2 and will dwell in the field, 
 \q2 and will come even to Babylon. 
 \q1 There you will be rescued. 
-\q2 There Yahweh will redeem you from the hand of your enemies. 
+\q2 There Yahuah will redeem you from the hand of your enemies. 
 \b
 \q1
 \v 11 Now many nations have assembled against you, that say, 
 \q2 “Let her be defiled, 
 \q2 and let our eye gloat over Zion.” 
 \q1
-\v 12 But they don’t know the thoughts of Yahweh, 
+\v 12 But they don’t know the thoughts of Yahuah, 
 \q2 neither do they understand his counsel; 
 \q2 for he has gathered them like the sheaves to the threshing floor. 
 \q1
@@ -260,7 +260,7 @@
 \q2 for I will make your horn iron, 
 \q2 and I will make your hoofs bronze. 
 \q1 You will beat in pieces many peoples. 
-\q1 I will devote their gain to Yahweh, 
+\q1 I will devote their gain to Yahuah, 
 \q2 and their substance to the Lord of the whole earth. 
 \b
 \c 5
@@ -278,8 +278,8 @@
 \v 3 Therefore he will abandon them until the time that she who is in labor gives birth. 
 \q2 Then the rest of his brothers will return to the children of Israel. 
 \q1
-\v 4 He shall stand, and shall shepherd in the strength of Yahweh, 
-\q2 in the majesty of the name of Yahweh his Elohim. 
+\v 4 He shall stand, and shall shepherd in the strength of Yahuah, 
+\q2 in the majesty of the name of Yahuah his Elohim. 
 \q2 They will live, for then he will be great to the ends of the earth. 
 \q1
 \v 5 He will be our peace when Assyria invades our land 
@@ -294,7 +294,7 @@
 \q2 and when he marches within our border. 
 \q1
 \v 7 The remnant of Jacob will be among many peoples 
-\q2 like dew from Yahweh, 
+\q2 like dew from Yahuah, 
 \q2 like showers on the grass, 
 \q2 that don’t wait for man 
 \q2 nor wait for the sons of men. 
@@ -309,7 +309,7 @@
 \v 9 Let your hand be lifted up above your adversaries, 
 \q2 and let all of your enemies be cut off. 
 \q1
-\v 10 “It will happen in that day”, says Yahweh, 
+\v 10 “It will happen in that day”, says Yahuah, 
 \q2 “that I will cut off your horses from among you 
 \q2 and will destroy your chariots. 
 \q1
@@ -329,13 +329,13 @@
 \q2 and wrath on the nations that didn’t listen.” 
 \c 6
 \p
-\v 1 Listen now to what Yahweh says: 
+\v 1 Listen now to what Yahuah says: 
 \q1 “Arise, plead your case before the mountains, 
 \q2 and let the hills hear what you have to say. 
 \q1
-\v 2 Hear, you mountains, Yahweh’s indictment, 
+\v 2 Hear, you mountains, Yahuah’s indictment, 
 \q2 and you enduring foundations of the earth; 
-\q2 for Yahweh has a case against his people, 
+\q2 for Yahuah has a case against his people, 
 \q2 and he will contend with Israel. 
 \q1
 \v 3 My people, what have I done to you? 
@@ -348,25 +348,25 @@
 \q1
 \v 5 My people, remember now what Balak king of Moab devised, 
 \q2 and what Balaam the son of Beor answered him from Shittim to Gilgal, 
-\q2 that you may know the righteous acts of Yahweh.” 
+\q2 that you may know the righteous acts of Yahuah.” 
 \b
 \q1
-\v 6 How shall I come before Yahweh, 
+\v 6 How shall I come before Yahuah, 
 \q2 and bow myself before the exalted Elohim? 
 \q1 Shall I come before him with burnt offerings, 
 \q2 with calves a year old? 
 \q1
-\v 7 Will Yahweh be pleased with thousands of rams? 
+\v 7 Will Yahuah be pleased with thousands of rams? 
 \q2 With tens of thousands of rivers of oil? 
 \q1 Shall I give my firstborn for my disobedience? 
 \q2 The fruit of my body for the sin of my soul? 
 \q1
 \v 8 He has shown you, O man, what is good. 
-\q2 What does Yahweh require of you, but to act justly, 
+\q2 What does Yahuah require of you, but to act justly, 
 \q2 to love mercy, and to walk humbly with your Elohim? 
 \b
 \q1
-\v 9 Yahweh’s voice calls to the city—\q2 and wisdom fears your name—\q1 “Listen to the rod, 
+\v 9 Yahuah’s voice calls to the city—\q2 and wisdom fears your name—\q1 “Listen to the rod, 
 \q2 and he who appointed it. 
 \q1
 \v 10 Are there yet treasures of wickedness in the house of the wicked, 
@@ -431,15 +431,15 @@
 \q2 the daughter-in-law against her mother-in-law; 
 \q2 a man’s enemies are the men of his own house. 
 \q1
-\v 7 But as for me, I will look to Yahweh. 
+\v 7 But as for me, I will look to Yahuah. 
 \q2 I will wait for the Elohim of my salvation. 
 \q2 My Elohim will hear me. 
 \q1
 \v 8 Don’t rejoice against me, my enemy. 
 \q2 When I fall, I will arise. 
-\q2 When I sit in darkness, Yahweh will be a light to me. 
+\q2 When I sit in darkness, Yahuah will be a light to me. 
 \q1
-\v 9 I will bear the indignation of Yahweh, 
+\v 9 I will bear the indignation of Yahuah, 
 \q2 because I have sinned against him, 
 \q2 until he pleads my case and executes judgment for me. 
 \q2 He will bring me out to the light. 
@@ -447,7 +447,7 @@
 \q1
 \v 10 Then my enemy will see it, 
 \q2 and shame will cover her who said to me, 
-\q2 “Where is Yahweh your Elohim?” 
+\q2 “Where is Yahuah your Elohim?” 
 \q1 My eyes will see her. 
 \q2 Now she will be trodden down like the mire of the streets. 
 \q1
@@ -477,7 +477,7 @@
 \q1
 \v 17 They will lick the dust like a serpent. 
 \q2 Like crawling things of the earth, they will come trembling out of their dens. 
-\q2 They will come with fear to Yahweh our Elohim, 
+\q2 They will come with fear to Yahuah our Elohim, 
 \q2 and will be afraid because of you. 
 \q1
 \v 18 Who is an Elohim like you, who pardons iniquity, 

--- a/usfm/nahum.usfm
+++ b/usfm/nahum.usfm
@@ -4,28 +4,28 @@
 \c 1
 \p
 \v 1 A revelation about Nineveh. The book of the vision of Nahum the Elkoshite. 
-\v 2 Yahweh is a jealous Elohim and avenges. Yahweh avenges and is full of wrath. Yahweh takes vengeance on his adversaries, and he maintains wrath against his enemies. 
-\v 3 Yahweh is slow to anger, and great in power, and will by no means leave the guilty unpunished. Yahweh has his way in the whirlwind and in the storm, and the clouds are the dust of his feet. 
+\v 2 Yahuah is a jealous Elohim and avenges. Yahuah avenges and is full of wrath. Yahuah takes vengeance on his adversaries, and he maintains wrath against his enemies. 
+\v 3 Yahuah is slow to anger, and great in power, and will by no means leave the guilty unpunished. Yahuah has his way in the whirlwind and in the storm, and the clouds are the dust of his feet. 
 \v 4 He rebukes the sea and makes it dry, and dries up all the rivers. Bashan and Carmel languish. The flower of Lebanon languishes. 
 \v 5 The mountains quake before him, and the hills melt away. The earth trembles at his presence, yes, the world, and all who dwell in it. 
 \v 6 Who can stand before his indignation? Who can endure the fierceness of his anger? His wrath is poured out like fire, and the rocks are broken apart by him. 
-\v 7 Yahweh is good, a stronghold in the day of trouble; and he knows those who take refuge in him. 
+\v 7 Yahuah is good, a stronghold in the day of trouble; and he knows those who take refuge in him. 
 \v 8 But with an overflowing flood, he will make a full end of her place, and will pursue his enemies into darkness. 
-\v 9 What do you plot against Yahweh? He will make a full end. Affliction won’t rise up the second time. 
+\v 9 What do you plot against Yahuah? He will make a full end. Affliction won’t rise up the second time. 
 \v 10 For entangled like thorns, and drunken as with their drink, they are consumed utterly like dry stubble. 
-\v 11 One has gone out of you who devises evil against Yahweh, who counsels wickedness. 
+\v 11 One has gone out of you who devises evil against Yahuah, who counsels wickedness. 
 \p
-\v 12 Yahweh says: “Though they are in full strength and likewise many, even so they will be cut down and pass away. Though I have afflicted you, I will afflict you no more. 
+\v 12 Yahuah says: “Though they are in full strength and likewise many, even so they will be cut down and pass away. Though I have afflicted you, I will afflict you no more. 
 \v 13 Now I will break his yoke from off you, and will burst your bonds apart.” 
 \p
-\v 14 Yahweh has commanded concerning you: “No more descendants will bear your name. Out of the house of your elohims, I will cut off the engraved image and the molten image. I will make your grave, for you are vile.” 
+\v 14 Yahuah has commanded concerning you: “No more descendants will bear your name. Out of the house of your elohims, I will cut off the engraved image and the molten image. I will make your grave, for you are vile.” 
 \p
 \v 15 Behold, on the mountains the feet of him who brings good news, who publishes peace! Keep your feasts, Judah! Perform your vows, for the wicked one will no more pass through you. He is utterly cut off. 
 \c 2
 \p
 \v 1 He who dashes in pieces has come up against you. Keep the fortress! Watch the way! Strengthen your waist! Fortify your power mightily! 
 \p
-\v 2 For Yahweh restores the excellency of Jacob as the excellency of Israel, for the destroyers have destroyed them and ruined their vine branches. 
+\v 2 For Yahuah restores the excellency of Jacob as the excellency of Israel, for the destroyers have destroyed them and ruined their vine branches. 
 \p
 \v 3 The shield of his mighty men is made red. The valiant men are in scarlet. The chariots flash with steel in the day of his preparation, and the pine spears are brandished. 
 \v 4 The chariots rage in the streets. They rush back and forth in the wide ways. Their appearance is like torches. They run like the lightnings. 
@@ -37,14 +37,14 @@
 \v 10 She is empty, void, and waste. The heart melts, the knees knock together, their bodies and faces have grown pale. 
 \v 11 Where is the den of the lions, and the feeding place of the young lions, where the lion and the lioness walked with the lion’s cubs, and no one made them afraid? 
 \v 12 The lion tore in pieces enough for his cubs, and strangled prey for his lionesses, and filled his caves with the kill and his dens with prey. 
-\v 13 “Behold, I am against you,” says Yahweh of Armies, “and I will burn her chariots in the smoke, and the sword will devour your young lions; and I will cut off your prey from the earth, and the voice of your messengers will no longer be heard.” 
+\v 13 “Behold, I am against you,” says Yahuah of Armies, “and I will burn her chariots in the smoke, and the sword will devour your young lions; and I will cut off your prey from the earth, and the voice of your messengers will no longer be heard.” 
 \c 3
 \p
 \v 1 Woe to the bloody city! It is all full of lies and robbery—no end to the prey. 
 \v 2 The noise of the whip, the noise of the rattling of wheels, prancing horses, and bounding chariots, 
 \v 3 the horseman charging, and the flashing sword, the glittering spear, and a multitude of slain, and a great heap of corpses, and there is no end of the bodies. They stumble on their bodies 
 \v 4 because of the multitude of the prostitution of the alluring prostitute, the mistress of witchcraft, who sells nations through her prostitution, and families through her witchcraft. 
-\v 5 “Behold, I am against you,” says Yahweh of Armies, “and I will lift your skirts over your face. I will show the nations your nakedness, and the kingdoms your shame. 
+\v 5 “Behold, I am against you,” says Yahuah of Armies, “and I will lift your skirts over your face. I will show the nations your nakedness, and the kingdoms your shame. 
 \v 6 I will throw abominable filth on you and make you vile, and will make you a spectacle. 
 \v 7 It will happen that all those who look at you will flee from you, and say, ‘Nineveh is laid waste! Who will mourn for her?’ Where will I seek comforters for you?” 
 \p

--- a/usfm/nehemiah.usfm
+++ b/usfm/nehemiah.usfm
@@ -9,7 +9,7 @@
 \v 3 They said to me, “The remnant who are left of the captivity there in the province are in great affliction and reproach. The wall of Jerusalem is also broken down, and its gates are burned with fire.” 
 \p
 \v 4 When I heard these words, I sat down and wept, and mourned several days; and I fasted and prayed before the Elohim of heaven, 
-\v 5 and said, “I beg you, Yahweh, the Elohim of heaven, the great and awesome Elohim who keeps covenant and loving kindness with those who love him and keep his commandments, 
+\v 5 and said, “I beg you, Yahuah, the Elohim of heaven, the great and awesome Elohim who keeps covenant and loving kindness with those who love him and keep his commandments, 
 \v 6 let your ear now be attentive and your eyes open, that you may listen to the prayer of your servant which I pray before you at this time, day and night, for the children of Israel your servants, while I confess the sins of the children of Israel which we have sinned against you. Yes, I and my father’s house have sinned. 
 \v 7 We have dealt very corruptly against you, and have not kept the commandments, nor the statutes, nor the ordinances, which you commanded your servant Moses. 
 \p
@@ -144,7 +144,7 @@
 \v 12 Then they said, “We will restore them, and will require nothing of them. We will do so, even as you say.” 
 \p Then I called the priests, and took an oath of them, that they would do according to this promise. 
 \v 13 Also I shook out my lap, and said, “So may Elohim shake out every man from his house, and from his labor, that doesn’t perform this promise; even may he be shaken out and emptied like this.” 
-\p All the assembly said, “Amen,” and praised Yahweh. The people did according to this promise. 
+\p All the assembly said, “Amen,” and praised Yahuah. The people did according to this promise. 
 \p
 \v 14 Moreover from the time that I was appointed to be their governor in the land of Judah, from the twentieth year even to the thirty-second year of Artaxerxes the king, that is, twelve years, I and my brothers have not eaten the bread of the governor. 
 \v 15 But the former governors who were before me were supported by the people, and took bread and wine from them, plus forty shekels of silver; yes, even their servants ruled over the people, but I didn’t do so, because of the fear of Elohim. 
@@ -310,25 +310,25 @@
 \p When the seventh month had come, the children of Israel were in their cities. 
 \c 8
 \p
-\v 1 All the people gathered themselves together as one man into the wide place that was in front of the water gate; and they spoke to Ezra the scribe to bring the book of the law of Moses, which Yahweh had commanded to Israel. 
+\v 1 All the people gathered themselves together as one man into the wide place that was in front of the water gate; and they spoke to Ezra the scribe to bring the book of the law of Moses, which Yahuah had commanded to Israel. 
 \v 2 Ezra the priest brought the law before the assembly, both men and women, and all who could hear with understanding, on the first day of the seventh month. 
 \v 3 He read from it before the wide place that was in front of the water gate from early morning until midday, in the presence of the men and the women, and of those who could understand. The ears of all the people were attentive to the book of the law. 
 \v 4 Ezra the scribe stood on a pulpit of wood, which they had made for the purpose; and beside him stood Mattithiah, Shema, Anaiah, Uriah, Hilkiah, and Maaseiah, on his right hand; and on his left hand, Pedaiah, Mishael, Malchijah, Hashum, Hashbaddanah, Zechariah, and Meshullam. 
 \v 5 Ezra opened the book in the sight of all the people (for he was above all the people), and when he opened it, all the people stood up. 
-\v 6 Then Ezra blessed Yahweh, the great Elohim. 
-\p All the people answered, “Amen, Amen,” with the lifting up of their hands. They bowed their heads, and worshiped Yahweh with their faces to the ground. 
+\v 6 Then Ezra blessed Yahuah, the great Elohim. 
+\p All the people answered, “Amen, Amen,” with the lifting up of their hands. They bowed their heads, and worshiped Yahuah with their faces to the ground. 
 \v 7 Also Jeshua, Bani, Sherebiah, Jamin, Akkub, Shabbethai, Hodiah, Maaseiah, Kelita, Azariah, Jozabad, Hanan, Pelaiah, and the Levites, caused the people to understand the law; and the people stayed in their place. 
 \v 8 They read in the book, in the law of Elohim, distinctly; and they gave the sense, so that they understood the reading. 
 \p
-\v 9 Nehemiah, who was the governor, Ezra the priest and scribe, and the Levites who taught the people said to all the people, “Today is set-apart to Yahweh your Elohim. Don’t mourn, nor weep.” For all the people wept when they heard the words of the law. 
-\v 10 Then he said to them, “Go your way. Eat the fat, drink the sweet, and send portions to him for whom nothing is prepared, for today is set-apart to our Lord. Don’t be grieved, for the joy of Yahweh is your strength.” 
+\v 9 Nehemiah, who was the governor, Ezra the priest and scribe, and the Levites who taught the people said to all the people, “Today is set-apart to Yahuah your Elohim. Don’t mourn, nor weep.” For all the people wept when they heard the words of the law. 
+\v 10 Then he said to them, “Go your way. Eat the fat, drink the sweet, and send portions to him for whom nothing is prepared, for today is set-apart to our Lord. Don’t be grieved, for the joy of Yahuah is your strength.” 
 \p
 \v 11 So the Levites calmed all the people, saying, “Hold your peace, for the day is set-apart. Don’t be grieved.” 
 \p
 \v 12 All the people went their way to eat, to drink, to send portions, and to celebrate, because they had understood the words that were declared to them. 
 \p
 \v 13 On the second day, the heads of fathers’ households of all the people, the priests, and the Levites were gathered together to Ezra the scribe, to study the words of the law. 
-\v 14 They found written in the law how Yahweh had commanded by Moses that the children of Israel should dwell in booths in the feast of the seventh month; 
+\v 14 They found written in the law how Yahuah had commanded by Moses that the children of Israel should dwell in booths in the feast of the seventh month; 
 \v 15 and that they should publish and proclaim in all their cities and in Jerusalem, saying, “Go out to the mountain, and get olive branches, branches of wild olive, myrtle branches, palm branches, and branches of thick trees, to make temporary shelters, as it is written.” 
 \p
 \v 16 So the people went out and brought them, and made themselves temporary shelters, everyone on the roof of his house, in their courts, in the courts of Elohim’s house, in the wide place of the water gate, and in the wide place of Ephraim’s gate. 
@@ -338,12 +338,12 @@
 \p
 \v 1 Now in the twenty-fourth day of this month the children of Israel were assembled with fasting, with sackcloth, and dirt on them. 
 \v 2 The offspring of Israel separated themselves from all foreigners and stood and confessed their sins and the iniquities of their fathers. 
-\v 3 They stood up in their place, and read in the book of the law of Yahweh their Elohim a fourth part of the day; and a fourth part they confessed and worshiped Yahweh their Elohim. 
-\v 4 Then Jeshua, Bani, Kadmiel, Shebaniah, Bunni, Sherebiah, Bani, and Chenani of the Levites stood up on the stairs, and cried with a loud voice to Yahweh their Elohim. 
+\v 3 They stood up in their place, and read in the book of the law of Yahuah their Elohim a fourth part of the day; and a fourth part they confessed and worshiped Yahuah their Elohim. 
+\v 4 Then Jeshua, Bani, Kadmiel, Shebaniah, Bunni, Sherebiah, Bani, and Chenani of the Levites stood up on the stairs, and cried with a loud voice to Yahuah their Elohim. 
 \p
-\v 5 Then the Levites, Jeshua, and Kadmiel, Bani, Hashabneiah, Sherebiah, Hodiah, Shebaniah, and Pethahiah, said, “Stand up and bless Yahweh your Elohim from everlasting to everlasting! Blessed be your glorious name, which is exalted above all blessing and praise! 
-\v 6 You are Yahweh, even you alone. You have made heaven, the heaven of heavens, with all their army, the earth and all things that are on it, the seas and all that is in them, and you preserve them all. The army of heaven worships you. 
-\v 7 You are Yahweh, the Elohim who chose Abram, brought him out of Ur of the Chaldees, gave him the name of Abraham, 
+\v 5 Then the Levites, Jeshua, and Kadmiel, Bani, Hashabneiah, Sherebiah, Hodiah, Shebaniah, and Pethahiah, said, “Stand up and bless Yahuah your Elohim from everlasting to everlasting! Blessed be your glorious name, which is exalted above all blessing and praise! 
+\v 6 You are Yahuah, even you alone. You have made heaven, the heaven of heavens, with all their army, the earth and all things that are on it, the seas and all that is in them, and you preserve them all. The army of heaven worships you. 
+\v 7 You are Yahuah, the Elohim who chose Abram, brought him out of Ur of the Chaldees, gave him the name of Abraham, 
 \v 8 found his heart faithful before you, and made a covenant with him to give the land of the Canaanite, the Hittite, the Amorite, the Perizzite, the Jebusite, and the Girgashite, to give it to his offspring, and have performed your words, for you are righteous. 
 \p
 \v 9 “You saw the affliction of our fathers in Egypt, and heard their cry by the Red Sea, 
@@ -414,14 +414,14 @@
 \v 26 Ahiah, Hanan, Anan, 
 \v 27 Malluch, Harim, and Baanah. 
 \p
-\v 28 The rest of the people, the priests, the Levites, the gatekeepers, the singers, the temple servants, and all those who had separated themselves from the peoples of the lands to the law of Elohim, their women, their sons, and their daughters—everyone who had knowledge and understanding—\v 29 joined with their brothers, their nobles, and entered into a curse and into an oath, to walk in Elohim’s law, which was given by Moses the servant of Elohim, and to observe and do all the commandments of Yahweh our Lord, and his ordinances and his statutes; 
+\v 28 The rest of the people, the priests, the Levites, the gatekeepers, the singers, the temple servants, and all those who had separated themselves from the peoples of the lands to the law of Elohim, their women, their sons, and their daughters—everyone who had knowledge and understanding—\v 29 joined with their brothers, their nobles, and entered into a curse and into an oath, to walk in Elohim’s law, which was given by Moses the servant of Elohim, and to observe and do all the commandments of Yahuah our Lord, and his ordinances and his statutes; 
 \v 30 and that we would not give our daughters to the peoples of the land, nor take their daughters for our sons; 
 \v 31 and if the peoples of the land bring wares or any grain on the Sabbath day to sell, that we would not buy from them on the Sabbath, or on a set-apart day; and that we would forego the seventh year crops and the exaction of every debt. 
 \p
 \v 32 Also we made ordinances for ourselves, to charge ourselves yearly with the third part of a shekel for the service of the house of our Elohim: 
 \v 33 for the show bread, for the continual meal offering, for the continual burnt offering, for the Sabbaths, for the new moons, for the set feasts, for the set-apart things, for the sin offerings to make atonement for Israel, and for all the work of the house of our Elohim. 
-\v 34 We, the priests, the Levites, and the people, cast lots for the wood offering, to bring it into the house of our Elohim, according to our fathers’ houses, at times appointed year by year, to burn on Yahweh our Elohim’s altar, as it is written in the law; 
-\v 35 and to bring the first fruits of our ground and the first fruits of all fruit of all kinds of trees, year by year, to Yahweh’s house; 
+\v 34 We, the priests, the Levites, and the people, cast lots for the wood offering, to bring it into the house of our Elohim, according to our fathers’ houses, at times appointed year by year, to burn on Yahuah our Elohim’s altar, as it is written in the law; 
+\v 35 and to bring the first fruits of our ground and the first fruits of all fruit of all kinds of trees, year by year, to Yahuah’s house; 
 \v 36 also the firstborn of our sons and of our livestock, as it is written in the law, and the firstborn of our herds and of our flocks, to bring to the house of our Elohim, to the priests who minister in the house of our Elohim; 
 \v 37 and that we should bring the first fruits of our dough, our wave offerings, the fruit of all kinds of trees, and the new wine and the oil, to the priests, to the rooms of the house of our Elohim; and the tithes of our ground to the Levites; for they, the Levites, take the tithes in all our farming villages. 
 \v 38 The priest, the descendent of Aaron, shall be with the Levites when the Levites take tithes. The Levites shall bring up the tithe of the tithes to the house of our Elohim, to the rooms, into the treasure house. 

--- a/usfm/numbers.usfm
+++ b/usfm/numbers.usfm
@@ -3,7 +3,7 @@
 \h Numbers
 \c 1
 \p
-\v 1 Yahweh spoke to Moses in the wilderness of Sinai, in the Tent of Meeting, on the first day of the second month, in the second year after they had come out of the land of Egypt, saying, 
+\v 1 Yahuah spoke to Moses in the wilderness of Sinai, in the Tent of Meeting, on the first day of the second month, in the second year after they had come out of the land of Egypt, saying, 
 \v 2 “Take a census of all the congregation of the children of Israel, by their families, by their fathers’ houses, according to the number of the names, every male, one by one, 
 \v 3 from twenty years old and upward, all who are able to go out to war in Israel. You and Aaron shall count them by their divisions. 
 \v 4 With you there shall be a man of every tribe, each one head of his fathers’ house. 
@@ -33,7 +33,7 @@
 \v 16 These are those who were called of the congregation, the princes of the tribes of their fathers; they were the heads of the thousands of Israel. 
 \v 17 Moses and Aaron took these men who are mentioned by name. 
 \v 18 They assembled all the congregation together on the first day of the second month; and they declared their ancestry by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, one by one. 
-\v 19 As Yahweh commanded Moses, so he counted them in the wilderness of Sinai. 
+\v 19 As Yahuah commanded Moses, so he counted them in the wilderness of Sinai. 
 \p
 \v 20 The children of Reuben, Israel’s firstborn, their generations, by their families, by their fathers’ houses, according to the number of the names, one by one, every male from twenty years old and upward, all who were able to go out to war: 
 \v 21 those who were counted of them, of the tribe of Reuben, were forty-six thousand five hundred. 
@@ -74,17 +74,17 @@
 \v 44 These are those who were counted, whom Moses and Aaron counted, and the twelve men who were princes of Israel, each one for his fathers’ house. 
 \v 45 So all those who were counted of the children of Israel by their fathers’ houses, from twenty years old and upward, all who were able to go out to war in Israel—\v 46 all those who were counted were six hundred three thousand five hundred fifty. 
 \v 47 But the Levites after the tribe of their fathers were not counted among them. 
-\v 48 For Yahweh spoke to Moses, saying, 
+\v 48 For Yahuah spoke to Moses, saying, 
 \v 49 “Only the tribe of Levi you shall not count, neither shall you take a census of them among the children of Israel; 
 \v 50 but appoint the Levites over the Tabernacle of the Testimony, and over all its furnishings, and over all that belongs to it. They shall carry the tabernacle and all its furnishings; and they shall take care of it, and shall encamp around it. 
 \v 51 When the tabernacle is to move, the Levites shall take it down; and when the tabernacle is to be set up, the Levites shall set it up. The stranger who comes near shall be put to death. 
 \v 52 The children of Israel shall pitch their tents, every man by his own camp, and every man by his own standard, according to their divisions. 
 \v 53 But the Levites shall encamp around the Tabernacle of the Testimony, that there may be no wrath on the congregation of the children of Israel. The Levites shall be responsible for the Tabernacle of the Testimony.” 
 \p
-\v 54 Thus the children of Israel did. According to all that Yahweh commanded Moses, so they did. 
+\v 54 Thus the children of Israel did. According to all that Yahuah commanded Moses, so they did. 
 \c 2
 \p
-\v 1 Yahweh spoke to Moses and to Aaron, saying, 
+\v 1 Yahuah spoke to Moses and to Aaron, saying, 
 \v 2 “The children of Israel shall encamp every man by his own standard, with the banners of their fathers’ houses. They shall encamp around the Tent of Meeting at a distance from it. 
 \p
 \v 3 “Those who encamp on the east side toward the sunrise shall be of the standard of the camp of Judah, according to their divisions. The prince of the children of Judah shall be Nahshon the son of Amminadab. 
@@ -134,32 +134,32 @@
 \v 31 “All who were counted of the camp of Dan were one hundred fifty-seven thousand six hundred. They shall set out last by their standards.” 
 \p
 \v 32 These are those who were counted of the children of Israel by their fathers’ houses. All who were counted of the camps according to their armies were six hundred three thousand five hundred fifty. 
-\v 33 But the Levites were not counted among the children of Israel, as Yahweh commanded Moses. 
+\v 33 But the Levites were not counted among the children of Israel, as Yahuah commanded Moses. 
 \p
-\v 34 Thus the children of Israel did. According to all that Yahweh commanded Moses, so they encamped by their standards, and so they set out, everyone by their families, according to their fathers’ houses. 
+\v 34 Thus the children of Israel did. According to all that Yahuah commanded Moses, so they encamped by their standards, and so they set out, everyone by their families, according to their fathers’ houses. 
 \c 3
 \p
-\v 1 Now this is the history of the generations of Aaron and Moses in the day that Yahweh spoke with Moses in Mount Sinai. 
+\v 1 Now this is the history of the generations of Aaron and Moses in the day that Yahuah spoke with Moses in Mount Sinai. 
 \v 2 These are the names of the sons of Aaron: Nadab the firstborn, and Abihu, Eleazar, and Ithamar. 
 \p
 \v 3 These are the names of the sons of Aaron, the priests who were anointed, whom he consecrated to minister in the priest’s office. 
-\v 4 Nadab and Abihu died before Yahweh when they offered strange fire before Yahweh in the wilderness of Sinai, and they had no children. Eleazar and Ithamar ministered in the priest’s office in the presence of Aaron their father. 
+\v 4 Nadab and Abihu died before Yahuah when they offered strange fire before Yahuah in the wilderness of Sinai, and they had no children. Eleazar and Ithamar ministered in the priest’s office in the presence of Aaron their father. 
 \p
-\v 5 Yahweh spoke to Moses, saying, 
+\v 5 Yahuah spoke to Moses, saying, 
 \v 6 “Bring the tribe of Levi near, and set them before Aaron the priest, that they may minister to him. 
 \v 7 They shall keep his requirements, and the requirements of the whole congregation before the Tent of Meeting, to do the service of the tabernacle. 
 \v 8 They shall keep all the furnishings of the Tent of Meeting, and the obligations of the children of Israel, to do the service of the tabernacle. 
 \v 9 You shall give the Levites to Aaron and to his sons. They are wholly given to him on the behalf of the children of Israel. 
 \v 10 You shall appoint Aaron and his sons, and they shall keep their priesthood, but the stranger who comes near shall be put to death.” 
 \p
-\v 11 Yahweh spoke to Moses, saying, 
+\v 11 Yahuah spoke to Moses, saying, 
 \v 12 “Behold, I have taken the Levites from among the children of Israel instead of all the firstborn who open the womb among the children of Israel; and the Levites shall be mine, 
-\v 13 for all the firstborn are mine. On the day that I struck down all the firstborn in the land of Egypt I made set-apart to me all the firstborn in Israel, both man and animal. They shall be mine. I am Yahweh.” 
+\v 13 for all the firstborn are mine. On the day that I struck down all the firstborn in the land of Egypt I made set-apart to me all the firstborn in Israel, both man and animal. They shall be mine. I am Yahuah.” 
 \p
-\v 14 Yahweh spoke to Moses in the wilderness of Sinai, saying, 
+\v 14 Yahuah spoke to Moses in the wilderness of Sinai, saying, 
 \v 15 “Count the children of Levi by their fathers’ houses, by their families. You shall count every male from a month old and upward.” 
 \p
-\v 16 Moses counted them according to Yahweh’s word, as he was commanded. 
+\v 16 Moses counted them according to Yahuah’s word, as he was commanded. 
 \p
 \v 17 These were the sons of Levi by their names: Gershon, Kohath, and Merari. 
 \p
@@ -196,26 +196,26 @@
 \v 37 the pillars of the court around it, their sockets, their pins, and their cords. 
 \p
 \v 38 Those who encamp before the tabernacle eastward, in front of the Tent of Meeting toward the sunrise, shall be Moses, with Aaron and his sons, keeping the requirements of the sanctuary for the duty of the children of Israel. The outsider who comes near shall be put to death. 
-\v 39 All who were counted of the Levites, whom Moses and Aaron counted at the commandment of Yahweh, by their families, all the males from a month old and upward, were twenty-two thousand. 
+\v 39 All who were counted of the Levites, whom Moses and Aaron counted at the commandment of Yahuah, by their families, all the males from a month old and upward, were twenty-two thousand. 
 \p
-\v 40 Yahweh said to Moses, “Count all the firstborn males of the children of Israel from a month old and upward, and take the number of their names. 
-\v 41 You shall take the Levites for me—I am Yahweh—instead of all the firstborn among the children of Israel; and the livestock of the Levites instead of all the firstborn among the livestock of the children of Israel.” 
+\v 40 Yahuah said to Moses, “Count all the firstborn males of the children of Israel from a month old and upward, and take the number of their names. 
+\v 41 You shall take the Levites for me—I am Yahuah—instead of all the firstborn among the children of Israel; and the livestock of the Levites instead of all the firstborn among the livestock of the children of Israel.” 
 \p
-\v 42 Moses counted, as Yahweh commanded him, all the firstborn among the children of Israel. 
+\v 42 Moses counted, as Yahuah commanded him, all the firstborn among the children of Israel. 
 \v 43 All the firstborn males according to the number of names from a month old and upward, of those who were counted of them, were twenty-two thousand two hundred seventy-three. 
 \p
-\v 44 Yahweh spoke to Moses, saying, 
-\v 45 “Take the Levites instead of all the firstborn among the children of Israel, and the livestock of the Levites instead of their livestock; and the Levites shall be mine. I am Yahweh. 
+\v 44 Yahuah spoke to Moses, saying, 
+\v 45 “Take the Levites instead of all the firstborn among the children of Israel, and the livestock of the Levites instead of their livestock; and the Levites shall be mine. I am Yahuah. 
 \v 46 For the redemption of the two hundred seventy-three of the firstborn of the children of Israel who exceed the number of the Levites, 
 \v 47 you shall take five shekels apiece for each one; according to the shekel of the sanctuary you shall take them (the shekel is twenty gerahs); 
 \v 48 and you shall give the money, with which their remainder is redeemed, to Aaron and to his sons.” 
 \p
 \v 49 Moses took the redemption money from those who exceeded the number of those who were redeemed by the Levites; 
 \v 50 from the firstborn of the children of Israel he took the money, one thousand three hundred sixty-five shekels, according to the shekel of the sanctuary; 
-\v 51 and Moses gave the redemption money to Aaron and to his sons, according to Yahweh’s word, as Yahweh commanded Moses. 
+\v 51 and Moses gave the redemption money to Aaron and to his sons, according to Yahuah’s word, as Yahuah commanded Moses. 
 \c 4
 \p
-\v 1 Yahweh spoke to Moses and to Aaron, saying, 
+\v 1 Yahuah spoke to Moses and to Aaron, saying, 
 \v 2 “Take a census of the sons of Kohath from among the sons of Levi, by their families, by their fathers’ houses, 
 \v 3 from thirty years old and upward even until fifty years old, all who enter into the service to do the work in the Tent of Meeting. 
 \p
@@ -240,12 +240,12 @@
 \p
 \v 16 “The duty of Eleazar the son of Aaron the priest shall be the oil for the light, the sweet incense, the continual meal offering, and the anointing oil, the requirements of all the tabernacle, and of all that is in it, the sanctuary, and its furnishings.” 
 \p
-\v 17 Yahweh spoke to Moses and to Aaron, saying, 
+\v 17 Yahuah spoke to Moses and to Aaron, saying, 
 \v 18 “Don’t cut off the tribe of the families of the Kohathites from among the Levites; 
 \v 19 but do this to them, that they may live, and not die, when they approach the most set-apart things: Aaron and his sons shall go in and appoint everyone to his service and to his burden; 
 \v 20 but they shall not go in to see the sanctuary even for a moment, lest they die.” 
 \p
-\v 21 Yahweh spoke to Moses, saying, 
+\v 21 Yahuah spoke to Moses, saying, 
 \v 22 “Take a census of the sons of Gershon also, by their fathers’ houses, by their families; 
 \v 23 you shall count them from thirty years old and upward until fifty years old: all who enter in to wait on the service, to do the work in the Tent of Meeting. 
 \p
@@ -264,98 +264,98 @@
 \v 34 Moses and Aaron and the princes of the congregation counted the sons of the Kohathites by their families, and by their fathers’ houses, 
 \v 35 from thirty years old and upward even to fifty years old, everyone who entered into the service for work in the Tent of Meeting. 
 \v 36 Those who were counted of them by their families were two thousand seven hundred fifty. 
-\v 37 These are those who were counted of the families of the Kohathites, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahweh by Moses. 
+\v 37 These are those who were counted of the families of the Kohathites, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahuah by Moses. 
 \p
 \v 38 Those who were counted of the sons of Gershon, by their families, and by their fathers’ houses, 
 \v 39 from thirty years old and upward even to fifty years old—everyone who entered into the service for work in the Tent of Meeting, 
 \v 40 even those who were counted of them, by their families, by their fathers’ houses, were two thousand six hundred thirty. 
-\v 41 These are those who were counted of the families of the sons of Gershon, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahweh. 
+\v 41 These are those who were counted of the families of the sons of Gershon, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahuah. 
 \p
 \v 42 Those who were counted of the families of the sons of Merari, by their families, by their fathers’ houses, 
 \v 43 from thirty years old and upward even to fifty years old—everyone who entered into the service for work in the Tent of Meeting, 
 \v 44 even those who were counted of them by their families, were three thousand two hundred. 
-\v 45 These are those who were counted of the families of the sons of Merari, whom Moses and Aaron counted according to the commandment of Yahweh by Moses. 
+\v 45 These are those who were counted of the families of the sons of Merari, whom Moses and Aaron counted according to the commandment of Yahuah by Moses. 
 \p
 \v 46 All those who were counted of the Levites whom Moses and Aaron and the princes of Israel counted, by their families and by their fathers’ houses, 
 \v 47 from thirty years old and upward even to fifty years old, everyone who entered in to do the work of service and the work of bearing burdens in the Tent of Meeting, 
 \v 48 even those who were counted of them, were eight thousand five hundred eighty. 
-\v 49 According to the commandment of Yahweh they were counted by Moses, everyone according to his service and according to his burden. Thus they were counted by him, as Yahweh commanded Moses. 
+\v 49 According to the commandment of Yahuah they were counted by Moses, everyone according to his service and according to his burden. Thus they were counted by him, as Yahuah commanded Moses. 
 \c 5
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Command the children of Israel that they put out of the camp every leper, everyone who has a discharge, and whoever is unclean by a corpse. 
 \v 3 You shall put both male and female outside of the camp so that they don’t defile their camp, in the midst of which I dwell.” 
 \p
-\v 4 The children of Israel did so, and put them outside of the camp; as Yahweh spoke to Moses, so the children of Israel did. 
+\v 4 The children of Israel did so, and put them outside of the camp; as Yahuah spoke to Moses, so the children of Israel did. 
 \p
-\v 5 Yahweh spoke to Moses, saying, 
-\v 6 “Speak to the children of Israel: ‘When a man or woman commits any sin that men commit, so as to trespass against Yahweh, and that soul is guilty, 
+\v 5 Yahuah spoke to Moses, saying, 
+\v 6 “Speak to the children of Israel: ‘When a man or woman commits any sin that men commit, so as to trespass against Yahuah, and that soul is guilty, 
 \v 7 then he shall confess his sin which he has done; and he shall make restitution for his guilt in full, add to it the fifth part of it, and give it to him in respect of whom he has been guilty. 
-\v 8 But if the man has no kinsman to whom restitution may be made for the guilt, the restitution for guilt which is made to Yahweh shall be the priest’s, in addition to the ram of the atonement, by which atonement shall be made for him. 
+\v 8 But if the man has no kinsman to whom restitution may be made for the guilt, the restitution for guilt which is made to Yahuah shall be the priest’s, in addition to the ram of the atonement, by which atonement shall be made for him. 
 \v 9 Every heave offering of all the set-apart things of the children of Israel, which they present to the priest, shall be his. 
 \v 10 Every man’s set-apart things shall be his; whatever any man gives the priest, it shall be his.’ ” 
 \p
-\v 11 Yahweh spoke to Moses, saying, 
+\v 11 Yahuah spoke to Moses, saying, 
 \v 12 “Speak to the children of Israel, and tell them: ‘If any man’s woman goes astray and is unfaithful to him, 
 \v 13 and a man lies with her carnally, and it is hidden from the eyes of her man and this is kept concealed, and she is defiled, there is no witness against her, and she isn’t taken in the act; 
 \v 14 and the spirit of jealousy comes on him, and he is jealous of his woman and she is defiled; or if the spirit of jealousy comes on him, and he is jealous of his woman and she isn’t defiled; 
 \v 15 then the man shall bring his woman to the priest, and shall bring her offering for her: one tenth of an ephah of barley meal. He shall pour no oil on it, nor put frankincense on it, for it is a meal offering of jealousy, a meal offering of memorial, bringing iniquity to memory. 
-\v 16 The priest shall bring her near, and set her before Yahweh. 
+\v 16 The priest shall bring her near, and set her before Yahuah. 
 \v 17 The priest shall take set-apart water in an earthen vessel; and the priest shall take some of the dust that is on the floor of the tabernacle and put it into the water. 
-\v 18 The priest shall set the woman before Yahweh, and let the hair of the woman’s head go loose, and put the meal offering of memorial in her hands, which is the meal offering of jealousy. The priest shall have in his hand the water of bitterness that brings a curse. 
+\v 18 The priest shall set the woman before Yahuah, and let the hair of the woman’s head go loose, and put the meal offering of memorial in her hands, which is the meal offering of jealousy. The priest shall have in his hand the water of bitterness that brings a curse. 
 \v 19 The priest shall cause her to take an oath and shall tell the woman, “If no man has lain with you, and if you haven’t gone aside to uncleanness, being under your man’s authority, be free from this water of bitterness that brings a curse. 
 \v 20 But if you have gone astray, being under your man’s authority, and if you are defiled, and some man has lain with you besides your man—” 
-\v 21 then the priest shall cause the woman to swear with the oath of cursing, and the priest shall tell the woman, “May Yahweh make you a curse and an oath among your people, when Yahweh allows your thigh to fall away, and your body to swell; 
+\v 21 then the priest shall cause the woman to swear with the oath of cursing, and the priest shall tell the woman, “May Yahuah make you a curse and an oath among your people, when Yahuah allows your thigh to fall away, and your body to swell; 
 \v 22 and this water that brings a curse will go into your bowels, and make your body swell, and your thigh fall away.” The woman shall say, “Amen, Amen.” 
 \p
 \v 23 “ ‘The priest shall write these curses in a book, and he shall wipe them into the water of bitterness. 
 \v 24 He shall make the woman drink the water of bitterness that causes the curse; and the water that causes the curse shall enter into her and become bitter. 
-\v 25 The priest shall take the meal offering of jealousy out of the woman’s hand, and shall wave the meal offering before Yahweh, and bring it to the altar. 
+\v 25 The priest shall take the meal offering of jealousy out of the woman’s hand, and shall wave the meal offering before Yahuah, and bring it to the altar. 
 \v 26 The priest shall take a handful of the meal offering, as its memorial portion, and burn it on the altar, and afterward shall make the woman drink the water. 
 \v 27 When he has made her drink the water, then it shall happen, if she is defiled and has committed a trespass against her man, that the water that causes the curse will enter into her and become bitter, and her body will swell, and her thigh will fall away; and the woman will be a curse among her people. 
 \v 28 If the woman isn’t defiled, but is clean; then she shall be free, and shall conceive offspring. 
 \p
 \v 29 “ ‘This is the law of jealousy, when a woman, being under her man, goes astray, and is defiled, 
-\v 30 or when the spirit of jealousy comes on a man, and he is jealous of his woman; then he shall set the woman before Yahweh, and the priest shall execute on her all this law. 
+\v 30 or when the spirit of jealousy comes on a man, and he is jealous of his woman; then he shall set the woman before Yahuah, and the priest shall execute on her all this law. 
 \v 31 The man shall be free from iniquity, and that woman shall bear her iniquity.’ ” 
 \c 6
 \p
-\v 1 Yahweh spoke to Moses, saying, 
-\v 2 “Speak to the children of Israel, and tell them: ‘When either man or woman shall make a special vow, the vow of a Nazirite, to separate himself to Yahweh, 
+\v 1 Yahuah spoke to Moses, saying, 
+\v 2 “Speak to the children of Israel, and tell them: ‘When either man or woman shall make a special vow, the vow of a Nazirite, to separate himself to Yahuah, 
 \v 3 he shall separate himself from wine and strong drink. He shall drink no vinegar of wine, or vinegar of fermented drink, neither shall he drink any juice of grapes, nor eat fresh grapes or dried. 
 \v 4 All the days of his separation he shall eat nothing that is made of the grapevine, from the seeds even to the skins. 
 \p
-\v 5 “ ‘All the days of his vow of separation no razor shall come on his head, until the days are fulfilled in which he separates himself to Yahweh. He shall be set-apart. He shall let the locks of the hair of his head grow long. 
+\v 5 “ ‘All the days of his vow of separation no razor shall come on his head, until the days are fulfilled in which he separates himself to Yahuah. He shall be set-apart. He shall let the locks of the hair of his head grow long. 
 \p
-\v 6 “ ‘All the days that he separates himself to Yahweh he shall not go near a dead body. 
+\v 6 “ ‘All the days that he separates himself to Yahuah he shall not go near a dead body. 
 \v 7 He shall not make himself unclean for his father, or for his mother, for his brother, or for his sister, when they die, because his separation to Elohim is on his head. 
-\v 8 All the days of his separation he is set-apart to Yahweh. 
+\v 8 All the days of his separation he is set-apart to Yahuah. 
 \p
 \v 9 “ ‘If any man dies very suddenly beside him, and he defiles the head of his separation, then he shall shave his head in the day of his cleansing. On the seventh day he shall shave it. 
 \v 10 On the eighth day he shall bring two turtledoves or two young pigeons to the priest, to the door of the Tent of Meeting. 
 \v 11 The priest shall offer one for a sin offering, and the other for a burnt offering, and make atonement for him, because he sinned by reason of the dead, and shall make his head set-apart that same day. 
-\v 12 He shall separate to Yahweh the days of his separation, and shall bring a male lamb a year old for a trespass offering; but the former days shall be void, because his separation was defiled. 
+\v 12 He shall separate to Yahuah the days of his separation, and shall bring a male lamb a year old for a trespass offering; but the former days shall be void, because his separation was defiled. 
 \p
 \v 13 “ ‘This is the law of the Nazirite: when the days of his separation are fulfilled, he shall be brought to the door of the Tent of Meeting, 
-\v 14 and he shall offer his offering to Yahweh: one male lamb a year old without defect for a burnt offering, one ewe lamb a year old without defect for a sin offering, one ram without defect for peace offerings, 
+\v 14 and he shall offer his offering to Yahuah: one male lamb a year old without defect for a burnt offering, one ewe lamb a year old without defect for a sin offering, one ram without defect for peace offerings, 
 \v 15 a basket of unleavened bread, cakes of fine flour mixed with oil, and unleavened wafers anointed with oil with their meal offering and their drink offerings. 
-\v 16 The priest shall present them before Yahweh, and shall offer his sin offering and his burnt offering. 
-\v 17 He shall offer the ram for a sacrifice of peace offerings to Yahweh, with the basket of unleavened bread. The priest shall offer also its meal offering and its drink offering. 
+\v 16 The priest shall present them before Yahuah, and shall offer his sin offering and his burnt offering. 
+\v 17 He shall offer the ram for a sacrifice of peace offerings to Yahuah, with the basket of unleavened bread. The priest shall offer also its meal offering and its drink offering. 
 \v 18 The Nazirite shall shave the head of his separation at the door of the Tent of Meeting, take the hair of the head of his separation, and put it on the fire which is under the sacrifice of peace offerings. 
 \v 19 The priest shall take the boiled shoulder of the ram, one unleavened cake out of the basket, and one unleavened wafer, and shall put them on the hands of the Nazirite after he has shaved the head of his separation; 
-\v 20 and the priest shall wave them for a wave offering before Yahweh. They are set-apart for the priest, together with the breast that is waved and the thigh that is offered. After that the Nazirite may drink wine. 
+\v 20 and the priest shall wave them for a wave offering before Yahuah. They are set-apart for the priest, together with the breast that is waved and the thigh that is offered. After that the Nazirite may drink wine. 
 \p
-\v 21 “ ‘This is the law of the Nazirite who vows and of his offering to Yahweh for his separation, in addition to that which he is able to afford. According to his vow which he vows, so he must do after the law of his separation.’ ” 
+\v 21 “ ‘This is the law of the Nazirite who vows and of his offering to Yahuah for his separation, in addition to that which he is able to afford. According to his vow which he vows, so he must do after the law of his separation.’ ” 
 \p
-\v 22 Yahweh spoke to Moses, saying, 
+\v 22 Yahuah spoke to Moses, saying, 
 \v 23 “Speak to Aaron and to his sons, saying, ‘This is how you shall bless the children of Israel.’ You shall tell them, 
 \q1
-\v 24 ‘Yahweh bless you, and keep you. 
+\v 24 ‘Yahuah bless you, and keep you. 
 \q2
-\v 25 Yahweh make his face to shine on you, 
+\v 25 Yahuah make his face to shine on you, 
 \q2 and be gracious to you. 
 \q1
-\v 26 Yahweh lift up his face toward you, 
+\v 26 Yahuah lift up his face toward you, 
 \q2 and give you peace.’ 
 \p
 \v 27 “So they shall put my name on the children of Israel; and I will bless them.” 
@@ -363,8 +363,8 @@
 \p
 \v 1 On the day that Moses had finished setting up the tabernacle, and had anointed it and sanctified it with all its furniture, and the altar with all its vessels, and had anointed and sanctified them; 
 \v 2 the princes of Israel, the heads of their fathers’ houses, gave offerings. These were the princes of the tribes. These are they who were over those who were counted; 
-\v 3 and they brought their offering before Yahweh, six covered wagons and twelve oxen; a wagon for every two of the princes, and for each one an ox. They presented them before the tabernacle. 
-\v 4 Yahweh spoke to Moses, saying, 
+\v 3 and they brought their offering before Yahuah, six covered wagons and twelve oxen; a wagon for every two of the princes, and for each one an ox. They presented them before the tabernacle. 
+\v 4 Yahuah spoke to Moses, saying, 
 \v 5 “Accept these from them, that they may be used in doing the service of the Tent of Meeting; and you shall give them to the Levites, to every man according to his service.” 
 \p
 \v 6 Moses took the wagons and the oxen, and gave them to the Levites. 
@@ -374,7 +374,7 @@
 \p
 \v 10 The princes gave offerings for the dedication of the altar in the day that it was anointed. The princes gave their offerings before the altar. 
 \p
-\v 11 Yahweh said to Moses, “They shall offer their offering, each prince on his day, for the dedication of the altar.” 
+\v 11 Yahuah said to Moses, “They shall offer their offering, each prince on his day, for the dedication of the altar.” 
 \p
 \v 12 He who offered his offering the first day was Nahshon the son of Amminadab, of the tribe of Judah, 
 \v 13 and his offering was: 
@@ -562,25 +562,25 @@
 \v 87 all the cattle for the burnt offering twelve bulls, the rams twelve, the male lambs a year old twelve, and their meal offering; and twelve male goats for a sin offering; 
 \v 88 and all the cattle for the sacrifice of peace offerings: twenty-four bulls, sixty rams, sixty male goats, and sixty male lambs a year old. This was the dedication offering of the altar, after it was anointed. 
 \p
-\v 89 When Moses went into the Tent of Meeting to speak with Yahweh, he heard his voice speaking to him from above the mercy seat that was on the ark of the Testimony, from between the two cherubim; and he spoke to him. 
+\v 89 When Moses went into the Tent of Meeting to speak with Yahuah, he heard his voice speaking to him from above the mercy seat that was on the ark of the Testimony, from between the two cherubim; and he spoke to him. 
 \c 8
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Speak to Aaron, and tell him, ‘When you light the lamps, the seven lamps shall give light in front of the lamp stand.’ ” 
 \p
-\v 3 Aaron did so. He lit its lamps to light the area in front of the lamp stand, as Yahweh commanded Moses. 
-\v 4 This was the workmanship of the lamp stand, beaten work of gold. From its base to its flowers, it was beaten work. He made the lamp stand according to the pattern which Yahweh had shown Moses. 
+\v 3 Aaron did so. He lit its lamps to light the area in front of the lamp stand, as Yahuah commanded Moses. 
+\v 4 This was the workmanship of the lamp stand, beaten work of gold. From its base to its flowers, it was beaten work. He made the lamp stand according to the pattern which Yahuah had shown Moses. 
 \p
-\v 5 Yahweh spoke to Moses, saying, 
+\v 5 Yahuah spoke to Moses, saying, 
 \v 6 “Take the Levites from among the children of Israel, and cleanse them. 
 \v 7 You shall do this to them to cleanse them: sprinkle the water of cleansing on them, let them shave their whole bodies with a razor, let them wash their clothes, and cleanse themselves. 
 \v 8 Then let them take a young bull and its meal offering, fine flour mixed with oil; and another young bull you shall take for a sin offering. 
 \v 9 You shall present the Levites before the Tent of Meeting. You shall assemble the whole congregation of the children of Israel. 
-\v 10 You shall present the Levites before Yahweh. The children of Israel shall lay their hands on the Levites, 
-\v 11 and Aaron shall offer the Levites before Yahweh for a wave offering on the behalf of the children of Israel, that it may be theirs to do the service of Yahweh. 
+\v 10 You shall present the Levites before Yahuah. The children of Israel shall lay their hands on the Levites, 
+\v 11 and Aaron shall offer the Levites before Yahuah for a wave offering on the behalf of the children of Israel, that it may be theirs to do the service of Yahuah. 
 \p
-\v 12 “The Levites shall lay their hands on the heads of the bulls, and you shall offer the one for a sin offering and the other for a burnt offering to Yahweh, to make atonement for the Levites. 
-\v 13 You shall set the Levites before Aaron and before his sons, and offer them as a wave offering to Yahweh. 
+\v 12 “The Levites shall lay their hands on the heads of the bulls, and you shall offer the one for a sin offering and the other for a burnt offering to Yahuah, to make atonement for the Levites. 
+\v 13 You shall set the Levites before Aaron and before his sons, and offer them as a wave offering to Yahuah. 
 \v 14 Thus you shall separate the Levites from among the children of Israel, and the Levites shall be mine. 
 \p
 \v 15 “After that, the Levites shall go in to do the service of the Tent of Meeting. You shall cleanse them, and offer them as a wave offering. 
@@ -589,47 +589,47 @@
 \v 18 I have taken the Levites instead of all the firstborn among the children of Israel. 
 \v 19 I have given the Levites as a gift to Aaron and to his sons from among the children of Israel, to do the service of the children of Israel in the Tent of Meeting, and to make atonement for the children of Israel, so that there will be no plague among the children of Israel when the children of Israel come near to the sanctuary.” 
 \p
-\v 20 Moses, and Aaron, and all the congregation of the children of Israel did so to the Levites. According to all that Yahweh commanded Moses concerning the Levites, so the children of Israel did to them. 
-\v 21 The Levites purified themselves from sin, and they washed their clothes; and Aaron offered them for a wave offering before Yahweh and Aaron made atonement for them to cleanse them. 
-\v 22 After that, the Levites went in to do their service in the Tent of Meeting before Aaron and before his sons: as Yahweh had commanded Moses concerning the Levites, so they did to them. 
+\v 20 Moses, and Aaron, and all the congregation of the children of Israel did so to the Levites. According to all that Yahuah commanded Moses concerning the Levites, so the children of Israel did to them. 
+\v 21 The Levites purified themselves from sin, and they washed their clothes; and Aaron offered them for a wave offering before Yahuah and Aaron made atonement for them to cleanse them. 
+\v 22 After that, the Levites went in to do their service in the Tent of Meeting before Aaron and before his sons: as Yahuah had commanded Moses concerning the Levites, so they did to them. 
 \p
-\v 23 Yahweh spoke to Moses, saying, 
+\v 23 Yahuah spoke to Moses, saying, 
 \v 24 “This is what is assigned to the Levites: from twenty-five years old and upward they shall go in to wait on the service in the work of the Tent of Meeting; 
 \v 25 and from the age of fifty years they shall retire from doing the work, and shall serve no more, 
 \v 26 but shall assist their brothers in the Tent of Meeting, to perform the duty, and shall perform no service. This is how you shall have the Levites do their duties.” 
 \c 9
 \p
-\v 1 Yahweh spoke to Moses in the wilderness of Sinai, in the first month of the second year after they had come out of the land of Egypt, saying, 
+\v 1 Yahuah spoke to Moses in the wilderness of Sinai, in the first month of the second year after they had come out of the land of Egypt, saying, 
 \v 2 “Let the children of Israel keep the Passover in its appointed season. 
 \v 3 On the fourteenth day of this month, at evening, you shall keep it in its appointed season. You shall keep it according to all its statutes and according to all its ordinances.” 
 \p
 \v 4 Moses told the children of Israel that they should keep the Passover. 
-\v 5 They kept the Passover in the first month, on the fourteenth day of the month at evening, in the wilderness of Sinai. According to all that Yahweh commanded Moses, so the children of Israel did. 
+\v 5 They kept the Passover in the first month, on the fourteenth day of the month at evening, in the wilderness of Sinai. According to all that Yahuah commanded Moses, so the children of Israel did. 
 \v 6 There were certain men who were unclean because of the dead body of a man, so that they could not keep the Passover on that day, and they came before Moses and Aaron on that day. 
-\v 7 Those men said to him, “We are unclean because of the dead body of a man. Why are we kept back, that we may not offer the offering of Yahweh in its appointed season among the children of Israel?” 
+\v 7 Those men said to him, “We are unclean because of the dead body of a man. Why are we kept back, that we may not offer the offering of Yahuah in its appointed season among the children of Israel?” 
 \p
-\v 8 Moses answered them, “Wait, that I may hear what Yahweh will command concerning you.” 
+\v 8 Moses answered them, “Wait, that I may hear what Yahuah will command concerning you.” 
 \p
-\v 9 Yahweh spoke to Moses, saying, 
-\v 10 “Say to the children of Israel, ‘If any man of you or of your generations is unclean by reason of a dead body, or is on a journey far away, he shall still keep the Passover to Yahweh. 
+\v 9 Yahuah spoke to Moses, saying, 
+\v 10 “Say to the children of Israel, ‘If any man of you or of your generations is unclean by reason of a dead body, or is on a journey far away, he shall still keep the Passover to Yahuah. 
 \v 11 In the second month, on the fourteenth day at evening they shall keep it; they shall eat it with unleavened bread and bitter herbs. 
 \v 12 They shall leave none of it until the morning, nor break a bone of it. According to all the statute of the Passover they shall keep it. 
-\v 13 But the man who is clean, and is not on a journey, and fails to keep the Passover, that soul shall be cut off from his people. Because he didn’t offer the offering of Yahweh in its appointed season, that man shall bear his sin. 
+\v 13 But the man who is clean, and is not on a journey, and fails to keep the Passover, that soul shall be cut off from his people. Because he didn’t offer the offering of Yahuah in its appointed season, that man shall bear his sin. 
 \p
-\v 14 “ ‘If a foreigner lives among you and desires to keep the Passover to Yahweh, then he shall do so according to the statute of the Passover, and according to its ordinance. You shall have one statute, both for the foreigner and for him who is born in the land.’ ” 
+\v 14 “ ‘If a foreigner lives among you and desires to keep the Passover to Yahuah, then he shall do so according to the statute of the Passover, and according to its ordinance. You shall have one statute, both for the foreigner and for him who is born in the land.’ ” 
 \p
 \v 15 On the day that the tabernacle was raised up, the cloud covered the tabernacle, even the Tent of the Testimony. At evening it was over the tabernacle, as it were the appearance of fire, until morning. 
 \v 16 So it was continually. The cloud covered it, and the appearance of fire by night. 
 \v 17 Whenever the cloud was taken up from over the Tent, then after that the children of Israel traveled; and in the place where the cloud remained, there the children of Israel encamped. 
-\v 18 At the commandment of Yahweh, the children of Israel traveled, and at the commandment of Yahweh they encamped. As long as the cloud remained on the tabernacle they remained encamped. 
-\v 19 When the cloud stayed on the tabernacle many days, then the children of Israel kept Yahweh’s command, and didn’t travel. 
-\v 20 Sometimes the cloud was a few days on the tabernacle; then according to the commandment of Yahweh they remained encamped, and according to the commandment of Yahweh they traveled. 
+\v 18 At the commandment of Yahuah, the children of Israel traveled, and at the commandment of Yahuah they encamped. As long as the cloud remained on the tabernacle they remained encamped. 
+\v 19 When the cloud stayed on the tabernacle many days, then the children of Israel kept Yahuah’s command, and didn’t travel. 
+\v 20 Sometimes the cloud was a few days on the tabernacle; then according to the commandment of Yahuah they remained encamped, and according to the commandment of Yahuah they traveled. 
 \v 21 Sometimes the cloud was from evening until morning; and when the cloud was taken up in the morning, they traveled; or by day and by night, when the cloud was taken up, they traveled. 
 \v 22 Whether it was two days, or a month, or a year that the cloud stayed on the tabernacle, remaining on it, the children of Israel remained encamped, and didn’t travel; but when it was taken up, they traveled. 
-\v 23 At the commandment of Yahweh they encamped, and at the commandment of Yahweh they traveled. They kept Yahweh’s command, at the commandment of Yahweh by Moses. 
+\v 23 At the commandment of Yahuah they encamped, and at the commandment of Yahuah they traveled. They kept Yahuah’s command, at the commandment of Yahuah by Moses. 
 \c 10
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Make two trumpets of silver. You shall make them of beaten work. You shall use them for the calling of the congregation and for the journeying of the camps. 
 \v 3 When they blow them, all the congregation shall gather themselves to you at the door of the Tent of Meeting. 
 \v 4 If they blow just one, then the princes, the heads of the thousands of Israel, shall gather themselves to you. 
@@ -638,13 +638,13 @@
 \v 7 But when the assembly is to be gathered together, you shall blow, but you shall not sound an alarm. 
 \p
 \v 8 “The sons of Aaron, the priests, shall blow the trumpets. This shall be to you for a statute forever throughout your generations. 
-\v 9 When you go to war in your land against the adversary who oppresses you, then you shall sound an alarm with the trumpets. Then you will be remembered before Yahweh your Elohim, and you will be saved from your enemies. 
+\v 9 When you go to war in your land against the adversary who oppresses you, then you shall sound an alarm with the trumpets. Then you will be remembered before Yahuah your Elohim, and you will be saved from your enemies. 
 \p
-\v 10 “Also in the day of your gladness, and in your set feasts, and in the beginnings of your months, you shall blow the trumpets over your burnt offerings, and over the sacrifices of your peace offerings; and they shall be to you for a memorial before your Elohim. I am Yahweh your Elohim.” 
+\v 10 “Also in the day of your gladness, and in your set feasts, and in the beginnings of your months, you shall blow the trumpets over your burnt offerings, and over the sacrifices of your peace offerings; and they shall be to you for a memorial before your Elohim. I am Yahuah your Elohim.” 
 \p
 \v 11 In the second year, in the second month, on the twentieth day of the month, the cloud was taken up from over the tabernacle of the covenant. 
 \v 12 The children of Israel went forward on their journeys out of the wilderness of Sinai; and the cloud stayed in the wilderness of Paran. 
-\v 13 They first went forward according to the commandment of Yahweh by Moses. 
+\v 13 They first went forward according to the commandment of Yahuah by Moses. 
 \p
 \v 14 First, the standard of the camp of the children of Judah went forward according to their armies. Nahshon the son of Amminadab was over his army. 
 \v 15 Nethanel the son of Zuar was over the army of the tribe of the children of Issachar. 
@@ -665,22 +665,22 @@
 \v 27 Ahira the son of Enan was over the army of the tribe of the children of Naphtali. 
 \v 28 Thus were the travels of the children of Israel according to their armies; and they went forward. 
 \p
-\v 29 Moses said to Hobab, the son of Reuel the Midianite, Moses’ father-in-law, “We are journeying to the place of which Yahweh said, ‘I will give it to you.’ Come with us, and we will treat you well; for Yahweh has spoken good concerning Israel.” 
+\v 29 Moses said to Hobab, the son of Reuel the Midianite, Moses’ father-in-law, “We are journeying to the place of which Yahuah said, ‘I will give it to you.’ Come with us, and we will treat you well; for Yahuah has spoken good concerning Israel.” 
 \p
 \v 30 He said to him, “I will not go; but I will depart to my own land, and to my relatives.” 
 \p
 \v 31 Moses said, “Don’t leave us, please; because you know how we are to encamp in the wilderness, and you can be our eyes. 
-\v 32 It shall be, if you go with us—yes, it shall be—that whatever good Yahweh does to us, we will do the same to you.” 
+\v 32 It shall be, if you go with us—yes, it shall be—that whatever good Yahuah does to us, we will do the same to you.” 
 \p
-\v 33 They set forward from the Mount of Yahweh three days’ journey. The ark of Yahweh’s covenant went before them three days’ journey, to seek out a resting place for them. 
-\v 34 The cloud of Yahweh was over them by day, when they set forward from the camp. 
-\v 35 When the ark went forward, Moses said, “Rise up, Yahweh, and let your enemies be scattered! Let those who hate you flee before you!” 
-\v 36 When it rested, he said, “Return, Yahweh, to the ten thousands of the thousands of Israel.” 
+\v 33 They set forward from the Mount of Yahuah three days’ journey. The ark of Yahuah’s covenant went before them three days’ journey, to seek out a resting place for them. 
+\v 34 The cloud of Yahuah was over them by day, when they set forward from the camp. 
+\v 35 When the ark went forward, Moses said, “Rise up, Yahuah, and let your enemies be scattered! Let those who hate you flee before you!” 
+\v 36 When it rested, he said, “Return, Yahuah, to the ten thousands of the thousands of Israel.” 
 \c 11
 \p
-\v 1 The people were complaining in the ears of Yahweh. When Yahweh heard it, his anger burned; and Yahweh’s fire burned among them, and consumed some of the outskirts of the camp. 
-\v 2 The people cried to Moses; and Moses prayed to Yahweh, and the fire abated. 
-\v 3 The name of that place was called Taberah, because Yahweh’s fire burned among them. 
+\v 1 The people were complaining in the ears of Yahuah. When Yahuah heard it, his anger burned; and Yahuah’s fire burned among them, and consumed some of the outskirts of the camp. 
+\v 2 The people cried to Moses; and Moses prayed to Yahuah, and the fire abated. 
+\v 3 The name of that place was called Taberah, because Yahuah’s fire burned among them. 
 \p
 \v 4 The mixed multitude that was among them lusted exceedingly; and the children of Israel also wept again, and said, “Who will give us meat to eat? 
 \v 5 We remember the fish, which we ate in Egypt for nothing; the cucumbers, and the melons, and the leeks, and the onions, and the garlic; 
@@ -689,72 +689,72 @@
 \v 8 The people went around, gathered it, and ground it in mills, or beat it in mortars, and boiled it in pots, and made cakes of it. Its taste was like the taste of fresh oil. 
 \v 9 When the dew fell on the camp in the night, the manna fell on it. 
 \p
-\v 10 Moses heard the people weeping throughout their families, every man at the door of his tent; and Yahweh’s anger burned greatly; and Moses was displeased. 
-\v 11 Moses said to Yahweh, “Why have you treated your servant so badly? Why haven’t I found favor in your sight, that you lay the burden of all this people on me? 
+\v 10 Moses heard the people weeping throughout their families, every man at the door of his tent; and Yahuah’s anger burned greatly; and Moses was displeased. 
+\v 11 Moses said to Yahuah, “Why have you treated your servant so badly? Why haven’t I found favor in your sight, that you lay the burden of all this people on me? 
 \v 12 Have I conceived all this people? Have I brought them out, that you should tell me, ‘Carry them in your bosom, as a nurse carries a nursing infant, to the land which you swore to their fathers’? 
 \v 13 Where could I get meat to give all these people? For they weep before me, saying, ‘Give us meat, that we may eat.’ 
 \v 14 I am not able to bear all this people alone, because it is too heavy for me. 
 \v 15 If you treat me this way, please kill me right now, if I have found favor in your sight; and don’t let me see my wretchedness.” 
 \p
-\v 16 Yahweh said to Moses, “Gather to me seventy men of the elders of Israel, whom you know to be the elders of the people and officers over them; and bring them to the Tent of Meeting, that they may stand there with you. 
+\v 16 Yahuah said to Moses, “Gather to me seventy men of the elders of Israel, whom you know to be the elders of the people and officers over them; and bring them to the Tent of Meeting, that they may stand there with you. 
 \v 17 I will come down and talk with you there. I will take of the Spirit which is on you, and will put it on them; and they shall bear the burden of the people with you, that you don’t bear it yourself alone. 
 \p
-\v 18 “Say to the people, ‘Sanctify yourselves in preparation for tomorrow, and you will eat meat; for you have wept in the ears of Yahweh, saying, “Who will give us meat to eat? For it was well with us in Egypt.” Therefore Yahweh will give you meat, and you will eat. 
+\v 18 “Say to the people, ‘Sanctify yourselves in preparation for tomorrow, and you will eat meat; for you have wept in the ears of Yahuah, saying, “Who will give us meat to eat? For it was well with us in Egypt.” Therefore Yahuah will give you meat, and you will eat. 
 \v 19 You will not eat just one day, or two days, or five days, or ten days, or twenty days, 
-\v 20 but a whole month, until it comes out at your nostrils, and it is loathsome to you; because you have rejected Yahweh who is among you, and have wept before him, saying, “Why did we come out of Egypt?” ’ ” 
+\v 20 but a whole month, until it comes out at your nostrils, and it is loathsome to you; because you have rejected Yahuah who is among you, and have wept before him, saying, “Why did we come out of Egypt?” ’ ” 
 \p
 \v 21 Moses said, “The people, among whom I am, are six hundred thousand men on foot; and you have said, ‘I will give them meat, that they may eat a whole month.’ 
 \v 22 Shall flocks and herds be slaughtered for them, to be sufficient for them? Shall all the fish of the sea be gathered together for them, to be sufficient for them?” 
 \p
-\v 23 Yahweh said to Moses, “Has Yahweh’s hand grown short? Now you will see whether my word will happen to you or not.” 
+\v 23 Yahuah said to Moses, “Has Yahuah’s hand grown short? Now you will see whether my word will happen to you or not.” 
 \p
-\v 24 Moses went out, and told the people Yahweh’s words; and he gathered seventy men of the elders of the people, and set them around the Tent. 
-\v 25 Yahweh came down in the cloud, and spoke to him, and took of the Spirit that was on him, and put it on the seventy elders. When the Spirit rested on them, they prophesied, but they did so no more. 
+\v 24 Moses went out, and told the people Yahuah’s words; and he gathered seventy men of the elders of the people, and set them around the Tent. 
+\v 25 Yahuah came down in the cloud, and spoke to him, and took of the Spirit that was on him, and put it on the seventy elders. When the Spirit rested on them, they prophesied, but they did so no more. 
 \v 26 But two men remained in the camp. The name of one was Eldad, and the name of the other Medad; and the Spirit rested on them. They were of those who were written, but had not gone out to the Tent; and they prophesied in the camp. 
 \v 27 A young man ran, and told Moses, and said, “Eldad and Medad are prophesying in the camp!” 
 \p
 \v 28 Joshua the son of Nun, the servant of Moses, one of his chosen men, answered, “My lord Moses, forbid them!” 
 \p
-\v 29 Moses said to him, “Are you jealous for my sake? I wish that all Yahweh’s people were prophets, that Yahweh would put his Spirit on them!” 
+\v 29 Moses said to him, “Are you jealous for my sake? I wish that all Yahuah’s people were prophets, that Yahuah would put his Spirit on them!” 
 \p
 \v 30 Moses went into the camp, he and the elders of Israel. 
-\v 31 A wind from Yahweh went out and brought quails from the sea, and let them fall by the camp, about a day’s journey on this side, and a day’s journey on the other side, around the camp, and about two cubits above the surface of the earth. 
+\v 31 A wind from Yahuah went out and brought quails from the sea, and let them fall by the camp, about a day’s journey on this side, and a day’s journey on the other side, around the camp, and about two cubits above the surface of the earth. 
 \v 32 The people rose up all that day, and all of that night, and all the next day, and gathered the quails. He who gathered least gathered ten homers; and they spread them all out for themselves around the camp. 
-\v 33 While the meat was still between their teeth, before it was chewed, Yahweh’s anger burned against the people, and Yahweh struck the people with a very great plague. 
+\v 33 While the meat was still between their teeth, before it was chewed, Yahuah’s anger burned against the people, and Yahuah struck the people with a very great plague. 
 \v 34 The name of that place was called Kibroth Hattaavah, because there they buried the people who lusted. 
 \p
 \v 35 From Kibroth Hattaavah the people traveled to Hazeroth; and they stayed at Hazeroth. 
 \c 12
 \p
 \v 1 Miriam and Aaron spoke against Moses because of the Cushite woman whom he had taken; for he had taken a Cushite woman. 
-\v 2 They said, “Has Yahweh indeed spoken only with Moses? Hasn’t he spoken also with us?” And Yahweh heard it. 
+\v 2 They said, “Has Yahuah indeed spoken only with Moses? Hasn’t he spoken also with us?” And Yahuah heard it. 
 \p
 \v 3 Now the man Moses was very humble, more than all the men who were on the surface of the earth. 
-\v 4 Yahweh spoke suddenly to Moses, to Aaron, and to Miriam, “You three come out to the Tent of Meeting!” 
+\v 4 Yahuah spoke suddenly to Moses, to Aaron, and to Miriam, “You three come out to the Tent of Meeting!” 
 \p The three of them came out. 
-\v 5 Yahweh came down in a pillar of cloud, and stood at the door of the Tent, and called Aaron and Miriam; and they both came forward. 
-\v 6 He said, “Now hear my words. If there is a prophet among you, I, Yahweh, will make myself known to him in a vision. I will speak with him in a dream. 
+\v 5 Yahuah came down in a pillar of cloud, and stood at the door of the Tent, and called Aaron and Miriam; and they both came forward. 
+\v 6 He said, “Now hear my words. If there is a prophet among you, I, Yahuah, will make myself known to him in a vision. I will speak with him in a dream. 
 \v 7 My servant Moses is not so. He is faithful in all my house. 
-\v 8 With him, I will speak mouth to mouth, even plainly, and not in riddles; and he shall see Yahweh’s form. Why then were you not afraid to speak against my servant, against Moses?” 
-\v 9 Yahweh’s anger burned against them; and he departed. 
+\v 8 With him, I will speak mouth to mouth, even plainly, and not in riddles; and he shall see Yahuah’s form. Why then were you not afraid to speak against my servant, against Moses?” 
+\v 9 Yahuah’s anger burned against them; and he departed. 
 \p
 \v 10 The cloud departed from over the Tent; and behold, Miriam was leprous, as white as snow. Aaron looked at Miriam, and behold, she was leprous. 
 \p
 \v 11 Aaron said to Moses, “Oh, my lord, please don’t count this sin against us, in which we have done foolishly, and in which we have sinned. 
 \v 12 Let her not, I pray, be as one dead, of whom the flesh is half consumed when he comes out of his mother’s womb.” 
 \p
-\v 13 Moses cried to Yahweh, saying, “Heal her, Elohim, I beg you!” 
+\v 13 Moses cried to Yahuah, saying, “Heal her, Elohim, I beg you!” 
 \p
-\v 14 Yahweh said to Moses, “If her father had but spit in her face, shouldn’t she be ashamed seven days? Let her be shut up outside of the camp seven days, and after that she shall be brought in again.” 
+\v 14 Yahuah said to Moses, “If her father had but spit in her face, shouldn’t she be ashamed seven days? Let her be shut up outside of the camp seven days, and after that she shall be brought in again.” 
 \p
 \v 15 Miriam was shut up outside of the camp seven days, and the people didn’t travel until Miriam was brought in again. 
 \v 16 Afterward the people traveled from Hazeroth, and encamped in the wilderness of Paran. 
 \c 13
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Send men, that they may spy out the land of Canaan, which I give to the children of Israel. Of every tribe of their fathers, you shall send a man, every one a prince among them.” 
 \p
-\v 3 Moses sent them from the wilderness of Paran according to the commandment of Yahweh. All of them were men who were heads of the children of Israel. 
+\v 3 Moses sent them from the wilderness of Paran according to the commandment of Yahuah. All of them were men who were heads of the children of Israel. 
 \v 4 These were their names: 
 \m Of the tribe of Reuben, Shammua the son of Zaccur. 
 \m
@@ -805,141 +805,141 @@
 \p
 \v 1 All the congregation lifted up their voice, and cried; and the people wept that night. 
 \v 2 All the children of Israel murmured against Moses and against Aaron. The whole congregation said to them, “We wish that we had died in the land of Egypt, or that we had died in this wilderness! 
-\v 3 Why does Yahweh bring us to this land, to fall by the sword? Our women and our little ones will be captured or killed! Wouldn’t it be better for us to return into Egypt?” 
+\v 3 Why does Yahuah bring us to this land, to fall by the sword? Our women and our little ones will be captured or killed! Wouldn’t it be better for us to return into Egypt?” 
 \v 4 They said to one another, “Let’s choose a leader, and let’s return into Egypt.” 
 \p
 \v 5 Then Moses and Aaron fell on their faces before all the assembly of the congregation of the children of Israel. 
 \p
 \v 6 Joshua the son of Nun and Caleb the son of Jephunneh, who were of those who spied out the land, tore their clothes. 
 \v 7 They spoke to all the congregation of the children of Israel, saying, “The land, which we passed through to spy it out, is an exceedingly good land. 
-\v 8 If Yahweh delights in us, then he will bring us into this land, and give it to us: a land which flows with milk and honey. 
-\v 9 Only don’t rebel against Yahweh, neither fear the people of the land; for they are bread for us. Their defense is removed from over them, and Yahweh is with us. Don’t fear them.” 
+\v 8 If Yahuah delights in us, then he will bring us into this land, and give it to us: a land which flows with milk and honey. 
+\v 9 Only don’t rebel against Yahuah, neither fear the people of the land; for they are bread for us. Their defense is removed from over them, and Yahuah is with us. Don’t fear them.” 
 \p
 \v 10 But all the congregation threatened to stone them with stones. 
-\p Yahweh’s glory appeared in the Tent of Meeting to all the children of Israel. 
-\v 11 Yahweh said to Moses, “How long will this people despise me? How long will they not believe in me, for all the signs which I have worked among them? 
+\p Yahuah’s glory appeared in the Tent of Meeting to all the children of Israel. 
+\v 11 Yahuah said to Moses, “How long will this people despise me? How long will they not believe in me, for all the signs which I have worked among them? 
 \v 12 I will strike them with the pestilence, and disinherit them, and will make of you a nation greater and mightier than they.” 
 \p
-\v 13 Moses said to Yahweh, “Then the Egyptians will hear it; for you brought up this people in your might from among them. 
-\v 14 They will tell it to the inhabitants of this land. They have heard that you Yahweh are among this people; for you Yahweh are seen face to face, and your cloud stands over them, and you go before them, in a pillar of cloud by day, and in a pillar of fire by night. 
+\v 13 Moses said to Yahuah, “Then the Egyptians will hear it; for you brought up this people in your might from among them. 
+\v 14 They will tell it to the inhabitants of this land. They have heard that you Yahuah are among this people; for you Yahuah are seen face to face, and your cloud stands over them, and you go before them, in a pillar of cloud by day, and in a pillar of fire by night. 
 \v 15 Now if you killed this people as one man, then the nations which have heard the fame of you will speak, saying, 
-\v 16 ‘Because Yahweh was not able to bring this people into the land which he swore to them, therefore he has slain them in the wilderness.’ 
+\v 16 ‘Because Yahuah was not able to bring this people into the land which he swore to them, therefore he has slain them in the wilderness.’ 
 \v 17 Now please let the power of the Lord be great, according as you have spoken, saying, 
-\v 18 ‘Yahweh is slow to anger, and abundant in loving kindness, forgiving iniquity and disobedience; and he will by no means clear the guilty, visiting the iniquity of the fathers on the children, on the third and on the fourth generation.’ 
+\v 18 ‘Yahuah is slow to anger, and abundant in loving kindness, forgiving iniquity and disobedience; and he will by no means clear the guilty, visiting the iniquity of the fathers on the children, on the third and on the fourth generation.’ 
 \v 19 Please pardon the iniquity of this people according to the greatness of your loving kindness, and just as you have forgiven this people, from Egypt even until now.” 
 \p
-\v 20 Yahweh said, “I have pardoned according to your word; 
-\v 21 but in very deed—as I live, and as all the earth shall be filled with Yahweh’s glory—\v 22 because all those men who have seen my glory and my signs, which I worked in Egypt and in the wilderness, yet have tempted me these ten times, and have not listened to my voice; 
+\v 20 Yahuah said, “I have pardoned according to your word; 
+\v 21 but in very deed—as I live, and as all the earth shall be filled with Yahuah’s glory—\v 22 because all those men who have seen my glory and my signs, which I worked in Egypt and in the wilderness, yet have tempted me these ten times, and have not listened to my voice; 
 \v 23 surely they shall not see the land which I swore to their fathers, neither shall any of those who despised me see it. 
 \v 24 But my servant Caleb, because he had another spirit with him, and has followed me fully, him I will bring into the land into which he went. His offspring shall possess it. 
 \v 25 Since the Amalekite and the Canaanite dwell in the valley, tomorrow turn and go into the wilderness by the way to the Red Sea.” 
-\v 26 Yahweh spoke to Moses and to Aaron, saying, 
+\v 26 Yahuah spoke to Moses and to Aaron, saying, 
 \v 27 “How long shall I bear with this evil congregation that complain against me? I have heard the complaints of the children of Israel, which they complain against me. 
-\v 28 Tell them, ‘As I live, says Yahweh, surely as you have spoken in my ears, so I will do to you. 
+\v 28 Tell them, ‘As I live, says Yahuah, surely as you have spoken in my ears, so I will do to you. 
 \v 29 Your dead bodies shall fall in this wilderness; and all who were counted of you, according to your whole number, from twenty years old and upward, who have complained against me, 
 \v 30 surely you shall not come into the land concerning which I swore that I would make you dwell therein, except Caleb the son of Jephunneh, and Joshua the son of Nun. 
 \v 31 But I will bring in your little ones that you said should be captured or killed, and they shall know the land which you have rejected. 
 \v 32 But as for you, your dead bodies shall fall in this wilderness. 
 \v 33 Your children shall be wanderers in the wilderness forty years, and shall bear your prostitution, until your dead bodies are consumed in the wilderness. 
 \v 34 After the number of the days in which you spied out the land, even forty days, for every day a year, you will bear your iniquities, even forty years, and you will know my alienation.’ 
-\v 35 I, Yahweh, have spoken. I will surely do this to all this evil congregation who are gathered together against me. In this wilderness they shall be consumed, and there they shall die.” 
+\v 35 I, Yahuah, have spoken. I will surely do this to all this evil congregation who are gathered together against me. In this wilderness they shall be consumed, and there they shall die.” 
 \p
 \v 36 The men whom Moses sent to spy out the land, who returned and made all the congregation to murmur against him by bringing up an evil report against the land, 
-\v 37 even those men who brought up an evil report of the land, died by the plague before Yahweh. 
+\v 37 even those men who brought up an evil report of the land, died by the plague before Yahuah. 
 \v 38 But Joshua the son of Nun and Caleb the son of Jephunneh remained alive of those men who went to spy out the land. 
 \p
 \v 39 Moses told these words to all the children of Israel, and the people mourned greatly. 
-\v 40 They rose up early in the morning and went up to the top of the mountain, saying, “Behold, we are here, and will go up to the place which Yahweh has promised; for we have sinned.” 
+\v 40 They rose up early in the morning and went up to the top of the mountain, saying, “Behold, we are here, and will go up to the place which Yahuah has promised; for we have sinned.” 
 \p
-\v 41 Moses said, “Why now do you disobey the commandment of Yahweh, since it shall not prosper? 
-\v 42 Don’t go up, for Yahweh isn’t among you; that way you won’t be struck down before your enemies. 
-\v 43 For there the Amalekite and the Canaanite are before you, and you will fall by the sword because you turned back from following Yahweh; therefore Yahweh will not be with you.” 
+\v 41 Moses said, “Why now do you disobey the commandment of Yahuah, since it shall not prosper? 
+\v 42 Don’t go up, for Yahuah isn’t among you; that way you won’t be struck down before your enemies. 
+\v 43 For there the Amalekite and the Canaanite are before you, and you will fall by the sword because you turned back from following Yahuah; therefore Yahuah will not be with you.” 
 \p
-\v 44 But they presumed to go up to the top of the mountain. Nevertheless, the ark of Yahweh’s covenant and Moses didn’t depart out of the camp. 
+\v 44 But they presumed to go up to the top of the mountain. Nevertheless, the ark of Yahuah’s covenant and Moses didn’t depart out of the camp. 
 \v 45 Then the Amalekites came down, and the Canaanites who lived in that mountain, and struck them and beat them down even to Hormah. 
 \c 15
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Speak to the children of Israel, and tell them, ‘When you have come into the land of your habitations, which I give to you, 
-\v 3 and will make an offering by fire to Yahweh—a burnt offering, or a sacrifice, to accomplish a vow, or as a free will offering, or in your set feasts, to make a pleasant aroma to Yahweh, of the herd, or of the flock—\v 4 then he who offers his offering shall offer to Yahweh a meal offering of one tenth of an ephah of fine flour mixed with one fourth of a hin of oil. 
+\v 3 and will make an offering by fire to Yahuah—a burnt offering, or a sacrifice, to accomplish a vow, or as a free will offering, or in your set feasts, to make a pleasant aroma to Yahuah, of the herd, or of the flock—\v 4 then he who offers his offering shall offer to Yahuah a meal offering of one tenth of an ephah of fine flour mixed with one fourth of a hin of oil. 
 \v 5 You shall prepare wine for the drink offering, one fourth of a hin, with the burnt offering or for the sacrifice, for each lamb. 
 \p
 \v 6 “ ‘For a ram, you shall prepare for a meal offering two tenths of an ephah of fine flour mixed with the third part of a hin of oil; 
-\v 7 and for the drink offering you shall offer the third part of a hin of wine, of a pleasant aroma to Yahweh. 
-\v 8 When you prepare a bull for a burnt offering or for a sacrifice, to accomplish a vow, or for peace offerings to Yahweh, 
+\v 7 and for the drink offering you shall offer the third part of a hin of wine, of a pleasant aroma to Yahuah. 
+\v 8 When you prepare a bull for a burnt offering or for a sacrifice, to accomplish a vow, or for peace offerings to Yahuah, 
 \v 9 then he shall offer with the bull a meal offering of three tenths of an ephah of fine flour mixed with half a hin of oil; 
-\v 10 and you shall offer for the drink offering half a hin of wine, for an offering made by fire, of a pleasant aroma to Yahweh. 
+\v 10 and you shall offer for the drink offering half a hin of wine, for an offering made by fire, of a pleasant aroma to Yahuah. 
 \v 11 Thus it shall be done for each bull, for each ram, for each of the male lambs, or of the young goats. 
 \v 12 According to the number that you shall prepare, so you shall do to everyone according to their number. 
 \p
-\v 13 “ ‘All who are native-born shall do these things in this way, in offering an offering made by fire, of a pleasant aroma to Yahweh. 
-\v 14 If a stranger lives as a foreigner with you, or whoever may be among you throughout your generations, and will offer an offering made by fire, of a pleasant aroma to Yahweh, as you do, so he shall do. 
-\v 15 For the assembly, there shall be one statute for you and for the stranger who lives as a foreigner, a statute forever throughout your generations. As you are, so the foreigner shall be before Yahweh. 
+\v 13 “ ‘All who are native-born shall do these things in this way, in offering an offering made by fire, of a pleasant aroma to Yahuah. 
+\v 14 If a stranger lives as a foreigner with you, or whoever may be among you throughout your generations, and will offer an offering made by fire, of a pleasant aroma to Yahuah, as you do, so he shall do. 
+\v 15 For the assembly, there shall be one statute for you and for the stranger who lives as a foreigner, a statute forever throughout your generations. As you are, so the foreigner shall be before Yahuah. 
 \v 16 One law and one ordinance shall be for you and for the stranger who lives as a foreigner with you.’ ” 
 \p
-\v 17 Yahweh spoke to Moses, saying, 
+\v 17 Yahuah spoke to Moses, saying, 
 \v 18 “Speak to the children of Israel, and tell them, ‘When you come into the land where I bring you, 
-\v 19 then it shall be that when you eat of the bread of the land, you shall offer up a wave offering to Yahweh. 
+\v 19 then it shall be that when you eat of the bread of the land, you shall offer up a wave offering to Yahuah. 
 \v 20 Of the first of your dough you shall offer up a cake for a wave offering. As the wave offering of the threshing floor, so you shall heave it. 
-\v 21 Of the first of your dough, you shall give to Yahweh a wave offering throughout your generations. 
+\v 21 Of the first of your dough, you shall give to Yahuah a wave offering throughout your generations. 
 \p
-\v 22 “ ‘When you err, and don’t observe all these commandments which Yahweh has spoken to Moses—\v 23 even all that Yahweh has commanded you by Moses, from the day that Yahweh gave commandment and onward throughout your generations—\v 24 then it shall be, if it was done unwittingly, without the knowledge of the congregation, that all the congregation shall offer one young bull for a burnt offering, for a pleasant aroma to Yahweh, with its meal offering and its drink offering, according to the ordinance, and one male goat for a sin offering. 
-\v 25 The priest shall make atonement for all the congregation of the children of Israel, and they shall be forgiven; for it was an error, and they have brought their offering, an offering made by fire to Yahweh, and their sin offering before Yahweh, for their error. 
+\v 22 “ ‘When you err, and don’t observe all these commandments which Yahuah has spoken to Moses—\v 23 even all that Yahuah has commanded you by Moses, from the day that Yahuah gave commandment and onward throughout your generations—\v 24 then it shall be, if it was done unwittingly, without the knowledge of the congregation, that all the congregation shall offer one young bull for a burnt offering, for a pleasant aroma to Yahuah, with its meal offering and its drink offering, according to the ordinance, and one male goat for a sin offering. 
+\v 25 The priest shall make atonement for all the congregation of the children of Israel, and they shall be forgiven; for it was an error, and they have brought their offering, an offering made by fire to Yahuah, and their sin offering before Yahuah, for their error. 
 \v 26 All the congregation of the children of Israel shall be forgiven, as well as the stranger who lives as a foreigner among them; for with regard to all the people, it was done unwittingly. 
 \p
 \v 27 “ ‘If a person sins unwittingly, then he shall offer a female goat a year old for a sin offering. 
-\v 28 The priest shall make atonement for the soul who errs when he sins unwittingly before Yahweh. He shall make atonement for him; and he shall be forgiven. 
+\v 28 The priest shall make atonement for the soul who errs when he sins unwittingly before Yahuah. He shall make atonement for him; and he shall be forgiven. 
 \v 29 You shall have one law for him who does anything unwittingly, for him who is native-born among the children of Israel, and for the stranger who lives as a foreigner among them. 
 \p
-\v 30 “ ‘But the soul who does anything with a high hand, whether he is native-born or a foreigner, blasphemes Yahweh. That soul shall be cut off from among his people. 
-\v 31 Because he has despised Yahweh’s word, and has broken his commandment, that soul shall be utterly cut off. His iniquity shall be on him.’ ” 
+\v 30 “ ‘But the soul who does anything with a high hand, whether he is native-born or a foreigner, blasphemes Yahuah. That soul shall be cut off from among his people. 
+\v 31 Because he has despised Yahuah’s word, and has broken his commandment, that soul shall be utterly cut off. His iniquity shall be on him.’ ” 
 \p
 \v 32 While the children of Israel were in the wilderness, they found a man gathering sticks on the Sabbath day. 
 \v 33 Those who found him gathering sticks brought him to Moses and Aaron, and to all the congregation. 
 \v 34 They put him in custody, because it had not been declared what should be done to him. 
 \p
-\v 35 Yahweh said to Moses, “The man shall surely be put to death. All the congregation shall stone him with stones outside of the camp.” 
-\v 36 All the congregation brought him outside of the camp, and stoned him to death with stones, as Yahweh commanded Moses. 
+\v 35 Yahuah said to Moses, “The man shall surely be put to death. All the congregation shall stone him with stones outside of the camp.” 
+\v 36 All the congregation brought him outside of the camp, and stoned him to death with stones, as Yahuah commanded Moses. 
 \p
-\v 37 Yahweh spoke to Moses, saying, 
+\v 37 Yahuah spoke to Moses, saying, 
 \v 38 “Speak to the children of Israel, and tell them that they should make themselves fringes on the borders of their garments throughout their generations, and that they put on the fringe of each border a cord of blue. 
-\v 39 It shall be to you for a fringe, that you may see it, and remember all Yahweh’s commandments, and do them; and that you don’t follow your own heart and your own eyes, after which you used to play the prostitute; 
+\v 39 It shall be to you for a fringe, that you may see it, and remember all Yahuah’s commandments, and do them; and that you don’t follow your own heart and your own eyes, after which you used to play the prostitute; 
 \v 40 so that you may remember and do all my commandments, and be set-apart to your Elohim. 
-\v 41 I am Yahweh your Elohim, who brought you out of the land of Egypt, to be your Elohim: I am Yahweh your Elohim.” 
+\v 41 I am Yahuah your Elohim, who brought you out of the land of Egypt, to be your Elohim: I am Yahuah your Elohim.” 
 \c 16
 \p
 \v 1 Now Korah, the son of Izhar, the son of Kohath, the son of Levi, with Dathan and Abiram, the sons of Eliab, and On, the son of Peleth, sons of Reuben, took some men. 
 \v 2 They rose up before Moses, with some of the children of Israel, two hundred fifty princes of the congregation, called to the assembly, men of renown. 
-\v 3 They assembled themselves together against Moses and against Aaron, and said to them, “You take too much on yourself, since all the congregation are set-apart, everyone of them, and Yahweh is among them! Why do you lift yourselves up above Yahweh’s assembly?” 
+\v 3 They assembled themselves together against Moses and against Aaron, and said to them, “You take too much on yourself, since all the congregation are set-apart, everyone of them, and Yahuah is among them! Why do you lift yourselves up above Yahuah’s assembly?” 
 \p
 \v 4 When Moses heard it, he fell on his face. 
-\v 5 He said to Korah and to all his company, “In the morning, Yahweh will show who are his, and who is set-apart, and will cause him to come near to him. Even him whom he shall choose, he will cause to come near to him. 
+\v 5 He said to Korah and to all his company, “In the morning, Yahuah will show who are his, and who is set-apart, and will cause him to come near to him. Even him whom he shall choose, he will cause to come near to him. 
 \v 6 Do this: have Korah and all his company take censers, 
-\v 7 put fire in them, and put incense on them before Yahweh tomorrow. It shall be that the man whom Yahweh chooses, he shall be set-apart. You have gone too far, you sons of Levi!” 
+\v 7 put fire in them, and put incense on them before Yahuah tomorrow. It shall be that the man whom Yahuah chooses, he shall be set-apart. You have gone too far, you sons of Levi!” 
 \p
 \v 8 Moses said to Korah, “Hear now, you sons of Levi! 
-\v 9 Is it a small thing to you that the Elohim of Israel has separated you from the congregation of Israel, to bring you near to himself, to do the service of Yahweh’s tabernacle, and to stand before the congregation to minister to them; 
+\v 9 Is it a small thing to you that the Elohim of Israel has separated you from the congregation of Israel, to bring you near to himself, to do the service of Yahuah’s tabernacle, and to stand before the congregation to minister to them; 
 \v 10 and that he has brought you near, and all your brothers the sons of Levi with you? Do you seek the priesthood also? 
-\v 11 Therefore you and all your company have gathered together against Yahweh! What is Aaron that you complain against him?” 
+\v 11 Therefore you and all your company have gathered together against Yahuah! What is Aaron that you complain against him?” 
 \p
 \v 12 Moses sent to call Dathan and Abiram, the sons of Eliab; and they said, “We won’t come up! 
 \v 13 Is it a small thing that you have brought us up out of a land flowing with milk and honey, to kill us in the wilderness, but you must also make yourself a prince over us? 
 \v 14 Moreover you haven’t brought us into a land flowing with milk and honey, nor given us inheritance of fields and vineyards. Will you put out the eyes of these men? We won’t come up.” 
 \p
-\v 15 Moses was very angry, and said to Yahweh, “Don’t respect their offering. I have not taken one donkey from them, neither have I hurt one of them.” 
+\v 15 Moses was very angry, and said to Yahuah, “Don’t respect their offering. I have not taken one donkey from them, neither have I hurt one of them.” 
 \p
-\v 16 Moses said to Korah, “You and all your company go before Yahweh, you, and they, and Aaron, tomorrow. 
-\v 17 Each man take his censer and put incense on it, and each man bring before Yahweh his censer, two hundred fifty censers; you also, and Aaron, each with his censer.” 
+\v 16 Moses said to Korah, “You and all your company go before Yahuah, you, and they, and Aaron, tomorrow. 
+\v 17 Each man take his censer and put incense on it, and each man bring before Yahuah his censer, two hundred fifty censers; you also, and Aaron, each with his censer.” 
 \p
 \v 18 They each took his censer, and put fire in it, and laid incense on it, and stood at the door of the Tent of Meeting with Moses and Aaron. 
 \v 19 Korah assembled all the congregation opposite them to the door of the Tent of Meeting. 
-\p Yahweh’s glory appeared to all the congregation. 
-\v 20 Yahweh spoke to Moses and to Aaron, saying, 
+\p Yahuah’s glory appeared to all the congregation. 
+\v 20 Yahuah spoke to Moses and to Aaron, saying, 
 \v 21 “Separate yourselves from among this congregation, that I may consume them in a moment!” 
 \p
 \v 22 They fell on their faces, and said, “Elohim, the Elohim of the spirits of all flesh, shall one man sin, and will you be angry with all the congregation?” 
 \p
-\v 23 Yahweh spoke to Moses, saying, 
+\v 23 Yahuah spoke to Moses, saying, 
 \v 24 “Speak to the congregation, saying, ‘Get away from around the tent of Korah, Dathan, and Abiram!’ ” 
 \p
 \v 25 Moses rose up and went to Dathan and Abiram; and the elders of Israel followed him. 
@@ -947,31 +947,31 @@
 \p
 \v 27 So they went away from the tent of Korah, Dathan, and Abiram, on every side. Dathan and Abiram came out, and stood at the door of their tents with their women, their sons, and their little ones. 
 \p
-\v 28 Moses said, “Hereby you shall know that Yahweh has sent me to do all these works; for they are not from my own mind. 
-\v 29 If these men die the common death of all men, or if they experience what all men experience, then Yahweh hasn’t sent me. 
-\v 30 But if Yahweh makes a new thing, and the ground opens its mouth, and swallows them up with all that belong to them, and they go down alive into Sheol, then you shall understand that these men have despised Yahweh.” 
+\v 28 Moses said, “Hereby you shall know that Yahuah has sent me to do all these works; for they are not from my own mind. 
+\v 29 If these men die the common death of all men, or if they experience what all men experience, then Yahuah hasn’t sent me. 
+\v 30 But if Yahuah makes a new thing, and the ground opens its mouth, and swallows them up with all that belong to them, and they go down alive into Sheol, then you shall understand that these men have despised Yahuah.” 
 \p
 \v 31 As he finished speaking all these words, the ground that was under them split apart. 
 \v 32 The earth opened its mouth and swallowed them up with their households, all of Korah’s men, and all their goods. 
 \v 33 So they, and all that belonged to them went down alive into Sheol. The earth closed on them, and they perished from among the assembly. 
 \v 34 All Israel that were around them fled at their cry; for they said, “Lest the earth swallow us up!” 
-\v 35 Fire came out from Yahweh, and devoured the two hundred fifty men who offered the incense. 
+\v 35 Fire came out from Yahuah, and devoured the two hundred fifty men who offered the incense. 
 \p
-\v 36 Yahweh spoke to Moses, saying, 
+\v 36 Yahuah spoke to Moses, saying, 
 \v 37 “Speak to Eleazar the son of Aaron the priest, that he take up the censers out of the burning, and scatter the fire away from the camp; for they are set-apart, 
-\v 38 even the censers of those who sinned against their own lives. Let them be beaten into plates for a covering of the altar, for they offered them before Yahweh. Therefore they are set-apart. They shall be a sign to the children of Israel.” 
+\v 38 even the censers of those who sinned against their own lives. Let them be beaten into plates for a covering of the altar, for they offered them before Yahuah. Therefore they are set-apart. They shall be a sign to the children of Israel.” 
 \p
 \v 39 Eleazar the priest took the bronze censers which those who were burned had offered; and they beat them out for a covering of the altar, 
-\v 40 to be a memorial to the children of Israel, to the end that no stranger who isn’t of the offspring of Aaron, would come near to burn incense before Yahweh, that he not be as Korah and as his company; as Yahweh spoke to him by Moses. 
+\v 40 to be a memorial to the children of Israel, to the end that no stranger who isn’t of the offspring of Aaron, would come near to burn incense before Yahuah, that he not be as Korah and as his company; as Yahuah spoke to him by Moses. 
 \p
-\v 41 But on the next day all the congregation of the children of Israel complained against Moses and against Aaron, saying, “You have killed Yahweh’s people!” 
+\v 41 But on the next day all the congregation of the children of Israel complained against Moses and against Aaron, saying, “You have killed Yahuah’s people!” 
 \p
-\v 42 When the congregation was assembled against Moses and against Aaron, they looked toward the Tent of Meeting. Behold, the cloud covered it, and Yahweh’s glory appeared. 
+\v 42 When the congregation was assembled against Moses and against Aaron, they looked toward the Tent of Meeting. Behold, the cloud covered it, and Yahuah’s glory appeared. 
 \v 43 Moses and Aaron came to the front of the Tent of Meeting. 
-\v 44 Yahweh spoke to Moses, saying, 
+\v 44 Yahuah spoke to Moses, saying, 
 \v 45 “Get away from among this congregation, that I may consume them in a moment!” They fell on their faces. 
 \p
-\v 46 Moses said to Aaron, “Take your censer, put fire from the altar in it, lay incense on it, carry it quickly to the congregation, and make atonement for them; for wrath has gone out from Yahweh! The plague has begun.” 
+\v 46 Moses said to Aaron, “Take your censer, put fire from the altar in it, lay incense on it, carry it quickly to the congregation, and make atonement for them; for wrath has gone out from Yahuah! The plague has begun.” 
 \p
 \v 47 Aaron did as Moses said, and ran into the middle of the assembly. The plague had already begun among the people. He put on the incense, and made atonement for the people. 
 \v 48 He stood between the dead and the living; and the plague was stayed. 
@@ -979,71 +979,71 @@
 \v 50 Aaron returned to Moses to the door of the Tent of Meeting, and the plague was stopped. 
 \c 17
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Speak to the children of Israel, and take rods from them, one for each fathers’ house, of all their princes according to their fathers’ houses, twelve rods. Write each man’s name on his rod. 
 \v 3 You shall write Aaron’s name on Levi’s rod. There shall be one rod for each head of their fathers’ houses. 
 \v 4 You shall lay them up in the Tent of Meeting before the covenant, where I meet with you. 
 \v 5 It shall happen that the rod of the man whom I shall choose shall bud. I will make the murmurings of the children of Israel, which they murmur against you, cease from me.” 
 \p
 \v 6 Moses spoke to the children of Israel; and all their princes gave him rods, for each prince one, according to their fathers’ houses, a total of twelve rods. Aaron’s rod was among their rods. 
-\v 7 Moses laid up the rods before Yahweh in the Tent of the Testimony. 
+\v 7 Moses laid up the rods before Yahuah in the Tent of the Testimony. 
 \p
 \v 8 On the next day, Moses went into the Tent of the Testimony; and behold, Aaron’s rod for the house of Levi had sprouted, budded, produced blossoms, and bore ripe almonds. 
-\v 9 Moses brought out all the rods from before Yahweh to all the children of Israel. They looked, and each man took his rod. 
+\v 9 Moses brought out all the rods from before Yahuah to all the children of Israel. They looked, and each man took his rod. 
 \p
-\v 10 Yahweh said to Moses, “Put back the rod of Aaron before the covenant, to be kept for a token against the children of rebellion; that you may make an end of their complaining against me, that they not die.” 
-\v 11 Moses did so. As Yahweh commanded him, so he did. 
+\v 10 Yahuah said to Moses, “Put back the rod of Aaron before the covenant, to be kept for a token against the children of rebellion; that you may make an end of their complaining against me, that they not die.” 
+\v 11 Moses did so. As Yahuah commanded him, so he did. 
 \p
 \v 12 The children of Israel spoke to Moses, saying, “Behold, we perish! We are undone! We are all undone! 
-\v 13 Everyone who keeps approaching Yahweh’s tabernacle, dies! Will we all perish?” 
+\v 13 Everyone who keeps approaching Yahuah’s tabernacle, dies! Will we all perish?” 
 \c 18
 \p
-\v 1 Yahweh said to Aaron, “You and your sons and your fathers’ house with you shall bear the iniquity of the sanctuary; and you and your sons with you shall bear the iniquity of your priesthood. 
+\v 1 Yahuah said to Aaron, “You and your sons and your fathers’ house with you shall bear the iniquity of the sanctuary; and you and your sons with you shall bear the iniquity of your priesthood. 
 \v 2 Bring your brothers also, the tribe of Levi, the tribe of your father, near with you, that they may be joined to you, and minister to you; but you and your sons with you shall be before the Tent of the Testimony. 
 \v 3 They shall keep your commands and the duty of the whole Tent; only they shall not come near to the vessels of the sanctuary and to the altar, that they not die, neither they nor you. 
 \v 4 They shall be joined to you and keep the responsibility of the Tent of Meeting, for all the service of the Tent. A stranger shall not come near to you. 
 \p
 \v 5 “You shall perform the duty of the sanctuary and the duty of the altar, that there be no more wrath on the children of Israel. 
-\v 6 Behold, I myself have taken your brothers the Levites from among the children of Israel. They are a gift to you, dedicated to Yahweh, to do the service of the Tent of Meeting. 
+\v 6 Behold, I myself have taken your brothers the Levites from among the children of Israel. They are a gift to you, dedicated to Yahuah, to do the service of the Tent of Meeting. 
 \v 7 You and your sons with you shall keep your priesthood for everything of the altar, and for that within the veil. You shall serve. I give you the service of the priesthood as a gift. The stranger who comes near shall be put to death.” 
 \p
-\v 8 Yahweh spoke to Aaron, “Behold, I myself have given you the command of my wave offerings, even all the set-apart things of the children of Israel. I have given them to you by reason of the anointing, and to your sons, as a portion forever. 
+\v 8 Yahuah spoke to Aaron, “Behold, I myself have given you the command of my wave offerings, even all the set-apart things of the children of Israel. I have given them to you by reason of the anointing, and to your sons, as a portion forever. 
 \v 9 This shall be yours of the most set-apart things from the fire: every offering of theirs, even every meal offering of theirs, and every sin offering of theirs, and every trespass offering of theirs, which they shall render to me, shall be most set-apart for you and for your sons. 
 \v 10 You shall eat of it like the most set-apart things. Every male shall eat of it. It shall be set-apart to you. 
 \p
 \v 11 “This is yours, too: the wave offering of their gift, even all the wave offerings of the children of Israel. I have given them to you, and to your sons and to your daughters with you, as a portion forever. Everyone who is clean in your house shall eat of it. 
 \p
-\v 12 “I have given to you all the best of the oil, all the best of the vintage, and of the grain, the first fruits of them which they give to Yahweh. 
-\v 13 The first-ripe fruits of all that is in their land, which they bring to Yahweh, shall be yours. Everyone who is clean in your house shall eat of it. 
+\v 12 “I have given to you all the best of the oil, all the best of the vintage, and of the grain, the first fruits of them which they give to Yahuah. 
+\v 13 The first-ripe fruits of all that is in their land, which they bring to Yahuah, shall be yours. Everyone who is clean in your house shall eat of it. 
 \p
 \v 14 “Everything devoted in Israel shall be yours. 
-\v 15 Everything that opens the womb, of all flesh which they offer to Yahweh, both of man and animal, shall be yours. Nevertheless, you shall surely redeem the firstborn of man, and you shall redeem the firstborn of unclean animals. 
+\v 15 Everything that opens the womb, of all flesh which they offer to Yahuah, both of man and animal, shall be yours. Nevertheless, you shall surely redeem the firstborn of man, and you shall redeem the firstborn of unclean animals. 
 \v 16 You shall redeem those who are to be redeemed of them from a month old, according to your estimation, for five shekels of money, according to the shekel of the sanctuary, which weighs twenty gerahs. 
 \p
-\v 17 “But you shall not redeem the firstborn of a cow, or the firstborn of a sheep, or the firstborn of a goat. They are set-apart. You shall sprinkle their blood on the altar, and shall burn their fat for an offering made by fire, for a pleasant aroma to Yahweh. 
+\v 17 “But you shall not redeem the firstborn of a cow, or the firstborn of a sheep, or the firstborn of a goat. They are set-apart. You shall sprinkle their blood on the altar, and shall burn their fat for an offering made by fire, for a pleasant aroma to Yahuah. 
 \v 18 Their meat shall be yours, as the wave offering breast and as the right thigh, it shall be yours. 
-\v 19 All the wave offerings of the set-apart things which the children of Israel offer to Yahweh, I have given you and your sons and your daughters with you, as a portion forever. It is a covenant of salt forever before Yahweh to you and to your offspring with you.” 
+\v 19 All the wave offerings of the set-apart things which the children of Israel offer to Yahuah, I have given you and your sons and your daughters with you, as a portion forever. It is a covenant of salt forever before Yahuah to you and to your offspring with you.” 
 \p
-\v 20 Yahweh said to Aaron, “You shall have no inheritance in their land, neither shall you have any portion among them. I am your portion and your inheritance among the children of Israel. 
+\v 20 Yahuah said to Aaron, “You shall have no inheritance in their land, neither shall you have any portion among them. I am your portion and your inheritance among the children of Israel. 
 \p
 \v 21 “To the children of Levi, behold, I have given all the tithe in Israel for an inheritance, in return for their service which they serve, even the service of the Tent of Meeting. 
 \v 22 Henceforth the children of Israel shall not come near the Tent of Meeting, lest they bear sin, and die. 
 \v 23 But the Levites shall do the service of the Tent of Meeting, and they shall bear their iniquity. It shall be a statute forever throughout your generations. Among the children of Israel, they shall have no inheritance. 
-\v 24 For the tithe of the children of Israel, which they offer as a wave offering to Yahweh, I have given to the Levites for an inheritance. Therefore I have said to them, ‘Among the children of Israel they shall have no inheritance.’ ” 
+\v 24 For the tithe of the children of Israel, which they offer as a wave offering to Yahuah, I have given to the Levites for an inheritance. Therefore I have said to them, ‘Among the children of Israel they shall have no inheritance.’ ” 
 \p
-\v 25 Yahweh spoke to Moses, saying, 
-\v 26 “Moreover you shall speak to the Levites, and tell them, ‘When you take of the children of Israel the tithe which I have given you from them for your inheritance, then you shall offer up a wave offering of it for Yahweh, a tithe of the tithe. 
+\v 25 Yahuah spoke to Moses, saying, 
+\v 26 “Moreover you shall speak to the Levites, and tell them, ‘When you take of the children of Israel the tithe which I have given you from them for your inheritance, then you shall offer up a wave offering of it for Yahuah, a tithe of the tithe. 
 \v 27 Your wave offering shall be credited to you, as though it were the grain of the threshing floor, and as the fullness of the wine press. 
-\v 28 Thus you also shall offer a wave offering to Yahweh of all your tithes, which you receive of the children of Israel; and of it you shall give Yahweh’s wave offering to Aaron the priest. 
-\v 29 Out of all your gifts, you shall offer every wave offering to Yahweh, of all its best parts, even the set-apart part of it.’ 
+\v 28 Thus you also shall offer a wave offering to Yahuah of all your tithes, which you receive of the children of Israel; and of it you shall give Yahuah’s wave offering to Aaron the priest. 
+\v 29 Out of all your gifts, you shall offer every wave offering to Yahuah, of all its best parts, even the set-apart part of it.’ 
 \p
 \v 30 “Therefore you shall tell them, ‘When you heave its best from it, then it shall be credited to the Levites as the increase of the threshing floor, and as the increase of the wine press. 
 \v 31 You may eat it anywhere, you and your households, for it is your reward in return for your service in the Tent of Meeting. 
 \v 32 You shall bear no sin by reason of it, when you have heaved from it its best. You shall not profane the set-apart things of the children of Israel, that you not die.’ ” 
 \c 19
 \p
-\v 1 Yahweh spoke to Moses and to Aaron, saying, 
-\v 2 “This is the statute of the law which Yahweh has commanded. Tell the children of Israel to bring you a red heifer without spot, in which is no defect, and which was never yoked. 
+\v 1 Yahuah spoke to Moses and to Aaron, saying, 
+\v 2 “This is the statute of the law which Yahuah has commanded. Tell the children of Israel to bring you a red heifer without spot, in which is no defect, and which was never yoked. 
 \v 3 You shall give her to Eleazar the priest, and he shall bring her outside of the camp, and one shall kill her before his face. 
 \v 4 Eleazar the priest shall take some of her blood with his finger, and sprinkle her blood toward the front of the Tent of Meeting seven times. 
 \v 5 One shall burn the heifer in his sight; her skin, and her meat, and her blood, with her dung, shall he burn. 
@@ -1056,7 +1056,7 @@
 \p
 \v 11 “He who touches the dead body of any man shall be unclean seven days. 
 \v 12 He shall purify himself with water on the third day, and on the seventh day he shall be clean; but if he doesn’t purify himself the third day, then the seventh day he shall not be clean. 
-\v 13 Whoever touches a dead person, the body of a man who has died, and doesn’t purify himself, defiles Yahweh’s tabernacle; and that soul shall be cut off from Israel; because the water for impurity was not sprinkled on him, he shall be unclean. His uncleanness is yet on him. 
+\v 13 Whoever touches a dead person, the body of a man who has died, and doesn’t purify himself, defiles Yahuah’s tabernacle; and that soul shall be cut off from Israel; because the water for impurity was not sprinkled on him, he shall be unclean. His uncleanness is yet on him. 
 \p
 \v 14 “This is the law when a man dies in a tent: everyone who comes into the tent, and everyone who is in the tent, shall be unclean seven days. 
 \v 15 Every open vessel, which has no covering bound on it, is unclean. 
@@ -1066,7 +1066,7 @@
 \v 17 “For the unclean, they shall take of the ashes of the burning of the sin offering; and running water shall be poured on them in a vessel. 
 \v 18 A clean person shall take hyssop, dip it in the water, and sprinkle it on the tent, on all the vessels, on the persons who were there, and on him who touched the bone, or the slain, or the dead, or the grave. 
 \v 19 The clean person shall sprinkle on the unclean on the third day, and on the seventh day. On the seventh day, he shall purify him. He shall wash his clothes and bathe himself in water, and shall be clean at evening. 
-\v 20 But the man who shall be unclean, and shall not purify himself, that soul shall be cut off from among the assembly, because he has defiled the sanctuary of Yahweh. The water for impurity has not been sprinkled on him. He is unclean. 
+\v 20 But the man who shall be unclean, and shall not purify himself, that soul shall be cut off from among the assembly, because he has defiled the sanctuary of Yahuah. The water for impurity has not been sprinkled on him. He is unclean. 
 \v 21 It shall be a perpetual statute to them. He who sprinkles the water for impurity shall wash his clothes, and he who touches the water for impurity shall be unclean until evening. 
 \p
 \v 22 “Whatever the unclean person touches shall be unclean; and the soul that touches it shall be unclean until evening.” 
@@ -1074,26 +1074,26 @@
 \p
 \v 1 The children of Israel, even the whole congregation, came into the wilderness of Zin in the first month. The people stayed in Kadesh. Miriam died there, and was buried there. 
 \v 2 There was no water for the congregation; and they assembled themselves together against Moses and against Aaron. 
-\v 3 The people quarreled with Moses, and spoke, saying, “We wish that we had died when our brothers died before Yahweh! 
-\v 4 Why have you brought Yahweh’s assembly into this wilderness, that we should die there, we and our animals? 
+\v 3 The people quarreled with Moses, and spoke, saying, “We wish that we had died when our brothers died before Yahuah! 
+\v 4 Why have you brought Yahuah’s assembly into this wilderness, that we should die there, we and our animals? 
 \v 5 Why have you made us to come up out of Egypt, to bring us in to this evil place? It is no place of seed, or of figs, or of vines, or of pomegranates; neither is there any water to drink.” 
 \p
-\v 6 Moses and Aaron went from the presence of the assembly to the door of the Tent of Meeting, and fell on their faces. Yahweh’s glory appeared to them. 
-\v 7 Yahweh spoke to Moses, saying, 
+\v 6 Moses and Aaron went from the presence of the assembly to the door of the Tent of Meeting, and fell on their faces. Yahuah’s glory appeared to them. 
+\v 7 Yahuah spoke to Moses, saying, 
 \v 8 “Take the rod, and assemble the congregation, you, and Aaron your brother, and speak to the rock before their eyes, that it pour out its water. You shall bring water to them out of the rock; so you shall give the congregation and their livestock drink.” 
 \p
-\v 9 Moses took the rod from before Yahweh, as he commanded him. 
+\v 9 Moses took the rod from before Yahuah, as he commanded him. 
 \v 10 Moses and Aaron gathered the assembly together before the rock, and he said to them, “Hear now, you rebels! Shall we bring water out of this rock for you?” 
 \v 11 Moses lifted up his hand, and struck the rock with his rod twice, and water came out abundantly. The congregation and their livestock drank. 
 \p
-\v 12 Yahweh said to Moses and Aaron, “Because you didn’t believe in me, to sanctify me in the eyes of the children of Israel, therefore you shall not bring this assembly into the land which I have given them.” 
+\v 12 Yahuah said to Moses and Aaron, “Because you didn’t believe in me, to sanctify me in the eyes of the children of Israel, therefore you shall not bring this assembly into the land which I have given them.” 
 \p
-\v 13 These are the waters of Meribah; because the children of Israel strove with Yahweh, and he was sanctified in them. 
+\v 13 These are the waters of Meribah; because the children of Israel strove with Yahuah, and he was sanctified in them. 
 \p
 \v 14 Moses sent messengers from Kadesh to the king of Edom, saying: 
 \p “Your brother Israel says: You know all the travail that has happened to us; 
 \v 15 how our fathers went down into Egypt, and we lived in Egypt a long time. The Egyptians mistreated us and our fathers. 
-\v 16 When we cried to Yahweh, he heard our voice, sent an angel, and brought us out of Egypt. Behold, we are in Kadesh, a city in the edge of your border. 
+\v 16 When we cried to Yahuah, he heard our voice, sent an angel, and brought us out of Egypt. Behold, we are in Kadesh, a city in the edge of your border. 
 \p
 \v 17 “Please let us pass through your land. We will not pass through field or through vineyard, neither will we drink from the water of the wells. We will go along the king’s highway. We will not turn away to the right hand nor to the left, until we have passed your border.” 
 \p
@@ -1105,37 +1105,37 @@
 \v 21 Thus Edom refused to give Israel passage through his border, so Israel turned away from him. 
 \p
 \v 22 They traveled from Kadesh, and the children of Israel, even the whole congregation, came to Mount Hor. 
-\v 23 Yahweh spoke to Moses and Aaron in Mount Hor, by the border of the land of Edom, saying, 
+\v 23 Yahuah spoke to Moses and Aaron in Mount Hor, by the border of the land of Edom, saying, 
 \v 24 “Aaron shall be gathered to his people; for he shall not enter into the land which I have given to the children of Israel, because you rebelled against my word at the waters of Meribah. 
 \v 25 Take Aaron and Eleazar his son, and bring them up to Mount Hor; 
 \v 26 and strip Aaron of his garments, and put them on Eleazar his son. Aaron shall be gathered, and shall die there.” 
 \p
-\v 27 Moses did as Yahweh commanded. They went up onto Mount Hor in the sight of all the congregation. 
+\v 27 Moses did as Yahuah commanded. They went up onto Mount Hor in the sight of all the congregation. 
 \v 28 Moses stripped Aaron of his garments, and put them on Eleazar his son. Aaron died there on the top of the mountain, and Moses and Eleazar came down from the mountain. 
 \v 29 When all the congregation saw that Aaron was dead, they wept for Aaron thirty days, even all the house of Israel. 
 \c 21
 \p
 \v 1 The Canaanite, the king of Arad, who lived in the South, heard that Israel came by the way of Atharim. He fought against Israel, and took some of them captive. 
-\v 2 Israel vowed a vow to Yahweh, and said, “If you will indeed deliver this people into my hand, then I will utterly destroy their cities.” 
-\v 3 Yahweh listened to the voice of Israel, and delivered up the Canaanites; and they utterly destroyed them and their cities. The name of the place was called Hormah. 
+\v 2 Israel vowed a vow to Yahuah, and said, “If you will indeed deliver this people into my hand, then I will utterly destroy their cities.” 
+\v 3 Yahuah listened to the voice of Israel, and delivered up the Canaanites; and they utterly destroyed them and their cities. The name of the place was called Hormah. 
 \p
 \v 4 They traveled from Mount Hor by the way to the Red Sea, to go around the land of Edom. The soul of the people was very discouraged because of the journey. 
 \v 5 The people spoke against Elohim and against Moses: “Why have you brought us up out of Egypt to die in the wilderness? For there is no bread, there is no water, and our soul loathes this disgusting food!” 
 \p
-\v 6 Yahweh sent venomous snakes among the people, and they bit the people. Many people of Israel died. 
-\v 7 The people came to Moses, and said, “We have sinned, because we have spoken against Yahweh and against you. Pray to Yahweh, that he take away the serpents from us.” Moses prayed for the people. 
+\v 6 Yahuah sent venomous snakes among the people, and they bit the people. Many people of Israel died. 
+\v 7 The people came to Moses, and said, “We have sinned, because we have spoken against Yahuah and against you. Pray to Yahuah, that he take away the serpents from us.” Moses prayed for the people. 
 \p
-\v 8 Yahweh said to Moses, “Make a venomous snake, and set it on a pole. It shall happen that everyone who is bitten, when he sees it, shall live.” 
+\v 8 Yahuah said to Moses, “Make a venomous snake, and set it on a pole. It shall happen that everyone who is bitten, when he sees it, shall live.” 
 \v 9 Moses made a serpent of bronze, and set it on the pole. If a serpent had bitten any man, when he looked at the serpent of bronze, he lived. 
 \p
 \v 10 The children of Israel traveled, and encamped in Oboth. 
 \v 11 They traveled from Oboth, and encamped at Iyeabarim, in the wilderness which is before Moab, toward the sunrise. 
 \v 12 From there they traveled, and encamped in the valley of Zered. 
 \v 13 From there they traveled, and encamped on the other side of the Arnon, which is in the wilderness that comes out of the border of the Amorites; for the Arnon is the border of Moab, between Moab and the Amorites. 
-\v 14 Therefore it is said in \bk The Book of the Wars of Yahweh\bk*, “Vaheb in Suphah, the valleys of the Arnon, 
+\v 14 Therefore it is said in \bk The Book of the Wars of Yahuah\bk*, “Vaheb in Suphah, the valleys of the Arnon, 
 \v 15 the slope of the valleys that incline toward the dwelling of Ar, leans on the border of Moab.” 
 \p
-\v 16 From there they traveled to Beer; that is the well of which Yahweh said to Moses, “Gather the people together, and I will give them water.” 
+\v 16 From there they traveled to Beer; that is the well of which Yahuah said to Moses, “Gather the people together, and I will give them water.” 
 \p
 \v 17 Then Israel sang this song: 
 \q1 “Spring up, well! Sing to it, 
@@ -1177,7 +1177,7 @@
 \v 32 Moses sent to spy out Jazer. They took its villages, and drove out the Amorites who were there. 
 \v 33 They turned and went up by the way of Bashan. Og the king of Bashan went out against them, he and all his people, to battle at Edrei. 
 \p
-\v 34 Yahweh said to Moses, “Don’t fear him, for I have delivered him into your hand, with all his people, and his land. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
+\v 34 Yahuah said to Moses, “Don’t fear him, for I have delivered him into your hand, with all his people, and his land. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
 \p
 \v 35 So they struck him, with his sons and all his people, until there were no survivors; and they possessed his land. 
 \c 22
@@ -1192,7 +1192,7 @@
 \p
 \v 7 The elders of Moab and the elders of Midian departed with the rewards of divination in their hand. They came to Balaam, and spoke to him the words of Balak. 
 \p
-\v 8 He said to them, “Lodge here this night, and I will bring you word again, as Yahweh shall speak to me.” The princes of Moab stayed with Balaam. 
+\v 8 He said to them, “Lodge here this night, and I will bring you word again, as Yahuah shall speak to me.” The princes of Moab stayed with Balaam. 
 \p
 \v 9 Elohim came to Balaam, and said, “Who are these men with you?” 
 \p
@@ -1201,7 +1201,7 @@
 \p
 \v 12 Elohim said to Balaam, “You shall not go with them. You shall not curse the people, for they are blessed.” 
 \p
-\v 13 Balaam rose up in the morning, and said to the princes of Balak, “Go to your land; for Yahweh refuses to permit me to go with you.” 
+\v 13 Balaam rose up in the morning, and said to the princes of Balak, “Go to your land; for Yahuah refuses to permit me to go with you.” 
 \p
 \v 14 The princes of Moab rose up, and they went to Balak, and said, “Balaam refuses to come with us.” 
 \p
@@ -1209,34 +1209,34 @@
 \v 16 They came to Balaam, and said to him, “Balak the son of Zippor says, ‘Please let nothing hinder you from coming to me, 
 \v 17 for I will promote you to very great honor, and whatever you say to me I will do. Please come therefore, and curse this people for me.’ ” 
 \p
-\v 18 Balaam answered the servants of Balak, “If Balak would give me his house full of silver and gold, I can’t go beyond the word of Yahweh my Elohim, to do less or more. 
-\v 19 Now therefore please stay here tonight as well, that I may know what else Yahweh will speak to me.” 
+\v 18 Balaam answered the servants of Balak, “If Balak would give me his house full of silver and gold, I can’t go beyond the word of Yahuah my Elohim, to do less or more. 
+\v 19 Now therefore please stay here tonight as well, that I may know what else Yahuah will speak to me.” 
 \p
 \v 20 Elohim came to Balaam at night, and said to him, “If the men have come to call you, rise up, go with them; but only the word which I speak to you, that you shall do.” 
 \p
 \v 21 Balaam rose up in the morning, and saddled his donkey, and went with the princes of Moab. 
-\v 22 Elohim’s anger burned because he went; and Yahweh’s angel placed himself in the way as an adversary against him. Now he was riding on his donkey, and his two servants were with him. 
-\v 23 The donkey saw Yahweh’s angel standing in the way, with his sword drawn in his hand; and the donkey turned out of the path, and went into the field. Balaam struck the donkey, to turn her into the path. 
-\v 24 Then Yahweh’s angel stood in a narrow path between the vineyards, a wall being on this side, and a wall on that side. 
-\v 25 The donkey saw Yahweh’s angel, and she thrust herself to the wall, and crushed Balaam’s foot against the wall. He struck her again. 
+\v 22 Elohim’s anger burned because he went; and Yahuah’s angel placed himself in the way as an adversary against him. Now he was riding on his donkey, and his two servants were with him. 
+\v 23 The donkey saw Yahuah’s angel standing in the way, with his sword drawn in his hand; and the donkey turned out of the path, and went into the field. Balaam struck the donkey, to turn her into the path. 
+\v 24 Then Yahuah’s angel stood in a narrow path between the vineyards, a wall being on this side, and a wall on that side. 
+\v 25 The donkey saw Yahuah’s angel, and she thrust herself to the wall, and crushed Balaam’s foot against the wall. He struck her again. 
 \p
-\v 26 Yahweh’s angel went further, and stood in a narrow place, where there was no way to turn either to the right hand or to the left. 
-\v 27 The donkey saw Yahweh’s angel, and she lay down under Balaam. Balaam’s anger burned, and he struck the donkey with his staff. 
+\v 26 Yahuah’s angel went further, and stood in a narrow place, where there was no way to turn either to the right hand or to the left. 
+\v 27 The donkey saw Yahuah’s angel, and she lay down under Balaam. Balaam’s anger burned, and he struck the donkey with his staff. 
 \p
-\v 28 Yahweh opened the mouth of the donkey, and she said to Balaam, “What have I done to you, that you have struck me these three times?” 
+\v 28 Yahuah opened the mouth of the donkey, and she said to Balaam, “What have I done to you, that you have struck me these three times?” 
 \p
 \v 29 Balaam said to the donkey, “Because you have mocked me, I wish there were a sword in my hand, for now I would have killed you.” 
 \p
 \v 30 The donkey said to Balaam, “Am I not your donkey, on which you have ridden all your life long until today? Was I ever in the habit of doing so to you?” 
 \p He said, “No.” 
 \p
-\v 31 Then Yahweh opened the eyes of Balaam, and he saw Yahweh’s angel standing in the way, with his sword drawn in his hand; and he bowed his head, and fell on his face. 
-\v 32 Yahweh’s angel said to him, “Why have you struck your donkey these three times? Behold, I have come out as an adversary, because your way is perverse before me. 
+\v 31 Then Yahuah opened the eyes of Balaam, and he saw Yahuah’s angel standing in the way, with his sword drawn in his hand; and he bowed his head, and fell on his face. 
+\v 32 Yahuah’s angel said to him, “Why have you struck your donkey these three times? Behold, I have come out as an adversary, because your way is perverse before me. 
 \v 33 The donkey saw me, and turned away before me these three times. Unless she had turned away from me, surely now I would have killed you, and saved her alive.” 
 \p
-\v 34 Balaam said to Yahweh’s angel, “I have sinned; for I didn’t know that you stood in the way against me. Now therefore, if it displeases you, I will go back again.” 
+\v 34 Balaam said to Yahuah’s angel, “I have sinned; for I didn’t know that you stood in the way against me. Now therefore, if it displeases you, I will go back again.” 
 \p
-\v 35 Yahweh’s angel said to Balaam, “Go with the men; but you shall only speak the word that I shall speak to you.” 
+\v 35 Yahuah’s angel said to Balaam, “Go with the men; but you shall only speak the word that I shall speak to you.” 
 \p So Balaam went with the princes of Balak. 
 \v 36 When Balak heard that Balaam had come, he went out to meet him to the City of Moab, which is on the border of the Arnon, which is in the utmost part of the border. 
 \v 37 Balak said to Balaam, “Didn’t I earnestly send for you to summon you? Why didn’t you come to me? Am I not able indeed to promote you to honor?” 
@@ -1251,11 +1251,11 @@
 \v 1 Balaam said to Balak, “Build here seven altars for me, and prepare here seven bulls and seven rams for me.” 
 \p
 \v 2 Balak did as Balaam had spoken; and Balak and Balaam offered on every altar a bull and a ram. 
-\v 3 Balaam said to Balak, “Stand by your burnt offering, and I will go. Perhaps Yahweh will come to meet me. Whatever he shows me I will tell you.” 
+\v 3 Balaam said to Balak, “Stand by your burnt offering, and I will go. Perhaps Yahuah will come to meet me. Whatever he shows me I will tell you.” 
 \p He went to a bare height. 
 \v 4 Elohim met Balaam, and he said to him, “I have prepared the seven altars, and I have offered up a bull and a ram on every altar.” 
 \p
-\v 5 Yahweh put a word in Balaam’s mouth, and said, “Return to Balak, and thus you shall speak.” 
+\v 5 Yahuah put a word in Balaam’s mouth, and said, “Return to Balak, and thus you shall speak.” 
 \p
 \v 6 He returned to him, and behold, he was standing by his burnt offering, he, and all the princes of Moab. 
 \v 7 He took up his parable, and said, 
@@ -1265,7 +1265,7 @@
 \q2 Come, defy Israel. 
 \q1
 \v 8 How shall I curse whom Elohim has not cursed? 
-\q2 How shall I defy whom Yahweh has not defied? 
+\q2 How shall I defy whom Yahuah has not defied? 
 \q1
 \v 9 For from the top of the rocks I see him. 
 \q2 From the hills I see him. 
@@ -1279,16 +1279,16 @@
 \p
 \v 11 Balak said to Balaam, “What have you done to me? I took you to curse my enemies, and behold, you have blessed them altogether.” 
 \p
-\v 12 He answered and said, “Must I not take heed to speak that which Yahweh puts in my mouth?” 
+\v 12 He answered and said, “Must I not take heed to speak that which Yahuah puts in my mouth?” 
 \p
 \v 13 Balak said to him, “Please come with me to another place, where you may see them. You shall see just part of them, and shall not see them all. Curse them from there for me.” 
 \p
 \v 14 He took him into the field of Zophim, to the top of Pisgah, and built seven altars, and offered up a bull and a ram on every altar. 
 \v 15 He said to Balak, “Stand here by your burnt offering, while I meet Elohim over there.” 
 \p
-\v 16 Yahweh met Balaam, and put a word in his mouth, and said, “Return to Balak, and say this.” 
+\v 16 Yahuah met Balaam, and put a word in his mouth, and said, “Return to Balak, and say this.” 
 \p
-\v 17 He came to him, and behold, he was standing by his burnt offering, and the princes of Moab with him. Balak said to him, “What has Yahweh spoken?” 
+\v 17 He came to him, and behold, he was standing by his burnt offering, and the princes of Moab with him. Balak said to him, “What has Yahuah spoken?” 
 \p
 \v 18 He took up his parable, and said, 
 \q1 “Rise up, Balak, and hear! 
@@ -1304,7 +1304,7 @@
 \q1
 \v 21 He has not seen iniquity in Jacob. 
 \q2 Neither has he seen perverseness in Israel. 
-\q1 Yahweh his Elohim is with him. 
+\q1 Yahuah his Elohim is with him. 
 \q2 The shout of a king is among them. 
 \q1
 \v 22 Elohim brings them out of Egypt. 
@@ -1322,7 +1322,7 @@
 \p
 \v 25 Balak said to Balaam, “Neither curse them at all, nor bless them at all.” 
 \p
-\v 26 But Balaam answered Balak, “Didn’t I tell you, saying, ‘All that Yahweh speaks, that I must do’?” 
+\v 26 But Balaam answered Balak, “Didn’t I tell you, saying, ‘All that Yahuah speaks, that I must do’?” 
 \p
 \v 27 Balak said to Balaam, “Come now, I will take you to another place; perhaps it will please Elohim that you may curse them for me from there.” 
 \p
@@ -1332,7 +1332,7 @@
 \v 30 Balak did as Balaam had said, and offered up a bull and a ram on every altar. 
 \c 24
 \p
-\v 1 When Balaam saw that it pleased Yahweh to bless Israel, he didn’t go, as at the other times, to use divination, but he set his face toward the wilderness. 
+\v 1 When Balaam saw that it pleased Yahuah to bless Israel, he didn’t go, as at the other times, to use divination, but he set his face toward the wilderness. 
 \v 2 Balaam lifted up his eyes, and he saw Israel dwelling according to their tribes; and the Spirit of Elohim came on him. 
 \v 3 He took up his parable, and said, 
 \q1 “Balaam the son of Beor says, 
@@ -1347,7 +1347,7 @@
 \q1
 \v 6 As valleys they are spread out, 
 \q2 as gardens by the riverside, 
-\q2 as aloes which Yahweh has planted, 
+\q2 as aloes which Yahuah has planted, 
 \q2 as cedar trees beside the waters. 
 \q1
 \v 7 Water shall flow from his buckets. 
@@ -1368,10 +1368,10 @@
 \q2 Everyone who curses you is cursed.” 
 \p
 \v 10 Balak’s anger burned against Balaam, and he struck his hands together. Balak said to Balaam, “I called you to curse my enemies, and, behold, you have altogether blessed them these three times. 
-\v 11 Therefore, flee to your place, now! I thought to promote you to great honor; but, behold, Yahweh has kept you back from honor.” 
+\v 11 Therefore, flee to your place, now! I thought to promote you to great honor; but, behold, Yahuah has kept you back from honor.” 
 \p
 \v 12 Balaam said to Balak, “Didn’t I also tell your messengers whom you sent to me, saying, 
-\v 13 ‘If Balak would give me his house full of silver and gold, I can’t go beyond Yahweh’s word, to do either good or bad from my own mind. I will say what Yahweh says’? 
+\v 13 ‘If Balak would give me his house full of silver and gold, I can’t go beyond Yahuah’s word, to do either good or bad from my own mind. I will say what Yahuah says’? 
 \v 14 Now, behold, I go to my people. Come, I will inform you what this people shall do to your people in the latter days.” 
 \p
 \v 15 He took up his parable, and said, 
@@ -1420,8 +1420,8 @@
 \p
 \v 1 Israel stayed in Shittim; and the people began to play the prostitute with the daughters of Moab; 
 \v 2 for they called the people to the sacrifices of their elohims. The people ate and bowed down to their elohims. 
-\v 3 Israel joined himself to Baal Peor, and Yahweh’s anger burned against Israel. 
-\v 4 Yahweh said to Moses, “Take all the chiefs of the people, and hang them up to Yahweh before the sun, that the fierce anger of Yahweh may turn away from Israel.” 
+\v 3 Israel joined himself to Baal Peor, and Yahuah’s anger burned against Israel. 
+\v 4 Yahuah said to Moses, “Take all the chiefs of the people, and hang them up to Yahuah before the sun, that the fierce anger of Yahuah may turn away from Israel.” 
 \p
 \v 5 Moses said to the judges of Israel, “Everyone kill his men who have joined themselves to Baal Peor.” 
 \p
@@ -1430,7 +1430,7 @@
 \v 8 He went after the man of Israel into the pavilion, and thrust both of them through, the man of Israel, and the woman through her body. So the plague was stopped among the children of Israel. 
 \v 9 Those who died by the plague were twenty-four thousand. 
 \p
-\v 10 Yahweh spoke to Moses, saying, 
+\v 10 Yahuah spoke to Moses, saying, 
 \v 11 “Phinehas, the son of Eleazar, the son of Aaron the priest, has turned my wrath away from the children of Israel, in that he was jealous with my jealousy among them, so that I didn’t consume the children of Israel in my jealousy. 
 \v 12 Therefore say, ‘Behold, I give to him my covenant of peace. 
 \v 13 It shall be to him, and to his offspring after him, the covenant of an everlasting priesthood, because he was jealous for his Elohim, and made atonement for the children of Israel.’ ” 
@@ -1438,21 +1438,21 @@
 \v 14 Now the name of the man of Israel that was slain, who was slain with the Midianite woman, was Zimri, the son of Salu, a prince of a fathers’ house among the Simeonites. 
 \v 15 The name of the Midianite woman who was slain was Cozbi, the daughter of Zur. He was head of the people of a fathers’ house in Midian. 
 \p
-\v 16 Yahweh spoke to Moses, saying, 
+\v 16 Yahuah spoke to Moses, saying, 
 \v 17 “Harass the Midianites, and strike them; 
 \v 18 for they harassed you with their wiles, wherein they have deceived you in the matter of Peor, and in the incident regarding Cozbi, the daughter of the prince of Midian, their sister, who was slain on the day of the plague in the matter of Peor.” 
 \c 26
 \p
-\v 1 After the plague, Yahweh spoke to Moses and to Eleazar the son of Aaron the priest, saying, 
+\v 1 After the plague, Yahuah spoke to Moses and to Eleazar the son of Aaron the priest, saying, 
 \v 2 “Take a census of all the congregation of the children of Israel, from twenty years old and upward, by their fathers’ houses, all who are able to go out to war in Israel.” 
 \v 3 Moses and Eleazar the priest spoke with them in the plains of Moab by the Jordan at Jericho, saying, 
-\v 4 “Take a census, from twenty years old and upward, as Yahweh commanded Moses and the children of Israel.” 
+\v 4 “Take a census, from twenty years old and upward, as Yahuah commanded Moses and the children of Israel.” 
 \p These are those who came out of the land of Egypt. 
 \v 5 Reuben, the firstborn of Israel; the sons of Reuben: of Hanoch, the family of the Hanochites; of Pallu, the family of the Palluites; 
 \v 6 of Hezron, the family of the Hezronites; of Carmi, the family of the Carmites. 
 \v 7 These are the families of the Reubenites; and those who were counted of them were forty-three thousand seven hundred thirty. 
 \v 8 The son of Pallu: Eliab. 
-\v 9 The sons of Eliab: Nemuel, Dathan, and Abiram. These are that Dathan and Abiram who were called by the congregation, who rebelled against Moses and against Aaron in the company of Korah when they rebelled against Yahweh; 
+\v 9 The sons of Eliab: Nemuel, Dathan, and Abiram. These are that Dathan and Abiram who were called by the congregation, who rebelled against Moses and against Aaron in the company of Korah when they rebelled against Yahuah; 
 \v 10 and the earth opened its mouth, and swallowed them up together with Korah when that company died; at the time the fire devoured two hundred fifty men, and they became a sign. 
 \v 11 Notwithstanding, the sons of Korah didn’t die. 
 \v 12 The sons of Simeon after their families: of Nemuel, the family of the Nemuelites; of Jamin, the family of the Jaminites; of Jachin, the family of the Jachinites; 
@@ -1496,7 +1496,7 @@
 \v 50 These are the families of Naphtali according to their families; and those who were counted of them were forty-five thousand four hundred. 
 \v 51 These are those who were counted of the children of Israel, six hundred one thousand seven hundred thirty. 
 \p
-\v 52 Yahweh spoke to Moses, saying, 
+\v 52 Yahuah spoke to Moses, saying, 
 \v 53 “To these the land shall be divided for an inheritance according to the number of names. 
 \v 54 To the more you shall give the more inheritance, and to the fewer you shall give the less inheritance. To everyone according to those who were counted of him shall his inheritance be given. 
 \v 55 Notwithstanding, the land shall be divided by lot. According to the names of the tribes of their fathers they shall inherit. 
@@ -1506,74 +1506,74 @@
 \v 58 These are the families of Levi: the family of the Libnites, the family of the Hebronites, the family of the Mahlites, the family of the Mushites, and the family of the Korahites. Kohath brought forth Amram. 
 \v 59 The name of Amram’s woman was Jochebed, the daughter of Levi, who was born to Levi in Egypt. She bore to Amram Aaron and Moses, and Miriam their sister. 
 \v 60 To Aaron were born Nadab and Abihu, Eleazar and Ithamar. 
-\v 61 Nadab and Abihu died when they offered strange fire before Yahweh. 
+\v 61 Nadab and Abihu died when they offered strange fire before Yahuah. 
 \v 62 Those who were counted of them were twenty-three thousand, every male from a month old and upward; for they were not counted among the children of Israel, because there was no inheritance given them among the children of Israel. 
 \v 63 These are those who were counted by Moses and Eleazar the priest, who counted the children of Israel in the plains of Moab by the Jordan at Jericho. 
 \v 64 But among these there was not a man of them who were counted by Moses and Aaron the priest, who counted the children of Israel in the wilderness of Sinai. 
-\v 65 For Yahweh had said of them, “They shall surely die in the wilderness.” There was not a man left of them, except Caleb the son of Jephunneh, and Joshua the son of Nun. 
+\v 65 For Yahuah had said of them, “They shall surely die in the wilderness.” There was not a man left of them, except Caleb the son of Jephunneh, and Joshua the son of Nun. 
 \c 27
 \p
 \v 1 Then the daughters of Zelophehad, the son of Hepher, the son of Gilead, the son of Machir, the son of Manasseh, of the families of Manasseh the son of Joseph came near. These are the names of his daughters: Mahlah, Noah, Hoglah, Milcah, and Tirzah. 
 \v 2 They stood before Moses, before Eleazar the priest, and before the princes and all the congregation, at the door of the Tent of Meeting, saying, 
-\v 3 “Our father died in the wilderness. He was not among the company of those who gathered themselves together against Yahweh in the company of Korah, but he died in his own sin. He had no sons. 
+\v 3 “Our father died in the wilderness. He was not among the company of those who gathered themselves together against Yahuah in the company of Korah, but he died in his own sin. He had no sons. 
 \v 4 Why should the name of our father be taken away from among his family, because he had no son? Give to us a possession among the brothers of our father.” 
 \p
-\v 5 Moses brought their cause before Yahweh. 
-\v 6 Yahweh spoke to Moses, saying, 
+\v 5 Moses brought their cause before Yahuah. 
+\v 6 Yahuah spoke to Moses, saying, 
 \v 7 “The daughters of Zelophehad speak right. You shall surely give them a possession of an inheritance among their father’s brothers. You shall cause the inheritance of their father to pass to them. 
 \v 8 You shall speak to the children of Israel, saying, ‘If a man dies, and has no son, then you shall cause his inheritance to pass to his daughter. 
 \v 9 If he has no daughter, then you shall give his inheritance to his brothers. 
 \v 10 If he has no brothers, then you shall give his inheritance to his father’s brothers. 
-\v 11 If his father has no brothers, then you shall give his inheritance to his kinsman who is next to him of his family, and he shall possess it. This shall be a statute and ordinance for the children of Israel, as Yahweh commanded Moses.’ ” 
+\v 11 If his father has no brothers, then you shall give his inheritance to his kinsman who is next to him of his family, and he shall possess it. This shall be a statute and ordinance for the children of Israel, as Yahuah commanded Moses.’ ” 
 \p
-\v 12 Yahweh said to Moses, “Go up into this mountain of Abarim, and see the land which I have given to the children of Israel. 
+\v 12 Yahuah said to Moses, “Go up into this mountain of Abarim, and see the land which I have given to the children of Israel. 
 \v 13 When you have seen it, you also shall be gathered to your people, as Aaron your brother was gathered; 
 \v 14 because in the strife of the congregation, you rebelled against my word in the wilderness of Zin, to honor me as set-apart at the waters before their eyes.” (These are the waters of Meribah of Kadesh in the wilderness of Zin.) 
 \p
-\v 15 Moses spoke to Yahweh, saying, 
-\v 16 “Let Yahweh, the Elohim of the spirits of all flesh, appoint a man over the congregation, 
-\v 17 who may go out before them, and who may come in before them, and who may lead them out, and who may bring them in, that the congregation of Yahweh may not be as sheep which have no shepherd.” 
+\v 15 Moses spoke to Yahuah, saying, 
+\v 16 “Let Yahuah, the Elohim of the spirits of all flesh, appoint a man over the congregation, 
+\v 17 who may go out before them, and who may come in before them, and who may lead them out, and who may bring them in, that the congregation of Yahuah may not be as sheep which have no shepherd.” 
 \p
-\v 18 Yahweh said to Moses, “Take Joshua the son of Nun, a man in whom is the Spirit, and lay your hand on him. 
+\v 18 Yahuah said to Moses, “Take Joshua the son of Nun, a man in whom is the Spirit, and lay your hand on him. 
 \v 19 Set him before Eleazar the priest, and before all the congregation; and commission him in their sight. 
 \v 20 You shall give authority to him, that all the congregation of the children of Israel may obey. 
-\v 21 He shall stand before Eleazar the priest, who shall inquire for him by the judgment of the Urim before Yahweh. At his word they shall go out, and at his word they shall come in, both he and all the children of Israel with him, even all the congregation.” 
+\v 21 He shall stand before Eleazar the priest, who shall inquire for him by the judgment of the Urim before Yahuah. At his word they shall go out, and at his word they shall come in, both he and all the children of Israel with him, even all the congregation.” 
 \p
-\v 22 Moses did as Yahweh commanded him. He took Joshua, and set him before Eleazar the priest and before all the congregation. 
-\v 23 He laid his hands on him and commissioned him, as Yahweh spoke by Moses. 
+\v 22 Moses did as Yahuah commanded him. He took Joshua, and set him before Eleazar the priest and before all the congregation. 
+\v 23 He laid his hands on him and commissioned him, as Yahuah spoke by Moses. 
 \c 28
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Command the children of Israel, and tell them, ‘See that you present my offering, my food for my offerings made by fire, as a pleasant aroma to me, in their due season.’ 
-\v 3 You shall tell them, ‘This is the offering made by fire which you shall offer to Yahweh: male lambs a year old without defect, two day by day, for a continual burnt offering. 
+\v 3 You shall tell them, ‘This is the offering made by fire which you shall offer to Yahuah: male lambs a year old without defect, two day by day, for a continual burnt offering. 
 \v 4 You shall offer the one lamb in the morning, and you shall offer the other lamb at evening, 
 \v 5 with one tenth of an ephah of fine flour for a meal offering, mixed with the fourth part of a hin of beaten oil. 
-\v 6 It is a continual burnt offering which was ordained in Mount Sinai for a pleasant aroma, an offering made by fire to Yahweh. 
-\v 7 Its drink offering shall be the fourth part of a hin for each lamb. You shall pour out a drink offering of strong drink to Yahweh in the set-apart place. 
-\v 8 The other lamb you shall offer at evening. As the meal offering of the morning, and as its drink offering, you shall offer it, an offering made by fire, for a pleasant aroma to Yahweh. 
+\v 6 It is a continual burnt offering which was ordained in Mount Sinai for a pleasant aroma, an offering made by fire to Yahuah. 
+\v 7 Its drink offering shall be the fourth part of a hin for each lamb. You shall pour out a drink offering of strong drink to Yahuah in the set-apart place. 
+\v 8 The other lamb you shall offer at evening. As the meal offering of the morning, and as its drink offering, you shall offer it, an offering made by fire, for a pleasant aroma to Yahuah. 
 \p
 \v 9 “ ‘On the Sabbath day, you shall offer two male lambs a year old without defect, and two tenths of an ephah of fine flour for a meal offering mixed with oil, and its drink offering: 
 \v 10 this is the burnt offering of every Sabbath, in addition to the continual burnt offering and its drink offering. 
 \p
-\v 11 “ ‘In the beginnings of your months, you shall offer a burnt offering to Yahweh: two young bulls, one ram, seven male lambs a year old without defect, 
+\v 11 “ ‘In the beginnings of your months, you shall offer a burnt offering to Yahuah: two young bulls, one ram, seven male lambs a year old without defect, 
 \v 12 and three tenths of an ephah of fine flour for a meal offering mixed with oil, for each bull; and two tenth parts of fine flour for a meal offering mixed with oil, for the one ram; 
-\v 13 and one tenth part of fine flour mixed with oil for a meal offering to every lamb, as a burnt offering of a pleasant aroma, an offering made by fire to Yahweh. 
+\v 13 and one tenth part of fine flour mixed with oil for a meal offering to every lamb, as a burnt offering of a pleasant aroma, an offering made by fire to Yahuah. 
 \v 14 Their drink offerings shall be half a hin of wine for a bull, the third part of a hin for the ram, and the fourth part of a hin for a lamb. This is the burnt offering of every month throughout the months of the year. 
-\v 15 Also, one male goat for a sin offering to Yahweh shall be offered in addition to the continual burnt offering and its drink offering. 
+\v 15 Also, one male goat for a sin offering to Yahuah shall be offered in addition to the continual burnt offering and its drink offering. 
 \p
-\v 16 “ ‘In the first month, on the fourteenth day of the month, is Yahweh’s Passover. 
+\v 16 “ ‘In the first month, on the fourteenth day of the month, is Yahuah’s Passover. 
 \v 17 On the fifteenth day of this month shall be a feast. Unleavened bread shall be eaten for seven days. 
 \v 18 In the first day shall be a set-apart convocation. You shall do no regular work, 
-\v 19 but you shall offer an offering made by fire, a burnt offering to Yahweh: two young bulls, one ram, and seven male lambs a year old. They shall be without defect, 
+\v 19 but you shall offer an offering made by fire, a burnt offering to Yahuah: two young bulls, one ram, and seven male lambs a year old. They shall be without defect, 
 \v 20 with their meal offering, fine flour mixed with oil. You shall offer three tenths for a bull, and two tenths for the ram. 
 \v 21 You shall offer one tenth for every lamb of the seven lambs; 
 \v 22 and one male goat for a sin offering, to make atonement for you. 
 \v 23 You shall offer these in addition to the burnt offering of the morning, which is for a continual burnt offering. 
-\v 24 In this way you shall offer daily, for seven days, the food of the offering made by fire, of a pleasant aroma to Yahweh. It shall be offered in addition to the continual burnt offering and its drink offering. 
+\v 24 In this way you shall offer daily, for seven days, the food of the offering made by fire, of a pleasant aroma to Yahuah. It shall be offered in addition to the continual burnt offering and its drink offering. 
 \v 25 On the seventh day you shall have a set-apart convocation. You shall do no regular work. 
 \p
-\v 26 “ ‘Also in the day of the first fruits, when you offer a new meal offering to Yahweh in your feast of weeks, you shall have a set-apart convocation. You shall do no regular work; 
-\v 27 but you shall offer a burnt offering for a pleasant aroma to Yahweh: two young bulls, one ram, seven male lambs a year old; 
+\v 26 “ ‘Also in the day of the first fruits, when you offer a new meal offering to Yahuah in your feast of weeks, you shall have a set-apart convocation. You shall do no regular work; 
+\v 27 but you shall offer a burnt offering for a pleasant aroma to Yahuah: two young bulls, one ram, seven male lambs a year old; 
 \v 28 and their meal offering, fine flour mixed with oil, three tenths for each bull, two tenths for the one ram, 
 \v 29 one tenth for every lamb of the seven lambs; 
 \v 30 and one male goat, to make atonement for you. 
@@ -1581,20 +1581,20 @@
 \c 29
 \p
 \v 1 “ ‘In the seventh month, on the first day of the month, you shall have a set-apart convocation; you shall do no regular work. It is a day of blowing of trumpets to you. 
-\v 2 You shall offer a burnt offering for a pleasant aroma to Yahweh: one young bull, one ram, seven male lambs a year old without defect; 
+\v 2 You shall offer a burnt offering for a pleasant aroma to Yahuah: one young bull, one ram, seven male lambs a year old without defect; 
 \v 3 and their meal offering, fine flour mixed with oil: three tenths for the bull, two tenths for the ram, 
 \v 4 and one tenth for every lamb of the seven lambs; 
 \v 5 and one male goat for a sin offering, to make atonement for you; 
-\v 6 in addition to the burnt offering of the new moon with its meal offering, and the continual burnt offering with its meal offering, and their drink offerings, according to their ordinance, for a pleasant aroma, an offering made by fire to Yahweh. 
+\v 6 in addition to the burnt offering of the new moon with its meal offering, and the continual burnt offering with its meal offering, and their drink offerings, according to their ordinance, for a pleasant aroma, an offering made by fire to Yahuah. 
 \p
 \v 7 “ ‘On the tenth day of this seventh month you shall have a set-apart convocation. You shall afflict your souls. You shall do no kind of work; 
-\v 8 but you shall offer a burnt offering to Yahweh for a pleasant aroma: one young bull, one ram, seven male lambs a year old, all without defect; 
+\v 8 but you shall offer a burnt offering to Yahuah for a pleasant aroma: one young bull, one ram, seven male lambs a year old, all without defect; 
 \v 9 and their meal offering, fine flour mixed with oil: three tenths for the bull, two tenths for the one ram, 
 \v 10 one tenth for every lamb of the seven lambs; 
 \v 11 one male goat for a sin offering, in addition to the sin offering of atonement, and the continual burnt offering, and its meal offering, and their drink offerings. 
 \p
-\v 12 “ ‘On the fifteenth day of the seventh month you shall have a set-apart convocation. You shall do no regular work. You shall keep a feast to Yahweh seven days. 
-\v 13 You shall offer a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh: thirteen young bulls, two rams, fourteen male lambs a year old, all without defect; 
+\v 12 “ ‘On the fifteenth day of the seventh month you shall have a set-apart convocation. You shall do no regular work. You shall keep a feast to Yahuah seven days. 
+\v 13 You shall offer a burnt offering, an offering made by fire, of a pleasant aroma to Yahuah: thirteen young bulls, two rams, fourteen male lambs a year old, all without defect; 
 \v 14 and their meal offering, fine flour mixed with oil: three tenths for every bull of the thirteen bulls, two tenths for each ram of the two rams, 
 \v 15 and one tenth for every lamb of the fourteen lambs; 
 \v 16 and one male goat for a sin offering, in addition to the continual burnt offering, its meal offering, and its drink offering. 
@@ -1624,46 +1624,46 @@
 \v 34 and one male goat for a sin offering; in addition to the continual burnt offering, its meal offering, and its drink offering. 
 \p
 \v 35 “ ‘On the eighth day you shall have a solemn assembly. You shall do no regular work; 
-\v 36 but you shall offer a burnt offering, an offering made by fire, a pleasant aroma to Yahweh: one bull, one ram, seven male lambs a year old without defect; 
+\v 36 but you shall offer a burnt offering, an offering made by fire, a pleasant aroma to Yahuah: one bull, one ram, seven male lambs a year old without defect; 
 \v 37 their meal offering and their drink offerings for the bull, for the ram, and for the lambs, shall be according to their number, after the ordinance, 
 \v 38 and one male goat for a sin offering, in addition to the continual burnt offering, with its meal offering, and its drink offering. 
 \p
-\v 39 “ ‘You shall offer these to Yahweh in your set feasts—in addition to your vows and your free will offerings—for your burnt offerings, your meal offerings, your drink offerings, and your peace offerings.’ ” 
+\v 39 “ ‘You shall offer these to Yahuah in your set feasts—in addition to your vows and your free will offerings—for your burnt offerings, your meal offerings, your drink offerings, and your peace offerings.’ ” 
 \p
-\v 40 Moses told the children of Israel according to all that Yahweh commanded Moses. 
+\v 40 Moses told the children of Israel according to all that Yahuah commanded Moses. 
 \c 30
 \p
-\v 1 Moses spoke to the heads of the tribes of the children of Israel, saying, “This is the thing which Yahweh has commanded. 
-\v 2 When a man vows a vow to Yahweh, or swears an oath to bind his soul with a bond, he shall not break his word. He shall do according to all that proceeds out of his mouth. 
+\v 1 Moses spoke to the heads of the tribes of the children of Israel, saying, “This is the thing which Yahuah has commanded. 
+\v 2 When a man vows a vow to Yahuah, or swears an oath to bind his soul with a bond, he shall not break his word. He shall do according to all that proceeds out of his mouth. 
 \p
-\v 3 “Also, when a woman vows a vow to Yahweh and binds herself by a pledge, being in her father’s house, in her youth, 
+\v 3 “Also, when a woman vows a vow to Yahuah and binds herself by a pledge, being in her father’s house, in her youth, 
 \v 4 and her father hears her vow and her pledge with which she has bound her soul, and her father says nothing to her, then all her vows shall stand, and every pledge with which she has bound her soul shall stand. 
-\v 5 But if her father forbids her in the day that he hears, none of her vows or of her pledges with which she has bound her soul, shall stand. Yahweh will forgive her, because her father has forbidden her. 
+\v 5 But if her father forbids her in the day that he hears, none of her vows or of her pledges with which she has bound her soul, shall stand. Yahuah will forgive her, because her father has forbidden her. 
 \p
 \v 6 “If she has a man, while her vows are on her, or the rash utterance of her lips with which she has bound her soul, 
 \v 7 and her man hears it, and says nothing to her in the day that he hears it; then her vows shall stand, and her pledges with which she has bound her soul shall stand. 
-\v 8 But if her man forbids her in the day that he hears it, then he makes void her vow which is on her and the rash utterance of her lips, with which she has bound her soul. Yahweh will forgive her. 
+\v 8 But if her man forbids her in the day that he hears it, then he makes void her vow which is on her and the rash utterance of her lips, with which she has bound her soul. Yahuah will forgive her. 
 \p
 \v 9 “But the vow of a widow, or of her who is divorced, everything with which she has bound her soul shall stand against her. 
 \p
 \v 10 “If she vowed in her man’s house or bound her soul by a bond with an oath, 
 \v 11 and her man heard it, and held his peace at her and didn’t disallow her, then all her vows shall stand, and every pledge with which she bound her soul shall stand. 
-\v 12 But if her man made them null and void in the day that he heard them, then whatever proceeded out of her lips concerning her vows, or concerning the bond of her soul, shall not stand. Her man has made them void. Yahweh will forgive her. 
+\v 12 But if her man made them null and void in the day that he heard them, then whatever proceeded out of her lips concerning her vows, or concerning the bond of her soul, shall not stand. Her man has made them void. Yahuah will forgive her. 
 \v 13 Every vow, and every binding oath to afflict the soul, her man may establish it, or her man may make it void. 
 \v 14 But if her man says nothing to her from day to day, then he establishes all her vows or all her pledges which are on her. He has established them, because he said nothing to her in the day that he heard them. 
 \v 15 But if he makes them null and void after he has heard them, then he shall bear her iniquity.” 
 \p
-\v 16 These are the statutes which Yahweh commanded Moses, between a man and his woman, between a father and his daughter, being in her youth, in her father’s house. 
+\v 16 These are the statutes which Yahuah commanded Moses, between a man and his woman, between a father and his daughter, being in her youth, in her father’s house. 
 \c 31
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Avenge the children of Israel on the Midianites. Afterward you shall be gathered to your people.” 
 \p
-\v 3 Moses spoke to the people, saying, “Arm men from among you for war, that they may go against Midian, to execute Yahweh’s vengeance on Midian. 
+\v 3 Moses spoke to the people, saying, “Arm men from among you for war, that they may go against Midian, to execute Yahuah’s vengeance on Midian. 
 \v 4 You shall send one thousand out of every tribe, throughout all the tribes of Israel, to the war.” 
 \v 5 So there were delivered, out of the thousands of Israel, a thousand from every tribe, twelve thousand armed for war. 
 \v 6 Moses sent them, one thousand of every tribe, to the war with Phinehas the son of Eleazar the priest, to the war, with the vessels of the sanctuary and the trumpets for the alarm in his hand. 
-\v 7 They fought against Midian, as Yahweh commanded Moses. They killed every male. 
+\v 7 They fought against Midian, as Yahuah commanded Moses. They killed every male. 
 \v 8 They killed the kings of Midian with the rest of their slain: Evi, Rekem, Zur, Hur, and Reba, the five kings of Midian. They also killed Balaam the son of Beor with the sword. 
 \v 9 The children of Israel took the women of Midian captive with their little ones; and all their livestock, all their flocks, and all their goods, they took as plunder. 
 \v 10 All their cities in the places in which they lived, and all their encampments, they burned with fire. 
@@ -1672,70 +1672,70 @@
 \v 13 Moses and Eleazar the priest, with all the princes of the congregation, went out to meet them outside of the camp. 
 \v 14 Moses was angry with the officers of the army, the captains of thousands and the captains of hundreds, who came from the service of the war. 
 \v 15 Moses said to them, “Have you saved all the women alive? 
-\v 16 Behold, these caused the children of Israel, through the counsel of Balaam, to commit trespass against Yahweh in the matter of Peor, and so the plague was among the congregation of Yahweh. 
+\v 16 Behold, these caused the children of Israel, through the counsel of Balaam, to commit trespass against Yahuah in the matter of Peor, and so the plague was among the congregation of Yahuah. 
 \v 17 Now therefore kill every male among the little ones, and kill every woman who has known man by lying with him. 
 \v 18 But all the girls, who have not known man by lying with him, keep alive for yourselves. 
 \p
 \v 19 “Encamp outside of the camp for seven days. Whoever has killed any person, and whoever has touched any slain, purify yourselves on the third day and on the seventh day, you and your captives. 
 \v 20 You shall purify every garment, and all that is made of skin, and all work of goats’ hair, and all things made of wood.” 
 \p
-\v 21 Eleazar the priest said to the men of war who went to the battle, “This is the statute of the law which Yahweh has commanded Moses. 
+\v 21 Eleazar the priest said to the men of war who went to the battle, “This is the statute of the law which Yahuah has commanded Moses. 
 \v 22 However the gold, and the silver, the bronze, the iron, the tin, and the lead, 
 \v 23 everything that may withstand the fire, you shall make to go through the fire, and it shall be clean; nevertheless it shall be purified with the water for impurity. All that doesn’t withstand the fire you shall make to go through the water. 
 \v 24 You shall wash your clothes on the seventh day, and you shall be clean. Afterward you shall come into the camp.” 
 \p
-\v 25 Yahweh spoke to Moses, saying, 
+\v 25 Yahuah spoke to Moses, saying, 
 \v 26 “Count the plunder that was taken, both of man and of animal, you, and Eleazar the priest, and the heads of the fathers’ households of the congregation; 
 \v 27 and divide the plunder into two parts: between the men skilled in war, who went out to battle, and all the congregation. 
-\v 28 Levy a tribute to Yahweh of the men of war who went out to battle: one soul of five hundred; of the persons, of the cattle, of the donkeys, and of the flocks. 
-\v 29 Take it from their half, and give it to Eleazar the priest, for Yahweh’s wave offering. 
-\v 30 Of the children of Israel’s half, you shall take one drawn out of every fifty, of the persons, of the cattle, of the donkeys, and of the flocks, of all the livestock, and give them to the Levites, who perform the duty of Yahweh’s tabernacle.” 
+\v 28 Levy a tribute to Yahuah of the men of war who went out to battle: one soul of five hundred; of the persons, of the cattle, of the donkeys, and of the flocks. 
+\v 29 Take it from their half, and give it to Eleazar the priest, for Yahuah’s wave offering. 
+\v 30 Of the children of Israel’s half, you shall take one drawn out of every fifty, of the persons, of the cattle, of the donkeys, and of the flocks, of all the livestock, and give them to the Levites, who perform the duty of Yahuah’s tabernacle.” 
 \p
-\v 31 Moses and Eleazar the priest did as Yahweh commanded Moses. 
+\v 31 Moses and Eleazar the priest did as Yahuah commanded Moses. 
 \p
 \v 32 Now the plunder, over and above the booty which the men of war took, was six hundred seventy-five thousand sheep, 
 \v 33 seventy-two thousand head of cattle, 
 \v 34 sixty-one thousand donkeys, 
 \v 35 and thirty-two thousand persons in all, of the women who had not known man by lying with him. 
 \v 36 The half, which was the portion of those who went out to war, was in number three hundred thirty-seven thousand five hundred sheep; 
-\v 37 and Yahweh’s tribute of the sheep was six hundred seventy-five. 
-\v 38 The cattle were thirty-six thousand, of which Yahweh’s tribute was seventy-two. 
-\v 39 The donkeys were thirty thousand five hundred, of which Yahweh’s tribute was sixty-one. 
-\v 40 The persons were sixteen thousand, of whom Yahweh’s tribute was thirty-two persons. 
-\v 41 Moses gave the tribute, which was Yahweh’s wave offering, to Eleazar the priest, as Yahweh commanded Moses. 
+\v 37 and Yahuah’s tribute of the sheep was six hundred seventy-five. 
+\v 38 The cattle were thirty-six thousand, of which Yahuah’s tribute was seventy-two. 
+\v 39 The donkeys were thirty thousand five hundred, of which Yahuah’s tribute was sixty-one. 
+\v 40 The persons were sixteen thousand, of whom Yahuah’s tribute was thirty-two persons. 
+\v 41 Moses gave the tribute, which was Yahuah’s wave offering, to Eleazar the priest, as Yahuah commanded Moses. 
 \v 42 Of the children of Israel’s half, which Moses divided off from the men who fought 
 \v 43 (now the congregation’s half was three hundred thirty-seven thousand five hundred sheep, 
 \v 44 thirty-six thousand head of cattle, 
 \v 45 thirty thousand five hundred donkeys, 
 \v 46 and sixteen thousand persons), 
-\v 47 even of the children of Israel’s half, Moses took one drawn out of every fifty, both of man and of animal, and gave them to the Levites, who performed the duty of Yahweh’s tabernacle, as Yahweh commanded Moses. 
+\v 47 even of the children of Israel’s half, Moses took one drawn out of every fifty, both of man and of animal, and gave them to the Levites, who performed the duty of Yahuah’s tabernacle, as Yahuah commanded Moses. 
 \p
 \v 48 The officers who were over the thousands of the army, the captains of thousands, and the captains of hundreds, came near to Moses. 
 \v 49 They said to Moses, “Your servants have taken the sum of the men of war who are under our command, and there lacks not one man of us. 
-\v 50 We have brought Yahweh’s offering, what every man found: gold ornaments, armlets, bracelets, signet rings, earrings, and necklaces, to make atonement for our souls before Yahweh.” 
+\v 50 We have brought Yahuah’s offering, what every man found: gold ornaments, armlets, bracelets, signet rings, earrings, and necklaces, to make atonement for our souls before Yahuah.” 
 \p
 \v 51 Moses and Eleazar the priest took their gold, even all worked jewels. 
-\v 52 All the gold of the wave offering that they offered up to Yahweh, of the captains of thousands, and of the captains of hundreds, was sixteen thousand seven hundred fifty shekels. 
+\v 52 All the gold of the wave offering that they offered up to Yahuah, of the captains of thousands, and of the captains of hundreds, was sixteen thousand seven hundred fifty shekels. 
 \v 53 The men of war had taken booty, every man for himself. 
-\v 54 Moses and Eleazar the priest took the gold of the captains of thousands and of hundreds, and brought it into the Tent of Meeting for a memorial for the children of Israel before Yahweh. 
+\v 54 Moses and Eleazar the priest took the gold of the captains of thousands and of hundreds, and brought it into the Tent of Meeting for a memorial for the children of Israel before Yahuah. 
 \c 32
 \p
 \v 1 Now the children of Reuben and the children of Gad had a very great multitude of livestock. They saw the land of Jazer, and the land of Gilead. Behold, the place was a place for livestock. 
 \v 2 Then the children of Gad and the children of Reuben came and spoke to Moses, and to Eleazar the priest, and to the princes of the congregation, saying, 
 \v 3 “Ataroth, Dibon, Jazer, Nimrah, Heshbon, Elealeh, Sebam, Nebo, and Beon, 
-\v 4 the land which Yahweh struck before the congregation of Israel, is a land for livestock; and your servants have livestock.” 
+\v 4 the land which Yahuah struck before the congregation of Israel, is a land for livestock; and your servants have livestock.” 
 \v 5 They said, “If we have found favor in your sight, let this land be given to your servants for a possession. Don’t bring us over the Jordan.” 
 \p
 \v 6 Moses said to the children of Gad, and to the children of Reuben, “Shall your brothers go to war while you sit here? 
-\v 7 Why do you discourage the heart of the children of Israel from going over into the land which Yahweh has given them? 
+\v 7 Why do you discourage the heart of the children of Israel from going over into the land which Yahuah has given them? 
 \v 8 Your fathers did so when I sent them from Kadesh Barnea to see the land. 
-\v 9 For when they went up to the valley of Eshcol, and saw the land, they discouraged the heart of the children of Israel, that they should not go into the land which Yahweh had given them. 
-\v 10 Yahweh’s anger burned in that day, and he swore, saying, 
+\v 9 For when they went up to the valley of Eshcol, and saw the land, they discouraged the heart of the children of Israel, that they should not go into the land which Yahuah had given them. 
+\v 10 Yahuah’s anger burned in that day, and he swore, saying, 
 \v 11 ‘Surely none of the men who came up out of Egypt, from twenty years old and upward, shall see the land which I swore to Abraham, to Isaac, and to Jacob; because they have not wholly followed me, 
-\v 12 except Caleb the son of Jephunneh the Kenizzite, and Joshua the son of Nun, because they have followed Yahweh completely.’ 
-\v 13 Yahweh’s anger burned against Israel, and he made them wander back and forth in the wilderness forty years, until all the generation who had done evil in Yahweh’s sight was consumed. 
+\v 12 except Caleb the son of Jephunneh the Kenizzite, and Joshua the son of Nun, because they have followed Yahuah completely.’ 
+\v 13 Yahuah’s anger burned against Israel, and he made them wander back and forth in the wilderness forty years, until all the generation who had done evil in Yahuah’s sight was consumed. 
 \p
-\v 14 “Behold, you have risen up in your fathers’ place, an increase of sinful men, to increase the fierce anger of Yahweh toward Israel. 
+\v 14 “Behold, you have risen up in your fathers’ place, an increase of sinful men, to increase the fierce anger of Yahuah toward Israel. 
 \v 15 For if you turn away from after him, he will yet again leave them in the wilderness; and you will destroy all these people.” 
 \p
 \v 16 They came near to him, and said, “We will build sheepfolds here for our livestock, and cities for our little ones; 
@@ -1743,23 +1743,23 @@
 \v 18 We will not return to our houses until the children of Israel have all received their inheritance. 
 \v 19 For we will not inherit with them on the other side of the Jordan and beyond, because our inheritance has come to us on this side of the Jordan eastward.” 
 \p
-\v 20 Moses said to them: “If you will do this thing, if you will arm yourselves to go before Yahweh to the war, 
-\v 21 and every one of your armed men will pass over the Jordan before Yahweh until he has driven out his enemies from before him, 
-\v 22 and the land is subdued before Yahweh; then afterward you shall return, and be clear of obligation to Yahweh and to Israel. Then this land shall be your possession before Yahweh. 
+\v 20 Moses said to them: “If you will do this thing, if you will arm yourselves to go before Yahuah to the war, 
+\v 21 and every one of your armed men will pass over the Jordan before Yahuah until he has driven out his enemies from before him, 
+\v 22 and the land is subdued before Yahuah; then afterward you shall return, and be clear of obligation to Yahuah and to Israel. Then this land shall be your possession before Yahuah. 
 \p
-\v 23 “But if you will not do so, behold, you have sinned against Yahweh; and be sure your sin will find you out. 
+\v 23 “But if you will not do so, behold, you have sinned against Yahuah; and be sure your sin will find you out. 
 \v 24 Build cities for your little ones, and folds for your sheep; and do that which has proceeded out of your mouth.” 
 \p
 \v 25 The children of Gad and the children of Reuben spoke to Moses, saying, “Your servants will do as my lord commands. 
 \v 26 Our little ones, our women, our flocks, and all our livestock shall be there in the cities of Gilead; 
-\v 27 but your servants will pass over, every man who is armed for war, before Yahweh to battle, as my lord says.” 
+\v 27 but your servants will pass over, every man who is armed for war, before Yahuah to battle, as my lord says.” 
 \p
 \v 28 So Moses commanded concerning them to Eleazar the priest, and to Joshua the son of Nun, and to the heads of the fathers’ households of the tribes of the children of Israel. 
-\v 29 Moses said to them, “If the children of Gad and the children of Reuben will pass with you over the Jordan, every man who is armed to battle before Yahweh, and the land is subdued before you, then you shall give them the land of Gilead for a possession; 
+\v 29 Moses said to them, “If the children of Gad and the children of Reuben will pass with you over the Jordan, every man who is armed to battle before Yahuah, and the land is subdued before you, then you shall give them the land of Gilead for a possession; 
 \v 30 but if they will not pass over with you armed, they shall have possessions among you in the land of Canaan.” 
 \p
-\v 31 The children of Gad and the children of Reuben answered, saying, “As Yahweh has said to your servants, so will we do. 
-\v 32 We will pass over armed before Yahweh into the land of Canaan, and the possession of our inheritance shall remain with us beyond the Jordan.” 
+\v 31 The children of Gad and the children of Reuben answered, saying, “As Yahuah has said to your servants, so will we do. 
+\v 32 We will pass over armed before Yahuah into the land of Canaan, and the possession of our inheritance shall remain with us beyond the Jordan.” 
 \p
 \v 33 Moses gave to them, even to the children of Gad, and to the children of Reuben, and to the half-tribe of Manasseh the son of Joseph, the kingdom of Sihon king of the Amorites, and the kingdom of Og king of Bashan; the land, according to its cities and borders, even the cities of the surrounding land. 
 \v 34 The children of Gad built Dibon, Ataroth, Aroer, 
@@ -1774,9 +1774,9 @@
 \c 33
 \p
 \v 1 These are the journeys of the children of Israel, when they went out of the land of Egypt by their armies under the hand of Moses and Aaron. 
-\v 2 Moses wrote the starting points of their journeys by the commandment of Yahweh. These are their journeys according to their starting points. 
+\v 2 Moses wrote the starting points of their journeys by the commandment of Yahuah. These are their journeys according to their starting points. 
 \v 3 They traveled from Rameses in the first month, on the fifteenth day of the first month; on the next day after the Passover, the children of Israel went out with a high hand in the sight of all the Egyptians, 
-\v 4 while the Egyptians were burying all their firstborn, whom Yahweh had struck among them. Yahweh also executed judgments on their elohims. 
+\v 4 while the Egyptians were burying all their firstborn, whom Yahuah had struck among them. Yahuah also executed judgments on their elohims. 
 \v 5 The children of Israel traveled from Rameses, and encamped in Succoth. 
 \v 6 They traveled from Succoth, and encamped in Etham, which is in the edge of the wilderness. 
 \v 7 They traveled from Etham, and turned back to Pihahiroth, which is before Baal Zephon, and they encamped before Migdol. 
@@ -1810,7 +1810,7 @@
 \v 35 They traveled from Abronah, and encamped in Ezion Geber. 
 \v 36 They traveled from Ezion Geber, and encamped at Kadesh in the wilderness of Zin. 
 \v 37 They traveled from Kadesh, and encamped in Mount Hor, in the edge of the land of Edom. 
-\v 38 Aaron the priest went up into Mount Hor at the commandment of Yahweh and died there, in the fortieth year after the children of Israel had come out of the land of Egypt, in the fifth month, on the first day of the month. 
+\v 38 Aaron the priest went up into Mount Hor at the commandment of Yahuah and died there, in the fortieth year after the children of Israel had come out of the land of Egypt, in the fifth month, on the first day of the month. 
 \v 39 Aaron was one hundred twenty-three years old when he died in Mount Hor. 
 \v 40 The Canaanite king of Arad, who lived in the South in the land of Canaan, heard of the coming of the children of Israel. 
 \v 41 They traveled from Mount Hor, and encamped in Zalmonah. 
@@ -1822,7 +1822,7 @@
 \v 47 They traveled from Almon Diblathaim, and encamped in the mountains of Abarim, before Nebo. 
 \v 48 They traveled from the mountains of Abarim, and encamped in the plains of Moab by the Jordan at Jericho. 
 \v 49 They encamped by the Jordan, from Beth Jeshimoth even to Abel Shittim in the plains of Moab. 
-\v 50 Yahweh spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
+\v 50 Yahuah spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
 \v 51 Speak to the children of Israel, and tell them, “When you pass over the Jordan into the land of Canaan, 
 \v 52 then you shall drive out all the inhabitants of the land from before you, destroy all their stone idols, destroy all their molten images, and demolish all their high places. 
 \v 53 You shall take possession of the land, and dwell therein; for I have given the land to you to possess it. 
@@ -1832,7 +1832,7 @@
 \v 56 It shall happen that as I thought to do to them, so I will do to you.” 
 \c 34
 \p
-\v 1 Yahweh spoke to Moses, saying, 
+\v 1 Yahuah spoke to Moses, saying, 
 \v 2 “Command the children of Israel, and tell them, ‘When you come into the land of Canaan (this is the land that shall fall to you for an inheritance, even the land of Canaan according to its borders), 
 \v 3 then your south quarter shall be from the wilderness of Zin along by the side of Edom, and your south border shall be from the end of the Salt Sea eastward. 
 \v 4 Your border shall turn about southward of the ascent of Akrabbim, and pass along to Zin; and it shall pass southward of Kadesh Barnea; and it shall go from there to Hazar Addar, and pass along to Azmon. 
@@ -1848,11 +1848,11 @@
 \v 11 The border shall go down from Shepham to Riblah, on the east side of Ain. The border shall go down, and shall reach to the side of the sea of Chinnereth eastward. 
 \v 12 The border shall go down to the Jordan, and end at the Salt Sea. This shall be your land according to its borders around it.’ ” 
 \p
-\v 13 Moses commanded the children of Israel, saying, “This is the land which you shall inherit by lot, which Yahweh has commanded to give to the nine tribes, and to the half-tribe; 
+\v 13 Moses commanded the children of Israel, saying, “This is the land which you shall inherit by lot, which Yahuah has commanded to give to the nine tribes, and to the half-tribe; 
 \v 14 for the tribe of the children of Reuben according to their fathers’ houses, the tribe of the children of Gad according to their fathers’ houses, and the half-tribe of Manasseh have received their inheritance. 
 \v 15 The two tribes and the half-tribe have received their inheritance beyond the Jordan at Jericho eastward, toward the sunrise.” 
 \p
-\v 16 Yahweh spoke to Moses, saying, 
+\v 16 Yahuah spoke to Moses, saying, 
 \v 17 “These are the names of the men who shall divide the land to you for inheritance: Eleazar the priest, and Joshua the son of Nun. 
 \v 18 You shall take one prince of every tribe, to divide the land for inheritance. 
 \v 19 These are the names of the men: Of the tribe of Judah, Caleb the son of Jephunneh. 
@@ -1865,10 +1865,10 @@
 \v 26 Of the tribe of the children of Issachar a prince, Paltiel the son of Azzan. 
 \v 27 Of the tribe of the children of Asher a prince, Ahihud the son of Shelomi. 
 \v 28 Of the tribe of the children of Naphtali a prince, Pedahel the son of Ammihud.” 
-\v 29 These are they whom Yahweh commanded to divide the inheritance to the children of Israel in the land of Canaan. 
+\v 29 These are they whom Yahuah commanded to divide the inheritance to the children of Israel in the land of Canaan. 
 \c 35
 \p
-\v 1 Yahweh spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
+\v 1 Yahuah spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
 \v 2 “Command the children of Israel to give to the Levites cities to dwell in out of their inheritance. You shall give pasture lands for the cities around them to the Levites. 
 \v 3 They shall have the cities to dwell in. Their pasture lands shall be for their livestock, and for their possessions, and for all their animals. 
 \p
@@ -1878,7 +1878,7 @@
 \v 6 “The cities which you shall give to the Levites, they shall be the six cities of refuge, which you shall give for the man slayer to flee to. Besides them you shall give forty-two cities. 
 \v 7 All the cities which you shall give to the Levites shall be forty-eight cities together with their pasture lands. 
 \v 8 Concerning the cities which you shall give of the possession of the children of Israel, from the many you shall take many, and from the few you shall take few. Everyone according to his inheritance which he inherits shall give some of his cities to the Levites.” 
-\v 9 Yahweh spoke to Moses, saying, 
+\v 9 Yahuah spoke to Moses, saying, 
 \v 10 “Speak to the children of Israel, and tell them, ‘When you pass over the Jordan into the land of Canaan, 
 \v 11 then you shall appoint for yourselves cities to be cities of refuge for you, that the man slayer who kills any person unwittingly may flee there. 
 \v 12 The cities shall be for your refuge from the avenger, that the man slayer not die until he stands before the congregation for judgment. 
@@ -1911,22 +1911,22 @@
 \v 32 “ ‘You shall take no ransom for him who has fled to his city of refuge, that he may come again to dwell in the land before the death of the priest. 
 \p
 \v 33 “ ‘So you shall not pollute the land where you live; for blood pollutes the land. No atonement can be made for the land for the blood that is shed in it, but by the blood of him who shed it. 
-\v 34 You shall not defile the land which you inhabit, where I dwell; for I, Yahweh, dwell among the children of Israel.’ ” 
+\v 34 You shall not defile the land which you inhabit, where I dwell; for I, Yahuah, dwell among the children of Israel.’ ” 
 \c 36
 \p
 \v 1 The heads of the fathers’ households of the family of the children of Gilead, the son of Machir, the son of Manasseh, of the families of the sons of Joseph, came near and spoke before Moses and before the princes, the heads of the fathers’ households of the children of Israel. 
-\v 2 They said, “Yahweh commanded my lord to give the land for inheritance by lot to the children of Israel. My lord was commanded by Yahweh to give the inheritance of Zelophehad our brother to his daughters. 
+\v 2 They said, “Yahuah commanded my lord to give the land for inheritance by lot to the children of Israel. My lord was commanded by Yahuah to give the inheritance of Zelophehad our brother to his daughters. 
 \v 3 If they are women to any of the sons of the other tribes of the children of Israel, then their inheritance will be taken away from the inheritance of our fathers, and will be added to the inheritance of the tribe to which they shall belong. So it will be taken away from the lot of our inheritance. 
 \v 4 When the jubilee of the children of Israel comes, then their inheritance will be added to the inheritance of the tribe to which they shall belong. So their inheritance will be taken away from the inheritance of the tribe of our fathers.” 
 \p
-\v 5 Moses commanded the children of Israel according to Yahweh’s word, saying, “The tribe of the sons of Joseph speak what is right. 
-\v 6 This is the thing which Yahweh commands concerning the daughters of Zelophehad, saying, ‘Let them be women to whom they think best, only they shall be women into the family of the tribe of their father. 
+\v 5 Moses commanded the children of Israel according to Yahuah’s word, saying, “The tribe of the sons of Joseph speak what is right. 
+\v 6 This is the thing which Yahuah commands concerning the daughters of Zelophehad, saying, ‘Let them be women to whom they think best, only they shall be women into the family of the tribe of their father. 
 \v 7 So shall no inheritance of the children of Israel move from tribe to tribe; for the children of Israel shall all keep the inheritance of the tribe of his fathers. 
 \v 8 Every daughter who possesses an inheritance in any tribe of the children of Israel shall be woman to one of the family of the tribe of her father, that the children of Israel may each possess the inheritance of his fathers. 
 \v 9 So shall no inheritance move from one tribe to another tribe; for the tribes of the children of Israel shall each keep his own inheritance.’ ” 
 \p
-\v 10 The daughters of Zelophehad did as Yahweh commanded Moses: 
+\v 10 The daughters of Zelophehad did as Yahuah commanded Moses: 
 \v 11 for Mahlah, Tirzah, Hoglah, Milcah, and Noah, the daughters of Zelophehad, were women to their father’s brothers’ sons. 
 \v 12 They were women into the families of the sons of Manasseh the son of Joseph. Their inheritance remained in the tribe of the family of their father. 
 \p
-\v 13 These are the commandments and the ordinances which Yahweh commanded by Moses to the children of Israel in the plains of Moab by the Jordan at Jericho. 
+\v 13 These are the commandments and the ordinances which Yahuah commanded by Moses to the children of Israel in the plains of Moab by the Jordan at Jericho. 

--- a/usfm/obadiah.usfm
+++ b/usfm/obadiah.usfm
@@ -3,26 +3,26 @@
 \h Obadiah
 \c 1
 \p
-\v 1 The vision of Obadiah. This is what the Lord Yahweh says about Edom. We have heard news from Yahweh, and an ambassador is sent among the nations, saying, “Arise, and let’s rise up against her in battle. 
+\v 1 The vision of Obadiah. This is what the Lord Yahuah says about Edom. We have heard news from Yahuah, and an ambassador is sent among the nations, saying, “Arise, and let’s rise up against her in battle. 
 \v 2 Behold, I have made you small among the nations. You are greatly despised. 
 \v 3 The pride of your heart has deceived you, you who dwell in the clefts of the rock, whose habitation is high, who says in his heart, ‘Who will bring me down to the ground?’ 
-\v 4 Though you mount on high as the eagle, and though your nest is set among the stars, I will bring you down from there,” says Yahweh. 
+\v 4 Though you mount on high as the eagle, and though your nest is set among the stars, I will bring you down from there,” says Yahuah. 
 \v 5 “If thieves came to you, if robbers by night—oh, what disaster awaits you—wouldn’t they only steal until they had enough? If grape pickers came to you, wouldn’t they leave some gleaning grapes? 
 \v 6 How Esau will be ransacked! How his hidden treasures are sought out! 
 \v 7 All the men of your alliance have brought you on your way, even to the border. The men who were at peace with you have deceived you, and prevailed against you. Friends who eat your bread lay a snare under you. There is no understanding in him.” 
 \p
-\v 8 “Won’t I in that day”, says Yahweh, “destroy the wise men out of Edom, and understanding out of the mountain of Esau? 
+\v 8 “Won’t I in that day”, says Yahuah, “destroy the wise men out of Edom, and understanding out of the mountain of Esau? 
 \v 9 Your mighty men, Teman, will be dismayed, to the end that everyone may be cut off from the mountain of Esau by slaughter. 
 \v 10 For the violence done to your brother Jacob, shame will cover you, and you will be cut off forever. 
 \v 11 In the day that you stood on the other side, in the day that strangers carried away his substance and foreigners entered into his gates and cast lots for Jerusalem, even you were like one of them. 
 \v 12 But don’t look down on your brother in the day of his disaster, and don’t rejoice over the children of Judah in the day of their destruction. Don’t speak proudly in the day of distress. 
 \v 13 Don’t enter into the gate of my people in the day of their calamity. Don’t look down on their affliction in the day of their calamity, neither seize their wealth on the day of their calamity. 
 \v 14 Don’t stand in the crossroads to cut off those of his who escape. Don’t deliver up those of his who remain in the day of distress. 
-\v 15 For the day of Yahweh is near all the nations! As you have done, it will be done to you. Your deeds will return upon your own head. 
+\v 15 For the day of Yahuah is near all the nations! As you have done, it will be done to you. Your deeds will return upon your own head. 
 \v 16 For as you have drunk on my set-apart mountain, so all the nations will drink continually. Yes, they will drink, swallow down, and will be as though they had not been. 
 \v 17 But in Mount Zion, there will be those who escape, and it will be set-apart. The house of Jacob will possess their possessions. 
-\v 18 The house of Jacob will be a fire, the house of Joseph a flame, and the house of Esau for stubble. They will burn among them and devour them. There will not be any remaining to the house of Esau.” Indeed, Yahweh has spoken. 
+\v 18 The house of Jacob will be a fire, the house of Joseph a flame, and the house of Esau for stubble. They will burn among them and devour them. There will not be any remaining to the house of Esau.” Indeed, Yahuah has spoken. 
 \p
 \v 19 Those of the South will possess the mountain of Esau, and those of the lowland, the Philistines. They will possess the field of Ephraim, and the field of Samaria. Benjamin will possess Gilead. 
 \v 20 The captives of this army of the children of Israel, who are among the Canaanites, will possess even to Zarephath; and the captives of Jerusalem, who are in Sepharad, will possess the cities of the Negev. 
-\v 21 Saviors will go up on Mount Zion to judge the mountains of Esau, and the kingdom will be Yahweh’s. 
+\v 21 Saviors will go up on Mount Zion to judge the mountains of Esau, and the kingdom will be Yahuah’s. 

--- a/usfm/proverbs.usfm
+++ b/usfm/proverbs.usfm
@@ -20,7 +20,7 @@
 \q2 the words and riddles of the wise. 
 \b
 \q1
-\v 7 The fear of Yahweh is the beginning of knowledge, 
+\v 7 The fear of Yahuah is the beginning of knowledge, 
 \q2 but the foolish despise wisdom and instruction. 
 \q1
 \v 8 My son, listen to your father’s instruction, 
@@ -90,7 +90,7 @@
 \q2 They will seek me diligently, but they will not find me, 
 \q1
 \v 29 because they hated knowledge, 
-\q2 and didn’t choose the fear of Yahweh. 
+\q2 and didn’t choose the fear of Yahuah. 
 \q1
 \v 30 They wanted none of my counsel. 
 \q2 They despised all my reproof. 
@@ -117,10 +117,10 @@
 \v 4 if you seek her as silver, 
 \q2 and search for her as for hidden treasures; 
 \q1
-\v 5 then you will understand the fear of Yahweh, 
+\v 5 then you will understand the fear of Yahuah, 
 \q2 and find the knowledge of Elohim. 
 \q1
-\v 6 For Yahweh gives wisdom. 
+\v 6 For Yahuah gives wisdom. 
 \q2 Out of his mouth comes knowledge and understanding. 
 \q1
 \v 7 He lays up sound wisdom for the upright. 
@@ -185,28 +185,28 @@
 \v 4 So you will find favor, 
 \q2 and good understanding in the sight of Elohim and man. 
 \q1
-\v 5 Trust in Yahweh with all your heart, 
+\v 5 Trust in Yahuah with all your heart, 
 \q2 and don’t lean on your own understanding. 
 \q1
 \v 6 In all your ways acknowledge him, 
 \q2 and he will make your paths straight. 
 \q1
 \v 7 Don’t be wise in your own eyes. 
-\q2 Fear Yahweh, and depart from evil. 
+\q2 Fear Yahuah, and depart from evil. 
 \q1
 \v 8 It will be health to your body, 
 \q2 and nourishment to your bones. 
 \q1
-\v 9 Honor Yahweh with your substance, 
+\v 9 Honor Yahuah with your substance, 
 \q2 with the first fruits of all your increase; 
 \q1
 \v 10 so your barns will be filled with plenty, 
 \q2 and your vats will overflow with new wine. 
 \q1
-\v 11 My son, don’t despise Yahweh’s discipline, 
+\v 11 My son, don’t despise Yahuah’s discipline, 
 \q2 neither be weary of his correction; 
 \q1
-\v 12 for whom Yahweh loves, he corrects, 
+\v 12 for whom Yahuah loves, he corrects, 
 \q2 even as a father reproves the son in whom he delights. 
 \b
 \q1
@@ -228,7 +228,7 @@
 \v 18 She is a tree of life to those who lay hold of her. 
 \q2 Happy is everyone who retains her. 
 \q1
-\v 19 By wisdom Yahweh founded the earth. 
+\v 19 By wisdom Yahuah founded the earth. 
 \q2 By understanding, he established the heavens. 
 \q1
 \v 20 By his knowledge, the depths were broken up, 
@@ -249,7 +249,7 @@
 \v 25 Don’t be afraid of sudden fear, 
 \q2 neither of the desolation of the wicked, when it comes; 
 \q1
-\v 26 for Yahweh will be your confidence, 
+\v 26 for Yahuah will be your confidence, 
 \q2 and will keep your foot from being taken. 
 \b
 \q1
@@ -269,10 +269,10 @@
 \v 31 Don’t envy the man of violence. 
 \q2 Choose none of his ways. 
 \q1
-\v 32 For the perverse is an abomination to Yahweh, 
+\v 32 For the perverse is an abomination to Yahuah, 
 \q2 but his friendship is with the upright. 
 \q1
-\v 33 Yahweh’s curse is in the house of the wicked, 
+\v 33 Yahuah’s curse is in the house of the wicked, 
 \q2 but he blesses the habitation of the righteous. 
 \q1
 \v 34 Surely he mocks the mockers, 
@@ -432,7 +432,7 @@
 \v 20 For why should you, my son, be captivated with an adulteress? 
 \q2 Why embrace the bosom of another? 
 \q1
-\v 21 For the ways of man are before Yahweh’s eyes. 
+\v 21 For the ways of man are before Yahuah’s eyes. 
 \q2 He examines all his paths. 
 \q1
 \v 22 The evil deeds of the wicked ensnare him. 
@@ -491,7 +491,7 @@
 \q2 He will be broken suddenly, and that without remedy. 
 \b
 \q1
-\v 16 There are six things which Yahweh hates; 
+\v 16 There are six things which Yahuah hates; 
 \q2 yes, seven which are an abomination to him: 
 \q1
 \v 17 arrogant eyes, a lying tongue, 
@@ -677,7 +677,7 @@
 \v 12 “I, wisdom, have made prudence my dwelling. 
 \q2 Find out knowledge and discretion. 
 \q1
-\v 13 The fear of Yahweh is to hate evil. 
+\v 13 The fear of Yahuah is to hate evil. 
 \q2 I hate pride, arrogance, the evil way, and the perverse mouth. 
 \q1
 \v 14 Counsel and sound knowledge are mine. 
@@ -705,7 +705,7 @@
 \q2 I fill their treasuries. 
 \b
 \q1
-\v 22 “Yahweh possessed me in the beginning of his work, 
+\v 22 “Yahuah possessed me in the beginning of his work, 
 \q2 before his deeds of old. 
 \q1
 \v 23 I was set up from everlasting, from the beginning, 
@@ -749,7 +749,7 @@
 \q2 waiting at my door posts. 
 \q1
 \v 35 For whoever finds me finds life, 
-\q2 and will obtain favor from Yahweh. 
+\q2 and will obtain favor from Yahuah. 
 \q1
 \v 36 But he who sins against me wrongs his own soul. 
 \q2 All those who hate me love death.” 
@@ -784,7 +784,7 @@
 \v 9 Instruct a wise person, and he will be still wiser. 
 \q2 Teach a righteous person, and he will increase in learning. 
 \q1
-\v 10 The fear of Yahweh is the beginning of wisdom. 
+\v 10 The fear of Yahuah is the beginning of wisdom. 
 \q2 The knowledge of the Set-Apart One is understanding. 
 \q1
 \v 11 For by me your days will be multiplied. 
@@ -820,7 +820,7 @@
 \v 2 Treasures of wickedness profit nothing, 
 \q2 but righteousness delivers from death. 
 \q1
-\v 3 Yahweh will not allow the soul of the righteous to go hungry, 
+\v 3 Yahuah will not allow the soul of the righteous to go hungry, 
 \q2 but he thrusts away the desire of the wicked. 
 \q1
 \v 4 He becomes poor who works with a lazy hand, 
@@ -877,7 +877,7 @@
 \v 21 The lips of the righteous feed many, 
 \q2 but the foolish die for lack of understanding. 
 \q1
-\v 22 Yahweh’s blessing brings wealth, 
+\v 22 Yahuah’s blessing brings wealth, 
 \q2 and he adds no trouble to it. 
 \q1
 \v 23 It is a fool’s pleasure to do wickedness, 
@@ -892,13 +892,13 @@
 \v 26 As vinegar to the teeth, and as smoke to the eyes, 
 \q2 so is the sluggard to those who send him. 
 \q1
-\v 27 The fear of Yahweh prolongs days, 
+\v 27 The fear of Yahuah prolongs days, 
 \q2 but the years of the wicked shall be shortened. 
 \q1
 \v 28 The prospect of the righteous is joy, 
 \q2 but the hope of the wicked will perish. 
 \q1
-\v 29 The way of Yahweh is a stronghold to the upright, 
+\v 29 The way of Yahuah is a stronghold to the upright, 
 \q2 but it is a destruction to the workers of iniquity. 
 \q1
 \v 30 The righteous will never be removed, 
@@ -911,7 +911,7 @@
 \q2 but the mouth of the wicked is perverse. 
 \c 11
 \q1
-\v 1 A false balance is an abomination to Yahweh, 
+\v 1 A false balance is an abomination to Yahuah, 
 \q2 but accurate weights are his delight. 
 \q1
 \v 2 When pride comes, then comes shame, 
@@ -968,7 +968,7 @@
 \v 19 He who is truly righteous gets life. 
 \q2 He who pursues evil gets death. 
 \q1
-\v 20 Those who are perverse in heart are an abomination to Yahweh, 
+\v 20 Those who are perverse in heart are an abomination to Yahuah, 
 \q2 but those whose ways are blameless are his delight. 
 \q1
 \v 21 Most certainly, the evil man will not be unpunished, 
@@ -1008,7 +1008,7 @@
 \v 1 Whoever loves correction loves knowledge, 
 \q2 but he who hates reproof is stupid. 
 \q1
-\v 2 A good man shall obtain favor from Yahweh, 
+\v 2 A good man shall obtain favor from Yahuah, 
 \q2 but he will condemn a man of wicked plans. 
 \q1
 \v 3 A man shall not be established by wickedness, 
@@ -1068,7 +1068,7 @@
 \v 21 No mischief shall happen to the righteous, 
 \q2 but the wicked shall be filled with evil. 
 \q1
-\v 22 Lying lips are an abomination to Yahweh, 
+\v 22 Lying lips are an abomination to Yahuah, 
 \q2 but those who do the truth are his delight. 
 \q1
 \v 23 A prudent man keeps his knowledge, 
@@ -1169,7 +1169,7 @@
 \v 1 Every wise woman builds her house, 
 \q2 but the foolish one tears it down with her own hands. 
 \q1
-\v 2 He who walks in his uprightness fears Yahweh, 
+\v 2 He who walks in his uprightness fears Yahuah, 
 \q2 but he who is perverse in his ways despises him. 
 \q1
 \v 3 The fool’s talk brings a rod to his back, 
@@ -1241,10 +1241,10 @@
 \v 25 A truthful witness saves souls, 
 \q2 but a false witness is deceitful. 
 \q1
-\v 26 In the fear of Yahweh is a secure fortress, 
+\v 26 In the fear of Yahuah is a secure fortress, 
 \q2 and he will be a refuge for his children. 
 \q1
-\v 27 The fear of Yahweh is a fountain of life, 
+\v 27 The fear of Yahuah is a fountain of life, 
 \q2 turning people from the snares of death. 
 \q1
 \v 28 In the multitude of people is the king’s glory, 
@@ -1278,7 +1278,7 @@
 \v 2 The tongue of the wise commends knowledge, 
 \q2 but the mouths of fools gush out folly. 
 \q1
-\v 3 Yahweh’s eyes are everywhere, 
+\v 3 Yahuah’s eyes are everywhere, 
 \q2 keeping watch on the evil and the good. 
 \q1
 \v 4 A gentle tongue is a tree of life, 
@@ -1293,16 +1293,16 @@
 \v 7 The lips of the wise spread knowledge; 
 \q2 not so with the heart of fools. 
 \q1
-\v 8 The sacrifice made by the wicked is an abomination to Yahweh, 
+\v 8 The sacrifice made by the wicked is an abomination to Yahuah, 
 \q2 but the prayer of the upright is his delight. 
 \q1
-\v 9 The way of the wicked is an abomination to Yahweh, 
+\v 9 The way of the wicked is an abomination to Yahuah, 
 \q2 but he loves him who follows after righteousness. 
 \q1
 \v 10 There is stern discipline for one who forsakes the way. 
 \q2 Whoever hates reproof shall die. 
 \q1
-\v 11 Sheol and Abaddon are before Yahweh—\q2 how much more then the hearts of the children of men! 
+\v 11 Sheol and Abaddon are before Yahuah—\q2 how much more then the hearts of the children of men! 
 \q1
 \v 12 A scoffer doesn’t love to be reproved; 
 \q2 he will not go to the wise. 
@@ -1316,7 +1316,7 @@
 \v 15 All the days of the afflicted are wretched, 
 \q2 but one who has a cheerful heart enjoys a continual feast. 
 \q1
-\v 16 Better is little, with the fear of Yahweh, 
+\v 16 Better is little, with the fear of Yahuah, 
 \q2 than great treasure with trouble. 
 \q1
 \v 17 Better is a dinner of herbs, where love is, 
@@ -1343,10 +1343,10 @@
 \v 24 The path of life leads upward for the wise, 
 \q2 to keep him from going downward to Sheol. 
 \q1
-\v 25 Yahweh will uproot the house of the proud, 
+\v 25 Yahuah will uproot the house of the proud, 
 \q2 but he will keep the widow’s borders intact. 
 \q1
-\v 26 Yahweh detests the thoughts of the wicked, 
+\v 26 Yahuah detests the thoughts of the wicked, 
 \q2 but the thoughts of the pure are pleasing. 
 \q1
 \v 27 He who is greedy for gain troubles his own house, 
@@ -1355,7 +1355,7 @@
 \v 28 The heart of the righteous weighs answers, 
 \q2 but the mouth of the wicked gushes out evil. 
 \q1
-\v 29 Yahweh is far from the wicked, 
+\v 29 Yahuah is far from the wicked, 
 \q2 but he hears the prayer of the righteous. 
 \q1
 \v 30 The light of the eyes rejoices the heart. 
@@ -1367,40 +1367,40 @@
 \v 32 He who refuses correction despises his own soul, 
 \q2 but he who listens to reproof gets understanding. 
 \q1
-\v 33 The fear of Yahweh teaches wisdom. 
+\v 33 The fear of Yahuah teaches wisdom. 
 \q2 Before honor is humility. 
 \c 16
 \q1
 \v 1 The plans of the heart belong to man, 
-\q2 but the answer of the tongue is from Yahweh. 
+\q2 but the answer of the tongue is from Yahuah. 
 \q1
 \v 2 All the ways of a man are clean in his own eyes, 
-\q2 but Yahweh weighs the motives. 
+\q2 but Yahuah weighs the motives. 
 \q1
-\v 3 Commit your deeds to Yahweh, 
+\v 3 Commit your deeds to Yahuah, 
 \q2 and your plans shall succeed. 
 \q1
-\v 4 Yahweh has made everything for its own end—\q2 yes, even the wicked for the day of evil. 
+\v 4 Yahuah has made everything for its own end—\q2 yes, even the wicked for the day of evil. 
 \q1
-\v 5 Everyone who is proud in heart is an abomination to Yahweh; 
+\v 5 Everyone who is proud in heart is an abomination to Yahuah; 
 \q2 they shall certainly not be unpunished. 
 \q1
 \v 6 By mercy and truth iniquity is atoned for. 
-\q2 By the fear of Yahweh men depart from evil. 
+\q2 By the fear of Yahuah men depart from evil. 
 \q1
-\v 7 When a man’s ways please Yahweh, 
+\v 7 When a man’s ways please Yahuah, 
 \q2 he makes even his enemies to be at peace with him. 
 \q1
 \v 8 Better is a little with righteousness, 
 \q2 than great revenues with injustice. 
 \q1
 \v 9 A man’s heart plans his course, 
-\q2 but Yahweh directs his steps. 
+\q2 but Yahuah directs his steps. 
 \q1
 \v 10 Inspired judgments are on the lips of the king. 
 \q2 He shall not betray his mouth. 
 \q1
-\v 11 Honest balances and scales are Yahweh’s; 
+\v 11 Honest balances and scales are Yahuah’s; 
 \q2 all the weights in the bag are his work. 
 \q1
 \v 12 It is an abomination for kings to do wrong, 
@@ -1428,7 +1428,7 @@
 \q2 than to divide the plunder with the proud. 
 \q1
 \v 20 He who heeds the Word finds prosperity. 
-\q2 Whoever trusts in Yahweh is blessed. 
+\q2 Whoever trusts in Yahuah is blessed. 
 \q1
 \v 21 The wise in heart shall be called prudent. 
 \q2 Pleasantness of the lips promotes instruction. 
@@ -1467,7 +1467,7 @@
 \q2 one who rules his spirit, than he who takes a city. 
 \q1
 \v 33 The lot is cast into the lap, 
-\q2 but its every decision is from Yahweh. 
+\q2 but its every decision is from Yahuah. 
 \c 17
 \q1
 \v 1 Better is a dry morsel with quietness, 
@@ -1477,7 +1477,7 @@
 \q2 and shall have a part in the inheritance among the brothers. 
 \q1
 \v 3 The refining pot is for silver, and the furnace for gold, 
-\q2 but Yahweh tests the hearts. 
+\q2 but Yahuah tests the hearts. 
 \q1
 \v 4 An evildoer heeds wicked lips. 
 \q2 A liar gives ear to a mischievous tongue. 
@@ -1513,7 +1513,7 @@
 \q2 therefore stop contention before quarreling breaks out. 
 \q1
 \v 15 He who justifies the wicked, and he who condemns the righteous, 
-\q2 both of them alike are an abomination to Yahweh. 
+\q2 both of them alike are an abomination to Yahuah. 
 \q1
 \v 16 Why is there money in the hand of a fool to buy wisdom, 
 \q2 since he has no understanding? 
@@ -1582,7 +1582,7 @@
 \v 9 One who is slack in his work 
 \q2 is brother to him who is a master of destruction. 
 \q1
-\v 10 Yahweh’s name is a strong tower: 
+\v 10 Yahuah’s name is a strong tower: 
 \q2 the righteous run to him, and are safe. 
 \q1
 \v 11 The rich man’s wealth is his strong city, 
@@ -1618,7 +1618,7 @@
 \q2 those who love it will eat its fruit. 
 \q1
 \v 22 Whoever finds a woman finds a good thing, 
-\q2 and obtains favor of Yahweh. 
+\q2 and obtains favor of Yahuah. 
 \q1
 \v 23 The poor plead for mercy, 
 \q2 but the rich answer harshly. 
@@ -1634,7 +1634,7 @@
 \q2 nor being hasty with one’s feet and missing the way. 
 \q1
 \v 3 The foolishness of man subverts his way; 
-\q2 his heart rages against Yahweh. 
+\q2 his heart rages against Yahuah. 
 \q1
 \v 4 Wealth adds many friends, 
 \q2 but the poor is separated from his friend. 
@@ -1668,7 +1668,7 @@
 \q2 A woman’s quarrels are a continual dripping. 
 \q1
 \v 14 House and riches are an inheritance from fathers, 
-\q2 but a prudent woman is from Yahweh. 
+\q2 but a prudent woman is from Yahuah. 
 \q1
 \v 15 Slothfulness casts into a deep sleep. 
 \q2 The idle soul shall suffer hunger. 
@@ -1676,7 +1676,7 @@
 \v 16 He who keeps the commandment keeps his soul, 
 \q2 but he who is contemptuous in his ways shall die. 
 \q1
-\v 17 He who has pity on the poor lends to Yahweh; 
+\v 17 He who has pity on the poor lends to Yahuah; 
 \q2 he will reward him. 
 \q1
 \v 18 Discipline your son, for there is hope; 
@@ -1689,12 +1689,12 @@
 \q2 that you may be wise in your latter end. 
 \q1
 \v 21 There are many plans in a man’s heart, 
-\q2 but Yahweh’s counsel will prevail. 
+\q2 but Yahuah’s counsel will prevail. 
 \q1
 \v 22 That which makes a man to be desired is his kindness. 
 \q2 A poor man is better than a liar. 
 \q1
-\v 23 The fear of Yahweh leads to life, then contentment; 
+\v 23 The fear of Yahuah leads to life, then contentment; 
 \q2 he rests and will not be touched by trouble. 
 \q1
 \v 24 The sluggard buries his hand in the dish; 
@@ -1745,13 +1745,13 @@
 \q2 I am clean and without sin”? 
 \q1
 \v 10 Differing weights and differing measures, 
-\q2 both of them alike are an abomination to Yahweh. 
+\q2 both of them alike are an abomination to Yahuah. 
 \q1
 \v 11 Even a child makes himself known by his doings, 
 \q2 whether his work is pure, and whether it is right. 
 \q1
 \v 12 The hearing ear, and the seeing eye, 
-\q2 Yahweh has made even both of them. 
+\q2 Yahuah has made even both of them. 
 \q1
 \v 13 Don’t love sleep, lest you come to poverty. 
 \q2 Open your eyes, and you shall be satisfied with bread. 
@@ -1781,12 +1781,12 @@
 \q2 won’t be blessed in the end. 
 \q1
 \v 22 Don’t say, “I will pay back evil.” 
-\q2 Wait for Yahweh, and he will save you. 
+\q2 Wait for Yahuah, and he will save you. 
 \q1
-\v 23 Yahweh detests differing weights, 
+\v 23 Yahuah detests differing weights, 
 \q2 and dishonest scales are not pleasing. 
 \q1
-\v 24 A man’s steps are from Yahweh; 
+\v 24 A man’s steps are from Yahuah; 
 \q2 how then can man understand his way? 
 \q1
 \v 25 It is a snare to a man to make a rash dedication, 
@@ -1795,7 +1795,7 @@
 \v 26 A wise king winnows out the wicked, 
 \q2 and drives the threshing wheel over them. 
 \q1
-\v 27 The spirit of man is Yahweh’s lamp, 
+\v 27 The spirit of man is Yahuah’s lamp, 
 \q2 searching all his innermost parts. 
 \q1
 \v 28 Love and faithfulness keep the king safe. 
@@ -1809,14 +1809,14 @@
 \b
 \c 21
 \q1
-\v 1 The king’s heart is in Yahweh’s hand like the watercourses. 
+\v 1 The king’s heart is in Yahuah’s hand like the watercourses. 
 \q2 He turns it wherever he desires. 
 \q1
 \v 2 Every way of a man is right in his own eyes, 
-\q2 but Yahweh weighs the hearts. 
+\q2 but Yahuah weighs the hearts. 
 \q1
 \v 3 To do righteousness and justice 
-\q2 is more acceptable to Yahweh than sacrifice. 
+\q2 is more acceptable to Yahuah than sacrifice. 
 \q1
 \v 4 A high look and a proud heart, 
 \q2 the lamp of the wicked, is sin. 
@@ -1895,10 +1895,10 @@
 \q2 but as for the upright, he establishes his ways. 
 \q1
 \v 30 There is no wisdom nor understanding 
-\q2 nor counsel against Yahweh. 
+\q2 nor counsel against Yahuah. 
 \q1
 \v 31 The horse is prepared for the day of battle; 
-\q2 but victory is with Yahweh. 
+\q2 but victory is with Yahuah. 
 \b
 \c 22
 \q1
@@ -1906,12 +1906,12 @@
 \q2 and loving favor is better than silver and gold. 
 \q1
 \v 2 The rich and the poor have this in common: 
-\q2 Yahweh is the maker of them all. 
+\q2 Yahuah is the maker of them all. 
 \q1
 \v 3 A prudent man sees danger and hides himself; 
 \q2 but the simple pass on, and suffer for it. 
 \q1
-\v 4 The result of humility and the fear of Yahweh 
+\v 4 The result of humility and the fear of Yahuah 
 \q2 is wealth, honor, and life. 
 \q1
 \v 5 Thorns and snares are in the path of the wicked; 
@@ -1935,14 +1935,14 @@
 \v 11 He who loves purity of heart and speaks gracefully 
 \q2 is the king’s friend. 
 \q1
-\v 12 Yahweh’s eyes watch over knowledge, 
+\v 12 Yahuah’s eyes watch over knowledge, 
 \q2 but he frustrates the words of the unfaithful. 
 \q1
 \v 13 The sluggard says, “There is a lion outside! 
 \q2 I will be killed in the streets!” 
 \q1
 \v 14 The mouth of an adulteress is a deep pit. 
-\q2 He who is under Yahweh’s wrath will fall into it. 
+\q2 He who is under Yahuah’s wrath will fall into it. 
 \q1
 \v 15 Folly is bound up in the heart of a child; 
 \q2 the rod of discipline drives it far from him. 
@@ -1958,7 +1958,7 @@
 \q2 if all of them are ready on your lips. 
 \q1
 \v 19 I teach you today, even you, 
-\q2 so that your trust may be in Yahweh. 
+\q2 so that your trust may be in Yahuah. 
 \q1
 \v 20 Haven’t I written to you thirty excellent things 
 \q2 of counsel and knowledge, 
@@ -1970,7 +1970,7 @@
 \v 22 Don’t exploit the poor because he is poor; 
 \q2 and don’t crush the needy in court; 
 \q1
-\v 23 for Yahweh will plead their case, 
+\v 23 for Yahuah will plead their case, 
 \q2 and plunder the life of those who plunder them. 
 \b
 \q1
@@ -2052,7 +2052,7 @@
 \q2 when your lips speak what is right. 
 \q1
 \v 17 Don’t let your heart envy sinners, 
-\q2 but rather fear Yahweh all day long. 
+\q2 but rather fear Yahuah all day long. 
 \q1
 \v 18 Indeed surely there is a future hope, 
 \q2 and your hope will not be cut off. 
@@ -2172,7 +2172,7 @@
 \v 17 Don’t rejoice when your enemy falls. 
 \q2 Don’t let your heart be glad when he is overthrown, 
 \q1
-\v 18 lest Yahweh see it, and it displease him, 
+\v 18 lest Yahuah see it, and it displease him, 
 \q2 and he turn away his wrath from him. 
 \q1
 \v 19 Don’t fret yourself because of evildoers, 
@@ -2181,7 +2181,7 @@
 \v 20 for there will be no reward to the evil man. 
 \q2 The lamp of the wicked will be snuffed out. 
 \q1
-\v 21 My son, fear Yahweh and the king. 
+\v 21 My son, fear Yahuah and the king. 
 \q2 Don’t join those who are rebellious, 
 \q1
 \v 22 for their calamity will rise suddenly. 
@@ -2295,7 +2295,7 @@
 \q2 If he is thirsty, give him water to drink; 
 \q1
 \v 22 for you will heap coals of fire on his head, 
-\q2 and Yahweh will reward you. 
+\q2 and Yahuah will reward you. 
 \q1
 \v 23 The north wind produces rain; 
 \q2 so a backbiting tongue brings an angry face. 
@@ -2507,7 +2507,7 @@
 \q2 but those who keep the law contend with them. 
 \q1
 \v 5 Evil men don’t understand justice; 
-\q2 but those who seek Yahweh understand it fully. 
+\q2 but those who seek Yahuah understand it fully. 
 \q1
 \v 6 Better is the poor who walks in his integrity 
 \q2 than he who is perverse in his ways, and he is rich. 
@@ -2568,7 +2568,7 @@
 \q2 is a partner with a destroyer. 
 \q1
 \v 25 One who is greedy stirs up strife; 
-\q2 but one who trusts in Yahweh will prosper. 
+\q2 but one who trusts in Yahuah will prosper. 
 \q1
 \v 26 One who trusts in himself is a fool; 
 \q2 but one who walks in wisdom is kept safe. 
@@ -2617,7 +2617,7 @@
 \q2 all of his officials are wicked. 
 \q1
 \v 13 The poor man and the oppressor have this in common: 
-\q2 Yahweh gives sight to the eyes of both. 
+\q2 Yahuah gives sight to the eyes of both. 
 \q1
 \v 14 The king who fairly judges the poor, 
 \q2 his throne shall be established forever. 
@@ -2653,10 +2653,10 @@
 \q2 He takes an oath, but dares not testify. 
 \q1
 \v 25 The fear of man proves to be a snare, 
-\q2 but whoever puts his trust in Yahweh is kept safe. 
+\q2 but whoever puts his trust in Yahuah is kept safe. 
 \q1
 \v 26 Many seek the ruler’s favor, 
-\q2 but a man’s justice comes from Yahweh. 
+\q2 but a man’s justice comes from Yahuah. 
 \q1
 \v 27 A dishonest man detests the righteous, 
 \q2 and the upright in their ways detest the wicked. 
@@ -2693,7 +2693,7 @@
 \q2 Give me neither poverty nor riches. 
 \q2 Feed me with the food that is needful for me, 
 \q1
-\v 9 lest I be full, deny you, and say, ‘Who is Yahweh?’ 
+\v 9 lest I be full, deny you, and say, ‘Who is Yahuah?’ 
 \q2 or lest I be poor, and steal, 
 \q2 and so dishonor the name of my Elohim. 
 \b
@@ -2886,7 +2886,7 @@
 \q2 but you excel them all.” 
 \q1
 \v 30 Charm is deceitful, and beauty is vain; 
-\q2 but a woman who fears Yahweh, she shall be praised. 
+\q2 but a woman who fears Yahuah, she shall be praised. 
 \q1
 \v 31 Give her of the fruit of her hands! 
 \q2 Let her works praise her in the gates! 

--- a/usfm/psalms.usfm
+++ b/usfm/psalms.usfm
@@ -9,7 +9,7 @@
 \q2 nor stand on the path of sinners, 
 \q2 nor sit in the seat of scoffers; 
 \q1
-\v 2 but his delight is in Yahweh’s law. 
+\v 2 but his delight is in Yahuah’s law. 
 \q2 On his law he meditates day and night. 
 \q1
 \v 3 He will be like a tree planted by the streams of water, 
@@ -23,7 +23,7 @@
 \v 5 Therefore the wicked shall not stand in the judgment, 
 \q2 nor sinners in the congregation of the righteous. 
 \q1
-\v 6 For Yahweh knows the way of the righteous, 
+\v 6 For Yahuah knows the way of the righteous, 
 \q2 but the way of the wicked shall perish. 
 \c 2
 \q1
@@ -32,7 +32,7 @@
 \q1
 \v 2 The kings of the earth take a stand, 
 \q2 and the rulers take counsel together, 
-\q2 against Yahweh, and against his Anointed, saying, 
+\q2 against Yahuah, and against his Anointed, saying, 
 \q1
 \v 3 “Let’s break their bonds apart, 
 \q2 and cast their cords from us.” 
@@ -46,7 +46,7 @@
 \v 6 “Yet I have set my King on my set-apart hill of Zion.” 
 \q2
 \v 7 I will tell of the decree: 
-\q1 Yahweh said to me, “You are my son. 
+\q1 Yahuah said to me, “You are my son. 
 \q2 Today I have become your father. 
 \q1
 \v 8 Ask of me, and I will give the nations for your inheritance, 
@@ -58,7 +58,7 @@
 \v 10 Now therefore be wise, you kings. 
 \q2 Be instructed, you judges of the earth. 
 \q1
-\v 11 Serve Yahweh with fear, 
+\v 11 Serve Yahuah with fear, 
 \q2 and rejoice with trembling. 
 \q1
 \v 12 Give sincere homage to the Son, lest he be angry, and you perish on the way, 
@@ -67,30 +67,30 @@
 \c 3
 \d A Psalm by David, when he fled from Absalom his son. 
 \q1
-\v 1 Yahweh, how my adversaries have increased! 
+\v 1 Yahuah, how my adversaries have increased! 
 \q2 Many are those who rise up against me. 
 \q1
 \v 2 Many there are who say of my soul, 
 \q2 “There is no help for him in Elohim.” \qs Selah.\qs* 
 \q1
-\v 3 But you, Yahweh, are a shield around me, 
+\v 3 But you, Yahuah, are a shield around me, 
 \q2 my glory, and the one who lifts up my head. 
 \q1
-\v 4 I cry to Yahweh with my voice, 
+\v 4 I cry to Yahuah with my voice, 
 \q2 and he answers me out of his set-apart hill. \qs Selah.\qs* 
 \q1
 \v 5 I laid myself down and slept. 
-\q2 I awakened, for Yahweh sustains me. 
+\q2 I awakened, for Yahuah sustains me. 
 \q1
 \v 6 I will not be afraid of tens of thousands of people 
 \q2 who have set themselves against me on every side. 
 \q1
-\v 7 Arise, Yahweh! 
+\v 7 Arise, Yahuah! 
 \q2 Save me, my Elohim! 
 \q1 For you have struck all of my enemies on the cheek bone. 
 \q2 You have broken the teeth of the wicked. 
 \q1
-\v 8 Salvation belongs to Yahweh. 
+\v 8 Salvation belongs to Yahuah. 
 \q2 May your blessing be on your people. \qs Selah.\qs* 
 \c 4
 \d For the Chief Musician; on stringed instruments. A Psalm by David. 
@@ -102,33 +102,33 @@
 \v 2 You sons of men, how long shall my glory be turned into dishonor? 
 \q2 Will you love vanity and seek after falsehood? \qs Selah.\qs* 
 \q1
-\v 3 But know that Yahweh has set apart for himself him who is elohimly; 
-\q2 Yahweh will hear when I call to him. 
+\v 3 But know that Yahuah has set apart for himself him who is elohimly; 
+\q2 Yahuah will hear when I call to him. 
 \q1
 \v 4 Stand in awe, and don’t sin. 
 \q2 Search your own heart on your bed, and be still. \qs Selah.\qs* 
 \q1
 \v 5 Offer the sacrifices of righteousness. 
-\q2 Put your trust in Yahweh. 
+\q2 Put your trust in Yahuah. 
 \q1
 \v 6 Many say, “Who will show us any good?” 
-\q2 Yahweh, let the light of your face shine on us. 
+\q2 Yahuah, let the light of your face shine on us. 
 \q1
 \v 7 You have put gladness in my heart, 
 \q2 more than when their grain and their new wine are increased. 
 \q1
 \v 8 In peace I will both lay myself down and sleep, 
-\q2 for you alone, Yahweh, make me live in safety. 
+\q2 for you alone, Yahuah, make me live in safety. 
 \c 5
 \d For the Chief Musician, with the flutes. A Psalm by David. 
 \q1
-\v 1 Give ear to my words, Yahweh. 
+\v 1 Give ear to my words, Yahuah. 
 \q2 Consider my meditation. 
 \q1
 \v 2 Listen to the voice of my cry, my King and my Elohim, 
 \q2 for I pray to you. 
 \q1
-\v 3 Yahweh, in the morning you will hear my voice. 
+\v 3 Yahuah, in the morning you will hear my voice. 
 \q2 In the morning I will lay my requests before you, and will watch expectantly. 
 \q1
 \v 4 For you are not an Elohim who has pleasure in wickedness. 
@@ -138,12 +138,12 @@
 \q2 You hate all workers of iniquity. 
 \q1
 \v 6 You will destroy those who speak lies. 
-\q2 Yahweh abhors the bloodthirsty and deceitful man. 
+\q2 Yahuah abhors the bloodthirsty and deceitful man. 
 \q1
 \v 7 But as for me, in the abundance of your loving kindness I will come into your house. 
 \q2 I will bow toward your set-apart temple in reverence of you. 
 \q1
-\v 8 Lead me, Yahweh, in your righteousness because of my enemies. 
+\v 8 Lead me, Yahuah, in your righteousness because of my enemies. 
 \q2 Make your way straight before my face. 
 \q1
 \v 9 For there is no faithfulness in their mouth. 
@@ -161,20 +161,20 @@
 \q1 Let them also who love your name be joyful in you. 
 \q2
 \v 12 For you will bless the righteous. 
-\q1 Yahweh, you will surround him with favor as with a shield. 
+\q1 Yahuah, you will surround him with favor as with a shield. 
 \c 6
 \d For the Chief Musician; on stringed instruments, upon the eight-stringed lyre. A Psalm by David. 
 \q1
-\v 1 Yahweh, don’t rebuke me in your anger, 
+\v 1 Yahuah, don’t rebuke me in your anger, 
 \q2 neither discipline me in your wrath. 
 \q1
-\v 2 Have mercy on me, Yahweh, for I am faint. 
-\q2 Yahweh, heal me, for my bones are troubled. 
+\v 2 Have mercy on me, Yahuah, for I am faint. 
+\q2 Yahuah, heal me, for my bones are troubled. 
 \q1
 \v 3 My soul is also in great anguish. 
-\q2 But you, Yahweh—how long? 
+\q2 But you, Yahuah—how long? 
 \q1
-\v 4 Return, Yahweh. Deliver my soul, 
+\v 4 Return, Yahuah. Deliver my soul, 
 \q2 and save me for your loving kindness’ sake. 
 \q1
 \v 5 For in death there is no memory of you. 
@@ -188,23 +188,23 @@
 \q2 It grows old because of all my adversaries. 
 \q1
 \v 8 Depart from me, all you workers of iniquity, 
-\q2 for Yahweh has heard the voice of my weeping. 
+\q2 for Yahuah has heard the voice of my weeping. 
 \q1
-\v 9 Yahweh has heard my supplication. 
-\q2 Yahweh accepts my prayer. 
+\v 9 Yahuah has heard my supplication. 
+\q2 Yahuah accepts my prayer. 
 \q1
 \v 10 May all my enemies be ashamed and dismayed. 
 \q2 They shall turn back, they shall be disgraced suddenly. 
 \c 7
-\d A meditation by David, which he sang to Yahweh, concerning the words of Cush, the Benjamite. 
+\d A meditation by David, which he sang to Yahuah, concerning the words of Cush, the Benjamite. 
 \q1
-\v 1 Yahweh, my Elohim, I take refuge in you. 
+\v 1 Yahuah, my Elohim, I take refuge in you. 
 \q2 Save me from all those who pursue me, and deliver me, 
 \q1
 \v 2 lest they tear apart my soul like a lion, 
 \q2 ripping it in pieces, while there is no one to deliver. 
 \q1
-\v 3 Yahweh, my Elohim, if I have done this, 
+\v 3 Yahuah, my Elohim, if I have done this, 
 \q2 if there is iniquity in my hands, 
 \q1
 \v 4 if I have rewarded evil to him who was at peace with me 
@@ -214,15 +214,15 @@
 \q1 yes, let him tread my life down to the earth, 
 \q2 and lay my glory in the dust. \qs Selah.\qs* 
 \q1
-\v 6 Arise, Yahweh, in your anger. 
+\v 6 Arise, Yahuah, in your anger. 
 \q2 Lift up yourself against the rage of my adversaries. 
 \q1 Awake for me. You have commanded judgment. 
 \q2
 \v 7 Let the congregation of the peoples surround you. 
 \q2 Rule over them on high. 
 \q1
-\v 8 Yahweh administers judgment to the peoples. 
-\q2 Judge me, Yahweh, according to my righteousness, 
+\v 8 Yahuah administers judgment to the peoples. 
+\q2 Judge me, Yahuah, according to my righteousness, 
 \q2 and to my integrity that is in me. 
 \q1
 \v 9 Oh let the wickedness of the wicked come to an end, 
@@ -251,12 +251,12 @@
 \v 16 The trouble he causes shall return to his own head. 
 \q2 His violence shall come down on the crown of his own head. 
 \q1
-\v 17 I will give thanks to Yahweh according to his righteousness, 
-\q2 and will sing praise to the name of Yahweh Most High. 
+\v 17 I will give thanks to Yahuah according to his righteousness, 
+\q2 and will sing praise to the name of Yahuah Most High. 
 \c 8
 \d For the Chief Musician; on an instrument of Gath. A Psalm by David. 
 \q1
-\v 1 Yahweh, our Lord, how majestic is your name in all the earth! 
+\v 1 Yahuah, our Lord, how majestic is your name in all the earth! 
 \q2 You have set your glory above the heavens! 
 \q1
 \v 2 From the lips of babes and infants you have established strength, 
@@ -280,12 +280,12 @@
 \v 8 the birds of the sky, the fish of the sea, 
 \q2 and whatever passes through the paths of the seas. 
 \q1
-\v 9 Yahweh, our Lord, 
+\v 9 Yahuah, our Lord, 
 \q2 how majestic is your name in all the earth! 
 \c 9
 \d For the Chief Musician. Set to “The Death of the Son.” A Psalm by David. 
 \q1
-\v 1 I will give thanks to Yahweh with my whole heart. 
+\v 1 I will give thanks to Yahuah with my whole heart. 
 \q2 I will tell of all your marvelous works. 
 \q1
 \v 2 I will be glad and rejoice in you. 
@@ -304,25 +304,25 @@
 \v 6 The enemy is overtaken by endless ruin. 
 \q2 The very memory of the cities which you have overthrown has perished. 
 \q1
-\v 7 But Yahweh reigns forever. 
+\v 7 But Yahuah reigns forever. 
 \q2 He has prepared his throne for judgment. 
 \q1
 \v 8 He will judge the world in righteousness. 
 \q2 He will administer judgment to the peoples in uprightness. 
 \q1
-\v 9 Yahweh will also be a high tower for the oppressed; 
+\v 9 Yahuah will also be a high tower for the oppressed; 
 \q2 a high tower in times of trouble. 
 \q1
 \v 10 Those who know your name will put their trust in you, 
-\q2 for you, Yahweh, have not forsaken those who seek you. 
+\q2 for you, Yahuah, have not forsaken those who seek you. 
 \q1
-\v 11 Sing praises to Yahweh, who dwells in Zion, 
+\v 11 Sing praises to Yahuah, who dwells in Zion, 
 \q2 and declare among the people what he has done. 
 \q1
 \v 12 For he who avenges blood remembers them. 
 \q2 He doesn’t forget the cry of the afflicted. 
 \q1
-\v 13 Have mercy on me, Yahweh. 
+\v 13 Have mercy on me, Yahuah. 
 \q2 See my affliction by those who hate me, 
 \q1 and lift me up from the gates of death, 
 \q2
@@ -332,7 +332,7 @@
 \v 15 The nations have sunk down in the pit that they made. 
 \q2 In the net which they hid, their own foot is taken. 
 \q1
-\v 16 Yahweh has made himself known. 
+\v 16 Yahuah has made himself known. 
 \q2 He has executed judgment. 
 \q2 The wicked is snared by the work of his own hands. \qs Meditation. Selah.\qs* 
 \q1
@@ -342,21 +342,21 @@
 \v 18 For the needy shall not always be forgotten, 
 \q2 nor the hope of the poor perish forever. 
 \q1
-\v 19 Arise, Yahweh! Don’t let man prevail. 
+\v 19 Arise, Yahuah! Don’t let man prevail. 
 \q2 Let the nations be judged in your sight. 
 \q1
-\v 20 Put them in fear, Yahweh. 
+\v 20 Put them in fear, Yahuah. 
 \q2 Let the nations know that they are only men. \qs Selah.\qs* 
 \c 10
 \q1
-\v 1 Why do you stand far off, Yahweh? 
+\v 1 Why do you stand far off, Yahuah? 
 \q2 Why do you hide yourself in times of trouble? 
 \q1
 \v 2 In arrogance, the wicked hunt down the weak. 
 \q2 They are caught in the schemes that they devise. 
 \q1
 \v 3 For the wicked boasts of his heart’s cravings. 
-\q2 He blesses the greedy and condemns Yahweh. 
+\q2 He blesses the greedy and condemns Yahuah. 
 \q1
 \v 4 The wicked, in the pride of his face, 
 \q2 has no room in his thoughts for Elohim. 
@@ -388,7 +388,7 @@
 \q2 He will never see it.” 
 \b
 \q1
-\v 12 Arise, Yahweh! 
+\v 12 Arise, Yahuah! 
 \q2 Elohim, lift up your hand! 
 \q2 Don’t forget the helpless. 
 \q1
@@ -402,10 +402,10 @@
 \v 15 Break the arm of the wicked. 
 \q2 As for the evil man, seek out his wickedness until you find none. 
 \q1
-\v 16 Yahweh is King forever and ever! 
+\v 16 Yahuah is King forever and ever! 
 \q2 The nations will perish out of his land. 
 \q1
-\v 17 Yahweh, you have heard the desire of the humble. 
+\v 17 Yahuah, you have heard the desire of the humble. 
 \q2 You will prepare their heart. 
 \q2 You will cause your ear to hear, 
 \q2
@@ -414,7 +414,7 @@
 \c 11
 \d For the Chief Musician. By David. 
 \q1
-\v 1 In Yahweh, I take refuge. 
+\v 1 In Yahuah, I take refuge. 
 \q2 How can you say to my soul, “Flee as a bird to your mountain”? 
 \q1
 \v 2 For, behold, the wicked bend their bows. 
@@ -424,30 +424,30 @@
 \v 3 If the foundations are destroyed, 
 \q2 what can the righteous do? 
 \q1
-\v 4 Yahweh is in his set-apart temple. 
-\q2 Yahweh is on his throne in heaven. 
+\v 4 Yahuah is in his set-apart temple. 
+\q2 Yahuah is on his throne in heaven. 
 \q1 His eyes observe. 
 \q2 His eyes examine the children of men. 
 \q1
-\v 5 Yahweh examines the righteous, 
+\v 5 Yahuah examines the righteous, 
 \q2 but his soul hates the wicked and him who loves violence. 
 \q1
 \v 6 On the wicked he will rain blazing coals; 
 \q2 fire, sulfur, and scorching wind shall be the portion of their cup. 
 \q1
-\v 7 For Yahweh is righteous. 
+\v 7 For Yahuah is righteous. 
 \q2 He loves righteousness. 
 \q2 The upright shall see his face. 
 \c 12
 \d For the Chief Musician; upon an eight-stringed lyre. A Psalm of David. 
 \q1
-\v 1 Help, Yahweh; for the elohimly man ceases. 
+\v 1 Help, Yahuah; for the elohimly man ceases. 
 \q2 For the faithful fail from among the children of men. 
 \q1
 \v 2 Everyone lies to his neighbor. 
 \q2 They speak with flattering lips, and with a double heart. 
 \q1
-\v 3 May Yahweh cut off all flattering lips, 
+\v 3 May Yahuah cut off all flattering lips, 
 \q2 and the tongue that boasts, 
 \q1
 \v 4 who have said, “With our tongue we will prevail. 
@@ -455,13 +455,13 @@
 \q2 Who is lord over us?” 
 \q1
 \v 5 “Because of the oppression of the weak and because of the groaning of the needy, 
-\q2 I will now arise,” says Yahweh; 
+\q2 I will now arise,” says Yahuah; 
 \q1 “I will set him in safety from those who malign him.” 
 \q1
-\v 6 Yahweh’s words are flawless words, 
+\v 6 Yahuah’s words are flawless words, 
 \q2 as silver refined in a clay furnace, purified seven times. 
 \q1
-\v 7 You will keep them, Yahweh. 
+\v 7 You will keep them, Yahuah. 
 \q2 You will preserve them from this generation forever. 
 \q1
 \v 8 The wicked walk on every side, 
@@ -469,7 +469,7 @@
 \c 13
 \d For the Chief Musician. A Psalm by David. 
 \q1
-\v 1 How long, Yahweh? 
+\v 1 How long, Yahuah? 
 \q2 Will you forget me forever? 
 \q2 How long will you hide your face from me? 
 \q1
@@ -477,7 +477,7 @@
 \q2 having sorrow in my heart every day? 
 \q2 How long shall my enemy triumph over me? 
 \q1
-\v 3 Behold, and answer me, Yahweh, my Elohim. 
+\v 3 Behold, and answer me, Yahuah, my Elohim. 
 \q2 Give light to my eyes, lest I sleep in death; 
 \q2
 \v 4 lest my enemy say, “I have prevailed against him;” 
@@ -487,7 +487,7 @@
 \v 5 But I trust in your loving kindness. 
 \q2 My heart rejoices in your salvation. 
 \q1
-\v 6 I will sing to Yahweh, 
+\v 6 I will sing to Yahuah, 
 \q2 because he has been good to me. 
 \c 14
 \d For the Chief Musician. By David. 
@@ -497,7 +497,7 @@
 \q2 They have done abominable deeds. 
 \q2 There is no one who does good. 
 \q1
-\v 2 Yahweh looked down from heaven on the children of men, 
+\v 2 Yahuah looked down from heaven on the children of men, 
 \q2 to see if there were any who understood, 
 \q2 who sought after Elohim. 
 \q1
@@ -507,21 +507,21 @@
 \q1
 \v 4 Have all the workers of iniquity no knowledge, 
 \q2 who eat up my people as they eat bread, 
-\q2 and don’t call on Yahweh? 
+\q2 and don’t call on Yahuah? 
 \q1
 \v 5 There they were in great fear, 
 \q2 for Elohim is in the generation of the righteous. 
 \q1
 \v 6 You frustrate the plan of the poor, 
-\q2 because Yahweh is his refuge. 
+\q2 because Yahuah is his refuge. 
 \q1
 \v 7 Oh that the salvation of Israel would come out of Zion! 
-\q2 When Yahweh restores the fortunes of his people, 
+\q2 When Yahuah restores the fortunes of his people, 
 \q2 then Jacob shall rejoice, and Israel shall be glad. 
 \c 15
 \d A Psalm by David. 
 \q1
-\v 1 Yahweh, who shall dwell in your sanctuary? 
+\v 1 Yahuah, who shall dwell in your sanctuary? 
 \q2 Who shall live on your set-apart hill? 
 \q1
 \v 2 He who walks blamelessly and does what is right, 
@@ -532,7 +532,7 @@
 \q2 nor casts slurs against his fellow man; 
 \q1
 \v 4 in whose eyes a vile man is despised, 
-\q2 but who honors those who fear Yahweh; 
+\q2 but who honors those who fear Yahuah; 
 \q2 he who keeps an oath even when it hurts, and doesn’t change; 
 \q1
 \v 5 he who doesn’t lend out his money for usury, 
@@ -544,7 +544,7 @@
 \q1
 \v 1 Preserve me, Elohim, for I take refuge in you. 
 \q1
-\v 2 My soul, you have said to Yahweh, “You are my Lord. 
+\v 2 My soul, you have said to Yahuah, “You are my Lord. 
 \q2 Apart from you I have no good thing.” 
 \q1
 \v 3 As for the saints who are in the earth, 
@@ -555,17 +555,17 @@
 \q2 Their drink offerings of blood I will not offer, 
 \q2 nor take their names on my lips. 
 \q1
-\v 5 Yahweh assigned my portion and my cup. 
+\v 5 Yahuah assigned my portion and my cup. 
 \q2 You made my lot secure. 
 \b
 \q1
 \v 6 The lines have fallen to me in pleasant places. 
 \q2 Yes, I have a good inheritance. 
 \q1
-\v 7 I will bless Yahweh, who has given me counsel. 
+\v 7 I will bless Yahuah, who has given me counsel. 
 \q2 Yes, my heart instructs me in the night seasons. 
 \q1
-\v 8 I have set Yahweh always before me. 
+\v 8 I have set Yahuah always before me. 
 \q2 Because he is at my right hand, I shall not be moved. 
 \q1
 \v 9 Therefore my heart is glad, and my tongue rejoices. 
@@ -580,7 +580,7 @@
 \c 17
 \d A Prayer by David. 
 \q1
-\v 1 Hear, Yahweh, my righteous plea. 
+\v 1 Hear, Yahuah, my righteous plea. 
 \q2 Give ear to my prayer that doesn’t go out of deceitful lips. 
 \q1
 \v 2 Let my sentence come out of your presence. 
@@ -619,11 +619,11 @@
 \v 12 He is like a lion that is greedy of his prey, 
 \q2 as it were a young lion lurking in secret places. 
 \q1
-\v 13 Arise, Yahweh, confront him. 
+\v 13 Arise, Yahuah, confront him. 
 \q2 Cast him down. 
 \q1 Deliver my soul from the wicked by your sword, 
 \q2
-\v 14 from men by your hand, Yahweh, 
+\v 14 from men by your hand, Yahuah, 
 \q2 from men of the world, whose portion is in this life. 
 \q1 You fill the belly of your cherished ones. 
 \q2 Your sons have plenty, 
@@ -632,15 +632,15 @@
 \v 15 As for me, I shall see your face in righteousness. 
 \q2 I shall be satisfied, when I awake, with seeing your form. 
 \c 18
-\d For the Chief Musician. By David the servant of Yahweh, who spoke to Yahweh the words of this song in the day that Yahweh delivered him from the hand of all his enemies, and from the hand of Saul. He said, 
+\d For the Chief Musician. By David the servant of Yahuah, who spoke to Yahuah the words of this song in the day that Yahuah delivered him from the hand of all his enemies, and from the hand of Saul. He said, 
 \q1
-\v 1 I love you, Yahweh, my strength. 
+\v 1 I love you, Yahuah, my strength. 
 \q1
-\v 2 Yahweh is my rock, my fortress, and my deliverer; 
+\v 2 Yahuah is my rock, my fortress, and my deliverer; 
 \q2 my Elohim, my rock, in whom I take refuge; 
 \q2 my shield, and the horn of my salvation, my high tower. 
 \q1
-\v 3 I call on Yahweh, who is worthy to be praised; 
+\v 3 I call on Yahuah, who is worthy to be praised; 
 \q2 and I am saved from my enemies. 
 \q1
 \v 4 The cords of death surrounded me. 
@@ -649,7 +649,7 @@
 \v 5 The cords of Sheol were around me. 
 \q2 The snares of death came on me. 
 \q1
-\v 6 In my distress I called on Yahweh, 
+\v 6 In my distress I called on Yahuah, 
 \q2 and cried to my Elohim. 
 \q1 He heard my voice out of his temple. 
 \q2 My cry before him came into his ears. 
@@ -674,7 +674,7 @@
 \v 12 At the brightness before him his thick clouds passed, 
 \q2 hailstones and coals of fire. 
 \q1
-\v 13 Yahweh also thundered in the sky. 
+\v 13 Yahuah also thundered in the sky. 
 \q2 The Most High uttered his voice: 
 \q2 hailstones and coals of fire. 
 \q1
@@ -682,7 +682,7 @@
 \q2 He routed them with great lightning bolts. 
 \q1
 \v 15 Then the channels of waters appeared. 
-\q2 The foundations of the world were laid bare at your rebuke, Yahweh, 
+\q2 The foundations of the world were laid bare at your rebuke, Yahuah, 
 \q2 at the blast of the breath of your nostrils. 
 \q1
 \v 16 He sent from on high. 
@@ -693,15 +693,15 @@
 \q2 from those who hated me; for they were too mighty for me. 
 \q1
 \v 18 They came on me in the day of my calamity, 
-\q2 but Yahweh was my support. 
+\q2 but Yahuah was my support. 
 \q1
 \v 19 He brought me out also into a large place. 
 \q2 He delivered me, because he delighted in me. 
 \q1
-\v 20 Yahweh has rewarded me according to my righteousness. 
+\v 20 Yahuah has rewarded me according to my righteousness. 
 \q2 According to the cleanness of my hands, he has recompensed me. 
 \q1
-\v 21 For I have kept the ways of Yahweh, 
+\v 21 For I have kept the ways of Yahuah, 
 \q2 and have not wickedly departed from my Elohim. 
 \q1
 \v 22 For all his ordinances were before me. 
@@ -710,7 +710,7 @@
 \v 23 I was also blameless with him. 
 \q2 I kept myself from my iniquity. 
 \q1
-\v 24 Therefore Yahweh has rewarded me according to my righteousness, 
+\v 24 Therefore Yahuah has rewarded me according to my righteousness, 
 \q2 according to the cleanness of my hands in his eyesight. 
 \q1
 \v 25 With the merciful you will show yourself merciful. 
@@ -722,17 +722,17 @@
 \v 27 For you will save the afflicted people, 
 \q2 but the arrogant eyes you will bring down. 
 \q1
-\v 28 For you will light my lamp, Yahweh. 
+\v 28 For you will light my lamp, Yahuah. 
 \q2 My Elohim will light up my darkness. 
 \q1
 \v 29 For by you, I advance through a troop. 
 \q2 By my Elohim, I leap over a wall. 
 \q1
 \v 30 As for Elohim, his way is perfect. 
-\q2 Yahweh’s word is tried. 
+\q2 Yahuah’s word is tried. 
 \q2 He is a shield to all those who take refuge in him. 
 \q1
-\v 31 For who is Elohim, except Yahweh? 
+\v 31 For who is Elohim, except Yahuah? 
 \q2 Who is a rock, besides our Elohim, 
 \q2
 \v 32 the Elohim who arms me with strength, and makes my way perfect? 
@@ -763,7 +763,7 @@
 \q2 that I might cut off those who hate me. 
 \q1
 \v 41 They cried, but there was no one to save; 
-\q2 even to Yahweh, but he didn’t answer them. 
+\q2 even to Yahuah, but he didn’t answer them. 
 \q1
 \v 42 Then I beat them small as the dust before the wind. 
 \q2 I cast them out as the mire of the streets. 
@@ -778,7 +778,7 @@
 \v 45 The foreigners shall fade away, 
 \q2 and shall come trembling out of their strongholds. 
 \q1
-\v 46 Yahweh lives! Blessed be my rock. 
+\v 46 Yahuah lives! Blessed be my rock. 
 \q2 Exalted be the Elohim of my salvation, 
 \q1
 \v 47 even the Elohim who executes vengeance for me, 
@@ -788,7 +788,7 @@
 \q2 Yes, you lift me up above those who rise up against me. 
 \q2 You deliver me from the violent man. 
 \q1
-\v 49 Therefore I will give thanks to you, Yahweh, among the nations, 
+\v 49 Therefore I will give thanks to you, Yahuah, among the nations, 
 \q2 and will sing praises to your name. 
 \q1
 \v 50 He gives great deliverance to his king, 
@@ -818,14 +818,14 @@
 \q2 There is nothing hidden from its heat. 
 \b
 \q1
-\v 7 Yahweh’s law is perfect, restoring the soul. 
-\q2 Yahweh’s covenant is sure, making wise the simple. 
+\v 7 Yahuah’s law is perfect, restoring the soul. 
+\q2 Yahuah’s covenant is sure, making wise the simple. 
 \q1
-\v 8 Yahweh’s precepts are right, rejoicing the heart. 
-\q2 Yahweh’s commandment is pure, enlightening the eyes. 
+\v 8 Yahuah’s precepts are right, rejoicing the heart. 
+\q2 Yahuah’s commandment is pure, enlightening the eyes. 
 \q1
-\v 9 The fear of Yahweh is clean, enduring forever. 
-\q2 Yahweh’s ordinances are true, and righteous altogether. 
+\v 9 The fear of Yahuah is clean, enduring forever. 
+\q2 Yahuah’s ordinances are true, and righteous altogether. 
 \q1
 \v 10 They are more to be desired than gold, yes, than much fine gold, 
 \q2 sweeter also than honey and the extract of the honeycomb. 
@@ -844,11 +844,11 @@
 \q1
 \v 14 Let the words of my mouth and the meditation of my heart 
 \q2 be acceptable in your sight, 
-\q2 Yahweh, my rock, and my redeemer. 
+\q2 Yahuah, my rock, and my redeemer. 
 \c 20
 \d For the Chief Musician. A Psalm by David. 
 \q1
-\v 1 May Yahweh answer you in the day of trouble. 
+\v 1 May Yahuah answer you in the day of trouble. 
 \q2 May the name of the Elohim of Jacob set you up on high, 
 \q2
 \v 2 send you help from the sanctuary, 
@@ -862,24 +862,24 @@
 \q1
 \v 5 We will triumph in your salvation. 
 \q2 In the name of our Elohim, we will set up our banners. 
-\q2 May Yahweh grant all your requests. 
+\q2 May Yahuah grant all your requests. 
 \q1
-\v 6 Now I know that Yahweh saves his anointed. 
+\v 6 Now I know that Yahuah saves his anointed. 
 \q2 He will answer him from his set-apart heaven, 
 \q2 with the saving strength of his right hand. 
 \q1
 \v 7 Some trust in chariots, and some in horses, 
-\q2 but we trust in the name of Yahweh our Elohim. 
+\q2 but we trust in the name of Yahuah our Elohim. 
 \q1
 \v 8 They are bowed down and fallen, 
 \q2 but we rise up, and stand upright. 
 \q1
-\v 9 Save, Yahweh! 
+\v 9 Save, Yahuah! 
 \q2 Let the King answer us when we call! 
 \c 21
 \d For the Chief Musician. A Psalm by David. 
 \q1
-\v 1 The king rejoices in your strength, Yahweh! 
+\v 1 The king rejoices in your strength, Yahuah! 
 \q2 How greatly he rejoices in your salvation! 
 \q1
 \v 2 You have given him his heart’s desire, 
@@ -897,14 +897,14 @@
 \v 6 For you make him most blessed forever. 
 \q2 You make him glad with joy in your presence. 
 \q1
-\v 7 For the king trusts in Yahweh. 
+\v 7 For the king trusts in Yahuah. 
 \q2 Through the loving kindness of the Most High, he shall not be moved. 
 \q1
 \v 8 Your hand will find out all of your enemies. 
 \q2 Your right hand will find out those who hate you. 
 \q1
 \v 9 You will make them as a fiery furnace in the time of your anger. 
-\q2 Yahweh will swallow them up in his wrath. 
+\q2 Yahuah will swallow them up in his wrath. 
 \q2 The fire shall devour them. 
 \q1
 \v 10 You will destroy their descendants from the earth, 
@@ -916,7 +916,7 @@
 \v 12 For you will make them turn their back, 
 \q2 when you aim drawn bows at their face. 
 \q1
-\v 13 Be exalted, Yahweh, in your strength, 
+\v 13 Be exalted, Yahuah, in your strength, 
 \q2 so we will sing and praise your power. 
 \c 22
 \d For the Chief Musician; set to “The Doe of the Morning.” A Psalm by David. 
@@ -942,7 +942,7 @@
 \v 7 All those who see me mock me. 
 \q2 They insult me with their lips. They shake their heads, saying, 
 \q2
-\v 8 “He trusts in Yahweh. 
+\v 8 “He trusts in Yahuah. 
 \q2 Let him deliver him. 
 \q2 Let him rescue him, since he delights in him.” 
 \q1
@@ -981,7 +981,7 @@
 \q2 They cast lots for my clothing. 
 \b
 \q1
-\v 19 But don’t be far off, Yahweh. 
+\v 19 But don’t be far off, Yahuah. 
 \q2 You are my help. Hurry to help me! 
 \q1
 \v 20 Deliver my soul from the sword, 
@@ -994,7 +994,7 @@
 \v 22 I will declare your name to my brothers. 
 \q2 Among the assembly, I will praise you. 
 \q1
-\v 23 You who fear Yahweh, praise him! 
+\v 23 You who fear Yahuah, praise him! 
 \q2 All you descendants of Jacob, glorify him! 
 \q2 Stand in awe of him, all you descendants of Israel! 
 \q1
@@ -1007,13 +1007,13 @@
 \q2 I will pay my vows before those who fear him. 
 \q1
 \v 26 The humble shall eat and be satisfied. 
-\q2 They shall praise Yahweh who seek after him. 
+\q2 They shall praise Yahuah who seek after him. 
 \q2 Let your hearts live forever. 
 \q1
-\v 27 All the ends of the earth shall remember and turn to Yahweh. 
+\v 27 All the ends of the earth shall remember and turn to Yahuah. 
 \q2 All the relatives of the nations shall worship before you. 
 \q1
-\v 28 For the kingdom is Yahweh’s. 
+\v 28 For the kingdom is Yahuah’s. 
 \q2 He is the ruler over the nations. 
 \q1
 \v 29 All the rich ones of the earth shall eat and worship. 
@@ -1028,7 +1028,7 @@
 \c 23
 \d A Psalm by David. 
 \q1
-\v 1 Yahweh is my shepherd; 
+\v 1 Yahuah is my shepherd; 
 \q2 I shall lack nothing. 
 \q1
 \v 2 He makes me lie down in green pastures. 
@@ -1048,25 +1048,25 @@
 \q2 My cup runs over. 
 \q1
 \v 6 Surely goodness and loving kindness shall follow me all the days of my life, 
-\q2 and I will dwell in Yahweh’s house forever. 
+\q2 and I will dwell in Yahuah’s house forever. 
 \c 24
 \d A Psalm by David. 
 \q1
-\v 1 The earth is Yahweh’s, with its fullness; 
+\v 1 The earth is Yahuah’s, with its fullness; 
 \q2 the world, and those who dwell in it. 
 \q1
 \v 2 For he has founded it on the seas, 
 \q2 and established it on the floods. 
 \b
 \q1
-\v 3 Who may ascend to Yahweh’s hill? 
+\v 3 Who may ascend to Yahuah’s hill? 
 \q2 Who may stand in his set-apart place? 
 \q1
 \v 4 He who has clean hands and a pure heart; 
 \q2 who has not lifted up his soul to falsehood, 
 \q2 and has not sworn deceitfully. 
 \q1
-\v 5 He shall receive a blessing from Yahweh, 
+\v 5 He shall receive a blessing from Yahuah, 
 \q2 righteousness from the Elohim of his salvation. 
 \q1
 \v 6 This is the generation of those who seek Him, 
@@ -1078,19 +1078,19 @@
 \q2 and the King of glory will come in. 
 \q1
 \v 8 Who is the King of glory? 
-\q2 Yahweh strong and mighty, 
-\q2 Yahweh mighty in battle. 
+\q2 Yahuah strong and mighty, 
+\q2 Yahuah mighty in battle. 
 \q1
 \v 9 Lift up your heads, you gates; 
 \q2 yes, lift them up, you everlasting doors, 
 \q2 and the King of glory will come in. 
 \q1
 \v 10 Who is this King of glory? 
-\q2 Yahweh of Armies is the King of glory! \qs Selah.\qs* 
+\q2 Yahuah of Armies is the King of glory! \qs Selah.\qs* 
 \c 25
 \d By David. 
 \q1
-\v 1 To you, Yahweh, I lift up my soul. 
+\v 1 To you, Yahuah, I lift up my soul. 
 \q1
 \v 2 My Elohim, I have trusted in you. 
 \q2 Don’t let me be shamed. 
@@ -1100,43 +1100,43 @@
 \q2 They will be shamed who deal treacherously without cause. 
 \b
 \q1
-\v 4 Show me your ways, Yahweh. 
+\v 4 Show me your ways, Yahuah. 
 \q2 Teach me your paths. 
 \q1
 \v 5 Guide me in your truth, and teach me, 
 \q2 for you are the Elohim of my salvation. 
 \q2 I wait for you all day long. 
 \q1
-\v 6 Yahweh, remember your tender mercies and your loving kindness, 
+\v 6 Yahuah, remember your tender mercies and your loving kindness, 
 \q2 for they are from old times. 
 \q1
 \v 7 Don’t remember the sins of my youth, nor my transgressions. 
 \q2 Remember me according to your loving kindness, 
-\q2 for your goodness’ sake, Yahweh. 
+\q2 for your goodness’ sake, Yahuah. 
 \q1
-\v 8 Good and upright is Yahweh, 
+\v 8 Good and upright is Yahuah, 
 \q2 therefore he will instruct sinners in the way. 
 \q1
 \v 9 He will guide the humble in justice. 
 \q2 He will teach the humble his way. 
 \q1
-\v 10 All the paths of Yahweh are loving kindness and truth 
+\v 10 All the paths of Yahuah are loving kindness and truth 
 \q2 to such as keep his covenant and his testimonies. 
 \q1
-\v 11 For your name’s sake, Yahweh, 
+\v 11 For your name’s sake, Yahuah, 
 \q2 pardon my iniquity, for it is great. 
 \q1
-\v 12 What man is he who fears Yahweh? 
+\v 12 What man is he who fears Yahuah? 
 \q2 He shall instruct him in the way that he shall choose. 
 \q1
 \v 13 His soul will dwell at ease. 
 \q2 His offspring will inherit the land. 
 \q1
-\v 14 The friendship of Yahweh is with those who fear him. 
+\v 14 The friendship of Yahuah is with those who fear him. 
 \q2 He will show them his covenant. 
 \b
 \q1
-\v 15 My eyes are ever on Yahweh, 
+\v 15 My eyes are ever on Yahuah, 
 \q2 for he will pluck my feet out of the net. 
 \q1
 \v 16 Turn to me, and have mercy on me, 
@@ -1162,10 +1162,10 @@
 \c 26
 \d By David. 
 \q1
-\v 1 Judge me, Yahweh, for I have walked in my integrity. 
-\q2 I have trusted also in Yahweh without wavering. 
+\v 1 Judge me, Yahuah, for I have walked in my integrity. 
+\q2 I have trusted also in Yahuah without wavering. 
 \q1
-\v 2 Examine me, Yahweh, and prove me. 
+\v 2 Examine me, Yahuah, and prove me. 
 \q2 Try my heart and my mind. 
 \q1
 \v 3 For your loving kindness is before my eyes. 
@@ -1178,12 +1178,12 @@
 \q2 and will not sit with the wicked. 
 \q1
 \v 6 I will wash my hands in innocence, 
-\q2 so I will go about your altar, Yahweh, 
+\q2 so I will go about your altar, Yahuah, 
 \q2
 \v 7 that I may make the voice of thanksgiving to be heard 
 \q2 and tell of all your wondrous deeds. 
 \q1
-\v 8 Yahweh, I love the habitation of your house, 
+\v 8 Yahuah, I love the habitation of your house, 
 \q2 the place where your glory dwells. 
 \q1
 \v 9 Don’t gather my soul with sinners, 
@@ -1197,13 +1197,13 @@
 \q2 Redeem me, and be merciful to me. 
 \q1
 \v 12 My foot stands in an even place. 
-\q2 In the congregations I will bless Yahweh. 
+\q2 In the congregations I will bless Yahuah. 
 \c 27
 \d By David. 
 \q1
-\v 1 Yahweh is my light and my salvation. 
+\v 1 Yahuah is my light and my salvation. 
 \q2 Whom shall I fear? 
-\q1 Yahweh is the strength of my life. 
+\q1 Yahuah is the strength of my life. 
 \q2 Of whom shall I be afraid? 
 \q1
 \v 2 When evildoers came at me to eat up my flesh, 
@@ -1214,9 +1214,9 @@
 \q1 Though war should rise against me, 
 \q2 even then I will be confident. 
 \q1
-\v 4 One thing I have asked of Yahweh, that I will seek after: 
-\q2 that I may dwell in Yahweh’s house all the days of my life, 
-\q2 to see Yahweh’s beauty, 
+\v 4 One thing I have asked of Yahuah, that I will seek after: 
+\q2 that I may dwell in Yahuah’s house all the days of my life, 
+\q2 to see Yahuah’s beauty, 
 \q2 and to inquire in his temple. 
 \q1
 \v 5 For in the day of trouble, he will keep me secretly in his pavilion. 
@@ -1225,14 +1225,14 @@
 \q1
 \v 6 Now my head will be lifted up above my enemies around me. 
 \q1 I will offer sacrifices of joy in his tent. 
-\q2 I will sing, yes, I will sing praises to Yahweh. 
+\q2 I will sing, yes, I will sing praises to Yahuah. 
 \b
 \q1
-\v 7 Hear, Yahweh, when I cry with my voice. 
+\v 7 Hear, Yahuah, when I cry with my voice. 
 \q2 Have mercy also on me, and answer me. 
 \q1
 \v 8 When you said, “Seek my face,” 
-\q2 my heart said to you, “I will seek your face, Yahweh.” 
+\q2 my heart said to you, “I will seek your face, Yahuah.” 
 \q1
 \v 9 Don’t hide your face from me. 
 \q2 Don’t put your servant away in anger. 
@@ -1241,9 +1241,9 @@
 \q2 neither forsake me, Elohim of my salvation. 
 \q1
 \v 10 When my father and my mother forsake me, 
-\q2 then Yahweh will take me up. 
+\q2 then Yahuah will take me up. 
 \q1
-\v 11 Teach me your way, Yahweh. 
+\v 11 Teach me your way, Yahuah. 
 \q2 Lead me in a straight path, because of my enemies. 
 \q1
 \v 12 Don’t deliver me over to the desire of my adversaries, 
@@ -1251,15 +1251,15 @@
 \q2 such as breathe out cruelty. 
 \q1
 \v 13 I am still confident of this: 
-\q2 I will see the goodness of Yahweh in the land of the living. 
+\q2 I will see the goodness of Yahuah in the land of the living. 
 \q1
-\v 14 Wait for Yahweh. 
+\v 14 Wait for Yahuah. 
 \q2 Be strong, and let your heart take courage. 
-\q1 Yes, wait for Yahweh. 
+\q1 Yes, wait for Yahuah. 
 \c 28
 \d By David. 
 \q1
-\v 1 To you, Yahweh, I call. 
+\v 1 To you, Yahuah, I call. 
 \q2 My rock, don’t be deaf to me, 
 \q2 lest, if you are silent to me, 
 \q2 I would become like those who go down into the pit. 
@@ -1275,20 +1275,20 @@
 \q2 Give them according to the operation of their hands. 
 \q2 Bring back on them what they deserve. 
 \q1
-\v 5 Because they don’t respect the works of Yahweh, 
+\v 5 Because they don’t respect the works of Yahuah, 
 \q2 nor the operation of his hands, 
 \q2 he will break them down and not build them up. 
 \b
 \q1
-\v 6 Blessed be Yahweh, 
+\v 6 Blessed be Yahuah, 
 \q2 because he has heard the voice of my petitions. 
 \q1
-\v 7 Yahweh is my strength and my shield. 
+\v 7 Yahuah is my strength and my shield. 
 \q2 My heart has trusted in him, and I am helped. 
 \q1 Therefore my heart greatly rejoices. 
 \q2 With my song I will thank him. 
 \q1
-\v 8 Yahweh is their strength. 
+\v 8 Yahuah is their strength. 
 \q2 He is a stronghold of salvation to his anointed. 
 \q1
 \v 9 Save your people, 
@@ -1298,53 +1298,53 @@
 \c 29
 \d A Psalm by David. 
 \q1
-\v 1 Ascribe to Yahweh, you sons of the mighty, 
-\q2 ascribe to Yahweh glory and strength. 
+\v 1 Ascribe to Yahuah, you sons of the mighty, 
+\q2 ascribe to Yahuah glory and strength. 
 \q1
-\v 2 Ascribe to Yahweh the glory due to his name. 
-\q2 Worship Yahweh in set-apart array. 
+\v 2 Ascribe to Yahuah the glory due to his name. 
+\q2 Worship Yahuah in set-apart array. 
 \b
 \q1
-\v 3 Yahweh’s voice is on the waters. 
-\q2 The Elohim of glory thunders, even Yahweh on many waters. 
+\v 3 Yahuah’s voice is on the waters. 
+\q2 The Elohim of glory thunders, even Yahuah on many waters. 
 \q1
-\v 4 Yahweh’s voice is powerful. 
-\q2 Yahweh’s voice is full of majesty. 
+\v 4 Yahuah’s voice is powerful. 
+\q2 Yahuah’s voice is full of majesty. 
 \q1
-\v 5 Yahweh’s voice breaks the cedars. 
-\q2 Yes, Yahweh breaks in pieces the cedars of Lebanon. 
+\v 5 Yahuah’s voice breaks the cedars. 
+\q2 Yes, Yahuah breaks in pieces the cedars of Lebanon. 
 \q1
 \v 6 He makes them also to skip like a calf; 
 \q2 Lebanon and Sirion like a young, wild ox. 
 \q1
-\v 7 Yahweh’s voice strikes with flashes of lightning. 
+\v 7 Yahuah’s voice strikes with flashes of lightning. 
 \q2
-\v 8 Yahweh’s voice shakes the wilderness. 
-\q2 Yahweh shakes the wilderness of Kadesh. 
+\v 8 Yahuah’s voice shakes the wilderness. 
+\q2 Yahuah shakes the wilderness of Kadesh. 
 \q1
-\v 9 Yahweh’s voice makes the deer calve, 
+\v 9 Yahuah’s voice makes the deer calve, 
 \q2 and strips the forests bare. 
 \q2 In his temple everything says, “Glory!” 
 \b
 \q1
-\v 10 Yahweh sat enthroned at the Flood. 
-\q2 Yes, Yahweh sits as King forever. 
+\v 10 Yahuah sat enthroned at the Flood. 
+\q2 Yes, Yahuah sits as King forever. 
 \q1
-\v 11 Yahweh will give strength to his people. 
-\q2 Yahweh will bless his people with peace. 
+\v 11 Yahuah will give strength to his people. 
+\q2 Yahuah will bless his people with peace. 
 \c 30
 \d A Psalm. A Song for the Dedication of the Temple. By David. 
 \q1
-\v 1 I will extol you, Yahweh, for you have raised me up, 
+\v 1 I will extol you, Yahuah, for you have raised me up, 
 \q2 and have not made my foes to rejoice over me. 
 \q1
-\v 2 Yahweh my Elohim, I cried to you, 
+\v 2 Yahuah my Elohim, I cried to you, 
 \q2 and you have healed me. 
 \q1
-\v 3 Yahweh, you have brought up my soul from Sheol. 
+\v 3 Yahuah, you have brought up my soul from Sheol. 
 \q2 You have kept me alive, that I should not go down to the pit. 
 \q1
-\v 4 Sing praise to Yahweh, you saints of his. 
+\v 4 Sing praise to Yahuah, you saints of his. 
 \q2 Give thanks to his set-apart name. 
 \q1
 \v 5 For his anger is but for a moment. 
@@ -1355,28 +1355,28 @@
 \v 6 As for me, I said in my prosperity, 
 \q2 “I shall never be moved.” 
 \q1
-\v 7 You, Yahweh, when you favored me, made my mountain stand strong; 
+\v 7 You, Yahuah, when you favored me, made my mountain stand strong; 
 \q2 but when you hid your face, I was troubled. 
 \q1
-\v 8 I cried to you, Yahweh. 
+\v 8 I cried to you, Yahuah. 
 \q2 I made supplication to the Lord: 
 \q1
 \v 9 “What profit is there in my destruction, if I go down to the pit? 
 \q2 Shall the dust praise you? 
 \q2 Shall it declare your truth? 
 \q1
-\v 10 Hear, Yahweh, and have mercy on me. 
-\q2 Yahweh, be my helper.” 
+\v 10 Hear, Yahuah, and have mercy on me. 
+\q2 Yahuah, be my helper.” 
 \q1
 \v 11 You have turned my mourning into dancing for me. 
 \q2 You have removed my sackcloth, and clothed me with gladness, 
 \q2
 \v 12 to the end that my heart may sing praise to you, and not be silent. 
-\q1 Yahweh my Elohim, I will give thanks to you forever! 
+\q1 Yahuah my Elohim, I will give thanks to you forever! 
 \c 31
 \d For the Chief Musician. A Psalm by David. 
 \q1
-\v 1 In you, Yahweh, I take refuge. 
+\v 1 In you, Yahuah, I take refuge. 
 \q2 Let me never be disappointed. 
 \q2 Deliver me in your righteousness. 
 \q1
@@ -1392,10 +1392,10 @@
 \q2 for you are my stronghold. 
 \q1
 \v 5 Into your hand I commend my spirit. 
-\q2 You redeem me, Yahweh, Elohim of truth. 
+\q2 You redeem me, Yahuah, Elohim of truth. 
 \q1
 \v 6 I hate those who regard lying vanities, 
-\q2 but I trust in Yahweh. 
+\q2 but I trust in Yahuah. 
 \q1
 \v 7 I will be glad and rejoice in your loving kindness, 
 \q2 for you have seen my affliction. 
@@ -1404,7 +1404,7 @@
 \v 8 You have not shut me up into the hand of the enemy. 
 \q2 You have set my feet in a large place. 
 \q1
-\v 9 Have mercy on me, Yahweh, for I am in distress. 
+\v 9 Have mercy on me, Yahuah, for I am in distress. 
 \q2 My eye, my soul, and my body waste away with grief. 
 \q1
 \v 10 For my life is spent with sorrow, 
@@ -1423,7 +1423,7 @@
 \q2 while they conspire together against me, 
 \q2 they plot to take away my life. 
 \q1
-\v 14 But I trust in you, Yahweh. 
+\v 14 But I trust in you, Yahuah. 
 \q2 I said, “You are my Elohim.” 
 \q1
 \v 15 My times are in your hand. 
@@ -1432,7 +1432,7 @@
 \v 16 Make your face to shine on your servant. 
 \q2 Save me in your loving kindness. 
 \q1
-\v 17 Let me not be disappointed, Yahweh, for I have called on you. 
+\v 17 Let me not be disappointed, Yahuah, for I have called on you. 
 \q2 Let the wicked be disappointed. 
 \q2 Let them be silent in Sheol. 
 \q1
@@ -1447,25 +1447,25 @@
 \v 20 In the shelter of your presence you will hide them from the plotting of man. 
 \q2 You will keep them secretly in a dwelling away from the strife of tongues. 
 \q1
-\v 21 Praise be to Yahweh, 
+\v 21 Praise be to Yahuah, 
 \q2 for he has shown me his marvelous loving kindness in a strong city. 
 \q1
 \v 22 As for me, I said in my haste, “I am cut off from before your eyes.” 
 \q2 Nevertheless you heard the voice of my petitions when I cried to you. 
 \q1
-\v 23 Oh love Yahweh, all you his saints! 
-\q2 Yahweh preserves the faithful, 
+\v 23 Oh love Yahuah, all you his saints! 
+\q2 Yahuah preserves the faithful, 
 \q1 and fully recompenses him who behaves arrogantly. 
 \q1
 \v 24 Be strong, and let your heart take courage, 
-\q2 all you who hope in Yahweh. 
+\q2 all you who hope in Yahuah. 
 \c 32
 \d By David. A contemplative psalm. 
 \q1
 \v 1 Blessed is he whose disobedience is forgiven, 
 \q2 whose sin is covered. 
 \q1
-\v 2 Blessed is the man to whom Yahweh doesn’t impute iniquity, 
+\v 2 Blessed is the man to whom Yahuah doesn’t impute iniquity, 
 \q2 in whose spirit there is no deceit. 
 \q1
 \v 3 When I kept silence, my bones wasted away through my groaning all day long. 
@@ -1475,7 +1475,7 @@
 \q1
 \v 5 I acknowledged my sin to you. 
 \q2 I didn’t hide my iniquity. 
-\q1 I said, I will confess my transgressions to Yahweh, 
+\q1 I said, I will confess my transgressions to Yahuah, 
 \q2 and you forgave the iniquity of my sin. \qs Selah.\qs* 
 \q1
 \v 6 For this, let everyone who is elohimly pray to you in a time when you may be found. 
@@ -1492,49 +1492,49 @@
 \q2 who are controlled by bit and bridle, or else they will not come near to you. 
 \q1
 \v 10 Many sorrows come to the wicked, 
-\q2 but loving kindness shall surround him who trusts in Yahweh. 
+\q2 but loving kindness shall surround him who trusts in Yahuah. 
 \q1
-\v 11 Be glad in Yahweh, and rejoice, you righteous! 
+\v 11 Be glad in Yahuah, and rejoice, you righteous! 
 \q2 Shout for joy, all you who are upright in heart! 
 \c 33
 \q1
-\v 1 Rejoice in Yahweh, you righteous! 
+\v 1 Rejoice in Yahuah, you righteous! 
 \q2 Praise is fitting for the upright. 
 \q1
-\v 2 Give thanks to Yahweh with the lyre. 
+\v 2 Give thanks to Yahuah with the lyre. 
 \q2 Sing praises to him with the harp of ten strings. 
 \q1
 \v 3 Sing to him a new song. 
 \q2 Play skillfully with a shout of joy! 
 \q1
-\v 4 For Yahweh’s word is right. 
+\v 4 For Yahuah’s word is right. 
 \q2 All his work is done in faithfulness. 
 \q1
 \v 5 He loves righteousness and justice. 
-\q2 The earth is full of the loving kindness of Yahweh. 
+\q2 The earth is full of the loving kindness of Yahuah. 
 \q1
-\v 6 By Yahweh’s word, the heavens were made: 
+\v 6 By Yahuah’s word, the heavens were made: 
 \q2 all their army by the breath of his mouth. 
 \q1
 \v 7 He gathers the waters of the sea together as a heap. 
 \q2 He lays up the deeps in storehouses. 
 \q1
-\v 8 Let all the earth fear Yahweh. 
+\v 8 Let all the earth fear Yahuah. 
 \q2 Let all the inhabitants of the world stand in awe of him. 
 \q1
 \v 9 For he spoke, and it was done. 
 \q2 He commanded, and it stood firm. 
 \q1
-\v 10 Yahweh brings the counsel of the nations to nothing. 
+\v 10 Yahuah brings the counsel of the nations to nothing. 
 \q2 He makes the thoughts of the peoples to be of no effect. 
 \q1
-\v 11 The counsel of Yahweh stands fast forever, 
+\v 11 The counsel of Yahuah stands fast forever, 
 \q2 the thoughts of his heart to all generations. 
 \q1
-\v 12 Blessed is the nation whose Elohim is Yahweh, 
+\v 12 Blessed is the nation whose Elohim is Yahuah, 
 \q2 the people whom he has chosen for his own inheritance. 
 \q1
-\v 13 Yahweh looks from heaven. 
+\v 13 Yahuah looks from heaven. 
 \q2 He sees all the sons of men. 
 \q1
 \v 14 From the place of his habitation he looks out on all the inhabitants of the earth, 
@@ -1548,56 +1548,56 @@
 \v 17 A horse is a vain thing for safety, 
 \q2 neither does he deliver any by his great power. 
 \q1
-\v 18 Behold, Yahweh’s eye is on those who fear him, 
+\v 18 Behold, Yahuah’s eye is on those who fear him, 
 \q2 on those who hope in his loving kindness, 
 \q2
 \v 19 to deliver their soul from death, 
 \q2 to keep them alive in famine. 
 \q1
-\v 20 Our soul has waited for Yahweh. 
+\v 20 Our soul has waited for Yahuah. 
 \q2 He is our help and our shield. 
 \q1
 \v 21 For our heart rejoices in him, 
 \q2 because we have trusted in his set-apart name. 
 \q1
-\v 22 Let your loving kindness be on us, Yahweh, 
+\v 22 Let your loving kindness be on us, Yahuah, 
 \q2 since we have hoped in you. 
 \c 34
 \d By David; when he pretended to be insane before Abimelech, who drove him away, and he departed. 
 \q1
-\v 1  I will bless Yahweh at all times. 
+\v 1  I will bless Yahuah at all times. 
 \q2 His praise will always be in my mouth. 
 \q1
-\v 2 My soul shall boast in Yahweh. 
+\v 2 My soul shall boast in Yahuah. 
 \q2 The humble shall hear of it and be glad. 
 \q1
-\v 3 Oh magnify Yahweh with me. 
+\v 3 Oh magnify Yahuah with me. 
 \q2 Let’s exalt his name together. 
 \q1
-\v 4 I sought Yahweh, and he answered me, 
+\v 4 I sought Yahuah, and he answered me, 
 \q2 and delivered me from all my fears. 
 \q1
 \v 5 They looked to him, and were radiant. 
 \q2 Their faces shall never be covered with shame. 
 \q1
-\v 6 This poor man cried, and Yahweh heard him, 
+\v 6 This poor man cried, and Yahuah heard him, 
 \q2 and saved him out of all his troubles. 
 \q1
-\v 7 Yahweh’s angel encamps around those who fear him, 
+\v 7 Yahuah’s angel encamps around those who fear him, 
 \q2 and delivers them. 
 \q1
-\v 8 Oh taste and see that Yahweh is good. 
+\v 8 Oh taste and see that Yahuah is good. 
 \q2 Blessed is the man who takes refuge in him. 
 \q1
-\v 9 Oh fear Yahweh, you his saints, 
+\v 9 Oh fear Yahuah, you his saints, 
 \q2 for there is no lack with those who fear him. 
 \q1
 \v 10 The young lions do lack, and suffer hunger, 
-\q2 but those who seek Yahweh shall not lack any good thing. 
+\q2 but those who seek Yahuah shall not lack any good thing. 
 \b
 \q1
 \v 11 Come, you children, listen to me. 
-\q2 I will teach you the fear of Yahweh. 
+\q2 I will teach you the fear of Yahuah. 
 \q1
 \v 12 Who is someone who desires life, 
 \q2 and loves many days, that he may see good? 
@@ -1608,20 +1608,20 @@
 \v 14 Depart from evil, and do good. 
 \q2 Seek peace, and pursue it. 
 \q1
-\v 15 Yahweh’s eyes are toward the righteous. 
+\v 15 Yahuah’s eyes are toward the righteous. 
 \q2 His ears listen to their cry. 
 \q1
-\v 16 Yahweh’s face is against those who do evil, 
+\v 16 Yahuah’s face is against those who do evil, 
 \q2 to cut off their memory from the earth. 
 \q1
-\v 17 The righteous cry, and Yahweh hears, 
+\v 17 The righteous cry, and Yahuah hears, 
 \q2 and delivers them out of all their troubles. 
 \q1
-\v 18 Yahweh is near to those who have a broken heart, 
+\v 18 Yahuah is near to those who have a broken heart, 
 \q2 and saves those who have a crushed spirit. 
 \q1
 \v 19 Many are the afflictions of the righteous, 
-\q2 but Yahweh delivers him out of them all. 
+\q2 but Yahuah delivers him out of them all. 
 \q1
 \v 20 He protects all of his bones. 
 \q2 Not one of them is broken. 
@@ -1629,12 +1629,12 @@
 \v 21 Evil shall kill the wicked. 
 \q2 Those who hate the righteous shall be condemned. 
 \q1
-\v 22 Yahweh redeems the soul of his servants. 
+\v 22 Yahuah redeems the soul of his servants. 
 \q2 None of those who take refuge in him shall be condemned. 
 \c 35
 \d By David. 
 \q1
-\v 1 Contend, Yahweh, with those who contend with me. 
+\v 1 Contend, Yahuah, with those who contend with me. 
 \q2 Fight against those who fight against me. 
 \q1
 \v 2 Take hold of shield and buckler, 
@@ -1647,10 +1647,10 @@
 \q2 Let those who plot my ruin be turned back and confounded. 
 \q1
 \v 5 Let them be as chaff before the wind, 
-\q2 Yahweh’s angel driving them on. 
+\q2 Yahuah’s angel driving them on. 
 \q1
 \v 6 Let their way be dark and slippery, 
-\q2 Yahweh’s angel pursuing them. 
+\q2 Yahuah’s angel pursuing them. 
 \q1
 \v 7 For without cause they have hidden their net in a pit for me. 
 \q2 Without cause they have dug a pit for my soul. 
@@ -1660,10 +1660,10 @@
 \q2 Let him fall into that destruction. 
 \b
 \q1
-\v 9 My soul shall be joyful in Yahweh. 
+\v 9 My soul shall be joyful in Yahuah. 
 \q2 It shall rejoice in his salvation. 
 \q1
-\v 10 All my bones shall say, “Yahweh, who is like you, 
+\v 10 All my bones shall say, “Yahuah, who is like you, 
 \q2 who delivers the poor from him who is too strong for him; 
 \q2 yes, the poor and the needy from him who robs him?” 
 \q1
@@ -1704,13 +1704,13 @@
 \v 21 Yes, they opened their mouth wide against me. 
 \q2 They said, “Aha! Aha! Our eye has seen it!” 
 \q1
-\v 22 You have seen it, Yahweh. Don’t keep silent. 
+\v 22 You have seen it, Yahuah. Don’t keep silent. 
 \q2 Lord, don’t be far from me. 
 \q1
 \v 23 Wake up! Rise up to defend me, my Elohim! 
 \q2 My Lord, contend for me! 
 \q1
-\v 24 Vindicate me, Yahweh my Elohim, according to your righteousness. 
+\v 24 Vindicate me, Yahuah my Elohim, according to your righteousness. 
 \q2 Don’t let them gloat over me. 
 \q1
 \v 25 Don’t let them say in their heart, “Aha! That’s the way we want it!” 
@@ -1721,12 +1721,12 @@
 \b
 \q1
 \v 27 Let those who favor my righteous cause shout for joy and be glad. 
-\q2 Yes, let them say continually, “May Yahweh be magnified, 
+\q2 Yes, let them say continually, “May Yahuah be magnified, 
 \q2 who has pleasure in the prosperity of his servant!” 
 \q1
 \v 28 My tongue shall talk about your righteousness and about your praise all day long. 
 \c 36
-\d For the Chief Musician. By David, the servant of Yahweh. 
+\d For the Chief Musician. By David, the servant of Yahuah. 
 \q1
 \v 1 A revelation is within my heart about the disobedience of the wicked: 
 \q2 There is no fear of Elohim before his eyes. 
@@ -1742,12 +1742,12 @@
 \q2 He doesn’t abhor evil. 
 \b
 \q1
-\v 5 Your loving kindness, Yahweh, is in the heavens. 
+\v 5 Your loving kindness, Yahuah, is in the heavens. 
 \q2 Your faithfulness reaches to the skies. 
 \q1
 \v 6 Your righteousness is like the mountains of Elohim. 
 \q2 Your judgments are like a great deep. 
-\q2 Yahweh, you preserve man and animal. 
+\q2 Yahuah, you preserve man and animal. 
 \q1
 \v 7 How precious is your loving kindness, Elohim! 
 \q2 The children of men take refuge under the shadow of your wings. 
@@ -1775,19 +1775,19 @@
 \v 2 For they shall soon be cut down like the grass, 
 \q2 and wither like the green herb. 
 \q1
-\v 3 Trust in Yahweh, and do good. 
+\v 3 Trust in Yahuah, and do good. 
 \q2 Dwell in the land, and enjoy safe pasture. 
 \q1
-\v 4 Also delight yourself in Yahweh, 
+\v 4 Also delight yourself in Yahuah, 
 \q2 and he will give you the desires of your heart. 
 \q1
-\v 5 Commit your way to Yahweh. 
+\v 5 Commit your way to Yahuah. 
 \q2 Trust also in him, and he will do this: 
 \q1
 \v 6 he will make your righteousness shine out like light, 
 \q2 and your justice as the noon day sun. 
 \q1
-\v 7 Rest in Yahweh, and wait patiently for him. 
+\v 7 Rest in Yahuah, and wait patiently for him. 
 \q2 Don’t fret because of him who prospers in his way, 
 \q2 because of the man who makes wicked plots happen. 
 \q1
@@ -1795,7 +1795,7 @@
 \q2 Don’t fret; it leads only to evildoing. 
 \q1
 \v 9 For evildoers shall be cut off, 
-\q2 but those who wait for Yahweh shall inherit the land. 
+\q2 but those who wait for Yahuah shall inherit the land. 
 \q1
 \v 10 For yet a little while, and the wicked will be no more. 
 \q2 Yes, though you look for his place, he isn’t there. 
@@ -1820,9 +1820,9 @@
 \q2 than the abundance of many wicked. 
 \q1
 \v 17 For the arms of the wicked shall be broken, 
-\q2 but Yahweh upholds the righteous. 
+\q2 but Yahuah upholds the righteous. 
 \q1
-\v 18 Yahweh knows the days of the perfect. 
+\v 18 Yahuah knows the days of the perfect. 
 \q2 Their inheritance shall be forever. 
 \q1
 \v 19 They shall not be disappointed in the time of evil. 
@@ -1830,7 +1830,7 @@
 \b
 \q1
 \v 20 But the wicked shall perish. 
-\q2 The enemies of Yahweh shall be like the beauty of the fields. 
+\q2 The enemies of Yahuah shall be like the beauty of the fields. 
 \q2 They will vanish—\q2 vanish like smoke. 
 \q1
 \v 21 The wicked borrow, and don’t pay back, 
@@ -1839,11 +1839,11 @@
 \v 22 For such as are blessed by him shall inherit the land. 
 \q2 Those who are cursed by him shall be cut off. 
 \q1
-\v 23 A man’s steps are established by Yahweh. 
+\v 23 A man’s steps are established by Yahuah. 
 \q2 He delights in his way. 
 \q1
 \v 24 Though he stumble, he shall not fall, 
-\q2 for Yahweh holds him up with his hand. 
+\q2 for Yahuah holds him up with his hand. 
 \q1
 \v 25 I have been young, and now am old, 
 \q2 yet I have not seen the righteous forsaken, 
@@ -1855,7 +1855,7 @@
 \v 27 Depart from evil, and do good. 
 \q2 Live securely forever. 
 \q1
-\v 28 For Yahweh loves justice, 
+\v 28 For Yahuah loves justice, 
 \q2 and doesn’t forsake his saints. 
 \q2 They are preserved forever, 
 \q2 but the children of the wicked shall be cut off. 
@@ -1873,10 +1873,10 @@
 \v 32 The wicked watch the righteous, 
 \q2 and seek to kill him. 
 \q1
-\v 33 Yahweh will not leave him in his hand, 
+\v 33 Yahuah will not leave him in his hand, 
 \q2 nor condemn him when he is judged. 
 \q1
-\v 34 Wait for Yahweh, and keep his way, 
+\v 34 Wait for Yahuah, and keep his way, 
 \q2 and he will exalt you to inherit the land. 
 \q2 When the wicked are cut off, you shall see it. 
 \b
@@ -1893,16 +1893,16 @@
 \v 38 As for transgressors, they shall be destroyed together. 
 \q2 The future of the wicked shall be cut off. 
 \q1
-\v 39 But the salvation of the righteous is from Yahweh. 
+\v 39 But the salvation of the righteous is from Yahuah. 
 \q2 He is their stronghold in the time of trouble. 
 \q1
-\v 40 Yahweh helps them and rescues them. 
+\v 40 Yahuah helps them and rescues them. 
 \q2 He rescues them from the wicked and saves them, 
 \q2 because they have taken refuge in him. 
 \c 38
 \d A Psalm by David, for a memorial. 
 \q1
-\v 1 Yahweh, don’t rebuke me in your wrath, 
+\v 1 Yahuah, don’t rebuke me in your wrath, 
 \q2 neither chasten me in your hot displeasure. 
 \q1
 \v 2 For your arrows have pierced me, 
@@ -1946,7 +1946,7 @@
 \v 14 Yes, I am as a man who doesn’t hear, 
 \q2 in whose mouth are no reproofs. 
 \q1
-\v 15 For I hope in you, Yahweh. 
+\v 15 For I hope in you, Yahuah. 
 \q2 You will answer, Lord my Elohim. 
 \q1
 \v 16 For I said, “Don’t let them gloat over me, 
@@ -1964,7 +1964,7 @@
 \v 20 They who render evil for good are also adversaries to me, 
 \q2 because I follow what is good. 
 \q1
-\v 21 Don’t forsake me, Yahweh. 
+\v 21 Don’t forsake me, Yahuah. 
 \q2 My Elohim, don’t be far from me. 
 \q1
 \v 22 Hurry to help me, 
@@ -1983,7 +1983,7 @@
 \q2 While I meditated, the fire burned. 
 \q1 I spoke with my tongue: 
 \q2
-\v 4 “Yahweh, show me my end, 
+\v 4 “Yahuah, show me my end, 
 \q2 what is the measure of my days. 
 \q2 Let me know how frail I am. 
 \q1
@@ -2012,7 +2012,7 @@
 \q2 you consume his wealth like a moth. 
 \q1 Surely every man is but a breath.” \qs Selah.\qs* 
 \q1
-\v 12 “Hear my prayer, Yahweh, and give ear to my cry. 
+\v 12 “Hear my prayer, Yahuah, and give ear to my cry. 
 \q2 Don’t be silent at my tears. 
 \q1 For I am a stranger with you, 
 \q2 a foreigner, as all my fathers were. 
@@ -2022,7 +2022,7 @@
 \c 40
 \d For the Chief Musician. A Psalm by David. 
 \q1
-\v 1 I waited patiently for Yahweh. 
+\v 1 I waited patiently for Yahuah. 
 \q2 He turned to me, and heard my cry. 
 \q1
 \v 2 He brought me up also out of a horrible pit, 
@@ -2031,12 +2031,12 @@
 \q2 and gave me a firm place to stand. 
 \q1
 \v 3 He has put a new song in my mouth, even praise to our Elohim. 
-\q2 Many shall see it, and fear, and shall trust in Yahweh. 
+\q2 Many shall see it, and fear, and shall trust in Yahuah. 
 \q1
-\v 4 Blessed is the man who makes Yahweh his trust, 
+\v 4 Blessed is the man who makes Yahuah his trust, 
 \q2 and doesn’t respect the proud, nor such as turn away to lies. 
 \q1
-\v 5 Many, Yahweh, my Elohim, are the wonderful works which you have done, 
+\v 5 Many, Yahuah, my Elohim, are the wonderful works which you have done, 
 \q2 and your thoughts which are toward us. 
 \q1 They can’t be declared back to you. 
 \q2 If I would declare and speak of them, they are more than can be counted. 
@@ -2052,13 +2052,13 @@
 \q2 Yes, your law is within my heart.” 
 \q1
 \v 9 I have proclaimed glad news of righteousness in the great assembly. 
-\q2 Behold, I will not seal my lips, Yahweh, you know. 
+\q2 Behold, I will not seal my lips, Yahuah, you know. 
 \q1
 \v 10 I have not hidden your righteousness within my heart. 
 \q2 I have declared your faithfulness and your salvation. 
 \q2 I have not concealed your loving kindness and your truth from the great assembly. 
 \q1
-\v 11 Don’t withhold your tender mercies from me, Yahweh. 
+\v 11 Don’t withhold your tender mercies from me, Yahuah. 
 \q2 Let your loving kindness and your truth continually preserve me. 
 \q1
 \v 12 For innumerable evils have surrounded me. 
@@ -2066,8 +2066,8 @@
 \q1 They are more than the hairs of my head. 
 \q2 My heart has failed me. 
 \q1
-\v 13 Be pleased, Yahweh, to deliver me. 
-\q2 Hurry to help me, Yahweh. 
+\v 13 Be pleased, Yahuah, to deliver me. 
+\q2 Hurry to help me, Yahuah. 
 \q1
 \v 14 Let them be disappointed and confounded together who seek after my soul to destroy it. 
 \q2 Let them be turned backward and brought to dishonor who delight in my hurt. 
@@ -2075,7 +2075,7 @@
 \v 15 Let them be desolate by reason of their shame that tell me, “Aha! Aha!” 
 \q1
 \v 16 Let all those who seek you rejoice and be glad in you. 
-\q2 Let such as love your salvation say continually, “Let Yahweh be exalted!” 
+\q2 Let such as love your salvation say continually, “Let Yahuah be exalted!” 
 \q1
 \v 17 But I am poor and needy. 
 \q2 May the Lord think about me. 
@@ -2085,16 +2085,16 @@
 \d For the Chief Musician. A Psalm by David. 
 \q1
 \v 1 Blessed is he who considers the poor. 
-\q2 Yahweh will deliver him in the day of evil. 
+\q2 Yahuah will deliver him in the day of evil. 
 \q1
-\v 2 Yahweh will preserve him, and keep him alive. 
+\v 2 Yahuah will preserve him, and keep him alive. 
 \q2 He shall be blessed on the earth, 
 \q2 and he will not surrender him to the will of his enemies. 
 \q1
-\v 3 Yahweh will sustain him on his sickbed, 
+\v 3 Yahuah will sustain him on his sickbed, 
 \q2 and restore him from his bed of illness. 
 \q1
-\v 4 I said, “Yahweh, have mercy on me! 
+\v 4 I said, “Yahuah, have mercy on me! 
 \q2 Heal me, for I have sinned against you.” 
 \q1
 \v 5 My enemies speak evil against me: 
@@ -2115,7 +2115,7 @@
 \q2 has lifted up his heel against me. 
 \b
 \q1
-\v 10 But you, Yahweh, have mercy on me, and raise me up, 
+\v 10 But you, Yahuah, have mercy on me, and raise me up, 
 \q2 that I may repay them. 
 \q1
 \v 11 By this I know that you delight in me, 
@@ -2125,7 +2125,7 @@
 \q2 and set me in your presence forever. 
 \b
 \q1
-\v 13 Blessed be Yahweh, the Elohim of Israel, 
+\v 13 Blessed be Yahuah, the Elohim of Israel, 
 \q2 from everlasting and to everlasting! 
 \q1 Amen and amen. 
 \c 42
@@ -2158,7 +2158,7 @@
 \q2 All your waves and your billows have swept over me. 
 \b
 \q1
-\v 8 Yahweh will command his loving kindness in the daytime. 
+\v 8 Yahuah will command his loving kindness in the daytime. 
 \q2 In the night his song shall be with me: 
 \q2 a prayer to the Elohim of my life. 
 \q1
@@ -2360,11 +2360,11 @@
 \v 6 The nations raged. The kingdoms were moved. 
 \q2 He lifted his voice and the earth melted. 
 \q1
-\v 7 Yahweh of Armies is with us. 
+\v 7 Yahuah of Armies is with us. 
 \q2 The Elohim of Jacob is our refuge. \qs Selah.\qs* 
 \b
 \q1
-\v 8 Come, see Yahweh’s works, 
+\v 8 Come, see Yahuah’s works, 
 \q2 what desolations he has made in the earth. 
 \q1
 \v 9 He makes wars cease to the end of the earth. 
@@ -2375,7 +2375,7 @@
 \q2 I will be exalted among the nations. 
 \q2 I will be exalted in the earth.” 
 \q1
-\v 11 Yahweh of Armies is with us. 
+\v 11 Yahuah of Armies is with us. 
 \q2 The Elohim of Jacob is our refuge. \qs Selah.\qs* 
 \b
 \c 47
@@ -2384,7 +2384,7 @@
 \v 1 Oh clap your hands, all you nations. 
 \q2 Shout to Elohim with the voice of triumph! 
 \q1
-\v 2 For Yahweh Most High is awesome. 
+\v 2 For Yahuah Most High is awesome. 
 \q2 He is a great King over all the earth. 
 \q1
 \v 3 He subdues nations under us, 
@@ -2394,7 +2394,7 @@
 \q2 the glory of Jacob whom he loved. \qs Selah.\qs* 
 \q1
 \v 5 Elohim has gone up with a shout, 
-\q2 Yahweh with the sound of a trumpet. 
+\q2 Yahuah with the sound of a trumpet. 
 \q1
 \v 6 Sing praises to Elohim! Sing praises! 
 \q2 Sing praises to our King! Sing praises! 
@@ -2412,7 +2412,7 @@
 \c 48
 \d A Song. A Psalm by the sons of Korah. 
 \q1
-\v 1 Great is Yahweh, and greatly to be praised, 
+\v 1 Great is Yahuah, and greatly to be praised, 
 \q2 in the city of our Elohim, in his set-apart mountain. 
 \q1
 \v 2 Beautiful in elevation, the joy of the whole earth, 
@@ -2434,7 +2434,7 @@
 \v 7 With the east wind, you break the ships of Tarshish. 
 \q1
 \v 8 As we have heard, so we have seen, 
-\q2 in the city of Yahweh of Armies, in the city of our Elohim. 
+\q2 in the city of Yahuah of Armies, in the city of our Elohim. 
 \q1 Elohim will establish it forever. \qs Selah.\qs* 
 \q1
 \v 9 We have thought about your loving kindness, Elohim, 
@@ -2524,7 +2524,7 @@
 \c 50
 \d A Psalm by Asaph. 
 \q1
-\v 1 The Mighty One, Elohim, Yahweh, speaks, 
+\v 1 The Mighty One, Elohim, Yahuah, speaks, 
 \q2 and calls the earth from sunrise to sunset. 
 \q1
 \v 2 Out of Zion, the perfection of beauty, 
@@ -2742,7 +2742,7 @@
 \q2 Destroy them in your truth. 
 \q1
 \v 6 With a free will offering, I will sacrifice to you. 
-\q2 I will give thanks to your name, Yahweh, for it is good. 
+\q2 I will give thanks to your name, Yahuah, for it is good. 
 \q1
 \v 7 For he has delivered me out of all trouble. 
 \q2 My eye has seen triumph over my enemies. 
@@ -2799,7 +2799,7 @@
 \q2 For wickedness is among them, in their dwelling. 
 \q1
 \v 16 As for me, I will call on Elohim. 
-\q2 Yahweh will save me. 
+\q2 Yahuah will save me. 
 \q1
 \v 17 Evening, morning, and at noon, I will cry out in distress. 
 \q2 He will hear my voice. 
@@ -2822,7 +2822,7 @@
 \q2 yet they were drawn swords. 
 \b
 \q1
-\v 22 Cast your burden on Yahweh and he will sustain you. 
+\v 22 Cast your burden on Yahuah and he will sustain you. 
 \q2 He will never allow the righteous to be moved. 
 \q1
 \v 23 But you, Elohim, will bring them down into the pit of destruction. 
@@ -2863,7 +2863,7 @@
 \q2 I know this: that Elohim is for me. 
 \q1
 \v 10 In Elohim, I will praise his word. 
-\q2 In Yahweh, I will praise his word. 
+\q2 In Yahuah, I will praise his word. 
 \q1
 \v 11 I have put my trust in Elohim. 
 \q2 I will not be afraid. 
@@ -2938,7 +2938,7 @@
 \q2 no matter how skillful the charmer may be. 
 \q1
 \v 6 Break their teeth, Elohim, in their mouth. 
-\q2 Break out the great teeth of the young lions, Yahweh. 
+\q2 Break out the great teeth of the young lions, Yahuah. 
 \q1
 \v 7 Let them vanish like water that flows away. 
 \q2 When they draw the bow, let their arrows be made blunt. 
@@ -2965,12 +2965,12 @@
 \q1
 \v 3 For, behold, they lie in wait for my soul. 
 \q2 The mighty gather themselves together against me, 
-\q2 not for my disobedience, nor for my sin, Yahweh. 
+\q2 not for my disobedience, nor for my sin, Yahuah. 
 \q1
 \v 4 I have done no wrong, yet they are ready to attack me. 
 \q2 Rise up, behold, and help me! 
 \q1
-\v 5 You, Yahweh Elohim of Armies, the Elohim of Israel, 
+\v 5 You, Yahuah Elohim of Armies, the Elohim of Israel, 
 \q2 rouse yourself to punish the nations. 
 \q2 Show no mercy to the wicked traitors. \qs Selah.\qs* 
 \q1
@@ -2981,7 +2981,7 @@
 \q2 Swords are in their lips, 
 \q2 “For”, they say, “who hears us?” 
 \q1
-\v 8 But you, Yahweh, laugh at them. 
+\v 8 But you, Yahuah, laugh at them. 
 \q2 You scoff at all the nations. 
 \q1
 \v 9 Oh, my Strength, I watch for you, 
@@ -3207,7 +3207,7 @@
 \q2 They shall declare the work of Elohim, 
 \q2 and shall wisely ponder what he has done. 
 \q1
-\v 10 The righteous shall be glad in Yahweh, 
+\v 10 The righteous shall be glad in Yahuah, 
 \q2 and shall take refuge in him. 
 \q2 All the upright in heart shall praise him! 
 \c 65
@@ -3409,7 +3409,7 @@
 \q1
 \v 16 Why do you look in envy, you rugged mountains, 
 \q2 at the mountain where Elohim chooses to reign? 
-\q2 Yes, Yahweh will dwell there forever. 
+\q2 Yes, Yahuah will dwell there forever. 
 \q1
 \v 17 The chariots of Elohim are tens of thousands and thousands of thousands. 
 \q2 The Lord is among them, from Sinai, into the sanctuary. 
@@ -3424,7 +3424,7 @@
 \q2 even the Elohim who is our salvation. \qs Selah.\qs* 
 \q1
 \v 20 Elohim is to us an Elohim of deliverance. 
-\q2 To Yahweh, the Lord, belongs escape from death. 
+\q2 To Yahuah, the Lord, belongs escape from death. 
 \q1
 \v 21 But Elohim will strike through the head of his enemies, 
 \q2 the hairy scalp of such a one as still continues in his guiltiness. 
@@ -3494,7 +3494,7 @@
 \v 5 Elohim, you know my foolishness. 
 \q2 My sins aren’t hidden from you. 
 \q1
-\v 6 Don’t let those who wait for you be shamed through me, Lord Yahweh of Armies. 
+\v 6 Don’t let those who wait for you be shamed through me, Lord Yahuah of Armies. 
 \q2 Don’t let those who seek you be brought to dishonor through me, Elohim of Israel. 
 \q1
 \v 7 Because for your sake, I have borne reproach. 
@@ -3515,7 +3515,7 @@
 \v 12 Those who sit in the gate talk about me. 
 \q2 I am the song of the drunkards. 
 \q1
-\v 13 But as for me, my prayer is to you, Yahweh, in an acceptable time. 
+\v 13 But as for me, my prayer is to you, Yahuah, in an acceptable time. 
 \q2 Elohim, in the abundance of your loving kindness, answer me in the truth of your salvation. 
 \q1
 \v 14 Deliver me out of the mire, and don’t let me sink. 
@@ -3525,7 +3525,7 @@
 \q2 neither let the deep swallow me up. 
 \q2 Don’t let the pit shut its mouth on me. 
 \q1
-\v 16 Answer me, Yahweh, for your loving kindness is good. 
+\v 16 Answer me, Yahuah, for your loving kindness is good. 
 \q2 According to the multitude of your tender mercies, turn to me. 
 \q1
 \v 17 Don’t hide your face from your servant, 
@@ -3572,13 +3572,13 @@
 \v 30 I will praise the name of Elohim with a song, 
 \q2 and will magnify him with thanksgiving. 
 \q1
-\v 31 It will please Yahweh better than an ox, 
+\v 31 It will please Yahuah better than an ox, 
 \q2 or a bull that has horns and hoofs. 
 \q1
 \v 32 The humble have seen it, and are glad. 
 \q2 You who seek after Elohim, let your heart live. 
 \q1
-\v 33 For Yahweh hears the needy, 
+\v 33 For Yahuah hears the needy, 
 \q2 and doesn’t despise his captive people. 
 \q1
 \v 34 Let heaven and earth praise him; 
@@ -3593,7 +3593,7 @@
 \d For the Chief Musician. By David. A reminder. 
 \q1
 \v 1 Hurry, Elohim, to deliver me. 
-\q2 Come quickly to help me, Yahweh. 
+\q2 Come quickly to help me, Yahuah. 
 \q1
 \v 2 Let them be disappointed and confounded who seek my soul. 
 \q2 Let those who desire my ruin be turned back in disgrace. 
@@ -3608,11 +3608,11 @@
 \v 5 But I am poor and needy. 
 \q2 Come to me quickly, Elohim. 
 \q1 You are my help and my deliverer. 
-\q2 Yahweh, don’t delay. 
+\q2 Yahuah, don’t delay. 
 \b
 \c 71
 \q1
-\v 1 In you, Yahweh, I take refuge. 
+\v 1 In you, Yahuah, I take refuge. 
 \q2 Never let me be disappointed. 
 \q1
 \v 2 Deliver me in your righteousness, and rescue me. 
@@ -3625,7 +3625,7 @@
 \v 4 Rescue me, my Elohim, from the hand of the wicked, 
 \q2 from the hand of the unrighteous and cruel man. 
 \q1
-\v 5 For you are my hope, Lord Yahweh, 
+\v 5 For you are my hope, Lord Yahuah, 
 \q2 my confidence from my youth. 
 \q1
 \v 6 I have relied on you from the womb. 
@@ -3660,7 +3660,7 @@
 \q2 and of your salvation all day, 
 \q2 though I don’t know its full measure. 
 \q1
-\v 16 I will come with the mighty acts of the Lord Yahweh. 
+\v 16 I will come with the mighty acts of the Lord Yahuah. 
 \q2 I will make mention of your righteousness, even of yours alone. 
 \q1
 \v 17 Elohim, you have taught me from my youth. 
@@ -3750,7 +3750,7 @@
 \q2 All nations will call him blessed. 
 \b
 \q1
-\v 18 Praise be to Yahweh Elohim, the Elohim of Israel, 
+\v 18 Praise be to Yahuah Elohim, the Elohim of Israel, 
 \q2 who alone does marvelous deeds. 
 \q1
 \v 19 Blessed be his glorious name forever! 
@@ -3844,7 +3844,7 @@
 \q2 You have destroyed all those who are unfaithful to you. 
 \q1
 \v 28 But it is good for me to come close to Elohim. 
-\q2 I have made the Lord Yahweh my refuge, 
+\q2 I have made the Lord Yahuah my refuge, 
 \q2 that I may tell of all your works. 
 \b
 \c 74
@@ -3904,7 +3904,7 @@
 \q2 You have made summer and winter. 
 \b
 \q1
-\v 18 Remember this, that the enemy has mocked you, Yahweh. 
+\v 18 Remember this, that the enemy has mocked you, Yahuah. 
 \q2 Foolish people have blasphemed your name. 
 \q1
 \v 19 Don’t deliver the soul of your dove to wild beasts. 
@@ -3948,7 +3948,7 @@
 \v 7 But Elohim is the judge. 
 \q2 He puts down one, and lifts up another. 
 \q1
-\v 8 For in Yahweh’s hand there is a cup, 
+\v 8 For in Yahuah’s hand there is a cup, 
 \q2 full of foaming wine mixed with spices. 
 \q1 He pours it out. 
 \q2 Indeed the wicked of the earth drink and drink it to its very dregs. 
@@ -3994,7 +3994,7 @@
 \v 10 Surely the wrath of man praises you. 
 \q2 The survivors of your wrath are restrained. 
 \q1
-\v 11 Make vows to Yahweh your Elohim, and fulfill them! 
+\v 11 Make vows to Yahuah your Elohim, and fulfill them! 
 \q2 Let all of his neighbors bring presents to him who is to be feared. 
 \q1
 \v 12 He will cut off the spirit of princes. 
@@ -4084,7 +4084,7 @@
 \q2 and our fathers have told us. 
 \q1
 \v 4 We will not hide them from their children, 
-\q2 telling to the generation to come the praises of Yahweh, 
+\q2 telling to the generation to come the praises of Yahuah, 
 \q2 his strength, and his wondrous deeds that he has done. 
 \q1
 \v 5 For he established a covenant in Jacob, 
@@ -4141,7 +4141,7 @@
 \q1 Can he give bread also? 
 \q2 Will he provide meat for his people?” 
 \q1
-\v 21 Therefore Yahweh heard, and was angry. 
+\v 21 Therefore Yahuah heard, and was angry. 
 \q2 A fire was kindled against Jacob, 
 \q2 anger also went up against Israel, 
 \q1
@@ -4320,7 +4320,7 @@
 \v 4 We have become a reproach to our neighbors, 
 \q2 a scoffing and derision to those who are around us. 
 \q1
-\v 5 How long, Yahweh? 
+\v 5 How long, Yahuah? 
 \q2 Will you be angry forever? 
 \q2 Will your jealousy burn like fire? 
 \q1
@@ -4366,7 +4366,7 @@
 \q2 and we will be saved. 
 \b
 \q1
-\v 4 Yahweh Elohim of Armies, 
+\v 4 Yahuah Elohim of Armies, 
 \q2 how long will you be angry against the prayer of your people? 
 \q1
 \v 5 You have fed them with the bread of tears, 
@@ -4414,7 +4414,7 @@
 \v 18 So we will not turn away from you. 
 \q2 Revive us, and we will call on your name. 
 \q1
-\v 19 Turn us again, Yahweh Elohim of Armies. 
+\v 19 Turn us again, Yahuah Elohim of Armies. 
 \q2 Cause your face to shine, and we will be saved. 
 \c 81
 \d For the Chief Musician. On an instrument of Gath. By Asaph. 
@@ -4449,7 +4449,7 @@
 \v 9 There shall be no strange elohim in you, 
 \q2 neither shall you worship any foreign elohim. 
 \q1
-\v 10 I am Yahweh, your Elohim, 
+\v 10 I am Yahuah, your Elohim, 
 \q2 who brought you up out of the land of Egypt. 
 \q2 Open your mouth wide, and I will fill it. 
 \q1
@@ -4465,7 +4465,7 @@
 \v 14 I would soon subdue their enemies, 
 \q2 and turn my hand against their adversaries. 
 \q1
-\v 15 The haters of Yahweh would cringe before him, 
+\v 15 The haters of Yahuah would cringe before him, 
 \q2 and their punishment would last forever. 
 \q1
 \v 16 But he would have also fed them with the finest of the wheat. 
@@ -4547,25 +4547,25 @@
 \q2 and terrify them with your storm. 
 \q1
 \v 16 Fill their faces with confusion, 
-\q2 that they may seek your name, Yahweh. 
+\q2 that they may seek your name, Yahuah. 
 \q1
 \v 17 Let them be disappointed and dismayed forever. 
 \q2 Yes, let them be confounded and perish; 
 \q1
-\v 18 that they may know that you alone, whose name is Yahweh, 
+\v 18 that they may know that you alone, whose name is Yahuah, 
 \q2 are the Most High over all the earth. 
 \c 84
 \d For the Chief Musician. On an instrument of Gath. A Psalm by the sons of Korah. 
 \q1
 \v 1 How lovely are your dwellings, 
-\q2 Yahweh of Armies! 
+\q2 Yahuah of Armies! 
 \q1
-\v 2 My soul longs, and even faints for the courts of Yahweh. 
+\v 2 My soul longs, and even faints for the courts of Yahuah. 
 \q2 My heart and my flesh cry out for the living Elohim. 
 \q1
 \v 3 Yes, the sparrow has found a home, 
 \q2 and the swallow a nest for herself, where she may have her young, 
-\q2 near your altars, Yahweh of Armies, my King, and my Elohim. 
+\q2 near your altars, Yahuah of Armies, my King, and my Elohim. 
 \q1
 \v 4 Blessed are those who dwell in your house. 
 \q2 They are always praising you. \qs Selah.\qs* 
@@ -4579,7 +4579,7 @@
 \v 7 They go from strength to strength. 
 \q2 Every one of them appears before Elohim in Zion. 
 \q1
-\v 8 Yahweh, Elohim of Armies, hear my prayer. 
+\v 8 Yahuah, Elohim of Armies, hear my prayer. 
 \q2 Listen, Elohim of Jacob. \qs Selah.\qs* 
 \q1
 \v 9 Behold, Elohim our shield, 
@@ -4589,16 +4589,16 @@
 \q2 I would rather be a doorkeeper in the house of my Elohim, 
 \q2 than to dwell in the tents of wickedness. 
 \q1
-\v 11 For Yahweh Elohim is a sun and a shield. 
-\q2 Yahweh will give grace and glory. 
+\v 11 For Yahuah Elohim is a sun and a shield. 
+\q2 Yahuah will give grace and glory. 
 \q2 He withholds no good thing from those who walk blamelessly. 
 \q1
-\v 12 Yahweh of Armies, 
+\v 12 Yahuah of Armies, 
 \q2 blessed is the man who trusts in you. 
 \c 85
 \d For the Chief Musician. A Psalm by the sons of Korah. 
 \q1
-\v 1 Yahweh, you have been favorable to your land. 
+\v 1 Yahuah, you have been favorable to your land. 
 \q2 You have restored the fortunes of Jacob. 
 \q1
 \v 2 You have forgiven the iniquity of your people. 
@@ -4616,10 +4616,10 @@
 \v 6 Won’t you revive us again, 
 \q2 that your people may rejoice in you? 
 \q1
-\v 7 Show us your loving kindness, Yahweh. 
+\v 7 Show us your loving kindness, Yahuah. 
 \q2 Grant us your salvation. 
 \q1
-\v 8 I will hear what Elohim, Yahweh, will speak, 
+\v 8 I will hear what Elohim, Yahuah, will speak, 
 \q2 for he will speak peace to his people, his saints; 
 \q2 but let them not turn again to folly. 
 \q1
@@ -4632,7 +4632,7 @@
 \v 11 Truth springs out of the earth. 
 \q2 Righteousness has looked down from heaven. 
 \q1
-\v 12 Yes, Yahweh will give that which is good. 
+\v 12 Yes, Yahuah will give that which is good. 
 \q2 Our land will yield its increase. 
 \q1
 \v 13 Righteousness goes before him, 
@@ -4640,7 +4640,7 @@
 \c 86
 \d A Prayer by David. 
 \q1
-\v 1 Hear, Yahweh, and answer me, 
+\v 1 Hear, Yahuah, and answer me, 
 \q2 for I am poor and needy. 
 \q1
 \v 2 Preserve my soul, for I am elohimly. 
@@ -4655,7 +4655,7 @@
 \v 5 For you, Lord, are good, and ready to forgive, 
 \q2 abundant in loving kindness to all those who call on you. 
 \q1
-\v 6 Hear, Yahweh, my prayer. 
+\v 6 Hear, Yahuah, my prayer. 
 \q2 Listen to the voice of my petitions. 
 \q1
 \v 7 In the day of my trouble I will call on you, 
@@ -4670,7 +4670,7 @@
 \v 10 For you are great, and do wondrous things. 
 \q2 You are Elohim alone. 
 \q1
-\v 11 Teach me your way, Yahweh. 
+\v 11 Teach me your way, Yahuah. 
 \q2 I will walk in your truth. 
 \q2 Make my heart undivided to fear your name. 
 \q1
@@ -4693,13 +4693,13 @@
 \q1
 \v 17 Show me a sign of your goodness, 
 \q2 that those who hate me may see it, and be shamed, 
-\q2 because you, Yahweh, have helped me, and comforted me. 
+\q2 because you, Yahuah, have helped me, and comforted me. 
 \c 87
 \d A Psalm by the sons of Korah; a Song. 
 \q1
 \v 1 His foundation is in the set-apart mountains. 
 \q2
-\v 2 Yahweh loves the gates of Zion more than all the dwellings of Jacob. 
+\v 2 Yahuah loves the gates of Zion more than all the dwellings of Jacob. 
 \q1
 \v 3 Glorious things are spoken about you, city of Elohim. \qs Selah.\qs* 
 \q1
@@ -4710,7 +4710,7 @@
 \v 5 Yes, of Zion it will be said, “This one and that one was born in her;” 
 \q2 the Most High himself will establish her. 
 \q1
-\v 6 Yahweh will count, when he writes up the peoples, 
+\v 6 Yahuah will count, when he writes up the peoples, 
 \q2 “This one was born there.” \qs Selah.\qs* 
 \q1
 \v 7 Those who sing as well as those who dance say, 
@@ -4718,7 +4718,7 @@
 \c 88
 \d A Song. A Psalm by the sons of Korah. For the Chief Musician. To the tune of “The Suffering of Affliction.” A contemplation by Heman, the Ezrahite. 
 \q1
-\v 1 Yahweh, the Elohim of my salvation, 
+\v 1 Yahuah, the Elohim of my salvation, 
 \q2 I have cried day and night before you. 
 \q1
 \v 2 Let my prayer enter into your presence. 
@@ -4746,7 +4746,7 @@
 \q2 I am confined, and I can’t escape. 
 \q1
 \v 9 My eyes are dim from grief. 
-\q2 I have called on you daily, Yahweh. 
+\q2 I have called on you daily, Yahuah. 
 \q2 I have spread out my hands to you. 
 \q1
 \v 10 Do you show wonders to the dead? 
@@ -4758,10 +4758,10 @@
 \v 12 Are your wonders made known in the dark? 
 \q2 Or your righteousness in the land of forgetfulness? 
 \q1
-\v 13 But to you, Yahweh, I have cried. 
+\v 13 But to you, Yahuah, I have cried. 
 \q2 In the morning, my prayer comes before you. 
 \q1
-\v 14 Yahweh, why do you reject my soul? 
+\v 14 Yahuah, why do you reject my soul? 
 \q2 Why do you hide your face from me? 
 \q1
 \v 15 I am afflicted and ready to die from my youth up. 
@@ -4778,7 +4778,7 @@
 \c 89
 \d A contemplation by Ethan, the Ezrahite. 
 \q1
-\v 1 I will sing of the loving kindness of Yahweh forever. 
+\v 1 I will sing of the loving kindness of Yahuah forever. 
 \q2 With my mouth, I will make known your faithfulness to all generations. 
 \q1
 \v 2 I indeed declare, “Love stands firm forever. 
@@ -4792,16 +4792,16 @@
 \v 4 ‘I will establish your offspring forever, 
 \q2 and build up your throne to all generations.’ ” \qs Selah.\qs* 
 \q1
-\v 5 The heavens will praise your wonders, Yahweh, 
+\v 5 The heavens will praise your wonders, Yahuah, 
 \q2 your faithfulness also in the assembly of the set-apart ones. 
 \q1
-\v 6 For who in the skies can be compared to Yahweh? 
-\q2 Who among the sons of the heavenly beings is like Yahweh, 
+\v 6 For who in the skies can be compared to Yahuah? 
+\q2 Who among the sons of the heavenly beings is like Yahuah, 
 \q1
 \v 7 a very awesome Elohim in the council of the set-apart ones, 
 \q2 to be feared above all those who are around him? 
 \q1
-\v 8 Yahweh, Elohim of Armies, who is a mighty one, like you? 
+\v 8 Yahuah, Elohim of Armies, who is a mighty one, like you? 
 \q2 Yah, your faithfulness is around you. 
 \q1
 \v 9 You rule the pride of the sea. 
@@ -4825,7 +4825,7 @@
 \q2 Loving kindness and truth go before your face. 
 \q1
 \v 15 Blessed are the people who learn to acclaim you. 
-\q2 They walk in the light of your presence, Yahweh. 
+\q2 They walk in the light of your presence, Yahuah. 
 \q1
 \v 16 In your name they rejoice all day. 
 \q2 In your righteousness, they are exalted. 
@@ -4833,7 +4833,7 @@
 \v 17 For you are the glory of their strength. 
 \q2 In your favor, our horn will be exalted. 
 \q1
-\v 18 For our shield belongs to Yahweh, 
+\v 18 For our shield belongs to Yahuah, 
 \q2 our king to the Set-Apart One of Israel. 
 \b
 \q1
@@ -4920,7 +4920,7 @@
 \v 45 You have shortened the days of his youth. 
 \q2 You have covered him with shame. \qs Selah.\qs* 
 \q1
-\v 46 How long, Yahweh? 
+\v 46 How long, Yahuah? 
 \q2 Will you hide yourself forever? 
 \q2 Will your wrath burn like fire? 
 \q1
@@ -4936,11 +4936,11 @@
 \v 50 Remember, Lord, the reproach of your servants, 
 \q2 how I bear in my heart the taunts of all the mighty peoples, 
 \q1
-\v 51 With which your enemies have mocked, Yahweh, 
+\v 51 With which your enemies have mocked, Yahuah, 
 \q2 with which they have mocked the footsteps of your anointed one. 
 \b
 \q1
-\v 52 Blessed be Yahweh forever more. 
+\v 52 Blessed be Yahuah forever more. 
 \q1 Amen, and Amen. 
 \c 90
 \ms1 BOOK 4
@@ -4984,7 +4984,7 @@
 \v 12 So teach us to count our days, 
 \q2 that we may gain a heart of wisdom. 
 \q1
-\v 13 Relent, Yahweh! 
+\v 13 Relent, Yahuah! 
 \q2 How long? 
 \q2 Have compassion on your servants! 
 \q1
@@ -5005,7 +5005,7 @@
 \v 1 He who dwells in the secret place of the Most High 
 \q2 will rest in the shadow of the Almighty. 
 \q1
-\v 2 I will say of Yahweh, “He is my refuge and my fortress; 
+\v 2 I will say of Yahuah, “He is my refuge and my fortress; 
 \q2 my Elohim, in whom I trust.” 
 \q1
 \v 3 For he will deliver you from the snare of the fowler, 
@@ -5028,7 +5028,7 @@
 \v 8 You will only look with your eyes, 
 \q2 and see the recompense of the wicked. 
 \q1
-\v 9 Because you have made Yahweh your refuge, 
+\v 9 Because you have made Yahuah your refuge, 
 \q2 and the Most High your dwelling place, 
 \q1
 \v 10 no evil shall happen to you, 
@@ -5055,7 +5055,7 @@
 \c 92
 \d A Psalm. A song for the Sabbath day. 
 \q1
-\v 1 It is a good thing to give thanks to Yahweh, 
+\v 1 It is a good thing to give thanks to Yahuah, 
 \q2 to sing praises to your name, Most High, 
 \q1
 \v 2 to proclaim your loving kindness in the morning, 
@@ -5064,10 +5064,10 @@
 \v 3 with the ten-stringed lute, with the harp, 
 \q2 and with the melody of the lyre. 
 \q1
-\v 4 For you, Yahweh, have made me glad through your work. 
+\v 4 For you, Yahuah, have made me glad through your work. 
 \q2 I will triumph in the works of your hands. 
 \q1
-\v 5 How great are your works, Yahweh! 
+\v 5 How great are your works, Yahuah! 
 \q2 Your thoughts are very deep. 
 \q1
 \v 6 A senseless man doesn’t know, 
@@ -5077,9 +5077,9 @@
 \q2 and all the evildoers flourish, 
 \q2 they will be destroyed forever. 
 \q1
-\v 8 But you, Yahweh, are on high forever more. 
+\v 8 But you, Yahuah, are on high forever more. 
 \q1
-\v 9 For behold, your enemies, Yahweh, 
+\v 9 For behold, your enemies, Yahuah, 
 \q2 for behold, your enemies shall perish. 
 \q2 All the evildoers will be scattered. 
 \q1
@@ -5092,52 +5092,52 @@
 \v 12 The righteous shall flourish like the palm tree. 
 \q2 He will grow like a cedar in Lebanon. 
 \q1
-\v 13 They are planted in Yahweh’s house. 
+\v 13 They are planted in Yahuah’s house. 
 \q2 They will flourish in our Elohim’s courts. 
 \q1
 \v 14 They will still produce fruit in old age. 
 \q2 They will be full of sap and green, 
 \q2
-\v 15 to show that Yahweh is upright. 
+\v 15 to show that Yahuah is upright. 
 \q1 He is my rock, 
 \q2 and there is no unrighteousness in him. 
 \c 93
 \q1
-\v 1 Yahweh reigns! 
+\v 1 Yahuah reigns! 
 \q2 He is clothed with majesty! 
-\q2 Yahweh is armed with strength. 
+\q2 Yahuah is armed with strength. 
 \q1 The world also is established. 
 \q2 It can’t be moved. 
 \q1
 \v 2 Your throne is established from long ago. 
 \q2 You are from everlasting. 
 \q1
-\v 3 The floods have lifted up, Yahweh, 
+\v 3 The floods have lifted up, Yahuah, 
 \q2 the floods have lifted up their voice. 
 \q2 The floods lift up their waves. 
 \q1
 \v 4 Above the voices of many waters, 
 \q2 the mighty breakers of the sea, 
-\q2 Yahweh on high is mighty. 
+\q2 Yahuah on high is mighty. 
 \q1
 \v 5 Your statutes stand firm. 
 \q2 Set-Apartness adorns your house, 
-\q2 Yahweh, forever more. 
+\q2 Yahuah, forever more. 
 \c 94
 \q1
-\v 1 Yahweh, you Elohim to whom vengeance belongs, 
+\v 1 Yahuah, you Elohim to whom vengeance belongs, 
 \q2 you Elohim to whom vengeance belongs, shine out. 
 \q1
 \v 2 Rise up, you judge of the earth. 
 \q2 Pay back the proud what they deserve. 
 \q1
-\v 3 Yahweh, how long will the wicked, 
+\v 3 Yahuah, how long will the wicked, 
 \q2 how long will the wicked triumph? 
 \q1
 \v 4 They pour out arrogant words. 
 \q2 All the evildoers boast. 
 \q1
-\v 5 They break your people in pieces, Yahweh, 
+\v 5 They break your people in pieces, Yahuah, 
 \q2 and afflict your heritage. 
 \q1
 \v 6 They kill the widow and the alien, 
@@ -5155,7 +5155,7 @@
 \v 10 He who disciplines the nations, won’t he punish? 
 \q2 He who teaches man knows. 
 \q1
-\v 11 Yahweh knows the thoughts of man, 
+\v 11 Yahuah knows the thoughts of man, 
 \q2 that they are futile. 
 \q1
 \v 12 Blessed is the man whom you discipline, Yah, 
@@ -5164,7 +5164,7 @@
 \v 13 that you may give him rest from the days of adversity, 
 \q2 until the pit is dug for the wicked. 
 \q1
-\v 14 For Yahweh won’t reject his people, 
+\v 14 For Yahuah won’t reject his people, 
 \q2 neither will he forsake his inheritance. 
 \q1
 \v 15 For judgment will return to righteousness. 
@@ -5173,11 +5173,11 @@
 \v 16 Who will rise up for me against the wicked? 
 \q2 Who will stand up for me against the evildoers? 
 \q1
-\v 17 Unless Yahweh had been my help, 
+\v 17 Unless Yahuah had been my help, 
 \q2 my soul would have soon lived in silence. 
 \q1
 \v 18 When I said, “My foot is slipping!” 
-\q2 Your loving kindness, Yahweh, held me up. 
+\q2 Your loving kindness, Yahuah, held me up. 
 \q1
 \v 19 In the multitude of my thoughts within me, 
 \q2 your comforts delight my soul. 
@@ -5188,21 +5188,21 @@
 \v 21 They gather themselves together against the soul of the righteous, 
 \q2 and condemn the innocent blood. 
 \q1
-\v 22 But Yahweh has been my high tower, 
+\v 22 But Yahuah has been my high tower, 
 \q2 my Elohim, the rock of my refuge. 
 \q1
 \v 23 He has brought on them their own iniquity, 
 \q2 and will cut them off in their own wickedness. 
-\q2 Yahweh, our Elohim, will cut them off. 
+\q2 Yahuah, our Elohim, will cut them off. 
 \c 95
 \q1
-\v 1 Oh come, let’s sing to Yahweh. 
+\v 1 Oh come, let’s sing to Yahuah. 
 \q2 Let’s shout aloud to the rock of our salvation! 
 \q1
 \v 2 Let’s come before his presence with thanksgiving. 
 \q2 Let’s extol him with songs! 
 \q1
-\v 3 For Yahweh is a great Elohim, 
+\v 3 For Yahuah is a great Elohim, 
 \q2 a great King above all elohims. 
 \q1
 \v 4 In his hand are the deep places of the earth. 
@@ -5212,7 +5212,7 @@
 \q2 His hands formed the dry land. 
 \q1
 \v 6 Oh come, let’s worship and bow down. 
-\q2 Let’s kneel before Yahweh, our Maker, 
+\q2 Let’s kneel before Yahuah, our Maker, 
 \q2
 \v 7 for he is our Elohim. 
 \q1 We are the people of his pasture, 
@@ -5233,35 +5233,35 @@
 \q2 “They won’t enter into my rest.” 
 \c 96
 \q1
-\v 1 Sing to Yahweh a new song! 
-\q2 Sing to Yahweh, all the earth. 
+\v 1 Sing to Yahuah a new song! 
+\q2 Sing to Yahuah, all the earth. 
 \q1
-\v 2 Sing to Yahweh! 
+\v 2 Sing to Yahuah! 
 \q2 Bless his name! 
 \q2 Proclaim his salvation from day to day! 
 \q1
 \v 3 Declare his glory among the nations, 
 \q2 his marvelous works among all the peoples. 
 \q1
-\v 4 For Yahweh is great, and greatly to be praised! 
+\v 4 For Yahuah is great, and greatly to be praised! 
 \q2 He is to be feared above all elohims. 
 \q1
 \v 5 For all the elohims of the peoples are idols, 
-\q2 but Yahweh made the heavens. 
+\q2 but Yahuah made the heavens. 
 \q1
 \v 6 Honor and majesty are before him. 
 \q2 Strength and beauty are in his sanctuary. 
 \q1
-\v 7 Ascribe to Yahweh, you families of nations, 
-\q2 ascribe to Yahweh glory and strength. 
+\v 7 Ascribe to Yahuah, you families of nations, 
+\q2 ascribe to Yahuah glory and strength. 
 \q1
-\v 8 Ascribe to Yahweh the glory due to his name. 
+\v 8 Ascribe to Yahuah the glory due to his name. 
 \q2 Bring an offering, and come into his courts. 
 \q1
-\v 9 Worship Yahweh in set-apart array. 
+\v 9 Worship Yahuah in set-apart array. 
 \q2 Tremble before him, all the earth. 
 \q1
-\v 10 Say among the nations, “Yahweh reigns.” 
+\v 10 Say among the nations, “Yahuah reigns.” 
 \q2 The world is also established. 
 \q2 It can’t be moved. 
 \q2 He will judge the peoples with equity. 
@@ -5272,13 +5272,13 @@
 \v 12 Let the field and all that is in it exult! 
 \q2 Then all the trees of the woods shall sing for joy 
 \q2
-\v 13 before Yahweh; for he comes, 
+\v 13 before Yahuah; for he comes, 
 \q2 for he comes to judge the earth. 
 \q1 He will judge the world with righteousness, 
 \q2 the peoples with his truth. 
 \c 97
 \q1
-\v 1 Yahweh reigns! 
+\v 1 Yahuah reigns! 
 \q2 Let the earth rejoice! 
 \q2 Let the multitude of islands be glad! 
 \q1
@@ -5291,7 +5291,7 @@
 \v 4 His lightning lights up the world. 
 \q2 The earth sees, and trembles. 
 \q1
-\v 5 The mountains melt like wax at the presence of Yahweh, 
+\v 5 The mountains melt like wax at the presence of Yahuah, 
 \q2 at the presence of the Lord of the whole earth. 
 \q1
 \v 6 The heavens declare his righteousness. 
@@ -5303,41 +5303,41 @@
 \q1
 \v 8 Zion heard and was glad. 
 \q2 The daughters of Judah rejoiced 
-\q2 because of your judgments, Yahweh. 
+\q2 because of your judgments, Yahuah. 
 \q1
-\v 9 For you, Yahweh, are most high above all the earth. 
+\v 9 For you, Yahuah, are most high above all the earth. 
 \q2 You are exalted far above all elohims. 
 \q1
-\v 10 You who love Yahweh, hate evil! 
+\v 10 You who love Yahuah, hate evil! 
 \q2 He preserves the souls of his saints. 
 \q2 He delivers them out of the hand of the wicked. 
 \q1
 \v 11 Light is sown for the righteous, 
 \q2 and gladness for the upright in heart. 
 \q1
-\v 12 Be glad in Yahweh, you righteous people! 
+\v 12 Be glad in Yahuah, you righteous people! 
 \q2 Give thanks to his set-apart Name. 
 \c 98
 \d A Psalm. 
 \q1
-\v 1 Sing to Yahweh a new song, 
+\v 1 Sing to Yahuah a new song, 
 \q2 for he has done marvelous things! 
 \q2 His right hand and his set-apart arm have worked salvation for him. 
 \q1
-\v 2 Yahweh has made known his salvation. 
+\v 2 Yahuah has made known his salvation. 
 \q2 He has openly shown his righteousness in the sight of the nations. 
 \q1
 \v 3 He has remembered his loving kindness and his faithfulness toward the house of Israel. 
 \q2 All the ends of the earth have seen the salvation of our Elohim. 
 \q1
-\v 4 Make a joyful noise to Yahweh, all the earth! 
+\v 4 Make a joyful noise to Yahuah, all the earth! 
 \q2 Burst out and sing for joy, yes, sing praises! 
 \q1
-\v 5 Sing praises to Yahweh with the harp, 
+\v 5 Sing praises to Yahuah with the harp, 
 \q2 with the harp and the voice of melody. 
 \q1
 \v 6 With trumpets and sound of the ram’s horn, 
-\q2 make a joyful noise before the King, Yahweh. 
+\q2 make a joyful noise before the King, Yahuah. 
 \q1
 \v 7 Let the sea roar with its fullness; 
 \q2 the world, and those who dwell therein. 
@@ -5345,17 +5345,17 @@
 \v 8 Let the rivers clap their hands. 
 \q2 Let the mountains sing for joy together. 
 \q1
-\v 9 Let them sing before Yahweh, 
+\v 9 Let them sing before Yahuah, 
 \q2 for he comes to judge the earth. 
 \q1 He will judge the world with righteousness, 
 \q2 and the peoples with equity. 
 \c 99
 \q1
-\v 1 Yahweh reigns! Let the peoples tremble. 
+\v 1 Yahuah reigns! Let the peoples tremble. 
 \q2 He sits enthroned among the cherubim. 
 \q2 Let the earth be moved. 
 \q1
-\v 2 Yahweh is great in Zion. 
+\v 2 Yahuah is great in Zion. 
 \q2 He is high above all the peoples. 
 \q1
 \v 3 Let them praise your great and awesome name. 
@@ -5366,35 +5366,35 @@
 \q2 You establish equity. 
 \q2 You execute justice and righteousness in Jacob. 
 \q1
-\v 5 Exalt Yahweh our Elohim. 
+\v 5 Exalt Yahuah our Elohim. 
 \q2 Worship at his footstool. 
 \q2 He is Set-Apart! 
 \b
 \q1
 \v 6 Moses and Aaron were among his priests, 
 \q2 Samuel was among those who call on his name. 
-\q2 They called on Yahweh, and he answered them. 
+\q2 They called on Yahuah, and he answered them. 
 \q1
 \v 7 He spoke to them in the pillar of cloud. 
 \q2 They kept his testimonies, 
 \q2 the statute that he gave them. 
 \q1
-\v 8 You answered them, Yahweh our Elohim. 
+\v 8 You answered them, Yahuah our Elohim. 
 \q2 You are an Elohim who forgave them, 
 \q2 although you took vengeance for their doings. 
 \q1
-\v 9 Exalt Yahweh, our Elohim. 
+\v 9 Exalt Yahuah, our Elohim. 
 \q2 Worship at his set-apart hill, 
-\q2 for Yahweh, our Elohim, is set-apart! 
+\q2 for Yahuah, our Elohim, is set-apart! 
 \c 100
 \d A Psalm of thanksgiving. 
 \q1
-\v 1 Shout for joy to Yahweh, all you lands! 
+\v 1 Shout for joy to Yahuah, all you lands! 
 \q2
-\v 2 Serve Yahweh with gladness. 
+\v 2 Serve Yahuah with gladness. 
 \q2 Come before his presence with singing. 
 \q1
-\v 3 Know that Yahweh, he is Elohim. 
+\v 3 Know that Yahuah, he is Elohim. 
 \q2 It is he who has made us, and we are his. 
 \q2 We are his people, and the sheep of his pasture. 
 \q1
@@ -5402,14 +5402,14 @@
 \q2 and into his courts with praise. 
 \q2 Give thanks to him, and bless his name. 
 \q1
-\v 5 For Yahweh is good. 
+\v 5 For Yahuah is good. 
 \q2 His loving kindness endures forever, 
 \q2 his faithfulness to all generations. 
 \c 101
 \d A Psalm by David. 
 \q1
 \v 1 I will sing of loving kindness and justice. 
-\q2 To you, Yahweh, I will sing praises. 
+\q2 To you, Yahuah, I will sing praises. 
 \q1
 \v 2 I will be careful to live a blameless life. 
 \q2 When will you come to me? 
@@ -5434,11 +5434,11 @@
 \q2 He who speaks falsehood won’t be established before my eyes. 
 \q1
 \v 8 Morning by morning, I will destroy all the wicked of the land, 
-\q2 to cut off all the workers of iniquity from Yahweh’s city. 
+\q2 to cut off all the workers of iniquity from Yahuah’s city. 
 \c 102
-\d A Prayer of the afflicted, when he is overwhelmed and pours out his complaint before Yahweh. 
+\d A Prayer of the afflicted, when he is overwhelmed and pours out his complaint before Yahuah. 
 \q1
-\v 1 Hear my prayer, Yahweh! 
+\v 1 Hear my prayer, Yahuah! 
 \q2 Let my cry come to you. 
 \q1
 \v 2 Don’t hide your face from me in the day of my distress. 
@@ -5472,7 +5472,7 @@
 \q2 I have withered like grass. 
 \b
 \q1
-\v 12 But you, Yahweh, will remain forever; 
+\v 12 But you, Yahuah, will remain forever; 
 \q2 your renown endures to all generations. 
 \q1
 \v 13 You will arise and have mercy on Zion, 
@@ -5482,10 +5482,10 @@
 \v 14 For your servants take pleasure in her stones, 
 \q2 and have pity on her dust. 
 \q1
-\v 15 So the nations will fear Yahweh’s name, 
+\v 15 So the nations will fear Yahuah’s name, 
 \q2 all the kings of the earth your glory. 
 \q1
-\v 16 For Yahweh has built up Zion. 
+\v 16 For Yahuah has built up Zion. 
 \q2 He has appeared in his glory. 
 \q1
 \v 17 He has responded to the prayer of the destitute, 
@@ -5495,16 +5495,16 @@
 \q2 A people which will be created will praise Yah, 
 \q1
 \v 19 for he has looked down from the height of his sanctuary. 
-\q2 From heaven, Yahweh saw the earth, 
+\q2 From heaven, Yahuah saw the earth, 
 \q1
 \v 20 to hear the groans of the prisoner, 
 \q2 to free those who are condemned to death, 
 \q1
-\v 21 that men may declare Yahweh’s name in Zion, 
+\v 21 that men may declare Yahuah’s name in Zion, 
 \q2 and his praise in Jerusalem, 
 \q1
 \v 22 when the peoples are gathered together, 
-\q2 the kingdoms, to serve Yahweh. 
+\q2 the kingdoms, to serve Yahuah. 
 \b
 \q1
 \v 23 He weakened my strength along the course. 
@@ -5528,10 +5528,10 @@
 \c 103
 \d By David. 
 \q1
-\v 1 Praise Yahweh, my soul! 
+\v 1 Praise Yahuah, my soul! 
 \q2 All that is within me, praise his set-apart name! 
 \q1
-\v 2 Praise Yahweh, my soul, 
+\v 2 Praise Yahuah, my soul, 
 \q2 and don’t forget all his benefits, 
 \q1
 \v 3 who forgives all your sins, 
@@ -5543,13 +5543,13 @@
 \v 5 who satisfies your desire with good things, 
 \q2 so that your youth is renewed like the eagle’s. 
 \q1
-\v 6 Yahweh executes righteous acts, 
+\v 6 Yahuah executes righteous acts, 
 \q2 and justice for all who are oppressed. 
 \q1
 \v 7 He made known his ways to Moses, 
 \q2 his deeds to the children of Israel. 
 \q1
-\v 8 Yahweh is merciful and gracious, 
+\v 8 Yahuah is merciful and gracious, 
 \q2 slow to anger, and abundant in loving kindness. 
 \q1
 \v 9 He will not always accuse; 
@@ -5565,7 +5565,7 @@
 \q2 so far has he removed our transgressions from us. 
 \q1
 \v 13 Like a father has compassion on his children, 
-\q2 so Yahweh has compassion on those who fear him. 
+\q2 so Yahuah has compassion on those who fear him. 
 \q1
 \v 14 For he knows how we are made. 
 \q2 He remembers that we are dust. 
@@ -5576,29 +5576,29 @@
 \v 16 For the wind passes over it, and it is gone. 
 \q2 Its place remembers it no more. 
 \q1
-\v 17 But Yahweh’s loving kindness is from everlasting to everlasting with those who fear him, 
+\v 17 But Yahuah’s loving kindness is from everlasting to everlasting with those who fear him, 
 \q2 his righteousness to children’s children, 
 \q1
 \v 18 to those who keep his covenant, 
 \q2 to those who remember to obey his precepts. 
 \q1
-\v 19 Yahweh has established his throne in the heavens. 
+\v 19 Yahuah has established his throne in the heavens. 
 \q2 His kingdom rules over all. 
 \q1
-\v 20 Praise Yahweh, you angels of his, 
+\v 20 Praise Yahuah, you angels of his, 
 \q2 who are mighty in strength, who fulfill his word, 
 \q2 obeying the voice of his word. 
 \q1
-\v 21 Praise Yahweh, all you armies of his, 
+\v 21 Praise Yahuah, all you armies of his, 
 \q2 you servants of his, who do his pleasure. 
 \q1
-\v 22 Praise Yahweh, all you works of his, 
+\v 22 Praise Yahuah, all you works of his, 
 \q2 in all places of his dominion. 
-\q2 Praise Yahweh, my soul! 
+\q2 Praise Yahuah, my soul! 
 \c 104
 \q1
-\v 1 Bless Yahweh, my soul. 
-\q2 Yahweh, my Elohim, you are very great. 
+\v 1 Bless Yahuah, my soul. 
+\q2 Yahuah, my Elohim, you are very great. 
 \q2 You are clothed with honor and majesty. 
 \q1
 \v 2 He covers himself with light as with a garment. 
@@ -5647,7 +5647,7 @@
 \q2 oil to make his face to shine, 
 \q2 and bread that strengthens man’s heart. 
 \q1
-\v 16 Yahweh’s trees are well watered, 
+\v 16 Yahuah’s trees are well watered, 
 \q2 the cedars of Lebanon, which he has planted, 
 \q1
 \v 17 where the birds make their nests. 
@@ -5671,7 +5671,7 @@
 \v 23 Man goes out to his work, 
 \q2 to his labor until the evening. 
 \q1
-\v 24 Yahweh, how many are your works! 
+\v 24 Yahuah, how many are your works! 
 \q2 In wisdom, you have made them all. 
 \q2 The earth is full of your riches. 
 \q1
@@ -5694,34 +5694,34 @@
 \v 30 You send out your Spirit and they are created. 
 \q2 You renew the face of the ground. 
 \q1
-\v 31 Let Yahweh’s glory endure forever. 
-\q2 Let Yahweh rejoice in his works. 
+\v 31 Let Yahuah’s glory endure forever. 
+\q2 Let Yahuah rejoice in his works. 
 \q1
 \v 32 He looks at the earth, and it trembles. 
 \q2 He touches the mountains, and they smoke. 
 \q1
-\v 33 I will sing to Yahweh as long as I live. 
+\v 33 I will sing to Yahuah as long as I live. 
 \q2 I will sing praise to my Elohim while I have any being. 
 \q1
 \v 34 Let my meditation be sweet to him. 
-\q2 I will rejoice in Yahweh. 
+\q2 I will rejoice in Yahuah. 
 \q1
 \v 35 Let sinners be consumed out of the earth. 
 \q2 Let the wicked be no more. 
-\q2 Bless Yahweh, my soul. 
+\q2 Bless Yahuah, my soul. 
 \q2 Praise Yah! 
 \c 105
 \q1
-\v 1 Give thanks to Yahweh! Call on his name! 
+\v 1 Give thanks to Yahuah! Call on his name! 
 \q2 Make his doings known among the peoples. 
 \q1
 \v 2 Sing to him, sing praises to him! 
 \q2 Tell of all his marvelous works. 
 \q1
 \v 3 Glory in his set-apart name. 
-\q2 Let the heart of those who seek Yahweh rejoice. 
+\q2 Let the heart of those who seek Yahuah rejoice. 
 \q1
-\v 4 Seek Yahweh and his strength. 
+\v 4 Seek Yahuah and his strength. 
 \q2 Seek his face forever more. 
 \q1
 \v 5 Remember his marvelous works that he has done: 
@@ -5730,7 +5730,7 @@
 \v 6 you offspring of Abraham, his servant, 
 \q2 you children of Jacob, his chosen ones. 
 \q1
-\v 7 He is Yahweh, our Elohim. 
+\v 7 He is Yahuah, our Elohim. 
 \q2 His judgments are in all the earth. 
 \q1
 \v 8 He has remembered his covenant forever, 
@@ -5767,7 +5767,7 @@
 \q2 His neck was locked in irons, 
 \q1
 \v 19 until the time that his word happened, 
-\q2 and Yahweh’s word proved him true. 
+\q2 and Yahuah’s word proved him true. 
 \q1
 \v 20 The king sent and freed him, 
 \q2 even the ruler of peoples, and let him go free. 
@@ -5849,17 +5849,17 @@
 \q2 Praise Yah! 
 \c 106
 \q1
-\v 1 Praise Yahweh! 
-\q2 Give thanks to Yahweh, for he is good, 
+\v 1 Praise Yahuah! 
+\q2 Give thanks to Yahuah, for he is good, 
 \q2 for his loving kindness endures forever. 
 \q1
-\v 2 Who can utter the mighty acts of Yahweh, 
+\v 2 Who can utter the mighty acts of Yahuah, 
 \q2 or fully declare all his praise? 
 \q1
 \v 3 Blessed are those who keep justice. 
 \q2 Blessed is one who does what is right at all times. 
 \q1
-\v 4 Remember me, Yahweh, with the favor that you show to your people. 
+\v 4 Remember me, Yahuah, with the favor that you show to your people. 
 \q2 Visit me with your salvation, 
 \q1
 \v 5 that I may see the prosperity of your chosen, 
@@ -5901,7 +5901,7 @@
 \q2 but sent leanness into their soul. 
 \q1
 \v 16 They envied Moses also in the camp, 
-\q2 and Aaron, Yahweh’s saint. 
+\q2 and Aaron, Yahuah’s saint. 
 \q1
 \v 17 The earth opened and swallowed up Dathan, 
 \q2 and covered the company of Abiram. 
@@ -5929,7 +5929,7 @@
 \q2 They didn’t believe his word, 
 \q2
 \v 25 but murmured in their tents, 
-\q2 and didn’t listen to Yahweh’s voice. 
+\q2 and didn’t listen to Yahuah’s voice. 
 \q1
 \v 26 Therefore he swore to them 
 \q2 that he would overthrow them in the wilderness, 
@@ -5956,7 +5956,7 @@
 \q2 he spoke rashly with his lips. 
 \q1
 \v 34 They didn’t destroy the peoples, 
-\q2 as Yahweh commanded them, 
+\q2 as Yahuah commanded them, 
 \q2
 \v 35 but mixed themselves with the nations, 
 \q2 and learned their works. 
@@ -5974,7 +5974,7 @@
 \v 39 Thus they were defiled with their works, 
 \q2 and prostituted themselves in their deeds. 
 \q1
-\v 40 Therefore Yahweh burned with anger against his people. 
+\v 40 Therefore Yahuah burned with anger against his people. 
 \q2 He abhorred his inheritance. 
 \q1
 \v 41 He gave them into the hand of the nations. 
@@ -5997,23 +5997,23 @@
 \q2 by all those who carried them captive. 
 \b
 \q1
-\v 47 Save us, Yahweh, our Elohim, 
+\v 47 Save us, Yahuah, our Elohim, 
 \q2 gather us from among the nations, 
 \q2 to give thanks to your set-apart name, 
 \q2 to triumph in your praise! 
 \b
 \q1
-\v 48 Blessed be Yahweh, the Elohim of Israel, 
+\v 48 Blessed be Yahuah, the Elohim of Israel, 
 \q2 from everlasting even to everlasting! 
 \q1 Let all the people say, “Amen.” 
 \q2 Praise Yah! 
 \c 107
 \ms1 BOOK 5
 \q1
-\v 1 Give thanks to Yahweh, for he is good, 
+\v 1 Give thanks to Yahuah, for he is good, 
 \q2 for his loving kindness endures forever. 
 \q1
-\v 2 Let the redeemed by Yahweh say so, 
+\v 2 Let the redeemed by Yahuah say so, 
 \q2 whom he has redeemed from the hand of the adversary, 
 \q2
 \v 3 and gathered out of the lands, 
@@ -6027,13 +6027,13 @@
 \v 5 Hungry and thirsty, 
 \q2 their soul fainted in them. 
 \q1
-\v 6 Then they cried to Yahweh in their trouble, 
+\v 6 Then they cried to Yahuah in their trouble, 
 \q2 and he delivered them out of their distresses. 
 \q1
 \v 7 He led them also by a straight way, 
 \q2 that they might go to a city to live in. 
 \q1
-\v 8 Let them praise Yahweh for his loving kindness, 
+\v 8 Let them praise Yahuah for his loving kindness, 
 \q2 for his wonderful deeds to the children of men! 
 \b
 \q1
@@ -6050,13 +6050,13 @@
 \v 12 Therefore he brought down their heart with labor. 
 \q2 They fell down, and there was no one to help. 
 \q1
-\v 13 Then they cried to Yahweh in their trouble, 
+\v 13 Then they cried to Yahuah in their trouble, 
 \q2 and he saved them out of their distresses. 
 \q1
 \v 14 He brought them out of darkness and the shadow of death, 
 \q2 and broke away their chains. 
 \q1
-\v 15 Let them praise Yahweh for his loving kindness, 
+\v 15 Let them praise Yahuah for his loving kindness, 
 \q2 for his wonderful deeds to the children of men! 
 \b
 \q1
@@ -6070,13 +6070,13 @@
 \v 18 Their soul abhors all kinds of food. 
 \q2 They draw near to the gates of death. 
 \q1
-\v 19 Then they cry to Yahweh in their trouble, 
+\v 19 Then they cry to Yahuah in their trouble, 
 \q2 and he saves them out of their distresses. 
 \q1
 \v 20 He sends his word, and heals them, 
 \q2 and delivers them from their graves. 
 \q1
-\v 21 Let them praise Yahweh for his loving kindness, 
+\v 21 Let them praise Yahuah for his loving kindness, 
 \q2 for his wonderful deeds to the children of men! 
 \b
 \q1
@@ -6087,7 +6087,7 @@
 \v 23 Those who go down to the sea in ships, 
 \q2 who do business in great waters, 
 \q2
-\v 24 these see Yahweh’s deeds, 
+\v 24 these see Yahuah’s deeds, 
 \q2 and his wonders in the deep. 
 \q1
 \v 25 For he commands, and raises the stormy wind, 
@@ -6099,7 +6099,7 @@
 \v 27 They reel back and forth, and stagger like a drunken man, 
 \q2 and are at their wits’ end. 
 \q1
-\v 28 Then they cry to Yahweh in their trouble, 
+\v 28 Then they cry to Yahuah in their trouble, 
 \q2 and he brings them out of their distress. 
 \q1
 \v 29 He makes the storm a calm, 
@@ -6108,7 +6108,7 @@
 \v 30 Then they are glad because it is calm, 
 \q2 so he brings them to their desired haven. 
 \q1
-\v 31 Let them praise Yahweh for his loving kindness, 
+\v 31 Let them praise Yahuah for his loving kindness, 
 \q2 for his wonderful deeds for the children of men! 
 \b
 \q1
@@ -6147,7 +6147,7 @@
 \q2 All the wicked will shut their mouths. 
 \q1
 \v 43 Whoever is wise will pay attention to these things. 
-\q2 They will consider the loving kindnesses of Yahweh. 
+\q2 They will consider the loving kindnesses of Yahuah. 
 \c 108
 \d A Song. A Psalm by David. 
 \q1
@@ -6157,7 +6157,7 @@
 \v 2 Wake up, harp and lyre! 
 \q2 I will wake up the dawn. 
 \q1
-\v 3 I will give thanks to you, Yahweh, among the nations. 
+\v 3 I will give thanks to you, Yahuah, among the nations. 
 \q2 I will sing praises to you among the peoples. 
 \q1
 \v 4 For your loving kindness is great above the heavens. 
@@ -6232,10 +6232,10 @@
 \v 13 Let his posterity be cut off. 
 \q2 In the generation following let their name be blotted out. 
 \q1
-\v 14 Let the iniquity of his fathers be remembered by Yahweh. 
+\v 14 Let the iniquity of his fathers be remembered by Yahuah. 
 \q2 Don’t let the sin of his mother be blotted out. 
 \q1
-\v 15 Let them be before Yahweh continually, 
+\v 15 Let them be before Yahuah continually, 
 \q2 that he may cut off their memory from the earth; 
 \q1
 \v 16 because he didn’t remember to show kindness, 
@@ -6252,11 +6252,11 @@
 \v 19 Let it be to him as the clothing with which he covers himself, 
 \q2 for the belt that is always around him. 
 \q1
-\v 20 This is the reward of my adversaries from Yahweh, 
+\v 20 This is the reward of my adversaries from Yahuah, 
 \q2 of those who speak evil against my soul. 
 \b
 \q1
-\v 21 But deal with me, Yahweh the Lord, for your name’s sake, 
+\v 21 But deal with me, Yahuah the Lord, for your name’s sake, 
 \q2 because your loving kindness is good, deliver me; 
 \q2
 \v 22 for I am poor and needy. 
@@ -6271,11 +6271,11 @@
 \v 25 I have also become a reproach to them. 
 \q2 When they see me, they shake their head. 
 \q1
-\v 26 Help me, Yahweh, my Elohim. 
+\v 26 Help me, Yahuah, my Elohim. 
 \q2 Save me according to your loving kindness; 
 \q1
 \v 27 that they may know that this is your hand; 
-\q2 that you, Yahweh, have done it. 
+\q2 that you, Yahuah, have done it. 
 \q1
 \v 28 They may curse, but you bless. 
 \q2 When they arise, they will be shamed, 
@@ -6284,7 +6284,7 @@
 \v 29 Let my adversaries be clothed with dishonor. 
 \q2 Let them cover themselves with their own shame as with a robe. 
 \q1
-\v 30 I will give great thanks to Yahweh with my mouth. 
+\v 30 I will give great thanks to Yahuah with my mouth. 
 \q2 Yes, I will praise him among the multitude. 
 \q1
 \v 31 For he will stand at the right hand of the needy, 
@@ -6292,16 +6292,16 @@
 \c 110
 \d A Psalm by David. 
 \q1
-\v 1 Yahweh says to my Lord, “Sit at my right hand, 
+\v 1 Yahuah says to my Lord, “Sit at my right hand, 
 \q2 until I make your enemies your footstool for your feet.” 
 \q1
-\v 2 Yahweh will send out the rod of your strength out of Zion. 
+\v 2 Yahuah will send out the rod of your strength out of Zion. 
 \q2 Rule among your enemies. 
 \q1
 \v 3 Your people offer themselves willingly in the day of your power, in set-apart array. 
 \q2 Out of the womb of the morning, you have the dew of your youth. 
 \q1
-\v 4 Yahweh has sworn, and will not change his mind: 
+\v 4 Yahuah has sworn, and will not change his mind: 
 \q2 “You are a priest forever in the order of Melchizedek.” 
 \q1
 \v 5 The Lord is at your right hand. 
@@ -6316,17 +6316,17 @@
 \c 111
 \q1
 \v 1 Praise Yah! 
-\q2 I will give thanks to Yahweh with my whole heart, 
+\q2 I will give thanks to Yahuah with my whole heart, 
 \q2 in the council of the upright, and in the congregation. 
 \q1
-\v 2 Yahweh’s works are great, 
+\v 2 Yahuah’s works are great, 
 \q2 pondered by all those who delight in them. 
 \q1
 \v 3 His work is honor and majesty. 
 \q2 His righteousness endures forever. 
 \q1
 \v 4 He has caused his wonderful works to be remembered. 
-\q2 Yahweh is gracious and merciful. 
+\q2 Yahuah is gracious and merciful. 
 \q1
 \v 5 He has given food to those who fear him. 
 \q2 He always remembers his covenant. 
@@ -6344,13 +6344,13 @@
 \q2 He has ordained his covenant forever. 
 \q2 His name is set-apart and awesome! 
 \q1
-\v 10 The fear of Yahweh is the beginning of wisdom. 
+\v 10 The fear of Yahuah is the beginning of wisdom. 
 \q2 All those who do his work have a good understanding. 
 \q1 His praise endures forever! 
 \c 112
 \q1
 \v 1 Praise Yah! 
-\q2 Blessed is the man who fears Yahweh, 
+\q2 Blessed is the man who fears Yahuah, 
 \q2 who delights greatly in his commandments. 
 \q1
 \v 2 His offspring will be mighty in the land. 
@@ -6369,7 +6369,7 @@
 \q2 The righteous will be remembered forever. 
 \q1
 \v 7 He will not be afraid of evil news. 
-\q2 His heart is steadfast, trusting in Yahweh. 
+\q2 His heart is steadfast, trusting in Yahuah. 
 \q1
 \v 8 His heart is established. 
 \q2 He will not be afraid in the end when he sees his adversaries. 
@@ -6384,19 +6384,19 @@
 \c 113
 \q1
 \v 1 Praise Yah! 
-\q2 Praise, you servants of Yahweh, 
-\q2 praise Yahweh’s name. 
+\q2 Praise, you servants of Yahuah, 
+\q2 praise Yahuah’s name. 
 \q1
-\v 2 Blessed be Yahweh’s name, 
+\v 2 Blessed be Yahuah’s name, 
 \q2 from this time forward and forever more. 
 \q1
 \v 3 From the rising of the sun to its going down, 
-\q2 Yahweh’s name is to be praised. 
+\q2 Yahuah’s name is to be praised. 
 \q1
-\v 4 Yahweh is high above all nations, 
+\v 4 Yahuah is high above all nations, 
 \q2 his glory above the heavens. 
 \q1
-\v 5 Who is like Yahweh, our Elohim, 
+\v 5 Who is like Yahuah, our Elohim, 
 \q2 who has his seat on high, 
 \q2
 \v 6 who stoops down to see in heaven and in the earth? 
@@ -6437,7 +6437,7 @@
 \q2 the flint into a spring of waters. 
 \c 115
 \q1
-\v 1 Not to us, Yahweh, not to us, 
+\v 1 Not to us, Yahuah, not to us, 
 \q2 but to your name give glory, 
 \q2 for your loving kindness, and for your truth’s sake. 
 \q1
@@ -6463,29 +6463,29 @@
 \v 8 Those who make them will be like them; 
 \q2 yes, everyone who trusts in them. 
 \q1
-\v 9 Israel, trust in Yahweh! 
+\v 9 Israel, trust in Yahuah! 
 \q2 He is their help and their shield. 
 \q1
-\v 10 House of Aaron, trust in Yahweh! 
+\v 10 House of Aaron, trust in Yahuah! 
 \q2 He is their help and their shield. 
 \q1
-\v 11 You who fear Yahweh, trust in Yahweh! 
+\v 11 You who fear Yahuah, trust in Yahuah! 
 \q2 He is their help and their shield. 
 \q1
-\v 12 Yahweh remembers us. He will bless us. 
+\v 12 Yahuah remembers us. He will bless us. 
 \q2 He will bless the house of Israel. 
 \q2 He will bless the house of Aaron. 
 \q1
-\v 13 He will bless those who fear Yahweh, 
+\v 13 He will bless those who fear Yahuah, 
 \q2 both small and great. 
 \q1
-\v 14 May Yahweh increase you more and more, 
+\v 14 May Yahuah increase you more and more, 
 \q2 you and your children. 
 \q1
-\v 15 Blessed are you by Yahweh, 
+\v 15 Blessed are you by Yahuah, 
 \q2 who made heaven and earth. 
 \q1
-\v 16 The heavens are Yahweh’s heavens, 
+\v 16 The heavens are Yahuah’s heavens, 
 \q2 but he has given the earth to the children of men. 
 \q1
 \v 17 The dead don’t praise Yah, 
@@ -6496,7 +6496,7 @@
 \q1 Praise Yah! 
 \c 116
 \q1
-\v 1 I love Yahweh, because he listens to my voice, 
+\v 1 I love Yahuah, because he listens to my voice, 
 \q2 and my cries for mercy. 
 \q1
 \v 2 Because he has turned his ear to me, 
@@ -6506,23 +6506,23 @@
 \q2 the pains of Sheol got a hold of me. 
 \q2 I found trouble and sorrow. 
 \q1
-\v 4 Then I called on Yahweh’s name: 
-\q2 “Yahweh, I beg you, deliver my soul.” 
+\v 4 Then I called on Yahuah’s name: 
+\q2 “Yahuah, I beg you, deliver my soul.” 
 \q1
-\v 5 Yahweh is gracious and righteous. 
+\v 5 Yahuah is gracious and righteous. 
 \q2 Yes, our Elohim is merciful. 
 \q1
-\v 6 Yahweh preserves the simple. 
+\v 6 Yahuah preserves the simple. 
 \q2 I was brought low, and he saved me. 
 \q1
 \v 7 Return to your rest, my soul, 
-\q2 for Yahweh has dealt bountifully with you. 
+\q2 for Yahuah has dealt bountifully with you. 
 \q1
 \v 8 For you have delivered my soul from death, 
 \q2 my eyes from tears, 
 \q2 and my feet from falling. 
 \q1
-\v 9 I will walk before Yahweh in the land of the living. 
+\v 9 I will walk before Yahuah in the land of the living. 
 \q1
 \v 10 I believed, therefore I said, 
 \q2 “I was greatly afflicted.” 
@@ -6530,39 +6530,39 @@
 \v 11 I said in my haste, 
 \q2 “All people are liars.” 
 \q1
-\v 12 What will I give to Yahweh for all his benefits toward me? 
+\v 12 What will I give to Yahuah for all his benefits toward me? 
 \q2
-\v 13 I will take the cup of salvation, and call on Yahweh’s name. 
+\v 13 I will take the cup of salvation, and call on Yahuah’s name. 
 \q1
-\v 14 I will pay my vows to Yahweh, 
+\v 14 I will pay my vows to Yahuah, 
 \q2 yes, in the presence of all his people. 
 \q1
-\v 15 Precious in Yahweh’s sight is the death of his saints. 
+\v 15 Precious in Yahuah’s sight is the death of his saints. 
 \q1
-\v 16 Yahweh, truly I am your servant. 
+\v 16 Yahuah, truly I am your servant. 
 \q2 I am your servant, the son of your servant girl. 
 \q2 You have freed me from my chains. 
 \q1
 \v 17 I will offer to you the sacrifice of thanksgiving, 
-\q2 and will call on Yahweh’s name. 
+\q2 and will call on Yahuah’s name. 
 \q1
-\v 18 I will pay my vows to Yahweh, 
+\v 18 I will pay my vows to Yahuah, 
 \q2 yes, in the presence of all his people, 
 \q1
-\v 19 in the courts of Yahweh’s house, 
+\v 19 in the courts of Yahuah’s house, 
 \q2 in the middle of you, Jerusalem. 
 \q1 Praise Yah! 
 \c 117
 \q1
-\v 1 Praise Yahweh, all you nations! 
+\v 1 Praise Yahuah, all you nations! 
 \q2 Extol him, all you peoples! 
 \q1
 \v 2 For his loving kindness is great toward us. 
-\q2 Yahweh’s faithfulness endures forever. 
+\q2 Yahuah’s faithfulness endures forever. 
 \q1 Praise Yah! 
 \c 118
 \q1
-\v 1 Give thanks to Yahweh, for he is good, 
+\v 1 Give thanks to Yahuah, for he is good, 
 \q2 for his loving kindness endures forever. 
 \q1
 \v 2 Let Israel now say 
@@ -6571,45 +6571,45 @@
 \v 3 Let the house of Aaron now say 
 \q2 that his loving kindness endures forever. 
 \q1
-\v 4 Now let those who fear Yahweh say 
+\v 4 Now let those who fear Yahuah say 
 \q2 that his loving kindness endures forever. 
 \q1
 \v 5 Out of my distress, I called on Yah. 
 \q2 Yah answered me with freedom. 
 \q1
-\v 6 Yahweh is on my side. I will not be afraid. 
+\v 6 Yahuah is on my side. I will not be afraid. 
 \q2 What can man do to me? 
 \q1
-\v 7 Yahweh is on my side among those who help me. 
+\v 7 Yahuah is on my side among those who help me. 
 \q2 Therefore I will look in triumph at those who hate me. 
 \q1
-\v 8 It is better to take refuge in Yahweh, 
+\v 8 It is better to take refuge in Yahuah, 
 \q2 than to put confidence in man. 
 \q1
-\v 9 It is better to take refuge in Yahweh, 
+\v 9 It is better to take refuge in Yahuah, 
 \q2 than to put confidence in princes. 
 \q1
 \v 10 All the nations surrounded me, 
-\q2 but in Yahweh’s name I cut them off. 
+\q2 but in Yahuah’s name I cut them off. 
 \q1
 \v 11 They surrounded me, yes, they surrounded me. 
-\q2 In Yahweh’s name I indeed cut them off. 
+\q2 In Yahuah’s name I indeed cut them off. 
 \q1
 \v 12 They surrounded me like bees. 
 \q2 They are quenched like the burning thorns. 
-\q2 In Yahweh’s name I cut them off. 
+\q2 In Yahuah’s name I cut them off. 
 \q1
 \v 13 You pushed me back hard, to make me fall, 
-\q2 but Yahweh helped me. 
+\q2 but Yahuah helped me. 
 \q1
 \v 14 Yah is my strength and song. 
 \q2 He has become my salvation. 
 \q1
 \v 15 The voice of rejoicing and salvation is in the tents of the righteous. 
-\q2 “The right hand of Yahweh does valiantly. 
+\q2 “The right hand of Yahuah does valiantly. 
 \q1
-\v 16 The right hand of Yahweh is exalted! 
-\q2 The right hand of Yahweh does valiantly!” 
+\v 16 The right hand of Yahuah is exalted! 
+\q2 The right hand of Yahuah does valiantly!” 
 \q1
 \v 17 I will not die, but live, 
 \q2 and declare Yah’s works. 
@@ -6621,7 +6621,7 @@
 \q2 I will enter into them. 
 \q2 I will give thanks to Yah. 
 \q1
-\v 20 This is the gate of Yahweh; 
+\v 20 This is the gate of Yahuah; 
 \q2 the righteous will enter into it. 
 \q1
 \v 21 I will give thanks to you, for you have answered me, 
@@ -6630,31 +6630,31 @@
 \v 22 The stone which the builders rejected 
 \q2 has become the cornerstone. 
 \q1
-\v 23 This is Yahweh’s doing. 
+\v 23 This is Yahuah’s doing. 
 \q2 It is marvelous in our eyes. 
 \q1
-\v 24 This is the day that Yahweh has made. 
+\v 24 This is the day that Yahuah has made. 
 \q2 We will rejoice and be glad in it! 
 \q1
-\v 25 Save us now, we beg you, Yahweh! 
-\q2 Yahweh, we beg you, send prosperity now. 
+\v 25 Save us now, we beg you, Yahuah! 
+\q2 Yahuah, we beg you, send prosperity now. 
 \q1
-\v 26 Blessed is he who comes in Yahweh’s name! 
-\q2 We have blessed you out of Yahweh’s house. 
+\v 26 Blessed is he who comes in Yahuah’s name! 
+\q2 We have blessed you out of Yahuah’s house. 
 \q1
-\v 27 Yahweh is Elohim, and he has given us light. 
+\v 27 Yahuah is Elohim, and he has given us light. 
 \q2 Bind the sacrifice with cords, even to the horns of the altar. 
 \q1
 \v 28 You are my Elohim, and I will give thanks to you. 
 \q2 You are my Elohim, I will exalt you. 
 \q1
-\v 29 Oh give thanks to Yahweh, for he is good, 
+\v 29 Oh give thanks to Yahuah, for he is good, 
 \q2 for his loving kindness endures forever. 
 \c 119
 \d ALEPH 
 \q1
 \v 1 Blessed are those whose ways are blameless, 
-\q2 who walk according to Yahweh’s law. 
+\q2 who walk according to Yahuah’s law. 
 \q1
 \v 2 Blessed are those who keep his statutes, 
 \q2 who seek him with their whole heart. 
@@ -6687,7 +6687,7 @@
 \v 11 I have hidden your word in my heart, 
 \q2 that I might not sin against you. 
 \q1
-\v 12 Blessed are you, Yahweh. 
+\v 12 Blessed are you, Yahuah. 
 \q2 Teach me your statutes. 
 \q1
 \v 13 With my lips, 
@@ -6745,14 +6745,14 @@
 \v 30 I have chosen the way of truth. 
 \q2 I have set your ordinances before me. 
 \q1
-\v 31 I cling to your statutes, Yahweh. 
+\v 31 I cling to your statutes, Yahuah. 
 \q2 Don’t let me be disappointed. 
 \q1
 \v 32 I run in the path of your commandments, 
 \q2 for you have set my heart free. 
 \d HE 
 \q1
-\v 33 Teach me, Yahweh, the way of your statutes. 
+\v 33 Teach me, Yahuah, the way of your statutes. 
 \q2 I will keep them to the end. 
 \q1
 \v 34 Give me understanding, and I will keep your law. 
@@ -6777,7 +6777,7 @@
 \q2 Revive me in your righteousness. 
 \d VAV 
 \q1
-\v 41 Let your loving kindness also come to me, Yahweh, 
+\v 41 Let your loving kindness also come to me, Yahuah, 
 \q2 your salvation, according to your word. 
 \q1
 \v 42 So I will have an answer for him who reproaches me, 
@@ -6811,7 +6811,7 @@
 \v 51 The arrogant mock me excessively, 
 \q2 but I don’t swerve from your law. 
 \q1
-\v 52 I remember your ordinances of old, Yahweh, 
+\v 52 I remember your ordinances of old, Yahuah, 
 \q2 and have comforted myself. 
 \q1
 \v 53 Indignation has taken hold on me, 
@@ -6820,14 +6820,14 @@
 \v 54 Your statutes have been my songs 
 \q2 in the house where I live. 
 \q1
-\v 55 I have remembered your name, Yahweh, in the night, 
+\v 55 I have remembered your name, Yahuah, in the night, 
 \q2 and I obey your law. 
 \q1
 \v 56 This is my way, 
 \q2 that I keep your precepts. 
 \d HETH 
 \q1
-\v 57 Yahweh is my portion. 
+\v 57 Yahuah is my portion. 
 \q2 I promised to obey your words. 
 \q1
 \v 58 I sought your favor with my whole heart. 
@@ -6848,12 +6848,12 @@
 \v 63 I am a friend of all those who fear you, 
 \q2 of those who observe your precepts. 
 \q1
-\v 64 The earth is full of your loving kindness, Yahweh. 
+\v 64 The earth is full of your loving kindness, Yahuah. 
 \q2 Teach me your statutes. 
 \d TETH 
 \q1
 \v 65 You have treated your servant well, 
-\q2 according to your word, Yahweh. 
+\q2 according to your word, Yahuah. 
 \q1
 \v 66 Teach me good judgment and knowledge, 
 \q2 for I believe in your commandments. 
@@ -6882,7 +6882,7 @@
 \v 74 Those who fear you will see me and be glad, 
 \q2 because I have put my hope in your word. 
 \q1
-\v 75 Yahweh, I know that your judgments are righteous, 
+\v 75 Yahuah, I know that your judgments are righteous, 
 \q2 that in faithfulness you have afflicted me. 
 \q1
 \v 76 Please let your loving kindness be for my comfort, 
@@ -6927,7 +6927,7 @@
 \q2 so I will obey the statutes of your mouth. 
 \d LAMEDH 
 \q1
-\v 89 Yahweh, your word is settled in heaven forever. 
+\v 89 Yahuah, your word is settled in heaven forever. 
 \q1
 \v 90 Your faithfulness is to all generations. 
 \q2 You have established the earth, and it remains. 
@@ -6983,10 +6983,10 @@
 \q2 that I will obey your righteous ordinances. 
 \q1
 \v 107 I am afflicted very much. 
-\q2 Revive me, Yahweh, according to your word. 
+\q2 Revive me, Yahuah, according to your word. 
 \q1
 \v 108 Accept, I beg you, the willing offerings of my mouth. 
-\q2 Yahweh, teach me your ordinances. 
+\q2 Yahuah, teach me your ordinances. 
 \q1
 \v 109 My soul is continually in my hand, 
 \q2 yet I won’t forget your law. 
@@ -7041,7 +7041,7 @@
 \v 125 I am your servant. Give me understanding, 
 \q2 that I may know your testimonies. 
 \q1
-\v 126 It is time to act, Yahweh, 
+\v 126 It is time to act, Yahuah, 
 \q2 for they break your law. 
 \q1
 \v 127 Therefore I love your commandments more than gold, 
@@ -7076,7 +7076,7 @@
 \q2 because they don’t observe your law. 
 \d TZADHE 
 \q1
-\v 137 You are righteous, Yahweh. 
+\v 137 You are righteous, Yahuah. 
 \q2 Your judgments are upright. 
 \q1
 \v 138 You have commanded your statutes in righteousness. 
@@ -7102,7 +7102,7 @@
 \d QOPH 
 \q1
 \v 145 I have called with my whole heart. 
-\q2 Answer me, Yahweh! 
+\q2 Answer me, Yahuah! 
 \q2 I will keep your statutes. 
 \q1
 \v 146 I have called to you. Save me! 
@@ -7115,12 +7115,12 @@
 \q2 that I might meditate on your word. 
 \q1
 \v 149 Hear my voice according to your loving kindness. 
-\q2 Revive me, Yahweh, according to your ordinances. 
+\q2 Revive me, Yahuah, according to your ordinances. 
 \q1
 \v 150 They draw near who follow after wickedness. 
 \q2 They are far from your law. 
 \q1
-\v 151 You are near, Yahweh. 
+\v 151 You are near, Yahuah. 
 \q2 All your commandments are truth. 
 \q1
 \v 152 Of old I have known from your testimonies, 
@@ -7136,7 +7136,7 @@
 \v 155 Salvation is far from the wicked, 
 \q2 for they don’t seek your statutes. 
 \q1
-\v 156 Great are your tender mercies, Yahweh. 
+\v 156 Great are your tender mercies, Yahuah. 
 \q2 Revive me according to your ordinances. 
 \q1
 \v 157 Many are my persecutors and my adversaries. 
@@ -7146,7 +7146,7 @@
 \q2 because they don’t observe your word. 
 \q1
 \v 159 Consider how I love your precepts. 
-\q2 Revive me, Yahweh, according to your loving kindness. 
+\q2 Revive me, Yahuah, according to your loving kindness. 
 \q1
 \v 160 All of your words are truth. 
 \q2 Every one of your righteous ordinances endures forever. 
@@ -7167,7 +7167,7 @@
 \v 165 Those who love your law have great peace. 
 \q2 Nothing causes them to stumble. 
 \q1
-\v 166 I have hoped for your salvation, Yahweh. 
+\v 166 I have hoped for your salvation, Yahuah. 
 \q2 I have done your commandments. 
 \q1
 \v 167 My soul has observed your testimonies. 
@@ -7177,7 +7177,7 @@
 \q2 for all my ways are before you. 
 \d TAV 
 \q1
-\v 169 Let my cry come before you, Yahweh. 
+\v 169 Let my cry come before you, Yahuah. 
 \q2 Give me understanding according to your word. 
 \q1
 \v 170 Let my supplication come before you. 
@@ -7192,7 +7192,7 @@
 \v 173 Let your hand be ready to help me, 
 \q2 for I have chosen your precepts. 
 \q1
-\v 174 I have longed for your salvation, Yahweh. 
+\v 174 I have longed for your salvation, Yahuah. 
 \q2 Your law is my delight. 
 \q1
 \v 175 Let my soul live, that I may praise you. 
@@ -7203,10 +7203,10 @@
 \c 120
 \d A Song of Ascents. 
 \q1
-\v 1 In my distress, I cried to Yahweh. 
+\v 1 In my distress, I cried to Yahuah. 
 \q2 He answered me. 
 \q1
-\v 2 Deliver my soul, Yahweh, from lying lips, 
+\v 2 Deliver my soul, Yahuah, from lying lips, 
 \q2 from a deceitful tongue. 
 \q1
 \v 3 What will be given to you, and what will be done more to you, 
@@ -7229,7 +7229,7 @@
 \v 1 I will lift up my eyes to the hills. 
 \q2 Where does my help come from? 
 \q1
-\v 2 My help comes from Yahweh, 
+\v 2 My help comes from Yahuah, 
 \q2 who made heaven and earth. 
 \b
 \q1
@@ -7239,22 +7239,22 @@
 \v 4 Behold, he who keeps Israel 
 \q2 will neither slumber nor sleep. 
 \q1
-\v 5 Yahweh is your keeper. 
-\q2 Yahweh is your shade on your right hand. 
+\v 5 Yahuah is your keeper. 
+\q2 Yahuah is your shade on your right hand. 
 \q1
 \v 6 The sun will not harm you by day, 
 \q2 nor the moon by night. 
 \q1
-\v 7 Yahweh will keep you from all evil. 
+\v 7 Yahuah will keep you from all evil. 
 \q2 He will keep your soul. 
 \q1
-\v 8 Yahweh will keep your going out and your coming in, 
+\v 8 Yahuah will keep your going out and your coming in, 
 \q2 from this time forward, and forever more. 
 \c 122
 \d A Song of Ascents. By David. 
 \q1
 \v 1 I was glad when they said to me, 
-\q2 “Let’s go to Yahweh’s house!” 
+\q2 “Let’s go to Yahuah’s house!” 
 \q1
 \v 2 Our feet are standing within your gates, Jerusalem! 
 \q2
@@ -7262,7 +7262,7 @@
 \q1
 \v 4 where the tribes go up, even Yah’s tribes, 
 \q2 according to an ordinance for Israel, 
-\q2 to give thanks to Yahweh’s name. 
+\q2 to give thanks to Yahuah’s name. 
 \q1
 \v 5 For there are set thrones for judgment, 
 \q2 the thrones of David’s house. 
@@ -7276,7 +7276,7 @@
 \v 8 For my brothers’ and companions’ sakes, 
 \q2 I will now say, “Peace be within you.” 
 \q1
-\v 9 For the sake of the house of Yahweh our Elohim, 
+\v 9 For the sake of the house of Yahuah our Elohim, 
 \q2 I will seek your good. 
 \c 123
 \d A Song of Ascents. 
@@ -7286,10 +7286,10 @@
 \q1
 \v 2 Behold, as the eyes of servants look to the hand of their master, 
 \q2 as the eyes of a maid to the hand of her mistress, 
-\q2 so our eyes look to Yahweh, our Elohim, 
+\q2 so our eyes look to Yahuah, our Elohim, 
 \q2 until he has mercy on us. 
 \q1
-\v 3 Have mercy on us, Yahweh, have mercy on us, 
+\v 3 Have mercy on us, Yahuah, have mercy on us, 
 \q2 for we have endured much contempt. 
 \q1
 \v 4 Our soul is exceedingly filled with the scoffing of those who are at ease, 
@@ -7297,10 +7297,10 @@
 \c 124
 \d A Song of Ascents. By David. 
 \q1
-\v 1 If it had not been Yahweh who was on our side, 
+\v 1 If it had not been Yahuah who was on our side, 
 \q2 let Israel now say, 
 \q1
-\v 2 if it had not been Yahweh who was on our side, 
+\v 2 if it had not been Yahuah who was on our side, 
 \q2 when men rose up against us, 
 \q1
 \v 3 then they would have swallowed us up alive, 
@@ -7311,47 +7311,47 @@
 \q1
 \v 5 Then the proud waters would have gone over our soul. 
 \q1
-\v 6 Blessed be Yahweh, 
+\v 6 Blessed be Yahuah, 
 \q2 who has not given us as a prey to their teeth. 
 \q1
 \v 7 Our soul has escaped like a bird out of the fowler’s snare. 
 \q2 The snare is broken, and we have escaped. 
 \q1
-\v 8 Our help is in Yahweh’s name, 
+\v 8 Our help is in Yahuah’s name, 
 \q2 who made heaven and earth. 
 \c 125
 \d A Song of Ascents. 
 \q1
-\v 1 Those who trust in Yahweh are as Mount Zion, 
+\v 1 Those who trust in Yahuah are as Mount Zion, 
 \q2 which can’t be moved, but remains forever. 
 \q1
 \v 2 As the mountains surround Jerusalem, 
-\q2 so Yahweh surrounds his people from this time forward and forever more. 
+\q2 so Yahuah surrounds his people from this time forward and forever more. 
 \q1
 \v 3 For the scepter of wickedness won’t remain over the allotment of the righteous, 
 \q2 so that the righteous won’t use their hands to do evil. 
 \q1
-\v 4 Do good, Yahweh, to those who are good, 
+\v 4 Do good, Yahuah, to those who are good, 
 \q2 to those who are upright in their hearts. 
 \q1
 \v 5 But as for those who turn away to their crooked ways, 
-\q2 Yahweh will lead them away with the workers of iniquity. 
+\q2 Yahuah will lead them away with the workers of iniquity. 
 \q1 Peace be on Israel. 
 \c 126
 \d A Song of Ascents. 
 \q1
-\v 1 When Yahweh brought back those who returned to Zion, 
+\v 1 When Yahuah brought back those who returned to Zion, 
 \q2 we were like those who dream. 
 \q1
 \v 2 Then our mouth was filled with laughter, 
 \q2 and our tongue with singing. 
 \q1 Then they said among the nations, 
-\q2 “Yahweh has done great things for them.” 
+\q2 “Yahuah has done great things for them.” 
 \q1
-\v 3 Yahweh has done great things for us, 
+\v 3 Yahuah has done great things for us, 
 \q2 and we are glad. 
 \q1
-\v 4 Restore our fortunes again, Yahweh, 
+\v 4 Restore our fortunes again, Yahuah, 
 \q2 like the streams in the Negev. 
 \q1
 \v 5 Those who sow in tears will reap in joy. 
@@ -7361,9 +7361,9 @@
 \c 127
 \d A Song of Ascents. By Solomon. 
 \q1
-\v 1 Unless Yahweh builds the house, 
+\v 1 Unless Yahuah builds the house, 
 \q2 they who build it labor in vain. 
-\q1 Unless Yahweh watches over the city, 
+\q1 Unless Yahuah watches over the city, 
 \q2 the watchman guards it in vain. 
 \q1
 \v 2 It is vain for you to rise up early, 
@@ -7371,7 +7371,7 @@
 \q2 eating the bread of toil, 
 \q2 for he gives sleep to his loved ones. 
 \q1
-\v 3 Behold, children are a heritage of Yahweh. 
+\v 3 Behold, children are a heritage of Yahuah. 
 \q2 The fruit of the womb is his reward. 
 \q1
 \v 4 As arrows in the hand of a mighty man, 
@@ -7382,7 +7382,7 @@
 \c 128
 \d A Song of Ascents. 
 \q1
-\v 1 Blessed is everyone who fears Yahweh, 
+\v 1 Blessed is everyone who fears Yahuah, 
 \q2 who walks in his ways. 
 \q1
 \v 2 For you will eat the labor of your hands. 
@@ -7391,9 +7391,9 @@
 \v 3 Your woman will be as a fruitful vine in the innermost parts of your house, 
 \q2 your children like olive shoots around your table. 
 \q1
-\v 4 Behold, this is how the man who fears Yahweh is blessed. 
+\v 4 Behold, this is how the man who fears Yahuah is blessed. 
 \q2
-\v 5 May Yahweh bless you out of Zion, 
+\v 5 May Yahuah bless you out of Zion, 
 \q2 and may you see the good of Jerusalem all the days of your life. 
 \q1
 \v 6 Yes, may you see your children’s children. 
@@ -7410,7 +7410,7 @@
 \v 3 The plowers plowed on my back. 
 \q2 They made their furrows long. 
 \q1
-\v 4 Yahweh is righteous. 
+\v 4 Yahuah is righteous. 
 \q2 He has cut apart the cords of the wicked. 
 \q1
 \v 5 Let them be disappointed and turned backward, 
@@ -7423,12 +7423,12 @@
 \q2 nor he who binds sheaves, his bosom. 
 \q1
 \v 8 Neither do those who go by say, 
-\q2 “The blessing of Yahweh be on you. 
-\q2 We bless you in Yahweh’s name.” 
+\q2 “The blessing of Yahuah be on you. 
+\q2 We bless you in Yahuah’s name.” 
 \c 130
 \d A Song of Ascents. 
 \q1
-\v 1 Out of the depths I have cried to you, Yahweh. 
+\v 1 Out of the depths I have cried to you, Yahuah. 
 \q1
 \v 2 Lord, hear my voice. 
 \q2 Let your ears be attentive to the voice of my petitions. 
@@ -7439,22 +7439,22 @@
 \v 4 But there is forgiveness with you, 
 \q2 therefore you are feared. 
 \q1
-\v 5 I wait for Yahweh. 
+\v 5 I wait for Yahuah. 
 \q2 My soul waits. 
 \q2 I hope in his word. 
 \q1
 \v 6 My soul longs for the Lord more than watchmen long for the morning, 
 \q2 more than watchmen for the morning. 
 \q1
-\v 7 Israel, hope in Yahweh, 
-\q2 for there is loving kindness with Yahweh. 
+\v 7 Israel, hope in Yahuah, 
+\q2 for there is loving kindness with Yahuah. 
 \q2 Abundant redemption is with him. 
 \q1
 \v 8 He will redeem Israel from all their sins. 
 \c 131
 \d A Song of Ascents. By David. 
 \q1
-\v 1 Yahweh, my heart isn’t arrogant, nor my eyes lofty; 
+\v 1 Yahuah, my heart isn’t arrogant, nor my eyes lofty; 
 \q2 nor do I concern myself with great matters, 
 \q2 or things too wonderful for me. 
 \q1
@@ -7462,14 +7462,14 @@
 \q2 like a weaned child with his mother, 
 \q2 like a weaned child is my soul within me. 
 \q1
-\v 3 Israel, hope in Yahweh, 
+\v 3 Israel, hope in Yahuah, 
 \q2 from this time forward and forever more. 
 \c 132
 \d A Song of Ascents. 
 \q1
-\v 1 Yahweh, remember David and all his affliction, 
+\v 1 Yahuah, remember David and all his affliction, 
 \q1
-\v 2 how he swore to Yahweh, 
+\v 2 how he swore to Yahuah, 
 \q2 and vowed to the Mighty One of Jacob: 
 \q1
 \v 3 “Surely I will not come into the structure of my house, 
@@ -7478,7 +7478,7 @@
 \v 4 I will not give sleep to my eyes, 
 \q2 or slumber to my eyelids, 
 \q1
-\v 5 until I find out a place for Yahweh, 
+\v 5 until I find out a place for Yahuah, 
 \q2 a dwelling for the Mighty One of Jacob.” 
 \q1
 \v 6 Behold, we heard of it in Ephrathah. 
@@ -7487,7 +7487,7 @@
 \v 7 “We will go into his dwelling place. 
 \q2 We will worship at his footstool.” 
 \q1
-\v 8 Arise, Yahweh, into your resting place, 
+\v 8 Arise, Yahuah, into your resting place, 
 \q2 you, and the ark of your strength. 
 \q1
 \v 9 Let your priests be clothed with righteousness. 
@@ -7496,7 +7496,7 @@
 \v 10 For your servant David’s sake, 
 \q2 don’t turn away the face of your anointed one. 
 \q1
-\v 11 Yahweh has sworn to David in truth. 
+\v 11 Yahuah has sworn to David in truth. 
 \q2 He will not turn from it: 
 \q2 “I will set the fruit of your body on your throne. 
 \q1
@@ -7504,7 +7504,7 @@
 \q2 my testimony that I will teach them, 
 \q2 their children also will sit on your throne forever more.” 
 \q1
-\v 13 For Yahweh has chosen Zion. 
+\v 13 For Yahuah has chosen Zion. 
 \q2 He has desired it for his habitation. 
 \q1
 \v 14 “This is my resting place forever. 
@@ -7534,38 +7534,38 @@
 \q1
 \v 3 like the dew of Hermon, 
 \q2 that comes down on the hills of Zion; 
-\q2 for there Yahweh gives the blessing, 
+\q2 for there Yahuah gives the blessing, 
 \q2 even life forever more. 
 \c 134
 \d A Song of Ascents. 
 \q1
-\v 1 Look! Praise Yahweh, all you servants of Yahweh, 
-\q2 who stand by night in Yahweh’s house! 
+\v 1 Look! Praise Yahuah, all you servants of Yahuah, 
+\q2 who stand by night in Yahuah’s house! 
 \q1
 \v 2 Lift up your hands in the sanctuary. 
-\q2 Praise Yahweh! 
+\q2 Praise Yahuah! 
 \q1
-\v 3 May Yahweh bless you from Zion, 
+\v 3 May Yahuah bless you from Zion, 
 \q2 even he who made heaven and earth. 
 \c 135
 \q1
 \v 1 Praise Yah! 
-\q2 Praise Yahweh’s name! 
-\q2 Praise him, you servants of Yahweh, 
+\q2 Praise Yahuah’s name! 
+\q2 Praise him, you servants of Yahuah, 
 \q1
-\v 2 you who stand in Yahweh’s house, 
+\v 2 you who stand in Yahuah’s house, 
 \q2 in the courts of our Elohim’s house. 
 \q1
-\v 3 Praise Yah, for Yahweh is good. 
+\v 3 Praise Yah, for Yahuah is good. 
 \q2 Sing praises to his name, for that is pleasant. 
 \q1
 \v 4 For Yah has chosen Jacob for himself, 
 \q2 Israel for his own possession. 
 \q1
-\v 5 For I know that Yahweh is great, 
+\v 5 For I know that Yahuah is great, 
 \q2 that our Lord is above all elohims. 
 \q1
-\v 6 Whatever Yahweh pleased, that he has done, 
+\v 6 Whatever Yahuah pleased, that he has done, 
 \q2 in heaven and in earth, in the seas and in all deeps. 
 \q1
 \v 7 He causes the clouds to rise from the ends of the earth. 
@@ -7586,10 +7586,10 @@
 \v 12 and gave their land for a heritage, 
 \q2 a heritage to Israel, his people. 
 \q1
-\v 13 Your name, Yahweh, endures forever; 
-\q2 your renown, Yahweh, throughout all generations. 
+\v 13 Your name, Yahuah, endures forever; 
+\q2 your renown, Yahuah, throughout all generations. 
 \q1
-\v 14 For Yahweh will judge his people 
+\v 14 For Yahuah will judge his people 
 \q2 and have compassion on his servants. 
 \b
 \q1
@@ -7605,18 +7605,18 @@
 \v 18 Those who make them will be like them, 
 \q2 yes, everyone who trusts in them. 
 \q1
-\v 19 House of Israel, praise Yahweh! 
-\q2 House of Aaron, praise Yahweh! 
+\v 19 House of Israel, praise Yahuah! 
+\q2 House of Aaron, praise Yahuah! 
 \q1
-\v 20 House of Levi, praise Yahweh! 
-\q2 You who fear Yahweh, praise Yahweh! 
+\v 20 House of Levi, praise Yahuah! 
+\q2 You who fear Yahuah, praise Yahuah! 
 \q1
-\v 21 Blessed be Yahweh from Zion, 
+\v 21 Blessed be Yahuah from Zion, 
 \q2 who dwells in Jerusalem. 
 \q1 Praise Yah! 
 \c 136
 \q1
-\v 1 Give thanks to Yahweh, for he is good, 
+\v 1 Give thanks to Yahuah, for he is good, 
 \q2 for his loving kindness endures forever. 
 \q1
 \v 2 Give thanks to the Elohim of elohims, 
@@ -7705,7 +7705,7 @@
 \q2 Those who tormented us demanded songs of joy: 
 \q2 “Sing us one of the songs of Zion!” 
 \q1
-\v 4 How can we sing Yahweh’s song in a foreign land? 
+\v 4 How can we sing Yahuah’s song in a foreign land? 
 \q1
 \v 5 If I forget you, Jerusalem, 
 \q2 let my right hand forget its skill. 
@@ -7713,7 +7713,7 @@
 \v 6 Let my tongue stick to the roof of my mouth if I don’t remember you, 
 \q2 if I don’t prefer Jerusalem above my chief joy. 
 \q1
-\v 7 Remember, Yahweh, against the children of Edom in the day of Jerusalem, 
+\v 7 Remember, Yahuah, against the children of Edom in the day of Jerusalem, 
 \q2 who said, “Raze it! 
 \q2 Raze it even to its foundation!” 
 \q1
@@ -7736,26 +7736,26 @@
 \v 3 In the day that I called, you answered me. 
 \q2 You encouraged me with strength in my soul. 
 \q1
-\v 4 All the kings of the earth will give you thanks, Yahweh, 
+\v 4 All the kings of the earth will give you thanks, Yahuah, 
 \q2 for they have heard the words of your mouth. 
 \q1
-\v 5 Yes, they will sing of the ways of Yahweh, 
-\q2 for Yahweh’s glory is great! 
+\v 5 Yes, they will sing of the ways of Yahuah, 
+\q2 for Yahuah’s glory is great! 
 \q1
-\v 6 For though Yahweh is high, yet he looks after the lowly; 
+\v 6 For though Yahuah is high, yet he looks after the lowly; 
 \q2 but he knows the proud from afar. 
 \q1
 \v 7 Though I walk in the middle of trouble, you will revive me. 
 \q2 You will stretch out your hand against the wrath of my enemies. 
 \q2 Your right hand will save me. 
 \q1
-\v 8 Yahweh will fulfill that which concerns me. 
-\q2 Your loving kindness, Yahweh, endures forever. 
+\v 8 Yahuah will fulfill that which concerns me. 
+\q2 Your loving kindness, Yahuah, endures forever. 
 \q2 Don’t forsake the works of your own hands. 
 \c 139
 \d For the Chief Musician. A Psalm by David. 
 \q1
-\v 1 Yahweh, you have searched me, 
+\v 1 Yahuah, you have searched me, 
 \q2 and you know me. 
 \q1
 \v 2 You know my sitting down and my rising up. 
@@ -7765,7 +7765,7 @@
 \q2 and are acquainted with all my ways. 
 \q1
 \v 4 For there is not a word on my tongue, 
-\q2 but behold, Yahweh, you know it altogether. 
+\q2 but behold, Yahuah, you know it altogether. 
 \q1
 \v 5 You hem me in behind and before. 
 \q2 You laid your hand on me. 
@@ -7822,7 +7822,7 @@
 \v 20 For they speak against you wickedly. 
 \q2 Your enemies take your name in vain. 
 \q1
-\v 21 Yahweh, don’t I hate those who hate you? 
+\v 21 Yahuah, don’t I hate those who hate you? 
 \q2 Am I not grieved with those who rise up against you? 
 \q1
 \v 22 I hate them with perfect hatred. 
@@ -7836,7 +7836,7 @@
 \c 140
 \d For the Chief Musician. A Psalm by David. 
 \q1
-\v 1 Deliver me, Yahweh, from evil men. 
+\v 1 Deliver me, Yahuah, from evil men. 
 \q2 Preserve me from violent men: 
 \q1
 \v 2 those who devise mischief in their hearts. 
@@ -7845,20 +7845,20 @@
 \v 3 They have sharpened their tongues like a serpent. 
 \q2 Viper’s poison is under their lips. \qs Selah.\qs* 
 \q1
-\v 4 Yahweh, keep me from the hands of the wicked. 
+\v 4 Yahuah, keep me from the hands of the wicked. 
 \q2 Preserve me from the violent men who have determined to trip my feet. 
 \q1
 \v 5 The proud have hidden a snare for me, 
 \q2 they have spread the cords of a net by the path. 
 \q2 They have set traps for me. \qs Selah.\qs* 
 \q1
-\v 6 I said to Yahweh, “You are my Elohim.” 
-\q2 Listen to the cry of my petitions, Yahweh. 
+\v 6 I said to Yahuah, “You are my Elohim.” 
+\q2 Listen to the cry of my petitions, Yahuah. 
 \q1
-\v 7 Yahweh, the Lord, the strength of my salvation, 
+\v 7 Yahuah, the Lord, the strength of my salvation, 
 \q2 you have covered my head in the day of battle. 
 \q1
-\v 8 Yahweh, don’t grant the desires of the wicked. 
+\v 8 Yahuah, don’t grant the desires of the wicked. 
 \q2 Don’t let their evil plans succeed, or they will become proud. \qs Selah.\qs* 
 \q1
 \v 9 As for the head of those who surround me, 
@@ -7871,7 +7871,7 @@
 \v 11 An evil speaker won’t be established in the earth. 
 \q2 Evil will hunt the violent man to overthrow him. 
 \q1
-\v 12 I know that Yahweh will maintain the cause of the afflicted, 
+\v 12 I know that Yahuah will maintain the cause of the afflicted, 
 \q2 and justice for the needy. 
 \q1
 \v 13 Surely the righteous will give thanks to your name. 
@@ -7879,14 +7879,14 @@
 \c 141
 \d A Psalm by David. 
 \q1
-\v 1 Yahweh, I have called on you. 
+\v 1 Yahuah, I have called on you. 
 \q2 Come to me quickly! 
 \q2 Listen to my voice when I call to you. 
 \q1
 \v 2 Let my prayer be set before you like incense; 
 \q2 the lifting up of my hands like the evening sacrifice. 
 \q1
-\v 3 Set a watch, Yahweh, before my mouth. 
+\v 3 Set a watch, Yahuah, before my mouth. 
 \q2 Keep the door of my lips. 
 \q1
 \v 4 Don’t incline my heart to any evil thing, 
@@ -7904,7 +7904,7 @@
 \v 7 “As when one plows and breaks up the earth, 
 \q2 our bones are scattered at the mouth of Sheol.” 
 \q1
-\v 8 For my eyes are on you, Yahweh, the Lord. 
+\v 8 For my eyes are on you, Yahuah, the Lord. 
 \q2 I take refuge in you. 
 \q2 Don’t leave my soul destitute. 
 \q1
@@ -7916,8 +7916,8 @@
 \c 142
 \d A contemplation by David, when he was in the cave. A Prayer. 
 \q1
-\v 1 I cry with my voice to Yahweh. 
-\q2 With my voice, I ask Yahweh for mercy. 
+\v 1 I cry with my voice to Yahuah. 
+\q2 With my voice, I ask Yahuah for mercy. 
 \q1
 \v 2 I pour out my complaint before him. 
 \q2 I tell him my troubles. 
@@ -7932,7 +7932,7 @@
 \q2 Refuge has fled from me. 
 \q2 No one cares for my soul. 
 \q1
-\v 5 I cried to you, Yahweh. 
+\v 5 I cried to you, Yahuah. 
 \q2 I said, “You are my refuge, 
 \q2 my portion in the land of the living.” 
 \q1
@@ -7948,7 +7948,7 @@
 \c 143
 \d A Psalm by David. 
 \q1
-\v 1 Hear my prayer, Yahweh. 
+\v 1 Hear my prayer, Yahuah. 
 \q2 Listen to my petitions. 
 \q2 In your faithfulness and righteousness, relieve me. 
 \q1
@@ -7969,7 +7969,7 @@
 \v 6 I spread out my hands to you. 
 \q2 My soul thirsts for you, like a parched land. \qs Selah.\qs* 
 \q1
-\v 7 Hurry to answer me, Yahweh. 
+\v 7 Hurry to answer me, Yahuah. 
 \q2 My spirit fails. 
 \q1 Don’t hide your face from me, 
 \q2 so that I don’t become like those who go down into the pit. 
@@ -7979,7 +7979,7 @@
 \q1 Cause me to know the way in which I should walk, 
 \q2 for I lift up my soul to you. 
 \q1
-\v 9 Deliver me, Yahweh, from my enemies. 
+\v 9 Deliver me, Yahuah, from my enemies. 
 \q2 I flee to you to hide me. 
 \q1
 \v 10 Teach me to do your will, 
@@ -7987,7 +7987,7 @@
 \q1 Your Spirit is good. 
 \q2 Lead me in the land of uprightness. 
 \q1
-\v 11 Revive me, Yahweh, for your name’s sake. 
+\v 11 Revive me, Yahuah, for your name’s sake. 
 \q2 In your righteousness, bring my soul out of trouble. 
 \q1
 \v 12 In your loving kindness, cut off my enemies, 
@@ -7996,7 +7996,7 @@
 \c 144
 \d By David. 
 \q1
-\v 1 Blessed be Yahweh, my rock, 
+\v 1 Blessed be Yahuah, my rock, 
 \q2 who trains my hands to war, 
 \q2 and my fingers to battle—\q1
 \v 2 my loving kindness, my fortress, 
@@ -8004,13 +8004,13 @@
 \q2 my shield, and he in whom I take refuge, 
 \q2 who subdues my people under me. 
 \q1
-\v 3 Yahweh, what is man, that you care for him? 
+\v 3 Yahuah, what is man, that you care for him? 
 \q2 Or the son of man, that you think of him? 
 \q1
 \v 4 Man is like a breath. 
 \q2 His days are like a shadow that passes away. 
 \q1
-\v 5 Part your heavens, Yahweh, and come down. 
+\v 5 Part your heavens, Yahuah, and come down. 
 \q2 Touch the mountains, and they will smoke. 
 \q1
 \v 6 Throw out lightning, and scatter them. 
@@ -8045,7 +8045,7 @@
 \q2 and no outcry in our streets. 
 \q1
 \v 15 Happy are the people who are in such a situation. 
-\q2 Happy are the people whose Elohim is Yahweh. 
+\q2 Happy are the people whose Elohim is Yahuah. 
 \c 145
 \d A praise psalm by David. 
 \q1
@@ -8055,7 +8055,7 @@
 \v 2 Every day I will praise you. 
 \q2 I will extol your name forever and ever. 
 \q1
-\v 3 Great is Yahweh, and greatly to be praised! 
+\v 3 Great is Yahuah, and greatly to be praised! 
 \q2 His greatness is unsearchable. 
 \q1
 \v 4 One generation will commend your works to another, 
@@ -8070,13 +8070,13 @@
 \v 7 They will utter the memory of your great goodness, 
 \q2 and will sing of your righteousness. 
 \q1
-\v 8 Yahweh is gracious, merciful, 
+\v 8 Yahuah is gracious, merciful, 
 \q2 slow to anger, and of great loving kindness. 
 \q1
-\v 9 Yahweh is good to all. 
+\v 9 Yahuah is good to all. 
 \q2 His tender mercies are over all his works. 
 \q1
-\v 10 All your works will give thanks to you, Yahweh. 
+\v 10 All your works will give thanks to you, Yahuah. 
 \q2 Your saints will extol you. 
 \q1
 \v 11 They will speak of the glory of your kingdom, 
@@ -8087,10 +8087,10 @@
 \q1
 \v 13 Your kingdom is an everlasting kingdom. 
 \q2 Your dominion endures throughout all generations. 
-\q1 Yahweh is faithful in all his words, 
+\q1 Yahuah is faithful in all his words, 
 \q2 and loving in all his deeds. 
 \q1
-\v 14 Yahweh upholds all who fall, 
+\v 14 Yahuah upholds all who fall, 
 \q2 and raises up all those who are bowed down. 
 \q1
 \v 15 The eyes of all wait for you. 
@@ -8099,27 +8099,27 @@
 \v 16 You open your hand, 
 \q2 and satisfy the desire of every living thing. 
 \q1
-\v 17 Yahweh is righteous in all his ways, 
+\v 17 Yahuah is righteous in all his ways, 
 \q2 and gracious in all his works. 
 \q1
-\v 18 Yahweh is near to all those who call on him, 
+\v 18 Yahuah is near to all those who call on him, 
 \q2 to all who call on him in truth. 
 \q1
 \v 19 He will fulfill the desire of those who fear him. 
 \q2 He also will hear their cry, and will save them. 
 \q1
-\v 20 Yahweh preserves all those who love him, 
+\v 20 Yahuah preserves all those who love him, 
 \q2 but he will destroy all the wicked. 
 \q1
-\v 21 My mouth will speak the praise of Yahweh. 
+\v 21 My mouth will speak the praise of Yahuah. 
 \q2 Let all flesh bless his set-apart name forever and ever. 
 \b
 \c 146
 \q1
 \v 1 Praise Yah! 
-\q2 Praise Yahweh, my soul. 
+\q2 Praise Yahuah, my soul. 
 \q1
-\v 2 While I live, I will praise Yahweh. 
+\v 2 While I live, I will praise Yahuah. 
 \q2 I will sing praises to my Elohim as long as I exist. 
 \q1
 \v 3 Don’t put your trust in princes, 
@@ -8129,7 +8129,7 @@
 \q2 In that very day, his thoughts perish. 
 \q1
 \v 5 Happy is he who has the Elohim of Jacob for his help, 
-\q2 whose hope is in Yahweh, his Elohim, 
+\q2 whose hope is in Yahuah, his Elohim, 
 \q1
 \v 6 who made heaven and earth, 
 \q2 the sea, and all that is in them; 
@@ -8137,17 +8137,17 @@
 \q1
 \v 7 who executes justice for the oppressed; 
 \q2 who gives food to the hungry. 
-\q1 Yahweh frees the prisoners. 
+\q1 Yahuah frees the prisoners. 
 \q2
-\v 8 Yahweh opens the eyes of the blind. 
-\q2 Yahweh raises up those who are bowed down. 
-\q2 Yahweh loves the righteous. 
+\v 8 Yahuah opens the eyes of the blind. 
+\q2 Yahuah raises up those who are bowed down. 
+\q2 Yahuah loves the righteous. 
 \q1
-\v 9 Yahweh preserves the foreigners. 
+\v 9 Yahuah preserves the foreigners. 
 \q2 He upholds the fatherless and widow, 
 \q2 but he turns the way of the wicked upside down. 
 \q1
-\v 10 Yahweh will reign forever; 
+\v 10 Yahuah will reign forever; 
 \q2 your Elohim, O Zion, to all generations. 
 \q1 Praise Yah! 
 \b
@@ -8157,7 +8157,7 @@
 \q2 for it is good to sing praises to our Elohim; 
 \q2 for it is pleasant and fitting to praise him. 
 \q1
-\v 2 Yahweh builds up Jerusalem. 
+\v 2 Yahuah builds up Jerusalem. 
 \q2 He gathers together the outcasts of Israel. 
 \q1
 \v 3 He heals the broken in heart, 
@@ -8169,10 +8169,10 @@
 \v 5 Great is our Lord, and mighty in power. 
 \q2 His understanding is infinite. 
 \q1
-\v 6 Yahweh upholds the humble. 
+\v 6 Yahuah upholds the humble. 
 \q2 He brings the wicked down to the ground. 
 \q1
-\v 7 Sing to Yahweh with thanksgiving. 
+\v 7 Sing to Yahuah with thanksgiving. 
 \q2 Sing praises on the harp to our Elohim, 
 \q1
 \v 8 who covers the sky with clouds, 
@@ -8185,10 +8185,10 @@
 \v 10 He doesn’t delight in the strength of the horse. 
 \q2 He takes no pleasure in the legs of a man. 
 \q1
-\v 11 Yahweh takes pleasure in those who fear him, 
+\v 11 Yahuah takes pleasure in those who fear him, 
 \q2 in those who hope in his loving kindness. 
 \q1
-\v 12 Praise Yahweh, Jerusalem! 
+\v 12 Praise Yahuah, Jerusalem! 
 \q2 Praise your Elohim, Zion! 
 \q1
 \v 13 For he has strengthened the bars of your gates. 
@@ -8219,7 +8219,7 @@
 \c 148
 \q1
 \v 1 Praise Yah! 
-\q2 Praise Yahweh from the heavens! 
+\q2 Praise Yahuah from the heavens! 
 \q2 Praise him in the heights! 
 \q1
 \v 2 Praise him, all his angels! 
@@ -8231,13 +8231,13 @@
 \v 4 Praise him, you heavens of heavens, 
 \q2 you waters that are above the heavens. 
 \q1
-\v 5 Let them praise Yahweh’s name, 
+\v 5 Let them praise Yahuah’s name, 
 \q2 for he commanded, and they were created. 
 \q1
 \v 6 He has also established them forever and ever. 
 \q2 He has made a decree which will not pass away. 
 \q1
-\v 7 Praise Yahweh from the earth, 
+\v 7 Praise Yahuah from the earth, 
 \q2 you great sea creatures, and all depths, 
 \q1
 \v 8 lightning and hail, snow and clouds, 
@@ -8255,7 +8255,7 @@
 \v 12 both young men and maidens, 
 \q2 old men and children. 
 \q1
-\v 13 Let them praise Yahweh’s name, 
+\v 13 Let them praise Yahuah’s name, 
 \q2 for his name alone is exalted. 
 \q2 His glory is above the earth and the heavens. 
 \q1
@@ -8266,8 +8266,8 @@
 \b
 \c 149
 \q1
-\v 1 Praise Yahweh! 
-\q2 Sing to Yahweh a new song, 
+\v 1 Praise Yahuah! 
+\q2 Sing to Yahuah a new song, 
 \q2 his praise in the assembly of the saints. 
 \q1
 \v 2 Let Israel rejoice in him who made them. 
@@ -8276,7 +8276,7 @@
 \v 3 Let them praise his name in the dance! 
 \q2 Let them sing praises to him with tambourine and harp! 
 \q1
-\v 4 For Yahweh takes pleasure in his people. 
+\v 4 For Yahuah takes pleasure in his people. 
 \q2 He crowns the humble with salvation. 
 \q1
 \v 5 Let the saints rejoice in honor. 

--- a/usfm/ruth.usfm
+++ b/usfm/ruth.usfm
@@ -8,29 +8,29 @@
 \v 3 Elimelech, Naomi’s man, died; and she was left with her two sons. 
 \v 4 They took for themselves women of the women of Moab. The name of the one was Orpah, and the name of the other was Ruth. They lived there about ten years. 
 \v 5 Mahlon and Chilion both died, and the woman was bereaved of her two children and of her man. 
-\v 6 Then she arose with her daughters-in-law, that she might return from the country of Moab; for she had heard in the country of Moab how Yahweh had visited his people in giving them bread. 
+\v 6 Then she arose with her daughters-in-law, that she might return from the country of Moab; for she had heard in the country of Moab how Yahuah had visited his people in giving them bread. 
 \v 7 She went out of the place where she was, and her two daughters-in-law with her. They went on the way to return to the land of Judah. 
-\v 8 Naomi said to her two daughters-in-law, “Go, return each of you to her mother’s house. May Yahweh deal kindly with you, as you have dealt with the dead and with me. 
-\v 9 May Yahweh grant you that you may find rest, each of you in the house of her man.” 
+\v 8 Naomi said to her two daughters-in-law, “Go, return each of you to her mother’s house. May Yahuah deal kindly with you, as you have dealt with the dead and with me. 
+\v 9 May Yahuah grant you that you may find rest, each of you in the house of her man.” 
 \p Then she kissed them, and they lifted up their voices, and wept. 
 \v 10 They said to her, “No, but we will return with you to your people.” 
 \p
 \v 11 Naomi said, “Go back, my daughters. Why do you want to go with me? Do I still have sons in my womb, that they may be your men? 
 \v 12 Go back, my daughters, go your way; for I am too old to have a man. If I should say, ‘I have hope,’ if I should even have a man tonight, and should also bear sons, 
-\v 13 would you then wait until they were grown? Would you then refrain from having men? No, my daughters, for it grieves me seriously for your sakes, for Yahweh’s hand has gone out against me.” 
+\v 13 would you then wait until they were grown? Would you then refrain from having men? No, my daughters, for it grieves me seriously for your sakes, for Yahuah’s hand has gone out against me.” 
 \p
 \v 14 They lifted up their voices and wept again; then Orpah kissed her mother-in-law, but Ruth stayed with her. 
 \v 15 She said, “Behold, your sister-in-law has gone back to her people and to her elohim. Follow your sister-in-law.” 
 \p
 \v 16 Ruth said, “Don’t urge me to leave you, and to return from following you, for where you go, I will go; and where you stay, I will stay. Your people will be my people, and your Elohim my Elohim. 
-\v 17 Where you die, I will die, and there I will be buried. May Yahweh do so to me, and more also, if anything but death parts you and me.” 
+\v 17 Where you die, I will die, and there I will be buried. May Yahuah do so to me, and more also, if anything but death parts you and me.” 
 \p
 \v 18 When Naomi saw that she was determined to go with her, she stopped urging her. 
 \p
 \v 19 So they both went until they came to Bethlehem. When they had come to Bethlehem, all the city was excited about them, and they asked, “Is this Naomi?” 
 \p
 \v 20 She said to them, “Don’t call me Naomi. Call me Mara, for the Almighty has dealt very bitterly with me. 
-\v 21 I went out full, and Yahweh has brought me home again empty. Why do you call me Naomi, since Yahweh has testified against me, and the Almighty has afflicted me?” 
+\v 21 I went out full, and Yahuah has brought me home again empty. Why do you call me Naomi, since Yahuah has testified against me, and the Almighty has afflicted me?” 
 \v 22 So Naomi returned, and Ruth the Moabitess, her daughter-in-law, with her, who returned out of the country of Moab. They came to Bethlehem in the beginning of barley harvest. 
 \c 2
 \p
@@ -39,8 +39,8 @@
 \p She said to her, “Go, my daughter.” 
 \v 3 She went, and came and gleaned in the field after the reapers; and she happened to come to the portion of the field belonging to Boaz, who was of the family of Elimelech. 
 \p
-\v 4 Behold, Boaz came from Bethlehem, and said to the reapers, “May Yahweh be with you.” 
-\p They answered him, “May Yahweh bless you.” 
+\v 4 Behold, Boaz came from Bethlehem, and said to the reapers, “May Yahuah be with you.” 
+\p They answered him, “May Yahuah bless you.” 
 \p
 \v 5 Then Boaz said to his servant who was set over the reapers, “Whose young lady is this?” 
 \p
@@ -53,7 +53,7 @@
 \v 10 Then she fell on her face and bowed herself to the ground, and said to him, “Why have I found favor in your sight, that you should take knowledge of me, since I am a foreigner?” 
 \p
 \v 11 Boaz answered her, “I have been told all about what you have done for your mother-in-law since the death of your man, and how you have left your father, your mother, and the land of your birth, and have come to a people that you didn’t know before. 
-\v 12 May Yahweh repay your work, and a full reward be given to you from Yahweh, the Elohim of Israel, under whose wings you have come to take refuge.” 
+\v 12 May Yahuah repay your work, and a full reward be given to you from Yahuah, the Elohim of Israel, under whose wings you have come to take refuge.” 
 \p
 \v 13 Then she said, “Let me find favor in your sight, my lord, because you have comforted me, and because you have spoken kindly to your servant, though I am not as one of your servants.” 
 \p
@@ -67,7 +67,7 @@
 \p
 \v 19 Her mother-in-law said to her, “Where have you gleaned today? Where have you worked? Blessed be he who noticed you.” 
 \p She told her mother-in-law with whom she had worked, “The man’s name with whom I worked today is Boaz.” 
-\v 20 Naomi said to her daughter-in-law, “May he be blessed by Yahweh, who has not abandoned his kindness to the living and to the dead.” Naomi said to her, “The man is a close relative to us, one of our near kinsmen.” 
+\v 20 Naomi said to her daughter-in-law, “May he be blessed by Yahuah, who has not abandoned his kindness to the living and to the dead.” Naomi said to her, “The man is a close relative to us, one of our near kinsmen.” 
 \p
 \v 21 Ruth the Moabitess said, “Yes, he said to me, ‘You shall stay close to my young men until they have finished all my harvest.’ ” 
 \p
@@ -87,10 +87,10 @@
 \v 9 He said, “Who are you?” 
 \p She answered, “I am Ruth your servant. Therefore spread the corner of your garment over your servant; for you are a near kinsman.” 
 \p
-\v 10 He said, “You are blessed by Yahweh, my daughter. You have shown more kindness in the latter end than at the beginning, because you didn’t follow young men, whether poor or rich. 
+\v 10 He said, “You are blessed by Yahuah, my daughter. You have shown more kindness in the latter end than at the beginning, because you didn’t follow young men, whether poor or rich. 
 \v 11 Now, my daughter, don’t be afraid. I will do to you all that you say; for all the city of my people knows that you are a worthy woman. 
 \v 12 Now it is true that I am a near kinsman. However, there is a kinsman nearer than I. 
-\v 13 Stay this night, and in the morning, if he will perform for you the part of a kinsman, good. Let him do the kinsman’s duty. But if he will not do the duty of a kinsman for you, then I will do the duty of a kinsman for you, as Yahweh lives. Lie down until the morning.” 
+\v 13 Stay this night, and in the morning, if he will perform for you the part of a kinsman, good. Let him do the kinsman’s duty. But if he will not do the duty of a kinsman for you, then I will do the duty of a kinsman for you, as Yahuah lives. Lie down until the morning.” 
 \p
 \v 14 She lay at his feet until the morning, then she rose up before one could discern another. For he said, “Let it not be known that the woman came to the threshing floor.” 
 \v 15 He said, “Bring the mantle that is on you, and hold it.” She held it; and he measured six measures of barley, and laid it on her; then he went into the city. 
@@ -118,11 +118,11 @@
 \v 9 Boaz said to the elders and to all the people, “You are witnesses today, that I have bought all that was Elimelech’s, and all that was Chilion’s and Mahlon’s, from the hand of Naomi. 
 \v 10 Moreover, Ruth the Moabitess, the woman of Mahlon, I have purchased to be my woman, to raise up the name of the dead on his inheritance, that the name of the dead may not be cut off from among his brothers and from the gate of his place. You are witnesses today.” 
 \p
-\v 11 All the people who were in the gate, and the elders, said, “We are witnesses. May Yahweh make the woman who has come into your house like Rachel and like Leah, which both built the house of Israel; and treat you worthily in Ephrathah, and be famous in Bethlehem. 
-\v 12 Let your house be like the house of Perez, whom Tamar bore to Judah, of the offspring which Yahweh will give you by this young woman.” 
+\v 11 All the people who were in the gate, and the elders, said, “We are witnesses. May Yahuah make the woman who has come into your house like Rachel and like Leah, which both built the house of Israel; and treat you worthily in Ephrathah, and be famous in Bethlehem. 
+\v 12 Let your house be like the house of Perez, whom Tamar bore to Judah, of the offspring which Yahuah will give you by this young woman.” 
 \p
-\v 13 So Boaz took Ruth and she became his woman; and he went in to her, and Yahweh enabled her to conceive, and she bore a son. 
-\v 14 The women said to Naomi, “Blessed be Yahweh, who has not left you today without a near kinsman. Let his name be famous in Israel. 
+\v 13 So Boaz took Ruth and she became his woman; and he went in to her, and Yahuah enabled her to conceive, and she bore a son. 
+\v 14 The women said to Naomi, “Blessed be Yahuah, who has not left you today without a near kinsman. Let his name be famous in Israel. 
 \v 15 He shall be to you a restorer of life and sustain you in your old age; for your daughter-in-law, who loves you, who is better to you than seven sons, has given birth to him.” 
 \v 16 Naomi took the child, laid him in her bosom, and became nurse to him. 
 \v 17 The women, her neighbors, gave him a name, saying, “A son is born to Naomi”. They named him Obed. He is the father of Jesse, the father of David. 

--- a/usfm/zechariah.usfm
+++ b/usfm/zechariah.usfm
@@ -3,37 +3,37 @@
 \h Zechariah
 \c 1
 \p
-\v 1 In the eighth month, in the second year of Darius, Yahweh’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
-\v 2 “Yahweh was very displeased with your fathers. 
-\v 3 Therefore tell them, Yahweh of Armies says: ‘Return to me,’ says Yahweh of Armies, ‘and I will return to you,’ says Yahweh of Armies. 
-\v 4 Don’t you be like your fathers, to whom the former prophets proclaimed, saying: Yahweh of Armies says, ‘Return now from your evil ways and from your evil doings;’ but they didn’t hear nor listen to me, says Yahweh. 
+\v 1 In the eighth month, in the second year of Darius, Yahuah’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
+\v 2 “Yahuah was very displeased with your fathers. 
+\v 3 Therefore tell them, Yahuah of Armies says: ‘Return to me,’ says Yahuah of Armies, ‘and I will return to you,’ says Yahuah of Armies. 
+\v 4 Don’t you be like your fathers, to whom the former prophets proclaimed, saying: Yahuah of Armies says, ‘Return now from your evil ways and from your evil doings;’ but they didn’t hear nor listen to me, says Yahuah. 
 \v 5 Your fathers, where are they? And the prophets, do they live forever? 
 \v 6 But my words and my decrees, which I commanded my servants the prophets, didn’t they overtake your fathers? 
-\p “Then they repented and said, ‘Just as Yahweh of Armies determined to do to us, according to our ways and according to our practices, so he has dealt with us.’ ” 
+\p “Then they repented and said, ‘Just as Yahuah of Armies determined to do to us, according to our ways and according to our practices, so he has dealt with us.’ ” 
 \p
-\v 7 On the twenty-fourth day of the eleventh month, which is the month Shebat, in the second year of Darius, Yahweh’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
+\v 7 On the twenty-fourth day of the eleventh month, which is the month Shebat, in the second year of Darius, Yahuah’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
 \v 8 “I had a vision in the night, and behold, a man riding on a red horse, and he stood among the myrtle trees that were in a ravine; and behind him there were red, brown, and white horses. 
 \v 9 Then I asked, ‘My lord, what are these?’ ” 
 \p The angel who talked with me said to me, “I will show you what these are.” 
 \p
-\v 10 The man who stood among the myrtle trees answered, “They are the ones Yahweh has sent to go back and forth through the earth.” 
+\v 10 The man who stood among the myrtle trees answered, “They are the ones Yahuah has sent to go back and forth through the earth.” 
 \p
-\v 11 They reported to Yahweh’s angel who stood among the myrtle trees, and said, “We have walked back and forth through the earth, and behold, all the earth is at rest and in peace.” 
+\v 11 They reported to Yahuah’s angel who stood among the myrtle trees, and said, “We have walked back and forth through the earth, and behold, all the earth is at rest and in peace.” 
 \p
-\v 12 Then Yahweh’s angel replied, “O Yahweh of Armies, how long will you not have mercy on Jerusalem and on the cities of Judah, against which you have had indignation these seventy years?” 
+\v 12 Then Yahuah’s angel replied, “O Yahuah of Armies, how long will you not have mercy on Jerusalem and on the cities of Judah, against which you have had indignation these seventy years?” 
 \p
-\v 13 Yahweh answered the angel who talked with me with kind and comforting words. 
-\v 14 So the angel who talked with me said to me, “Proclaim, saying, ‘Yahweh of Armies says: “I am jealous for Jerusalem and for Zion with a great jealousy. 
+\v 13 Yahuah answered the angel who talked with me with kind and comforting words. 
+\v 14 So the angel who talked with me said to me, “Proclaim, saying, ‘Yahuah of Armies says: “I am jealous for Jerusalem and for Zion with a great jealousy. 
 \v 15 I am very angry with the nations that are at ease; for I was but a little displeased, but they added to the calamity.” 
-\v 16 Therefore Yahweh says: “I have returned to Jerusalem with mercy. My house shall be built in it,” says Yahweh of Armies, “and a line shall be stretched out over Jerusalem.” ’ 
+\v 16 Therefore Yahuah says: “I have returned to Jerusalem with mercy. My house shall be built in it,” says Yahuah of Armies, “and a line shall be stretched out over Jerusalem.” ’ 
 \p
-\v 17 “Proclaim further, saying, ‘Yahweh of Armies says: “My cities will again overflow with prosperity, and Yahweh will again comfort Zion, and will again choose Jerusalem.” ’ ” 
+\v 17 “Proclaim further, saying, ‘Yahuah of Armies says: “My cities will again overflow with prosperity, and Yahuah will again comfort Zion, and will again choose Jerusalem.” ’ ” 
 \p
 \v 18 I lifted up my eyes and saw, and behold, four horns. 
 \v 19 I asked the angel who talked with me, “What are these?” 
 \p He answered me, “These are the horns which have scattered Judah, Israel, and Jerusalem.” 
 \p
-\v 20 Yahweh showed me four craftsmen. 
+\v 20 Yahuah showed me four craftsmen. 
 \v 21 Then I asked, “What are these coming to do?” 
 \p He said, “These are the horns which scattered Judah, so that no man lifted up his head; but these have come to terrify them, to cast down the horns of the nations that lifted up their horn against the land of Judah to scatter it.” 
 \c 2
@@ -44,32 +44,32 @@
 \p
 \v 3 Behold, the angel who talked with me went out, and another angel went out to meet him, 
 \v 4 and said to him, “Run, speak to this young man, saying, ‘Jerusalem will be inhabited as villages without walls, because of the multitude of men and livestock in it. 
-\v 5 For I,’ says Yahweh, ‘will be to her a wall of fire around it, and I will be the glory in the middle of her. 
+\v 5 For I,’ says Yahuah, ‘will be to her a wall of fire around it, and I will be the glory in the middle of her. 
 \p
-\v 6 Come! Come! Flee from the land of the north,’ says Yahweh; ‘for I have spread you abroad as the four winds of the sky,’ says Yahweh. 
+\v 6 Come! Come! Flee from the land of the north,’ says Yahuah; ‘for I have spread you abroad as the four winds of the sky,’ says Yahuah. 
 \v 7 ‘Come, Zion! Escape, you who dwell with the daughter of Babylon.’ 
-\v 8 For Yahweh of Armies says: ‘For honor he has sent me to the nations which plundered you; for he who touches you touches the apple of his eye. 
-\v 9 For, behold, I will shake my hand over them, and they will be a plunder to those who served them; and you will know that Yahweh of Armies has sent me. 
-\v 10 Sing and rejoice, daughter of Zion! For behold, I come and I will dwell within you,’ says Yahweh. 
-\v 11 Many nations shall join themselves to Yahweh in that day, and shall be my people; and I will dwell among you, and you shall know that Yahweh of Armies has sent me to you. 
-\v 12 Yahweh will inherit Judah as his portion in the set-apart land, and will again choose Jerusalem. 
-\v 13 Be silent, all flesh, before Yahweh; for he has roused himself from his set-apart habitation!” 
+\v 8 For Yahuah of Armies says: ‘For honor he has sent me to the nations which plundered you; for he who touches you touches the apple of his eye. 
+\v 9 For, behold, I will shake my hand over them, and they will be a plunder to those who served them; and you will know that Yahuah of Armies has sent me. 
+\v 10 Sing and rejoice, daughter of Zion! For behold, I come and I will dwell within you,’ says Yahuah. 
+\v 11 Many nations shall join themselves to Yahuah in that day, and shall be my people; and I will dwell among you, and you shall know that Yahuah of Armies has sent me to you. 
+\v 12 Yahuah will inherit Judah as his portion in the set-apart land, and will again choose Jerusalem. 
+\v 13 Be silent, all flesh, before Yahuah; for he has roused himself from his set-apart habitation!” 
 \c 3
 \p
-\v 1 He showed me Joshua the high priest standing before Yahweh’s angel, and Satan standing at his right hand to be his adversary. 
-\v 2 Yahweh said to Satan, “Yahweh rebuke you, Satan! Yes, Yahweh who has chosen Jerusalem rebuke you! Isn’t this a burning stick plucked out of the fire?” 
+\v 1 He showed me Joshua the high priest standing before Yahuah’s angel, and Satan standing at his right hand to be his adversary. 
+\v 2 Yahuah said to Satan, “Yahuah rebuke you, Satan! Yes, Yahuah who has chosen Jerusalem rebuke you! Isn’t this a burning stick plucked out of the fire?” 
 \p
 \v 3 Now Joshua was clothed with filthy garments, and was standing before the angel. 
 \v 4 He answered and spoke to those who stood before him, saying, “Take the filthy garments off him.” To him he said, “Behold, I have caused your iniquity to pass from you, and I will clothe you with rich clothing.” 
 \p
 \v 5 I said, “Let them set a clean turban on his head.” 
-\p So they set a clean turban on his head, and clothed him; and Yahweh’s angel was standing by. 
+\p So they set a clean turban on his head, and clothed him; and Yahuah’s angel was standing by. 
 \p
-\v 6 Yahweh’s angel solemnly assured Joshua, saying, 
-\v 7 “Yahweh of Armies says: ‘If you will walk in my ways, and if you will follow my instructions, then you also shall judge my house, and shall also keep my courts, and I will give you a place of access among these who stand by. 
+\v 6 Yahuah’s angel solemnly assured Joshua, saying, 
+\v 7 “Yahuah of Armies says: ‘If you will walk in my ways, and if you will follow my instructions, then you also shall judge my house, and shall also keep my courts, and I will give you a place of access among these who stand by. 
 \v 8 Hear now, Joshua the high priest, you and your fellows who sit before you, for they are men who are a sign; for, behold, I will bring out my servant, the Branch. 
-\v 9 For, behold, the stone that I have set before Joshua: on one stone are seven eyes; behold, I will engrave its inscription,’ says Yahweh of Armies, ‘and I will remove the iniquity of that land in one day. 
-\v 10 In that day,’ says Yahweh of Armies, ‘you will invite every man his neighbor under the vine and under the fig tree.’ ” 
+\v 9 For, behold, the stone that I have set before Joshua: on one stone are seven eyes; behold, I will engrave its inscription,’ says Yahuah of Armies, ‘and I will remove the iniquity of that land in one day. 
+\v 10 In that day,’ says Yahuah of Armies, ‘you will invite every man his neighbor under the vine and under the fig tree.’ ” 
 \c 4
 \p
 \v 1 The angel who talked with me came again and wakened me, as a man who is wakened out of his sleep. 
@@ -82,12 +82,12 @@
 \v 5 Then the angel who talked with me answered me, “Don’t you know what these are?” 
 \p I said, “No, my lord.” 
 \p
-\v 6 Then he answered and spoke to me, saying, “This is Yahweh’s word to Zerubbabel, saying, ‘Not by might, nor by power, but by my Spirit,’ says Yahweh of Armies. 
+\v 6 Then he answered and spoke to me, saying, “This is Yahuah’s word to Zerubbabel, saying, ‘Not by might, nor by power, but by my Spirit,’ says Yahuah of Armies. 
 \v 7 Who are you, great mountain? Before Zerubbabel you are a plain; and he will bring out the capstone with shouts of ‘Grace, grace, to it!’ ” 
 \p
-\v 8 Moreover Yahweh’s word came to me, saying, 
-\v 9 “The hands of Zerubbabel have laid the foundation of this house. His hands shall also finish it; and you will know that Yahweh of Armies has sent me to you. 
-\v 10 Indeed, who despises the day of small things? For these seven shall rejoice, and shall see the plumb line in the hand of Zerubbabel. These are Yahweh’s eyes, which run back and forth through the whole earth.” 
+\v 8 Moreover Yahuah’s word came to me, saying, 
+\v 9 “The hands of Zerubbabel have laid the foundation of this house. His hands shall also finish it; and you will know that Yahuah of Armies has sent me to you. 
+\v 10 Indeed, who despises the day of small things? For these seven shall rejoice, and shall see the plumb line in the hand of Zerubbabel. These are Yahuah’s eyes, which run back and forth through the whole earth.” 
 \p
 \v 11 Then I asked him, “What are these two olive trees on the right side of the lamp stand and on the left side of it?” 
 \p
@@ -104,7 +104,7 @@
 \p I answered, “I see a flying scroll; its length is twenty cubits, and its width ten cubits.” 
 \p
 \v 3 Then he said to me, “This is the curse that goes out over the surface of the whole land, for everyone who steals shall be cut off according to it on the one side; and everyone who swears falsely shall be cut off according to it on the other side. 
-\v 4 I will cause it to go out,” says Yahweh of Armies, “and it will enter into the house of the thief, and into the house of him who swears falsely by my name; and it will remain in the middle of his house, and will destroy it with its timber and its stones.” 
+\v 4 I will cause it to go out,” says Yahuah of Armies, “and it will enter into the house of the thief, and into the house of him who swears falsely by my name; and it will remain in the middle of his house, and will destroy it with its timber and its stones.” 
 \p
 \v 5 Then the angel who talked with me came forward and said to me, “Lift up now your eyes and see what this is that is appearing.” 
 \p
@@ -129,71 +129,71 @@
 \p
 \v 8 Then he called to me, and spoke to me, saying, “Behold, those who go toward the north country have quieted my spirit in the north country.” 
 \p
-\v 9 Yahweh’s word came to me, saying, 
+\v 9 Yahuah’s word came to me, saying, 
 \v 10 “Take of them of the captivity, even of Heldai, of Tobijah, and of Jedaiah; and come the same day, and go into the house of Josiah the son of Zephaniah, where they have come from Babylon. 
 \v 11 Yes, take silver and gold, and make crowns, and set them on the head of Joshua the son of Jehozadak, the high priest; 
-\v 12 and speak to him, saying, ‘Yahweh of Armies says, “Behold, the man whose name is the Branch! He will grow up out of his place; and he will build Yahweh’s temple. 
-\v 13 He will build Yahweh’s temple. He will bear the glory, and will sit and rule on his throne. He will be a priest on his throne. The counsel of peace will be between them both. 
-\v 14 The crowns shall be to Helem, to Tobijah, to Jedaiah, and to Hen the son of Zephaniah, for a memorial in Yahweh’s temple. 
+\v 12 and speak to him, saying, ‘Yahuah of Armies says, “Behold, the man whose name is the Branch! He will grow up out of his place; and he will build Yahuah’s temple. 
+\v 13 He will build Yahuah’s temple. He will bear the glory, and will sit and rule on his throne. He will be a priest on his throne. The counsel of peace will be between them both. 
+\v 14 The crowns shall be to Helem, to Tobijah, to Jedaiah, and to Hen the son of Zephaniah, for a memorial in Yahuah’s temple. 
 \p
-\v 15 Those who are far off shall come and build in Yahweh’s temple; and you shall know that Yahweh of Armies has sent me to you. This will happen, if you will diligently obey Yahweh your Elohim’s voice.” ’ ” 
+\v 15 Those who are far off shall come and build in Yahuah’s temple; and you shall know that Yahuah of Armies has sent me to you. This will happen, if you will diligently obey Yahuah your Elohim’s voice.” ’ ” 
 \c 7
 \p
-\v 1 In the fourth year of King Darius, Yahweh’s word came to Zechariah in the fourth day of the ninth month, the month of Chislev. 
-\v 2 The people of Bethel sent Sharezer and Regem Melech and their men to entreat Yahweh’s favor, 
-\v 3 and to speak to the priests of the house of Yahweh of Armies and to the prophets, saying, “Should I weep in the fifth month, separating myself, as I have done these so many years?” 
+\v 1 In the fourth year of King Darius, Yahuah’s word came to Zechariah in the fourth day of the ninth month, the month of Chislev. 
+\v 2 The people of Bethel sent Sharezer and Regem Melech and their men to entreat Yahuah’s favor, 
+\v 3 and to speak to the priests of the house of Yahuah of Armies and to the prophets, saying, “Should I weep in the fifth month, separating myself, as I have done these so many years?” 
 \p
-\v 4 Then the word of Yahweh of Armies came to me, saying, 
+\v 4 Then the word of Yahuah of Armies came to me, saying, 
 \v 5 “Speak to all the people of the land and to the priests, saying, ‘When you fasted and mourned in the fifth and in the seventh month for these seventy years, did you at all fast to me, really to me? 
 \v 6 When you eat and when you drink, don’t you eat for yourselves and drink for yourselves? 
-\v 7 Aren’t these the words which Yahweh proclaimed by the former prophets when Jerusalem was inhabited and in prosperity, and its cities around her, and the South and the lowland were inhabited?’ ” 
+\v 7 Aren’t these the words which Yahuah proclaimed by the former prophets when Jerusalem was inhabited and in prosperity, and its cities around her, and the South and the lowland were inhabited?’ ” 
 \p
-\v 8 Yahweh’s word came to Zechariah, saying, 
-\v 9 “Thus has Yahweh of Armies spoken, saying, ‘Execute true judgment, and show kindness and compassion every man to his brother. 
+\v 8 Yahuah’s word came to Zechariah, saying, 
+\v 9 “Thus has Yahuah of Armies spoken, saying, ‘Execute true judgment, and show kindness and compassion every man to his brother. 
 \v 10 Don’t oppress the widow, the fatherless, the foreigner, nor the poor; and let none of you devise evil against his brother in your heart.’ 
 \v 11 But they refused to listen, and turned their backs, and stopped their ears, that they might not hear. 
-\v 12 Yes, they made their hearts as hard as flint, lest they might hear the law and the words which Yahweh of Armies had sent by his Spirit by the former prophets. Therefore great wrath came from Yahweh of Armies. 
-\v 13 It has come to pass that, as he called and they refused to listen, so they will call and I will not listen,” said Yahweh of Armies; 
+\v 12 Yes, they made their hearts as hard as flint, lest they might hear the law and the words which Yahuah of Armies had sent by his Spirit by the former prophets. Therefore great wrath came from Yahuah of Armies. 
+\v 13 It has come to pass that, as he called and they refused to listen, so they will call and I will not listen,” said Yahuah of Armies; 
 \v 14 “but I will scatter them with a whirlwind among all the nations which they have not known. Thus the land was desolate after them, so that no man passed through nor returned; for they made the pleasant land desolate.” 
 \c 8
 \p
-\v 1 The word of Yahweh of Armies came to me. 
-\v 2 Yahweh of Armies says: “I am jealous for Zion with great jealousy, and I am jealous for her with great wrath.” 
+\v 1 The word of Yahuah of Armies came to me. 
+\v 2 Yahuah of Armies says: “I am jealous for Zion with great jealousy, and I am jealous for her with great wrath.” 
 \p
-\v 3 Yahweh says: “I have returned to Zion, and will dwell in the middle of Jerusalem. Jerusalem shall be called ‘The City of Truth;’ and the mountain of Yahweh of Armies, ‘The Set-Apart Mountain.’ ” 
+\v 3 Yahuah says: “I have returned to Zion, and will dwell in the middle of Jerusalem. Jerusalem shall be called ‘The City of Truth;’ and the mountain of Yahuah of Armies, ‘The Set-Apart Mountain.’ ” 
 \p
-\v 4 Yahweh of Armies says: “Old men and old women will again dwell in the streets of Jerusalem, every man with his staff in his hand because of their old age. 
+\v 4 Yahuah of Armies says: “Old men and old women will again dwell in the streets of Jerusalem, every man with his staff in his hand because of their old age. 
 \v 5 The streets of the city will be full of boys and girls playing in its streets.” 
 \p
-\v 6 Yahweh of Armies says: “If it is marvelous in the eyes of the remnant of this people in those days, should it also be marvelous in my eyes?” says Yahweh of Armies. 
+\v 6 Yahuah of Armies says: “If it is marvelous in the eyes of the remnant of this people in those days, should it also be marvelous in my eyes?” says Yahuah of Armies. 
 \p
-\v 7 Yahweh of Armies says: “Behold, I will save my people from the east country and from the west country. 
+\v 7 Yahuah of Armies says: “Behold, I will save my people from the east country and from the west country. 
 \v 8 I will bring them, and they will dwell within Jerusalem. They will be my people, and I will be their Elohim, in truth and in righteousness.” 
 \p
-\v 9 Yahweh of Armies says: “Let your hands be strong, you who hear in these days these words from the mouth of the prophets who were in the day that the foundation of the house of Yahweh of Armies was laid, even the temple, that it might be built. 
+\v 9 Yahuah of Armies says: “Let your hands be strong, you who hear in these days these words from the mouth of the prophets who were in the day that the foundation of the house of Yahuah of Armies was laid, even the temple, that it might be built. 
 \v 10 For before those days there was no wages for man nor any wages for an animal, neither was there any peace to him who went out or came in, because of the adversary. For I set all men everyone against his neighbor. 
-\v 11 But now I will not be to the remnant of this people as in the former days,” says Yahweh of Armies. 
+\v 11 But now I will not be to the remnant of this people as in the former days,” says Yahuah of Armies. 
 \v 12 “For the seed of peace and the vine will yield its fruit, and the ground will give its increase, and the heavens will give their dew. I will cause the remnant of this people to inherit all these things. 
 \v 13 It shall come to pass that, as you were a curse among the nations, house of Judah and house of Israel, so I will save you, and you shall be a blessing. Don’t be afraid. Let your hands be strong.” 
 \p
-\v 14 For Yahweh of Armies says: “As I thought to do evil to you when your fathers provoked me to wrath,” says Yahweh of Armies, “and I didn’t repent, 
+\v 14 For Yahuah of Armies says: “As I thought to do evil to you when your fathers provoked me to wrath,” says Yahuah of Armies, “and I didn’t repent, 
 \v 15 so again I have thought in these days to do good to Jerusalem and to the house of Judah. Don’t be afraid. 
 \v 16 These are the things that you shall do: speak every man the truth with his neighbor. Execute the judgment of truth and peace in your gates, 
-\v 17 and let none of you devise evil in your hearts against his neighbor, and love no false oath; for all these are things that I hate,” says Yahweh. 
+\v 17 and let none of you devise evil in your hearts against his neighbor, and love no false oath; for all these are things that I hate,” says Yahuah. 
 \p
-\v 18 The word of Yahweh of Armies came to me. 
-\v 19 Yahweh of Armies says: “The fasts of the fourth, fifth, seventh, and tenth months shall be for the house of Judah joy, gladness, and cheerful feasts. Therefore love truth and peace.” 
+\v 18 The word of Yahuah of Armies came to me. 
+\v 19 Yahuah of Armies says: “The fasts of the fourth, fifth, seventh, and tenth months shall be for the house of Judah joy, gladness, and cheerful feasts. Therefore love truth and peace.” 
 \p
-\v 20 Yahweh of Armies says: “Many peoples and the inhabitants of many cities will yet come. 
-\v 21 The inhabitants of one will go to another, saying, ‘Let’s go speedily to entreat the favor of Yahweh, and to seek Yahweh of Armies. I will go also.’ 
-\v 22 Yes, many peoples and strong nations will come to seek Yahweh of Armies in Jerusalem and to entreat the favor of Yahweh.” 
-\v 23 Yahweh of Armies says: “In those days, ten men out of all the languages of the nations will take hold of the skirt of him who is a Jew, saying, ‘We will go with you, for we have heard that Elohim is with you.’ ” 
+\v 20 Yahuah of Armies says: “Many peoples and the inhabitants of many cities will yet come. 
+\v 21 The inhabitants of one will go to another, saying, ‘Let’s go speedily to entreat the favor of Yahuah, and to seek Yahuah of Armies. I will go also.’ 
+\v 22 Yes, many peoples and strong nations will come to seek Yahuah of Armies in Jerusalem and to entreat the favor of Yahuah.” 
+\v 23 Yahuah of Armies says: “In those days, ten men out of all the languages of the nations will take hold of the skirt of him who is a Jew, saying, ‘We will go with you, for we have heard that Elohim is with you.’ ” 
 \c 9
 \p
 \v 1 A revelation. 
-\q1 Yahweh’s word is against the land of Hadrach, 
+\q1 Yahuah’s word is against the land of Hadrach, 
 \q2 and will rest upon Damascus—\q1 for the eye of man 
-\q2 and of all the tribes of Israel is toward Yahweh—\q1
+\q2 and of all the tribes of Israel is toward Yahuah—\q1
 \v 2 and Hamath, also, which borders on it, 
 \q2 Tyre and Sidon, because they are very wise. 
 \q1
@@ -256,19 +256,19 @@
 \q2 and will make you like the sword of a mighty man. 
 \b
 \q1
-\v 14 Yahweh will be seen over them. 
+\v 14 Yahuah will be seen over them. 
 \q2 His arrow will flash like lightning. 
-\q1 The Lord Yahweh will blow the trumpet, 
+\q1 The Lord Yahuah will blow the trumpet, 
 \q2 and will go with whirlwinds of the south. 
 \q1
-\v 15 Yahweh of Armies will defend them. 
+\v 15 Yahuah of Armies will defend them. 
 \q2 They will destroy and overcome with sling stones. 
 \q1 They will drink, and roar as through wine. 
 \q2 They will be filled like bowls, 
 \q2 like the corners of the altar. 
 \b
 \q1
-\v 16 Yahweh their Elohim will save them in that day as the flock of his people; 
+\v 16 Yahuah their Elohim will save them in that day as the flock of his people; 
 \q2 for they are like the jewels of a crown, 
 \q2 lifted on high over his land. 
 \q1
@@ -278,8 +278,8 @@
 \q2 and new wine the virgins. 
 \c 10
 \q1
-\v 1 Ask of Yahweh rain in the spring time, 
-\q2 Yahweh who makes storm clouds, 
+\v 1 Ask of Yahuah rain in the spring time, 
+\q2 Yahuah who makes storm clouds, 
 \q2 and he gives rain showers to everyone for the plants in the field. 
 \q1
 \v 2 For the teraphim have spoken vanity, 
@@ -292,7 +292,7 @@
 \q1
 \v 3 My anger is kindled against the shepherds, 
 \q2 and I will punish the male goats, 
-\q2 for Yahweh of Armies has visited his flock, the house of Judah, 
+\q2 for Yahuah of Armies has visited his flock, the house of Judah, 
 \q2 and will make them as his majestic horse in the battle. 
 \q1
 \v 4 From him will come the cornerstone, 
@@ -302,7 +302,7 @@
 \q2
 \v 5 They will be as mighty men, 
 \q2 treading down muddy streets in the battle. 
-\q1 They will fight, because Yahweh is with them. 
+\q1 They will fight, because Yahuah is with them. 
 \q2 The riders on horses will be confounded. 
 \b
 \q1
@@ -311,12 +311,12 @@
 \q1 I will bring them back, 
 \q2 for I have mercy on them. 
 \q1 They will be as though I had not cast them off, 
-\q2 for I am Yahweh their Elohim, and I will hear them. 
+\q2 for I am Yahuah their Elohim, and I will hear them. 
 \q1
 \v 7 Ephraim will be like a mighty man, 
 \q2 and their heart will rejoice as through wine. 
 \q1 Yes, their children will see it and rejoice. 
-\q2 Their heart will be glad in Yahweh. 
+\q2 Their heart will be glad in Yahuah. 
 \q1
 \v 8 I will signal for them and gather them, 
 \q2 for I have redeemed them. 
@@ -337,8 +337,8 @@
 \q2 and the pride of Assyria will be brought down, 
 \q2 and the scepter of Egypt will depart. 
 \q1
-\v 12 I will strengthen them in Yahweh. 
-\q2 They will walk up and down in his name,” says Yahweh. 
+\v 12 I will strengthen them in Yahuah. 
+\q2 They will walk up and down in his name,” says Yahuah. 
 \c 11
 \q1
 \v 1 Open your doors, Lebanon, 
@@ -353,34 +353,34 @@
 \q2 For their glory is destroyed—a voice of the roaring of young lions! 
 \q2 For the pride of the Jordan is ruined. 
 \p
-\v 4 Yahweh my Elohim says: “Feed the flock of slaughter. 
-\v 5 Their buyers slaughter them and go unpunished. Those who sell them say, ‘Blessed be Yahweh, for I am rich;’ and their own shepherds don’t pity them. 
-\v 6 For I will no more pity the inhabitants of the land,” says Yahweh; “but, behold, I will deliver every one of the men into his neighbor’s hand and into the hand of his king. They will strike the land, and out of their hand I will not deliver them.” 
+\v 4 Yahuah my Elohim says: “Feed the flock of slaughter. 
+\v 5 Their buyers slaughter them and go unpunished. Those who sell them say, ‘Blessed be Yahuah, for I am rich;’ and their own shepherds don’t pity them. 
+\v 6 For I will no more pity the inhabitants of the land,” says Yahuah; “but, behold, I will deliver every one of the men into his neighbor’s hand and into the hand of his king. They will strike the land, and out of their hand I will not deliver them.” 
 \p
 \v 7 So I fed the flock to be slaughtered, especially the oppressed of the flock. I took for myself two staffs. The one I called “Favor” and the other I called “Union”, and I fed the flock. 
 \v 8 I cut off the three shepherds in one month; for my soul was weary of them, and their soul also loathed me. 
 \v 9 Then I said, “I will not feed you. That which dies, let it die; and that which is to be cut off, let it be cut off; and let those who are left eat each other’s flesh.” 
 \v 10 I took my staff Favor and cut it apart, that I might break my covenant that I had made with all the peoples. 
-\v 11 It was broken in that day; and thus the poor of the flock that listened to me knew that it was Yahweh’s word. 
+\v 11 It was broken in that day; and thus the poor of the flock that listened to me knew that it was Yahuah’s word. 
 \v 12 I said to them, “If you think it best, give me my wages; and if not, keep them.” So they weighed for my wages thirty pieces of silver. 
-\v 13 Yahweh said to me, “Throw it to the potter—the handsome price that I was valued at by them!” I took the thirty pieces of silver and threw them to the potter in Yahweh’s house. 
+\v 13 Yahuah said to me, “Throw it to the potter—the handsome price that I was valued at by them!” I took the thirty pieces of silver and threw them to the potter in Yahuah’s house. 
 \v 14 Then I cut apart my other staff, Union, that I might break the brotherhood between Judah and Israel. 
 \p
-\v 15 Yahweh said to me, “Take for yourself yet again the equipment of a foolish shepherd. 
+\v 15 Yahuah said to me, “Take for yourself yet again the equipment of a foolish shepherd. 
 \v 16 For, behold, I will raise up a shepherd in the land who will not visit those who are cut off, neither will seek those who are scattered, nor heal that which is broken, nor feed that which is sound; but he will eat the meat of the fat sheep, and will tear their hoofs in pieces. 
 \v 17 Woe to the worthless shepherd who leaves the flock! The sword will strike his arm and his right eye. His arm will be completely withered, and his right eye will be totally blinded!” 
 \c 12
 \p
-\v 1 A revelation of Yahweh’s word concerning Israel: Yahweh, who stretches out the heavens and lays the foundation of the earth, and forms the spirit of man within him says: 
+\v 1 A revelation of Yahuah’s word concerning Israel: Yahuah, who stretches out the heavens and lays the foundation of the earth, and forms the spirit of man within him says: 
 \v 2 “Behold, I will make Jerusalem a cup of reeling to all the surrounding peoples, and it will also be on Judah in the siege against Jerusalem. 
 \v 3 It will happen in that day that I will make Jerusalem a burdensome stone for all the peoples. All who burden themselves with it will be severely wounded, and all the nations of the earth will be gathered together against it. 
-\v 4 In that day,” says Yahweh, “I will strike every horse with terror and his rider with madness. I will open my eyes on the house of Judah, and will strike every horse of the peoples with blindness. 
-\v 5 The chieftains of Judah will say in their heart, ‘The inhabitants of Jerusalem are my strength in Yahweh of Armies their Elohim.’ 
+\v 4 In that day,” says Yahuah, “I will strike every horse with terror and his rider with madness. I will open my eyes on the house of Judah, and will strike every horse of the peoples with blindness. 
+\v 5 The chieftains of Judah will say in their heart, ‘The inhabitants of Jerusalem are my strength in Yahuah of Armies their Elohim.’ 
 \p
 \v 6 In that day I will make the chieftains of Judah like a pan of fire among wood, and like a flaming torch among sheaves. They will devour all the surrounding peoples on the right hand and on the left; and Jerusalem will yet again dwell in their own place, even in Jerusalem. 
 \p
-\v 7 Yahweh also will save the tents of Judah first, that the glory of David’s house and the glory of the inhabitants of Jerusalem not be magnified above Judah. 
-\v 8 In that day Yahweh will defend the inhabitants of Jerusalem. He who is feeble among them at that day will be like David, and David’s house will be like Elohim, like Yahweh’s angel before them. 
+\v 7 Yahuah also will save the tents of Judah first, that the glory of David’s house and the glory of the inhabitants of Jerusalem not be magnified above Judah. 
+\v 8 In that day Yahuah will defend the inhabitants of Jerusalem. He who is feeble among them at that day will be like David, and David’s house will be like Elohim, like Yahuah’s angel before them. 
 \v 9 It will happen in that day, that I will seek to destroy all the nations that come against Jerusalem. 
 \p
 \v 10 I will pour on David’s house and on the inhabitants of Jerusalem the spirit of grace and of supplication. They will look to me whom they have pierced; and they shall mourn for him as one mourns for his only son, and will grieve bitterly for him as one grieves for his firstborn. 
@@ -392,19 +392,19 @@
 \p
 \v 1 “In that day there will be a fountain opened to David’s house and to the inhabitants of Jerusalem, for sin and for uncleanness. 
 \p
-\v 2 It will come to pass in that day, says Yahweh of Armies, that I will cut off the names of the idols out of the land, and they will be remembered no more. I will also cause the prophets and the spirit of impurity to pass out of the land. 
-\v 3 It will happen that when anyone still prophesies, then his father and his mother who bore him will tell him, ‘You must die, because you speak lies in Yahweh’s name;’ and his father and his mother who bore him will stab him when he prophesies. 
+\v 2 It will come to pass in that day, says Yahuah of Armies, that I will cut off the names of the idols out of the land, and they will be remembered no more. I will also cause the prophets and the spirit of impurity to pass out of the land. 
+\v 3 It will happen that when anyone still prophesies, then his father and his mother who bore him will tell him, ‘You must die, because you speak lies in Yahuah’s name;’ and his father and his mother who bore him will stab him when he prophesies. 
 \v 4 It will happen in that day that the prophets will each be ashamed of his vision when he prophesies; they won’t wear a hairy mantle to deceive, 
 \v 5 but he will say, ‘I am no prophet, I am a tiller of the ground; for I have been made a bondservant from my youth.’ 
 \v 6 One will say to him, ‘What are these wounds between your arms?’ Then he will answer, ‘Those with which I was wounded in the house of my friends.’ 
 \b
 \q1
 \v 7 “Awake, sword, against my shepherd, 
-\q2 and against the man who is close to me,” says Yahweh of Armies. 
+\q2 and against the man who is close to me,” says Yahuah of Armies. 
 \q1 “Strike the shepherd, and the sheep will be scattered; 
 \q2 and I will turn my hand against the little ones. 
 \q1
-\v 8 It shall happen that in all the land,” says Yahweh, 
+\v 8 It shall happen that in all the land,” says Yahuah, 
 \q2 “two parts in it will be cut off and die; 
 \q2 but the third will be left in it. 
 \q1
@@ -413,35 +413,35 @@
 \q2 and will test them like gold is tested. 
 \q1 They will call on my name, and I will hear them. 
 \q2 I will say, ‘It is my people;’ 
-\q2 and they will say, ‘Yahweh is my Elohim.’ ” 
+\q2 and they will say, ‘Yahuah is my Elohim.’ ” 
 \c 14
 \p
-\v 1 Behold, a day of Yahweh comes, when your plunder will be divided within you. 
+\v 1 Behold, a day of Yahuah comes, when your plunder will be divided within you. 
 \v 2 For I will gather all nations against Jerusalem to battle; and the city will be taken, the houses rifled, and the women ravished. Half of the city will go out into captivity, and the rest of the people will not be cut off from the city. 
-\v 3 Then Yahweh will go out and fight against those nations, as when he fought in the day of battle. 
+\v 3 Then Yahuah will go out and fight against those nations, as when he fought in the day of battle. 
 \v 4 His feet will stand in that day on the Mount of Olives, which is before Jerusalem on the east; and the Mount of Olives will be split in two from east to west, making a very great valley. Half of the mountain will move toward the north, and half of it toward the south. 
-\v 5 You shall flee by the valley of my mountains, for the valley of the mountains shall reach to Azel. Yes, you shall flee, just like you fled from before the earthquake in the days of Uzziah king of Judah. Yahweh my Elohim will come, and all the set-apart ones with you. 
+\v 5 You shall flee by the valley of my mountains, for the valley of the mountains shall reach to Azel. Yes, you shall flee, just like you fled from before the earthquake in the days of Uzziah king of Judah. Yahuah my Elohim will come, and all the set-apart ones with you. 
 \p
 \v 6 It will happen in that day that there will not be light, cold, or frost. 
-\v 7 It will be a unique day which is known to Yahweh—not day, and not night; but it will come to pass that at evening time there will be light. 
+\v 7 It will be a unique day which is known to Yahuah—not day, and not night; but it will come to pass that at evening time there will be light. 
 \p
 \v 8 It will happen in that day that living waters will go out from Jerusalem, half of them toward the eastern sea, and half of them toward the western sea. It will be so in summer and in winter. 
 \p
-\v 9 Yahweh will be King over all the earth. In that day Yahweh will be one, and his name one. 
+\v 9 Yahuah will be King over all the earth. In that day Yahuah will be one, and his name one. 
 \p
 \v 10 All the land will be made like the Arabah, from Geba to Rimmon south of Jerusalem; and she will be lifted up and will dwell in her place, from Benjamin’s gate to the place of the first gate, to the corner gate, and from the tower of Hananel to the king’s wine presses. 
 \v 11 Men will dwell therein, and there will be no more curse; but Jerusalem will dwell safely. 
 \p
-\v 12 This will be the plague with which Yahweh will strike all the peoples who have fought against Jerusalem: their flesh will consume away while they stand on their feet, and their eyes will consume away in their sockets, and their tongue will consume away in their mouth. 
-\v 13 It will happen in that day that a great panic from Yahweh will be among them; and they will each seize the hand of his neighbor, and his hand will rise up against the hand of his neighbor. 
+\v 12 This will be the plague with which Yahuah will strike all the peoples who have fought against Jerusalem: their flesh will consume away while they stand on their feet, and their eyes will consume away in their sockets, and their tongue will consume away in their mouth. 
+\v 13 It will happen in that day that a great panic from Yahuah will be among them; and they will each seize the hand of his neighbor, and his hand will rise up against the hand of his neighbor. 
 \v 14 Judah also will fight at Jerusalem; and the wealth of all the surrounding nations will be gathered together: gold, silver, and clothing, in great abundance. 
 \p
 \v 15 A plague like this will fall on the horse, on the mule, on the camel, on the donkey, and on all the animals that will be in those camps. 
 \p
-\v 16 It will happen that everyone who is left of all the nations that came against Jerusalem will go up from year to year to worship the King, Yahweh of Armies, and to keep the feast of booths. 
-\v 17 It will be that whoever of all the families of the earth doesn’t go up to Jerusalem to worship the King, Yahweh of Armies, on them there will be no rain. 
-\v 18 If the family of Egypt doesn’t go up and doesn’t come, neither will it rain on them. This will be the plague with which Yahweh will strike the nations that don’t go up to keep the feast of booths. 
+\v 16 It will happen that everyone who is left of all the nations that came against Jerusalem will go up from year to year to worship the King, Yahuah of Armies, and to keep the feast of booths. 
+\v 17 It will be that whoever of all the families of the earth doesn’t go up to Jerusalem to worship the King, Yahuah of Armies, on them there will be no rain. 
+\v 18 If the family of Egypt doesn’t go up and doesn’t come, neither will it rain on them. This will be the plague with which Yahuah will strike the nations that don’t go up to keep the feast of booths. 
 \v 19 This will be the punishment of Egypt and the punishment of all the nations that don’t go up to keep the feast of booths. 
 \p
-\v 20 In that day there will be inscribed on the bells of the horses, “SET-APART TO YAHWEH”; and the pots in Yahweh’s house will be like the bowls before the altar. 
-\v 21 Yes, every pot in Jerusalem and in Judah will be set-apart to Yahweh of Armies; and all those who sacrifice will come and take of them, and cook in them. In that day there will no longer be a Canaanite in the house of Yahweh of Armies. 
+\v 20 In that day there will be inscribed on the bells of the horses, “SET-APART TO YAHUAH”; and the pots in Yahuah’s house will be like the bowls before the altar. 
+\v 21 Yes, every pot in Jerusalem and in Judah will be set-apart to Yahuah of Armies; and all those who sacrifice will come and take of them, and cook in them. In that day there will no longer be a Canaanite in the house of Yahuah of Armies. 

--- a/usfm/zephaniah.usfm
+++ b/usfm/zephaniah.usfm
@@ -3,41 +3,41 @@
 \h Zephaniah
 \c 1
 \p
-\v 1 Yahweh’s word which came to Zephaniah, the son of Cushi, the son of Gedaliah, the son of Amariah, the son of Hezekiah, in the days of Josiah, the son of Amon, king of Judah. 
+\v 1 Yahuah’s word which came to Zephaniah, the son of Cushi, the son of Gedaliah, the son of Amariah, the son of Hezekiah, in the days of Josiah, the son of Amon, king of Judah. 
 \p
-\v 2 I will utterly sweep away everything from the surface of the earth, says Yahweh. 
-\v 3 I will sweep away man and animal. I will sweep away the birds of the sky, the fish of the sea, and the heaps of rubble with the wicked. I will cut off man from the surface of the earth, says Yahweh. 
+\v 2 I will utterly sweep away everything from the surface of the earth, says Yahuah. 
+\v 3 I will sweep away man and animal. I will sweep away the birds of the sky, the fish of the sea, and the heaps of rubble with the wicked. I will cut off man from the surface of the earth, says Yahuah. 
 \v 4 I will stretch out my hand against Judah and against all the inhabitants of Jerusalem. I will cut off the remnant of Baal from this place—the name of the idolatrous and pagan priests, 
-\v 5 those who worship the army of the sky on the housetops, those who worship and swear by Yahweh and also swear by Malcam, 
-\v 6 those who have turned back from following Yahweh, and those who haven’t sought Yahweh nor inquired after him. 
+\v 5 those who worship the army of the sky on the housetops, those who worship and swear by Yahuah and also swear by Malcam, 
+\v 6 those who have turned back from following Yahuah, and those who haven’t sought Yahuah nor inquired after him. 
 \p
-\v 7 Be silent at the presence of the Lord Yahweh, for the day of Yahweh is at hand. For Yahweh has prepared a sacrifice. He has consecrated his guests. 
-\v 8 It will happen in the day of Yahweh’s sacrifice that I will punish the princes, the king’s sons, and all those who are clothed with foreign clothing. 
+\v 7 Be silent at the presence of the Lord Yahuah, for the day of Yahuah is at hand. For Yahuah has prepared a sacrifice. He has consecrated his guests. 
+\v 8 It will happen in the day of Yahuah’s sacrifice that I will punish the princes, the king’s sons, and all those who are clothed with foreign clothing. 
 \v 9 In that day, I will punish all those who leap over the threshold, who fill their master’s house with violence and deceit. 
 \p
-\v 10 In that day, says Yahweh, there will be the noise of a cry from the fish gate, a wailing from the second quarter, and a great crashing from the hills. 
+\v 10 In that day, says Yahuah, there will be the noise of a cry from the fish gate, a wailing from the second quarter, and a great crashing from the hills. 
 \v 11 Wail, you inhabitants of Maktesh, for all the people of Canaan are undone! All those who were loaded with silver are cut off. 
-\v 12 It will happen at that time, that I will search Jerusalem with lamps, and I will punish the men who are settled on their dregs, who say in their heart, “Yahweh will not do good, neither will he do evil.” 
+\v 12 It will happen at that time, that I will search Jerusalem with lamps, and I will punish the men who are settled on their dregs, who say in their heart, “Yahuah will not do good, neither will he do evil.” 
 \v 13 Their wealth will become a plunder, and their houses a desolation. Yes, they will build houses, but won’t inhabit them. They will plant vineyards, but won’t drink their wine. 
 \p
-\v 14 The great day of Yahweh is near. It is near and hurries greatly, the voice of the day of Yahweh. The mighty man cries there bitterly. 
+\v 14 The great day of Yahuah is near. It is near and hurries greatly, the voice of the day of Yahuah. The mighty man cries there bitterly. 
 \v 15 That day is a day of wrath, a day of distress and anguish, a day of trouble and ruin, a day of darkness and gloom, a day of clouds and blackness, 
 \v 16 a day of the trumpet and alarm against the fortified cities and against the high battlements. 
-\v 17 I will bring such distress on men that they will walk like blind men because they have sinned against Yahweh. Their blood will be poured out like dust and their flesh like dung. 
-\v 18 Neither their silver nor their gold will be able to deliver them in the day of Yahweh’s wrath, but the whole land will be devoured by the fire of his jealousy; for he will make an end, yes, a terrible end, of all those who dwell in the land. 
+\v 17 I will bring such distress on men that they will walk like blind men because they have sinned against Yahuah. Their blood will be poured out like dust and their flesh like dung. 
+\v 18 Neither their silver nor their gold will be able to deliver them in the day of Yahuah’s wrath, but the whole land will be devoured by the fire of his jealousy; for he will make an end, yes, a terrible end, of all those who dwell in the land. 
 \c 2
 \p
 \v 1 Gather yourselves together, yes, gather together, you nation that has no shame, 
-\v 2 before the appointed time when the day passes as the chaff, before the fierce anger of Yahweh comes on you, before the day of Yahweh’s anger comes on you. 
-\v 3 Seek Yahweh, all you humble of the land, who have kept his ordinances. Seek righteousness. Seek humility. It may be that you will be hidden in the day of Yahweh’s anger. 
+\v 2 before the appointed time when the day passes as the chaff, before the fierce anger of Yahuah comes on you, before the day of Yahuah’s anger comes on you. 
+\v 3 Seek Yahuah, all you humble of the land, who have kept his ordinances. Seek righteousness. Seek humility. It may be that you will be hidden in the day of Yahuah’s anger. 
 \v 4 For Gaza will be forsaken, and Ashkelon a desolation. They will drive out Ashdod at noonday, and Ekron will be rooted up. 
-\v 5 Woe to the inhabitants of the sea coast, the nation of the Cherethites! Yahweh’s word is against you, Canaan, the land of the Philistines. I will destroy you until there is no inhabitant. 
+\v 5 Woe to the inhabitants of the sea coast, the nation of the Cherethites! Yahuah’s word is against you, Canaan, the land of the Philistines. I will destroy you until there is no inhabitant. 
 \v 6 The sea coast will be pastures, with cottages for shepherds and folds for flocks. 
-\v 7 The coast will be for the remnant of the house of Judah. They will find pasture. In the houses of Ashkelon, they will lie down in the evening, for Yahweh, their Elohim, will visit them and restore them. 
+\v 7 The coast will be for the remnant of the house of Judah. They will find pasture. In the houses of Ashkelon, they will lie down in the evening, for Yahuah, their Elohim, will visit them and restore them. 
 \v 8 I have heard the reproach of Moab and the insults of the children of Ammon, with which they have reproached my people and magnified themselves against their border. 
-\v 9 Therefore, as I live, says Yahweh of Armies, the Elohim of Israel, surely Moab will be as Sodom, and the children of Ammon as Gomorrah, a possession of nettles and salt pits, and a perpetual desolation. The remnant of my people will plunder them, and the survivors of my nation will inherit them. 
-\v 10 This they will have for their pride, because they have reproached and magnified themselves against the people of Yahweh of Armies. 
-\v 11 Yahweh will be awesome to them, for he will famish all the elohims of the land. Men will worship him, everyone from his place, even all the shores of the nations. 
+\v 9 Therefore, as I live, says Yahuah of Armies, the Elohim of Israel, surely Moab will be as Sodom, and the children of Ammon as Gomorrah, a possession of nettles and salt pits, and a perpetual desolation. The remnant of my people will plunder them, and the survivors of my nation will inherit them. 
+\v 10 This they will have for their pride, because they have reproached and magnified themselves against the people of Yahuah of Armies. 
+\v 11 Yahuah will be awesome to them, for he will famish all the elohims of the land. Men will worship him, everyone from his place, even all the shores of the nations. 
 \p
 \v 12 You Cushites also, you will be killed by my sword. 
 \p
@@ -47,27 +47,27 @@
 \c 3
 \p
 \v 1 Woe to her who is rebellious and polluted, the oppressing city! 
-\v 2 She didn’t obey the voice. She didn’t receive correction. She didn’t trust in Yahweh. She didn’t draw near to her Elohim. 
+\v 2 She didn’t obey the voice. She didn’t receive correction. She didn’t trust in Yahuah. She didn’t draw near to her Elohim. 
 \p
 \v 3 Her princes within her are roaring lions. Her judges are evening wolves. They leave nothing until the next day. 
 \v 4 Her prophets are arrogant and treacherous people. Her priests have profaned the sanctuary. They have done violence to the law. 
-\v 5 Yahweh, within her, is righteous. He will do no wrong. Every morning he brings his justice to light. He doesn’t fail, but the unjust know no shame. 
+\v 5 Yahuah, within her, is righteous. He will do no wrong. Every morning he brings his justice to light. He doesn’t fail, but the unjust know no shame. 
 \p
 \v 6 I have cut off nations. Their battlements are desolate. I have made their streets waste, so that no one passes by. Their cities are destroyed, so that there is no man, so that there is no inhabitant. 
 \v 7 I said, “Just fear me. Receive correction,” so that her dwelling won’t be cut off, according to all that I have appointed concerning her. But they rose early and corrupted all their doings. 
 \p
-\v 8 “Therefore wait for me”, says Yahweh, “until the day that I rise up to the prey, for my determination is to gather the nations, that I may assemble the kingdoms to pour on them my indignation, even all my fierce anger, for all the earth will be devoured with the fire of my jealousy. 
+\v 8 “Therefore wait for me”, says Yahuah, “until the day that I rise up to the prey, for my determination is to gather the nations, that I may assemble the kingdoms to pour on them my indignation, even all my fierce anger, for all the earth will be devoured with the fire of my jealousy. 
 \p
-\v 9 For then I will purify the lips of the peoples, that they may all call on Yahweh’s name, to serve him shoulder to shoulder. 
+\v 9 For then I will purify the lips of the peoples, that they may all call on Yahuah’s name, to serve him shoulder to shoulder. 
 \v 10 From beyond the rivers of Cush, my worshipers, even the daughter of my dispersed people, will bring my offering. 
 \v 11 In that day you will not be disappointed for all your doings in which you have transgressed against me; for then I will take away out from among you your proudly exulting ones, and you will no more be arrogant in my set-apart mountain. 
-\v 12 But I will leave among you an afflicted and poor people, and they will take refuge in Yahweh’s name. 
+\v 12 But I will leave among you an afflicted and poor people, and they will take refuge in Yahuah’s name. 
 \v 13 The remnant of Israel will not do iniquity nor speak lies, neither will a deceitful tongue be found in their mouth, for they will feed and lie down, and no one will make them afraid.” 
 \p
 \v 14 Sing, daughter of Zion! Shout, Israel! Be glad and rejoice with all your heart, daughter of Jerusalem. 
-\v 15 Yahweh has taken away your judgments. He has thrown out your enemy. The King of Israel, Yahweh, is among you. You will not be afraid of evil any more. 
+\v 15 Yahuah has taken away your judgments. He has thrown out your enemy. The King of Israel, Yahuah, is among you. You will not be afraid of evil any more. 
 \v 16 In that day, it will be said to Jerusalem, “Don’t be afraid, Zion. Don’t let your hands be weak.” 
-\v 17 Yahweh, your Elohim, is among you, a mighty one who will save. He will rejoice over you with joy. He will calm you in his love. He will rejoice over you with singing. 
+\v 17 Yahuah, your Elohim, is among you, a mighty one who will save. He will rejoice over you with joy. He will calm you in his love. He will rejoice over you with singing. 
 \v 18 I will remove those who grieve about the appointed feasts from you. They are a burden and a reproach to you. 
 \v 19 Behold, at that time I will deal with all those who afflict you; and I will save those who are lame and gather those who were driven away. I will give them praise and honor, whose shame has been in all the earth. 
-\v 20 At that time I will bring you in, and at that time I will gather you; for I will give you honor and praise among all the peoples of the earth when I restore your fortunes before your eyes, says Yahweh. 
+\v 20 At that time I will bring you in, and at that time I will gather you; for I will give you honor and praise among all the peoples of the earth when I restore your fortunes before your eyes, says Yahuah. 


### PR DESCRIPTION
```

# update to best known transliteration
# this transliteration is more compatible with the transliteration of yahushua's
# name, and is derived from a straightforward, natural, and consistent way to
# pronounce hebrew characters, rather than forcing an inflection that is similar
# to the vowels of 'adonai'.
sed -i 's/Yahweh/Yahuah/g' *.usfm
sed -i 's/YAHWEH/YAHUAH/g' *.usfm

```